### PR TITLE
fix: restart https-portal on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,3 +24,4 @@ jobs:
             cd ~/github/afjk.jp
             git pull
             docker compose up -d --build presence-server
+            docker compose restart https-portal


### PR DESCRIPTION
afjk.jp 復旧のため https-portal を deploy 後に再起動する