### PR TITLE
fix: deploy only presence-server, not all services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
           script: |
             cd ~/github/afjk.jp
             git pull
-            docker compose up -d --build
+            docker compose up -d --build presence-server


### PR DESCRIPTION
## 問題
`docker compose up -d --build` で全サービスをビルド対象にしたため、DOMAINSの変更を検知した https-portal が再作成され、afjk.jp がダウンした。

## 修正
`docker compose up -d --build presence-server` で presence-server のみを対象にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)