### PR TITLE
Add presence server and peer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ curl -o file.zip https://pipe.afjk.jp/mypath
 
 送信側と受信側が同じパスにアクセスすることでデータが転送される。送信側は受信側が接続するまで待機する。
 
+### presence.afjk.jp — Presence Server (WebSocket)
+
+`html/pipe/index.html` から利用するプレゼンス兼シグナリング通知用の WebSocket。クライアントは接続元 IP もしくは `?room=` パラメータで同じルームに入り、端末一覧やハンドオフメッセージ（受信パスの自動共有）をやり取りする。ブラウザ側で `?presence=ws://localhost:8787` のようにクエリを指定すると任意のエンドポイントを強制できる。DNS で `presence.afjk.jp` をサーバーの IP に向けておくと、`https-portal` が自動で証明書を発行してくれる。
+
 ---
 
 ## ローカル開発
@@ -88,6 +92,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 | メインサイト (afjk.jp) | http://localhost:8888 |
 | Verdaccio (upm.afjk.jp) | http://localhost:4873 |
 | Piping Server (pipe.afjk.jp) | http://localhost:8080 |
+| Presence Server (presence.afjk.jp) | ws://localhost:8787 |
 
 ### 停止
 

--- a/apps/presence-server/Dockerfile
+++ b/apps/presence-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY src ./src
+COPY package.json ./package.json
+EXPOSE 8787
+CMD ["node", "src/server.mjs"]

