### PR TITLE
feat: 画像プレビューモーダルに背景削除編集機能を追加

### DIFF
--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3482,18 +3482,21 @@ PreviewRegistry.register({
     progressEl.className = 'img-edit-progress';
 
     let _resultUrl = null;
+    let _disposed = false;
 
     removeBgBtn.addEventListener('click', async () => {
       removeBgBtn.disabled = true;
       progressEl.textContent = currentLang === 'ja' ? 'モデル読み込み中…' : 'Loading model…';
       try {
-        const { removeBackground } = await import('https://esm.sh/@imgly/background-removal');
+        const { removeBackground } = await import('https://esm.sh/@imgly/background-removal@1.7.0?target=es2022');
+        if (_disposed) return;
         progressEl.textContent = currentLang === 'ja' ? '処理中…' : 'Processing…';
         const blob = await removeBackground(url, {
           progress(key, cur, total) {
             if (total > 0) progressEl.textContent = `${Math.round(cur / total * 100)}%`;
           }
         });
+        if (_disposed) return;
         if (_resultUrl) URL.revokeObjectURL(_resultUrl);
         _resultUrl = URL.createObjectURL(blob);
 
@@ -3511,13 +3514,16 @@ PreviewRegistry.register({
           toolbar.appendChild(dlBtn);
         }
         dlBtn.href = _resultUrl;
-        dlBtn.download = (meta && meta.name ? meta.name.replace(/\.[^.]+$/, '') : 'image') + '_nobg.png';
+        const safeName = (meta && meta.name ? meta.name.replace(/\.[^.]+$/, '') : 'image')
+          .replace(/[/\\?%*:|"<>]/g, '_');
+        dlBtn.download = safeName + '_nobg.png';
 
         progressEl.textContent = '';
         removeBgBtn.disabled = false;
         removeBgBtn.textContent = currentLang === 'ja' ? '↺ 再実行' : '↺ Retry';
       } catch (err) {
-        progressEl.textContent = err.message || 'Error';
+        if (_disposed) return;
+        progressEl.textContent = err?.message || String(err ?? 'Error');
         removeBgBtn.disabled = false;
       }
     });
@@ -3526,7 +3532,10 @@ PreviewRegistry.register({
     toolbar.appendChild(progressEl);
     wrap.appendChild(toolbar);
     container.appendChild(wrap);
-    return () => { if (_resultUrl) URL.revokeObjectURL(_resultUrl); };
+    return () => {
+      _disposed = true;
+      if (_resultUrl) URL.revokeObjectURL(_resultUrl);
+    };
   }
 });
 

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -851,6 +851,53 @@
       white-space: nowrap;
     }
     .preview-open-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* ── Image Editor ── */
+    .img-edit-wrap {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+    }
+    .img-edit-wrap img {
+      max-width: 100%;
+      max-height: 55vh;
+      border-radius: 6px;
+      object-fit: contain;
+    }
+    .img-edit-result {
+      background:
+        repeating-conic-gradient(#bbb 0% 25%, #fff 0% 50%)
+        0 0 / 12px 12px;
+    }
+    .img-edit-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .img-edit-btn {
+      background: none;
+      border: 1px solid var(--border2);
+      color: var(--text2);
+      cursor: pointer;
+      font-size: 0.78rem;
+      padding: 5px 12px;
+      border-radius: 4px;
+      white-space: nowrap;
+      text-decoration: none;
+      display: inline-block;
+    }
+    .img-edit-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+    .img-edit-btn:disabled { opacity: 0.45; cursor: not-allowed; pointer-events: none; }
+    .img-edit-progress {
+      font-size: 0.76rem;
+      color: var(--muted);
+      min-width: 4em;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
@@ -3417,10 +3464,69 @@ PreviewRegistry.register({
     });
     return _a11yBtn(img, onClick, meta.name);
   },
-  renderDetail(container, url) {
-    const img = Object.assign(document.createElement('img'), { src: url });
-    container.appendChild(img);
-    return null;
+  renderDetail(container, url, meta) {
+    const wrap = document.createElement('div');
+    wrap.className = 'img-edit-wrap';
+
+    const imgEl = Object.assign(document.createElement('img'), { src: url });
+    wrap.appendChild(imgEl);
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'img-edit-toolbar';
+
+    const removeBgBtn = document.createElement('button');
+    removeBgBtn.className = 'img-edit-btn';
+    removeBgBtn.textContent = currentLang === 'ja' ? '✂ 背景を削除' : '✂ Remove BG';
+
+    const progressEl = document.createElement('span');
+    progressEl.className = 'img-edit-progress';
+
+    let _resultUrl = null;
+
+    removeBgBtn.addEventListener('click', async () => {
+      removeBgBtn.disabled = true;
+      progressEl.textContent = currentLang === 'ja' ? 'モデル読み込み中…' : 'Loading model…';
+      try {
+        const { removeBackground } = await import('https://esm.sh/@imgly/background-removal');
+        progressEl.textContent = currentLang === 'ja' ? '処理中…' : 'Processing…';
+        const blob = await removeBackground(url, {
+          progress(key, cur, total) {
+            if (total > 0) progressEl.textContent = `${Math.round(cur / total * 100)}%`;
+          }
+        });
+        if (_resultUrl) URL.revokeObjectURL(_resultUrl);
+        _resultUrl = URL.createObjectURL(blob);
+
+        let resultImg = wrap.querySelector('.img-edit-result');
+        if (!resultImg) {
+          resultImg = Object.assign(document.createElement('img'), { className: 'img-edit-result' });
+          wrap.insertBefore(resultImg, toolbar);
+        }
+        resultImg.src = _resultUrl;
+
+        let dlBtn = toolbar.querySelector('.img-edit-dl-btn');
+        if (!dlBtn) {
+          dlBtn = Object.assign(document.createElement('a'), { className: 'img-edit-btn img-edit-dl-btn' });
+          dlBtn.textContent = currentLang === 'ja' ? '⬇ 保存' : '⬇ Save';
+          toolbar.appendChild(dlBtn);
+        }
+        dlBtn.href = _resultUrl;
+        dlBtn.download = (meta && meta.name ? meta.name.replace(/\.[^.]+$/, '') : 'image') + '_nobg.png';
+
+        progressEl.textContent = '';
+        removeBgBtn.disabled = false;
+        removeBgBtn.textContent = currentLang === 'ja' ? '↺ 再実行' : '↺ Retry';
+      } catch (err) {
+        progressEl.textContent = err.message || 'Error';
+        removeBgBtn.disabled = false;
+      }
+    });
+
+    toolbar.appendChild(removeBgBtn);
+    toolbar.appendChild(progressEl);
+    wrap.appendChild(toolbar);
+    container.appendChild(wrap);
+    return () => { if (_resultUrl) URL.revokeObjectURL(_resultUrl); };
   }
 });
 


### PR DESCRIPTION
## 概要

`/pipe` ページの画像プレビューモーダルに、`@imgly/background-removal` を使った背景削除編集機能を追加しました。

## 変更内容

### 機能
- 画像をプレビューモーダルで開くと、下部に **「✂ 背景を削除」** ボタンを表示
- クリックすると `@imgly/background-removal` を esm.sh CDN から動的インポートして処理開始
- 処理中は進捗をリアルタイム表示（「モデル読み込み中…」→「処理中…」→「XX%」）
- 処理完了後、透過PNG結果を **市松模様背景**（透過確認用）の上に表示
- **「⬇ 保存」** ボタンで `元ファイル名_nobg.png` としてダウンロード
- 再実行ボタン（**「↺ 再実行」**）で処理をやり直し可能
- JA / EN 両言語対応

### 技術的な詳細
- `import('https://esm.sh/@imgly/background-removal')` で初回のみ動的ロード（ONNXモデルはブラウザにキャッシュされる）
- モーダルを閉じると結果の Object URL を自動解放（メモリリークなし）
- ライブラリの読み込みは遅延実行のため、使用しない場合はパフォーマンスに影響なし

## スクリーンショット（動作フロー）

1. 画像サムネイルをクリック → モーダルが開き「✂ 背景を削除」ボタンが表示される
2. ボタンをクリック → モデルがダウンロードされ処理が進む
3. 完了 → 透過PNG結果 + 「⬇ 保存」ボタンが表示される