### PR TITLE
emergency: remove presence.afjk.jp from DOMAINS to restore site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
             cd ~/github/afjk.jp
             git pull
             docker compose up -d --build presence-server
-            docker compose restart https-portal
+            docker compose up -d https-portal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
         afjk.jp -> http://www-service:80,
         www.afjk.jp -> http://www-service:80,
         upm.afjk.jp -> http://verdaccio:4873,
-        pipe.afjk.jp -> http://piping-server:8080,
-        presence.afjk.jp -> http://presence-server:8787
+        pipe.afjk.jp -> http://piping-server:8080
       CLIENT_MAX_BODY_SIZE: 0
       # piping-server のストリーミング転送を最適化
       CUSTOM_NGINX_SERVER_CONFIG_BLOCK: |


### PR DESCRIPTION
afjk.jp がダウン中。https-portal が presence.afjk.jp 証明書取得でクラッシュしている可能性が高いため一時的に DOMAINS から除外して復旧する。