--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "presence-server",
+  "version": "0.1.0",
+  "description": "WebSocket presence broker for pipe.afjk.jp",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "start": "node src/server.mjs"
+  }
+}

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -1,0 +1,311 @@
+import { createServer } from 'node:http';
+import { createHash, randomUUID } from 'node:crypto';
+import { URL } from 'node:url';
+
+const PORT = Number(process.env.PORT || 8787);
+const HEARTBEAT_MS = 30000;
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+const rooms = new Map(); // roomId -> Map<clientId, Client>
+
+function log(...args) {
+  console.log(new Date().toISOString(), '-', ...args);
+}
+
+function sanitizeName(raw) {
+  if (!raw) return '';
+  return String(raw).trim().slice(0, 40);
+}
+
+function sanitizeDevice(raw) {
+  if (!raw) return '';
+  return String(raw).trim().slice(0, 60);
+}
+
+function sanitizeRoom(raw) {
+  if (!raw) return null;
+  const cleaned = raw.toLowerCase().replace(/[^a-z0-9\-]/g, '').slice(0, 32);
+  return cleaned || null;
+}
+
+function inferRoomFromReq(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  const first = forwarded ? forwarded.split(',')[0].trim() : null;
+  const ip = first || req.socket.remoteAddress || 'global';
+  if (ip.includes(':')) {
+    return ip.replace('::ffff:', '').split(':')[0] || 'global-v6';
+  }
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return `${parts[0]}.${parts[1]}.${parts[2]}.x`;
+  }
+  return ip || 'global';
+}
+
+class WsConnection {
+  constructor(socket) {
+    this.socket = socket;
+    this.buffer = Buffer.alloc(0);
+    this.alive = true;
+    socket.on('data', chunk => this.#handle(chunk));
+    socket.on('close', () => this.onClose && this.onClose());
+    socket.on('error', () => this.onClose && this.onClose());
+  }
+
+  send(obj) {
+    try {
+      const payload = Buffer.from(JSON.stringify(obj));
+      this.socket.write(encodeFrame(payload));
+    } catch (err) {
+      log('send error', err.message);
+    }
+  }
+
+  ping() {
+    this.socket.write(Buffer.from([0x89, 0x00]));
+  }
+
+  close() {
+    try {
+      this.socket.end();
+    } catch {}
+  }
+
+  #handle(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.buffer.length >= 2) {
+      const first = this.buffer[0];
+      const opcode = first & 0x0f;
+      const isMasked = Boolean(this.buffer[1] & 0x80);
+      let length = this.buffer[1] & 0x7f;
+      let offset = 2;
+
+      if (length === 126) {
+        if (this.buffer.length < 4) return;
+        length = this.buffer.readUInt16BE(2);
+        offset = 4;
+      } else if (length === 127) {
+        if (this.buffer.length < 10) return;
+        const big = this.buffer.readBigUInt64BE(2);
+        length = Number(big);
+        offset = 10;
+      }
+
+      const mask = isMasked ? this.buffer.slice(offset, offset + 4) : null;
+      offset += isMasked ? 4 : 0;
+      if (this.buffer.length < offset + length) return;
+
+      let payload = this.buffer.slice(offset, offset + length);
+      this.buffer = this.buffer.slice(offset + length);
+
+      if (mask) payload = applyMask(payload, mask);
+
+      if (opcode === 0x8) {
+        this.close();
+        return;
+      }
+      if (opcode === 0x9) {
+        // ping -> respond with pong
+        this.socket.write(Buffer.concat([Buffer.from([0x8a, payload.length]), payload]));
+        continue;
+      }
+      if (opcode === 0xa) {
+        this.alive = true;
+        continue;
+      }
+      if (opcode !== 0x1) continue; // text frames only
+
+      this.alive = true;
+      const text = payload.toString('utf8');
+      this.onMessage && this.onMessage(text);
+    }
+  }
+}
+
+function applyMask(buf, mask) {
+  const out = Buffer.allocUnsafe(buf.length);
+  for (let i = 0; i < buf.length; i += 1) {
+    out[i] = buf[i] ^ mask[i % 4];
+  }
+  return out;
+}
+
+function encodeFrame(payload) {
+  const len = payload.length;
+  if (len < 126) {
+    const header = Buffer.from([0x81, len]);
+    return Buffer.concat([header, payload]);
+  }
+  if (len < 65536) {
+    const header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+    return Buffer.concat([header, payload]);
+  }
+  const header = Buffer.alloc(10);
+  header[0] = 0x81;
+  header[1] = 127;
+  header.writeBigUInt64BE(BigInt(len), 2);
+  return Buffer.concat([header, payload]);
+}
+
+function acceptWebSocket(req, socket) {
+  const key = req.headers['sec-websocket-key'];
+  if (!key) {
+    socket.destroy();
+    return null;
+  }
+  const accept = createHash('sha1').update(key + WS_GUID).digest('base64');
+  const headers = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${accept}`,
+    '\r\n'
+  ];
+  socket.write(headers.join('\r\n'));
+  return new WsConnection(socket);
+}
+
+function makeClient(conn, roomId) {
+  const client = {
+    id: randomUUID(),
+    conn,
+    roomId,
+    nickname: '',
+    device: '',
+    lastSeen: Date.now()
+  };
+  const room = rooms.get(roomId) ?? new Map();
+  room.set(client.id, client);
+  rooms.set(roomId, room);
+  return client;
+}
+
+function removeClient(client) {
+  const room = rooms.get(client.roomId);
+  if (!room) return;
+  room.delete(client.id);
+  if (!room.size) {
+    rooms.delete(client.roomId);
+  }
+}
+
+function listPeers(roomId, excludeId) {
+  const room = rooms.get(roomId);
+  if (!room) return [];
+  return Array.from(room.values())
+    .filter(p => p.id !== excludeId)
+    .map(p => ({
+      id: p.id,
+      nickname: p.nickname,
+      device: p.device,
+      lastSeen: p.lastSeen
+    }));
+}
+
+function broadcastPeers(roomId) {
+  const room = rooms.get(roomId);
+  if (!room) return;
+  room.forEach(client => {
+    safeSend(client.conn, { type: 'peers', peers: listPeers(roomId, client.id) });
+  });
+}
+
+function safeSend(conn, message) {
+  try {
+    conn.send(message);
+  } catch (err) {
+    log('send fail', err.message);
+  }
+}
+
+function deliverHandoff(sender, msg) {
+  const room = rooms.get(sender.roomId);
+  if (!room) return;
+  const target = room.get(msg.targetId);
+  if (!target) return;
+  const payload = {
+    type: 'handoff',
+    from: {
+      id: sender.id,
+      nickname: sender.nickname,
+      device: sender.device
+    },
+    payload: msg.payload || {}
+  };
+  safeSend(target.conn, payload);
+}
+
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'text/plain' }).end('presence ok');
+});
+
+server.on('upgrade', (req, socket) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname !== '/' && url.pathname !== '/ws') {
+    socket.destroy();
+    return;
+  }
+  const roomOverride = sanitizeRoom(url.searchParams.get('room'));
+  const roomId = roomOverride || inferRoomFromReq(req);
+  const conn = acceptWebSocket(req, socket);
+  if (!conn) return;
+
+  const client = makeClient(conn, roomId);
+  log('client connected', client.id, 'room', roomId);
+
+  conn.send({ type: 'welcome', id: client.id, room: roomId });
+  broadcastPeers(roomId);
+
+  conn.onMessage = raw => {
+    client.lastSeen = Date.now();
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    switch (data.type) {
+      case 'hello':
+        client.nickname = sanitizeName(data.nickname);
+        client.device = sanitizeDevice(data.device);
+        broadcastPeers(roomId);
+        break;
+      case 'handoff':
+        if (data.targetId && data.payload) {
+          deliverHandoff(client, data);
+        }
+        break;
+      case 'ping':
+        safeSend(conn, { type: 'pong', at: Date.now() });
+        break;
+      default:
+        break;
+    }
+  };
+
+  conn.onClose = () => {
+    log('client disconnected', client.id);
+    removeClient(client);
+    broadcastPeers(roomId);
+  };
+});
+
+setInterval(() => {
+  rooms.forEach(room => {
+    room.forEach(client => {
+      if (!client.conn.alive) {
+        client.conn.close();
+        return;
+      }
+      client.conn.alive = false;
+      client.conn.ping();
+    });
+  });
+}, HEARTBEAT_MS);
+
+server.listen(PORT, () => {
+  log(`presence server listening on ${PORT}`);
+});

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -14,3 +14,7 @@ services:
   piping-server:
     ports:
       - "8080:8080"
+
+  presence-server:
+    ports:
+      - "8787:8787"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
         afjk.jp -> http://www-service:80,
         www.afjk.jp -> http://www-service:80,
         upm.afjk.jp -> http://verdaccio:4873,
-        pipe.afjk.jp -> http://piping-server:8080
+        pipe.afjk.jp -> http://piping-server:8080,
+        presence.afjk.jp -> http://presence-server:8787
       CLIENT_MAX_BODY_SIZE: 0
       # piping-server のストリーミング転送を最適化
       CUSTOM_NGINX_SERVER_CONFIG_BLOCK: |
@@ -57,3 +58,10 @@ services:
     environment:
       - PORT=8080 # Piping Serverがリッスンするポート
     restart: always
+
+  presence-server:
+    build: ./apps/presence-server
+    container_name: presence-server
+    restart: always
+    environment:
+      - PORT=8787

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -52,6 +52,73 @@
     h1 { font-size: 1.6rem; font-weight: 800; margin-bottom: 6px; }
     .lead { color: var(--text2); font-size: 0.9rem; margin-bottom: 32px; line-height: 1.6; }
 
+    /* ── Presence ── */
+    .presence {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 18px;
+      margin-bottom: 28px;
+    }
+    .presence-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: flex-start;
+    }
+    .presence-label {
+      font-size: 0.75rem;
+      color: var(--muted);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .presence-status { font-size: 0.9rem; color: var(--text2); margin-top: 4px; }
+    .presence-room { font-size: 0.78rem; color: var(--muted); margin-top: 6px; }
+    .device-chip {
+      border: 1px solid var(--border2);
+      background: var(--surface2);
+      border-radius: 999px;
+      color: var(--text2);
+      font-size: 0.8rem;
+      padding: 6px 14px;
+      cursor: pointer;
+      font-family: inherit;
+      white-space: nowrap;
+    }
+    .device-chip span { color: var(--text); font-weight: 600; }
+    .device-chip:hover { border-color: var(--accent); color: var(--accent); }
+    .peer-grid {
+      margin-top: 16px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .peer-grid.empty {
+      display: block;
+    }
+    .presence-empty {
+      font-size: 0.85rem;
+      color: var(--text2);
+    }
+    .peer-card {
+      border: 1px solid var(--border2);
+      border-radius: var(--radius);
+      background: var(--surface2);
+      padding: 12px 14px;
+      min-width: 160px;
+      flex: 1 1 180px;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      cursor: pointer;
+      text-align: left;
+    }
+    .peer-card:hover { border-color: var(--accent); }
+    .peer-name { font-weight: 600; color: var(--text); }
+    .peer-meta { font-size: 0.78rem; color: var(--text2); margin-top: 4px; }
+    .peer-action { font-size: 0.78rem; color: var(--accent); font-weight: 600; }
+
     /* ── Tabs ── */
     .tabs {
       display: flex;
@@ -244,6 +311,20 @@
   <h1>File Transfer</h1>
   <p class="lead">URLを共有するだけ。ブラウザだけで安全にファイルを送受信。<br>No upload to cloud — P2P streaming via piping-server.</p>
 
+  <section class="presence">
+    <div class="presence-head">
+      <div>
+        <div class="presence-label">近くのデバイス</div>
+        <div class="presence-status" id="presence-status">接続中…</div>
+        <div class="presence-room" id="presence-room">同じネットワークにいる端末がここに表示されます。</div>
+      </div>
+      <button class="device-chip" id="device-name-btn" type="button">端末名: <span id="device-name-label"></span></button>
+    </div>
+    <div class="peer-grid empty" id="peer-grid">
+      <div class="presence-empty" id="presence-empty">接続中…</div>
+    </div>
+  </section>
+
   <div class="tabs">
     <button class="tab active" data-tab="send">📤 送信</button>
     <button class="tab" data-tab="receive">📥 受信</button>
@@ -350,6 +431,22 @@
 <script>
 // ── Config ────────────────────────────────────────────────────────────────────
 const PIPE        = 'https://pipe.afjk.jp';
+const params      = new URLSearchParams(location.search);
+const ROOM_CODE   = sanitizeRoomCode(params.get('room'));
+const PRESENCE_OVERRIDE = params.get('presence');
+const DEFAULT_PRESENCE =
+  (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+    ? `ws://${location.hostname}:8787`
+    : 'wss://presence.afjk.jp';
+const PRESENCE_ENDPOINT = PRESENCE_OVERRIDE || DEFAULT_PRESENCE;
+const presenceState = { ws: null, id: null, peers: new Map(), reconnectTimer: null };
+let deviceName = localStorage.getItem('pipe.deviceName') || defaultDeviceName();
+const deviceInfo = detectDeviceInfo();
+const presenceStatusEl = document.getElementById('presence-status');
+const presenceRoomEl   = document.getElementById('presence-room');
+const deviceNameLabel  = document.getElementById('device-name-label');
+const deviceNameBtn    = document.getElementById('device-name-btn');
+const peerGrid         = document.getElementById('peer-grid');
 // ── Cancellation state ────────────────────────────────────────────────────────
 let _sendXHR = null, _sendPC = null;   // file send
 let _recvPC  = null, _recvAC = null;   // file receive
@@ -411,6 +508,219 @@ function copyField(fieldId, btnId) {
     setTimeout(() => { btn.textContent = 'コピー'; btn.classList.remove('copied'); }, 2000);
   });
 }
