### PR TITLE
Move targetHash declaration before conditional check

### DIFF
--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -2888,10 +2888,10 @@ async function receiveTorrent(magnetURI, sender) {
   });
 
   // Process any wt-signal offers already queued
+  const targetHash = torrent.infoHash || null;
   if (_wtPendingSignals.length) {
     logSwarm('flushing pending signals', { count: _wtPendingSignals.length, targetHash });
     const remaining = [];
-    const targetHash = torrent.infoHash || null;
     _wtPendingSignals.forEach(({ fromId, signal, infoHash }) => {
       if (!targetHash || !infoHash || infoHash === targetHash) {
         _wtHandleOffer(torrent, fromId, signal);


### PR DESCRIPTION
## Summary
Refactored the variable declaration order in the WebTorrent signal processing logic to improve code clarity and ensure the variable is available for logging before the conditional block.

## Key Changes
- Moved `targetHash` variable declaration outside and before the `if (_wtPendingSignals.length)` conditional block
- This ensures `targetHash` is defined before being used in the `logSwarm()` call within the conditional

## Implementation Details
The `targetHash` constant is now initialized at the beginning of the signal processing section, making it available for the logging statement that references it. This change maintains the same functionality while improving code organization and preventing potential issues with variable scope in the logging context.

https://claude.ai/code/session_01FQHQD1ctZS5CUTZQaNvXqS