### PR TITLE
feat: 背景削除後の保存先をフォトに変更（Web Share API）

### DIFF
--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3481,6 +3481,7 @@ PreviewRegistry.register({
     const progressEl = document.createElement('span');
     progressEl.className = 'img-edit-progress';
 
+    let _resultBlob = null;
     let _resultUrl = null;
     let _disposed = false;
 
@@ -3498,6 +3499,7 @@ PreviewRegistry.register({
         });
         if (_disposed) return;
         if (_resultUrl) URL.revokeObjectURL(_resultUrl);
+        _resultBlob = blob;
         _resultUrl = URL.createObjectURL(blob);
 
         let resultImg = wrap.querySelector('.img-edit-result');
@@ -3507,16 +3509,30 @@ PreviewRegistry.register({
         }
         resultImg.src = _resultUrl;
 
-        let dlBtn = toolbar.querySelector('.img-edit-dl-btn');
-        if (!dlBtn) {
-          dlBtn = Object.assign(document.createElement('a'), { className: 'img-edit-btn img-edit-dl-btn' });
-          dlBtn.textContent = currentLang === 'ja' ? '⬇ 保存' : '⬇ Save';
-          toolbar.appendChild(dlBtn);
-        }
-        dlBtn.href = _resultUrl;
         const safeName = (meta && meta.name ? meta.name.replace(/\.[^.]+$/, '') : 'image')
           .replace(/[/\\?%*:|"<>]/g, '_');
-        dlBtn.download = safeName + '_nobg.png';
+        const filename = safeName + '_nobg.png';
+
+        let saveBtn = toolbar.querySelector('.img-edit-dl-btn');
+        if (!saveBtn) {
+          saveBtn = document.createElement('button');
+          saveBtn.className = 'img-edit-btn img-edit-dl-btn';
+          saveBtn.addEventListener('click', async () => {
+            if (!_resultBlob) return;
+            const file = new File([_resultBlob], filename, { type: 'image/png' });
+            if (navigator.canShare && navigator.canShare({ files: [file] })) {
+              try {
+                await navigator.share({ files: [file], title: filename });
+              } catch (e) {
+                if (e.name !== 'AbortError') _fallbackDownload(_resultUrl, filename);
+              }
+            } else {
+              _fallbackDownload(_resultUrl, filename);
+            }
+          });
+          toolbar.appendChild(saveBtn);
+        }
+        saveBtn.textContent = currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos';
 
         progressEl.textContent = '';
         removeBgBtn.disabled = false;
@@ -3538,6 +3554,13 @@ PreviewRegistry.register({
     };
   }
 });
+
+function _fallbackDownload(url, filename) {
+  const a = Object.assign(document.createElement('a'), { href: url, download: filename });
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
 
 // T9: Video provider
 PreviewRegistry.register({

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3517,21 +3517,21 @@ PreviewRegistry.register({
         if (!saveBtn) {
           saveBtn = document.createElement('button');
           saveBtn.className = 'img-edit-btn img-edit-dl-btn';
-          saveBtn.addEventListener('click', async () => {
-            if (!_resultBlob) return;
-            const file = new File([_resultBlob], filename, { type: 'image/png' });
-            if (navigator.canShare && navigator.canShare({ files: [file] })) {
-              try {
-                await navigator.share({ files: [file], title: filename });
-              } catch (e) {
-                if (e.name !== 'AbortError') _fallbackDownload(_resultUrl, filename);
-              }
-            } else {
-              _fallbackDownload(_resultUrl, filename);
-            }
-          });
           toolbar.appendChild(saveBtn);
         }
+        saveBtn.onclick = async () => {
+          if (!_resultBlob) return;
+          const file = new File([_resultBlob], filename, { type: 'image/png' });
+          if (navigator.canShare && navigator.canShare({ files: [file] })) {
+            try {
+              await navigator.share({ files: [file], title: filename });
+            } catch (e) {
+              if (e.name !== 'AbortError') _fallbackDownload(_resultUrl, filename);
+            }
+          } else {
+            _fallbackDownload(_resultUrl, filename);
+          }
+        };
         saveBtn.textContent = currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos';
 
         progressEl.textContent = '';


### PR DESCRIPTION
## 概要

背景削除後の「保存」ボタンを、Web Share API を使ったフォト保存に変更しました。

## 変更内容

- 保存ボタンを `⬇ 保存` → `📤 フォトに保存` に変更
- `navigator.share({ files: [file] })` が使える環境ではシェアシートを開き、フォト/カメラロールへの保存が可能
- Web Share API 非対応環境（デスクトップ等）はファイルダウンロードにフォールバック
- シェアシートをキャンセルした場合（`AbortError`）は何も起こらない
- `_resultBlob` を保持し、保存時に `File` オブジェクトを生成して渡す
- `_fallbackDownload` ヘルパー関数を追加

## 動作環境

| 環境 | 動作 |
|---|---|
| iOS Safari / Android Chrome | シェアシートが開き、フォト/カメラロールへ保存できる |
| デスクトップブラウザ | ファイルダウンロード |
| シェアシートをキャンセル | 何もしない（AbortError を無視） |