### PR TITLE
feat: 背景削除後の画像を送信できる「送信」ボタンを追加

### DIFF
--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3519,22 +3519,23 @@ PreviewRegistry.register({
           saveBtn.className = 'img-edit-btn img-edit-dl-btn';
           toolbar.appendChild(saveBtn);
         }
-        const useShare = _isMobile && !!navigator.canShare &&
-          navigator.canShare({ files: [new File([], 'x.png', { type: 'image/png' })] });
         saveBtn.onclick = async () => {
           if (!_resultBlob) return;
           const file = new File([_resultBlob], filename, { type: 'image/png' });
-          if (useShare) {
+          if (_isMobile && navigator.canShare) {
             try {
-              await navigator.share({ files: [file], title: filename });
+              if (navigator.canShare({ files: [file] })) {
+                await navigator.share({ files: [file], title: filename });
+                return;
+              }
             } catch (e) {
-              if (e.name !== 'AbortError') _fallbackDownload(_resultUrl, filename);
+              if (e.name === 'AbortError') return;
+              // その他のエラーはダウンロードにフォールバック
             }
-          } else {
-            _fallbackDownload(_resultUrl, filename);
           }
+          _fallbackDownload(_resultUrl, filename);
         };
-        saveBtn.textContent = useShare
+        saveBtn.textContent = _isMobile
           ? (currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos')
           : (currentLang === 'ja' ? '⬇ ダウンロード' : '⬇ Download');
 
@@ -3580,7 +3581,8 @@ function _fallbackDownload(url, filename) {
   a.click();
   document.body.removeChild(a);
 }
-const _isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+const _isMobile = navigator.userAgentData?.mobile ??
+  /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 // T9: Video provider
 PreviewRegistry.register({

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3538,6 +3538,21 @@ PreviewRegistry.register({
           ? (currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos')
           : (currentLang === 'ja' ? '⬇ ダウンロード' : '⬇ Download');
 
+        let sendBtn = toolbar.querySelector('.img-edit-send-btn');
+        if (!sendBtn) {
+          sendBtn = document.createElement('button');
+          sendBtn.className = 'img-edit-btn img-edit-send-btn';
+          toolbar.appendChild(sendBtn);
+        }
+        sendBtn.onclick = () => {
+          if (!_resultBlob) return;
+          const file = new File([_resultBlob], filename, { type: 'image/png' });
+          closePreviewModal();
+          setFiles([file]);
+          switchTab('send');
+        };
+        sendBtn.textContent = currentLang === 'ja' ? '➤ 送信' : '➤ Send';
+
         progressEl.textContent = '';
         removeBgBtn.disabled = false;
         removeBgBtn.textContent = currentLang === 'ja' ? '↺ 再実行' : '↺ Retry';

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -3519,10 +3519,12 @@ PreviewRegistry.register({
           saveBtn.className = 'img-edit-btn img-edit-dl-btn';
           toolbar.appendChild(saveBtn);
         }
+        const useShare = _isMobile && !!navigator.canShare &&
+          navigator.canShare({ files: [new File([], 'x.png', { type: 'image/png' })] });
         saveBtn.onclick = async () => {
           if (!_resultBlob) return;
           const file = new File([_resultBlob], filename, { type: 'image/png' });
-          if (navigator.canShare && navigator.canShare({ files: [file] })) {
+          if (useShare) {
             try {
               await navigator.share({ files: [file], title: filename });
             } catch (e) {
@@ -3532,7 +3534,9 @@ PreviewRegistry.register({
             _fallbackDownload(_resultUrl, filename);
           }
         };
-        saveBtn.textContent = currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos';
+        saveBtn.textContent = useShare
+          ? (currentLang === 'ja' ? '📤 フォトに保存' : '📤 Save to Photos')
+          : (currentLang === 'ja' ? '⬇ ダウンロード' : '⬇ Download');
 
         progressEl.textContent = '';
         removeBgBtn.disabled = false;
@@ -3561,6 +3565,7 @@ function _fallbackDownload(url, filename) {
   a.click();
   document.body.removeChild(a);
 }
+const _isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 // T9: Video provider
 PreviewRegistry.register({


### PR DESCRIPTION
## 概要

背景削除後の画像をそのまま pipe の送信機能に渡せる「送信」ボタンを追加しました。

## 変更内容

### 新機能
- 背景削除の処理完了後、ツールバーに **「➤ 送信」** ボタンを追加
- クリックするとモーダルを閉じ、編集済み画像（`_nobg.png`）を送信タブにセットして切り替える
- `setFiles([file])` → `switchTab('send')` の流れで既存の送信機能をそのまま利用
- JA / EN 両言語対応

### あわせて含まれる修正
- デスクトップ（Mac Chrome 等）では Web Share API を使わずダウンロードに切り替え（`_isMobile` UA 判定）

## 動作フロー

1. 画像をプレビューモーダルで開く
2. 「✂ 背景を削除」をクリック → 処理完了
3. ツールバーに「➤ 送信」「📤 フォトに保存 or ⬇ ダウンロード」が並ぶ
4. 「➤ 送信」をクリック → モーダルが閉じ、送信タブに編集済み画像がセットされる
5. そのまま相手へ送信できる