+
+function sanitizeRoomCode(raw) {
+  if (!raw) return null;
+  const cleaned = raw.toLowerCase().replace(/[^a-z0-9\-]/g, '').slice(0, 24);
+  return cleaned || null;
+}
+
+function detectDeviceInfo() {
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('iphone')) return 'iPhone';
+  if (ua.includes('ipad')) return 'iPad';
+  if (ua.includes('android')) return 'Android';
+  if (ua.includes('mac os x')) return 'macOS';
+  if (ua.includes('windows')) return 'Windows';
+  if (ua.includes('linux')) return 'Linux';
+  return 'Browser';
+}
+
+function defaultDeviceName() {
+  const platform = navigator.userAgentData?.platform || navigator.platform || 'Device';
+  return platform.replace(/_/g, ' ');
+}
+
+function updateDeviceNameLabel() {
+  if (deviceNameLabel) deviceNameLabel.textContent = deviceName;
+}
+
+function editDeviceName() {
+  const next = prompt('表示する端末名を入力', deviceName) || '';
+  const cleaned = next.trim().slice(0, 40);
+  if (!cleaned) return;
+  deviceName = cleaned;
+  localStorage.setItem('pipe.deviceName', deviceName);
+  updateDeviceNameLabel();
+  sendPresenceHello();
+}
+
+function buildPresenceUrl() {
+  try {
+    const url = new URL(PRESENCE_ENDPOINT, location.href);
+    if (ROOM_CODE && !url.searchParams.get('room')) url.searchParams.set('room', ROOM_CODE);
+    return url;
+  } catch {
+    const fallback = new URL('ws://localhost:8787');
+    if (ROOM_CODE) fallback.searchParams.set('room', ROOM_CODE);
+    return fallback;
+  }
+}
+
+function connectPresence() {
+  if (!peerGrid || !presenceStatusEl) return;
+  const url = buildPresenceUrl();
+  presenceStatusEl.textContent = '接続中…';
+  const ws = new WebSocket(url);
+  presenceState.ws = ws;
+  ws.addEventListener('open', () => {
+    if (presenceState.reconnectTimer) {
+      clearTimeout(presenceState.reconnectTimer);
+      presenceState.reconnectTimer = null;
+    }
+    presenceStatusEl.textContent = '接続済み';
+    renderPeerGrid();
+    sendPresenceHello();
+  });
+  ws.addEventListener('message', handlePresenceMessage);
+  ws.addEventListener('close', () => {
+    presenceStatusEl.textContent = '切断されました。再接続しています…';
+    presenceState.ws = null;
+    presenceState.id = null;
+    if (presenceState.reconnectTimer) clearTimeout(presenceState.reconnectTimer);
+    presenceState.reconnectTimer = setTimeout(connectPresence, 3000);
+  });
+  ws.addEventListener('error', () => {
+    presenceStatusEl.textContent = '接続に失敗しました';
+  });
+}
+
+function handlePresenceMessage(ev) {
+  let data;
+  try {
+    data = JSON.parse(ev.data);
+  } catch {
+    return;
+  }
+  switch (data.type) {
+    case 'welcome':
+      presenceState.id = data.id;
+      updateRoomLabel(data.room);
+      sendPresenceHello();
+      break;
+    case 'peers':
+      presenceState.peers = new Map((data.peers || []).map(p => [p.id, p]));
+      renderPeerGrid();
+      break;
+    case 'handoff':
+      handleIncomingHandoff(data);
+      break;
+    default:
+      break;
+  }
+}
+
+function updateRoomLabel(roomId) {
+  if (!presenceRoomEl) return;
+  if (ROOM_CODE) {
+    presenceRoomEl.textContent = `ルームコード: ${ROOM_CODE}`;
+  } else if (roomId) {
+    presenceRoomEl.textContent = `検出されたグループ: ${roomId}`;
+  }
+}
+
+function sendPresenceHello() {
+  if (!presenceState.ws || presenceState.ws.readyState !== WebSocket.OPEN) return;
+  presenceState.ws.send(JSON.stringify({
+    type: 'hello',
+    nickname: deviceName,
+    device: deviceInfo,
+    capabilities: { file: true, text: true }
+  }));
+}
+
+function renderPeerGrid() {
+  if (!peerGrid) return;
+  peerGrid.innerHTML = '';
+  const peers = Array.from(presenceState.peers.values());
+  if (!peers.length) {
+    peerGrid.classList.add('empty');
+    const empty = document.createElement('div');
+    empty.className = 'presence-empty';
+    empty.textContent = presenceState.ws ? '接続中のデバイスはありません。' : '接続されていません。';
+    peerGrid.appendChild(empty);
+    return;
+  }
+  peerGrid.classList.remove('empty');
+  peers.forEach(peer => {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = 'peer-card';
+    const left = document.createElement('div');
+    const name = document.createElement('div');
+    name.className = 'peer-name';
+    name.textContent = peer.nickname || 'デバイス';
+    const meta = document.createElement('div');
+    meta.className = 'peer-meta';
+    const bits = [];
+    if (peer.device) bits.push(peer.device);
+    if (peer.lastSeen) bits.push(fmtLastSeen(peer.lastSeen));
+    meta.textContent = bits.join(' · ');
+    left.appendChild(name);
+    left.appendChild(meta);
+    const action = document.createElement('div');
+    action.className = 'peer-action';
+    action.textContent = '送信';
+    card.append(left, action);
+    card.addEventListener('click', () => startSendToPeer(peer.id));
+    peerGrid.appendChild(card);
+  });
+}
+
+function fmtLastSeen(ts) {
+  const diff = Date.now() - Number(ts || 0);
+  if (diff < 10_000) return 'オンライン';
+  if (diff < 60_000) return `${Math.round(diff / 1000)}秒前`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}分前`;
+  return `${Math.floor(diff / 3_600_000)}時間前`;
+}
+
+function startSendToPeer(peerId) {
+  if (!selFile || !curPath) {
+    setStatus('send-status', '先にファイルを選択してください。', 'err');
+    return;
+  }
+  if (!presenceState.ws || presenceState.ws.readyState !== WebSocket.OPEN) {
+    setStatus('send-status', '近くのデバイスとの接続を確立できません。', 'err');
+    return;
+  }
+  presenceState.ws.send(JSON.stringify({
+    type: 'handoff',
+    targetId: peerId,
+    payload: {
+      kind: 'file',
+      path: curPath,
+      filename: selFile.name,
+      size: selFile.size,
+      mime: selFile.type || 'application/octet-stream',
+      url: recvUrl(curPath)
+    }
+  }));
+  setStatus('send-status', '通知を送信しました。P2P 接続を開始します…', 'waiting');
+  startSend();
+}
+
+function handleIncomingHandoff(msg) {
+  const payload = msg.payload || {};
+  if (!payload.path) return;
+  const sender = msg.from?.nickname || '相手';
+  const label = payload.filename ? `「${payload.filename}」` : 'ファイル';
+  switchTab('receive');
+  const input = document.getElementById('recv-path');
+  input.value = payload.path;
+  document.getElementById('recv-btn').disabled = false;
+  setStatus('recv-status', `${sender} から ${label} が届きます。接続しています…`, 'waiting');
+  startReceive();
+}
+
+function initPresence() {
+  if (!peerGrid || !presenceStatusEl) return;
+  updateDeviceNameLabel();
+  if (deviceNameBtn) deviceNameBtn.addEventListener('click', editDeviceName);
+  connectPresence();
+}
+
+initPresence();
 
 // ── Tabs ──────────────────────────────────────────────────────────────────────
 document.querySelectorAll('.tab').forEach(btn => {


### PR DESCRIPTION
## Summary
- WebSocket プレゼンスサーバー (`apps/presence-server`) を新規追加
- `html/pipe/index.html` に「近くのデバイス」UI を追加（同一ネットワーク端末の検出・ファイルハンドオフ）
- `docker-compose.yml` に presence-server サービスと `presence.afjk.jp` ルーティングを追加

## Test plan
- [ ] ローカルで presence-server 起動、2タブで互いに検出されることを確認
- [ ] 片方でファイル選択 → ピアカードをクリック → もう片方で自動受信されることを確認
- [ ] 本番デプロイ後: `docker compose up -d --build presence-server` の実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)