### PR TITLE
feat: ルーム内映像配信 (MediaMTX WHIP/WHEP)

### DIFF
--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -263,6 +263,7 @@ function makeClient(conn, roomId) {
     roomId,
     nickname: '',
     device: '',
+    streaming: false,
     lastSeen: Date.now()
   };
   const room = rooms.get(roomId) ?? new Map();
@@ -289,6 +290,7 @@ function listPeers(roomId, excludeId) {
       id: p.id,
       nickname: p.nickname,
       device: p.device,
+      streaming: p.streaming,
       lastSeen: p.lastSeen
     }));
 }
@@ -486,6 +488,7 @@ server.on('upgrade', (req, socket) => {
       case 'hello':
         client.nickname = sanitizeName(data.nickname);
         client.device = sanitizeDevice(data.device);
+        client.streaming = Boolean(data.streaming);
         broadcastPeers(roomId);
         break;
       case 'handoff':

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,3 +18,8 @@ services:
   presence-server:
     ports:
       - "8787:8787"
+
+  mediamtx:
+    ports:
+      - "8889:8889"   # WHIP / WHEP HTTP (ローカル開発用)
+      - "9997:9997"   # Control API (ローカル開発用)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,15 @@ services:
           proxy_set_header X-Forwarded-Proto $$scheme;
           proxy_read_timeout 3600s;
         }
+        location /stream/ {
+          proxy_pass http://mediamtx:8889/;
+          proxy_http_version 1.1;
+          proxy_set_header Host $$host;
+          proxy_set_header X-Real-IP $$remote_addr;
+          proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $$scheme;
+          proxy_read_timeout 3600s;
+        }
       # 本番環境の場合は "production" を指定
       STAGE: production
     volumes:
@@ -107,6 +116,20 @@ services:
     volumes:
       - ./coturn:/etc/coturn:ro
       - ./https-portal-certs:/etc/certs:ro  # https-portal の TLS 証明書を共有
+
+  # MediaMTX — WebRTC (WHIP/WHEP) メディアサーバー
+  # .env に MEDIAMTX_EXTERNAL_IP=<公開IP> を設定すると ICE 候補に含まれる
+  mediamtx:
+    image: bluenviron/mediamtx:latest
+    container_name: mediamtx
+    restart: always
+    ports:
+      - "8189:8189/udp"   # WebRTC ICE メディア (ファイアウォールで開放必要)
+    environment:
+      # 公開サーバーの実 IP — 設定すると ICE 候補に追加される
+      - MTX_WEBRTCADDITIONALHOSTS=${MEDIAMTX_EXTERNAL_IP:-}
+    volumes:
+      - ./mediamtx/mediamtx.yml:/mediamtx.yml:ro
 
 volumes:
   presence-stats:

--- a/html/assets/css/pipe.css
+++ b/html/assets/css/pipe.css
@@ -256,10 +256,70 @@
       font-size: 0.88rem;
       transition: all .15s;
       font-family: inherit;
+      position: relative;
     }
     .tab.active { background: var(--accent); color: #000; font-weight: 700; }
     .tab-panel { display: none; }
     .tab-panel.active { display: block; }
+
+    /* ── Live dot (streaming indicator) ── */
+    .tab-live-dot {
+      position: absolute;
+      top: 5px;
+      right: 5px;
+      width: 8px;
+      height: 8px;
+      background: #ff3b30;
+      border-radius: 50%;
+      animation: live-pulse 1.4s ease-in-out infinite;
+      pointer-events: none;
+    }
+    @keyframes live-pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%       { opacity: 0.6; transform: scale(1.35); }
+    }
+
+    /* ── Stream tab ── */
+    .stream-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    .stream-video {
+      width: 100%;
+      border-radius: var(--radius);
+      background: #000;
+      display: block;
+      max-height: 340px;
+      object-fit: contain;
+    }
+    .stream-video-local {
+      margin-bottom: 12px;
+      border: 2px solid #ff3b30;
+    }
+    .stream-who {
+      font-size: 0.82rem;
+      color: var(--text2);
+      margin-bottom: 8px;
+    }
+    .stream-who::before {
+      content: '● ';
+      color: #ff3b30;
+      animation: live-pulse 1.4s ease-in-out infinite;
+    }
+    .btn-stream-stop {
+      background: #3a0f0f;
+      border: 1px solid #8b2020;
+      color: #f87171;
+      padding: 11px 22px;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: inherit;
+      transition: background .15s, border-color .15s;
+    }
+    .btn-stream-stop:hover { background: #4a1414; border-color: #c0392b; }
 
     /* ── Drop zone ── */
     .dropzone {

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -11,6 +11,16 @@ import {
   unregisterAllLocalSeeders,
   handleSwarmHandoff,
 } from './swarm.js';
+import {
+  initStreamModule,
+  onStreamingPeersChange,
+  onStreamTabEntered,
+  startBroadcast,
+  stopBroadcast,
+  startWatch,
+  stopWatch,
+  cleanupStream,
+} from './stream.js';
 
 // ── i18n ──────────────────────────────────────────────────────────────────────
 const I18N = {
@@ -109,6 +119,15 @@ const I18N = {
     previewLoadError:  'プレビューの表示に失敗しました',
     torrentFallback:   'P2P 接続なし — HTTP 経由でフォールバック中…',
     torrentFallbackDL: 'HTTP でダウンロード中…',
+    streamNoRoom:            'ルームに参加してから配信してください',
+    streamAlreadyLive:       '他の人が配信中です',
+    streamGettingMedia:      'カメラ・マイクを取得中…',
+    streamConnecting:        'サーバーに接続中…',
+    streamConnectingViewer:  '配信に接続中…',
+    streamError:             '接続エラー',
+    streamStatusLive:        '● 配信中',
+    streamStatusViewing:     '視聴中',
+    streamFrom:    name => `${name} が配信中`,
   },
   en: {
     copying:            'Copied ✓',
@@ -205,6 +224,15 @@ const I18N = {
     previewLoadError:  'Failed to load preview',
     torrentFallback:   'No P2P peers — falling back to HTTP…',
     torrentFallbackDL: 'Downloading via HTTP…',
+    streamNoRoom:            'Join a room before streaming',
+    streamAlreadyLive:       'Someone else is already streaming',
+    streamGettingMedia:      'Accessing camera & microphone…',
+    streamConnecting:        'Connecting to server…',
+    streamConnectingViewer:  'Joining stream…',
+    streamError:             'Connection error',
+    streamStatusLive:        '● Live',
+    streamStatusViewing:     'Watching',
+    streamFrom:    name => `${name} is live`,
   }
 };
 
@@ -337,6 +365,11 @@ const GDRIVE_CLIENT_ID = '109611024015-h8dt5416re6edbun25a5iq1a3spuj0qc.apps.goo
 const GDRIVE_API_KEY   = 'AIzaSyCHXozZm9QMqLRgQOrKmq74Q6yutFHHeA0';
 const PIPE        = 'https://pipe.afjk.jp';
 const PIPE_MAX_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
+
+// MediaMTX streaming base URL
+const STREAM_BASE = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+  ? `http://${location.hostname}:8889`
+  : `${location.origin}/stream`;
 
 // ICE server config — fetched once from presence-server; TURN credentials are set via env vars
 class IceConfigService {
@@ -762,6 +795,7 @@ function handlePresenceMessage(ev) {
       requestSwarmSyncFromPeers();
       announceCatalogEntriesOnce();
       pruneSwarmEntries();
+      onStreamingPeersChange(data.peers || []);
       // Auto-select a paired peer if exactly one is present and none selected yet
       if (!selPeerId) {
         const paired = (data.peers || []).filter(p => pairedIds.has(p.id));
@@ -799,9 +833,15 @@ function sendPresenceHello() {
     type: 'hello',
     nickname: deviceName,
     device: deviceInfo,
-    capabilities: { file: true, text: true }
+    capabilities: { file: true, text: true },
+    streaming: streamIsActive(),
   }));
 }
+
+// Returns true while this client is broadcasting (read by sendPresenceHello)
+let _streamingActive = false;
+function streamIsActive() { return _streamingActive; }
+function setStreamingActive(v) { _streamingActive = v; }
 
 function updateSendAllBtns() {
   const count = presenceState.peers.size;
@@ -1316,6 +1356,7 @@ document.querySelectorAll('.tab').forEach(btn => {
     document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
     btn.classList.add('active');
     document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+    if (btn.dataset.tab === 'stream') onStreamTabEntered();
   });
 });
 
@@ -3142,6 +3183,15 @@ initSwarmModule({
   getCurrentLang: () => currentLang,
 });
 
+initStreamModule({
+  t,
+  fetchIceServers,
+  getStreamBase: () => STREAM_BASE,
+  getActiveRoomCode: () => activeRoomCode,
+  sendPresenceHello,
+  setStreamingActive,
+});
+
 languageManager.init();
 renderHistory();
 renderSwarmList();
@@ -3179,8 +3229,13 @@ Object.assign(window, {
   copyHistItem,
   removeFromHistory,
   closePreviewModal,
+  startBroadcast,
+  stopBroadcast,
+  startWatch,
+  stopWatch,
 });
 
 window.addEventListener('beforeunload', () => {
   unregisterAllLocalSeeders();
+  cleanupStream();
 });

--- a/html/assets/js/pipe/stream.js
+++ b/html/assets/js/pipe/stream.js
@@ -1,0 +1,286 @@
+// ── WHIP/WHEP streaming module ────────────────────────────────────────────────
+// Provides startBroadcast / stopBroadcast (WHIP) and startWatch / stopWatch (WHEP).
+// Integrates with presence for live-dot and auto-watch.
+
+let _deps = null;
+
+const _state = {
+  isStreaming: false,
+  isWatching: false,
+  localStream: null,
+  publisherPc: null,
+  viewerPc: null,
+  activeStreamerNickname: null, // nickname of the peer who is currently streaming
+};
+
+export function initStreamModule(deps) {
+  _deps = deps;
+}
+
+// ── Called by app.js on peer list update ──────────────────────────────────────
+
+export function onStreamingPeersChange(peers) {
+  const streamer = peers.find(p => p.streaming);
+  _state.activeStreamerNickname = streamer ? (streamer.nickname || '?') : null;
+
+  // Live dot: anyone in the room is streaming (including self)
+  _setLiveDot(!!streamer || _state.isStreaming);
+
+  if (streamer && !_state.isWatching && !_state.isStreaming) {
+    // Auto-watch if stream tab is already open
+    const tab = document.getElementById('tab-stream');
+    if (tab?.classList.contains('active')) {
+      startWatch();
+      return;
+    }
+  }
+
+  // Streamer disconnected while we were watching
+  if (!streamer && _state.isWatching) {
+    stopWatch();
+    return;
+  }
+
+  _renderTab();
+}
+
+// Called when the user clicks the stream tab
+export function onStreamTabEntered() {
+  if (_state.activeStreamerNickname && !_state.isWatching && !_state.isStreaming) {
+    startWatch();
+    return;
+  }
+  _renderTab();
+}
+
+// ── WHIP — publish ────────────────────────────────────────────────────────────
+
+export async function startBroadcast() {
+  if (_state.isStreaming || _state.isWatching) return;
+  const { t, fetchIceServers, getStreamBase, getActiveRoomCode, sendPresenceHello } = _deps;
+  const roomCode = getActiveRoomCode();
+  if (!roomCode) {
+    _setStatus(t('streamNoRoom'), 'err');
+    return;
+  }
+
+  try {
+    _setStatus(t('streamGettingMedia'), 'waiting');
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    _state.localStream = stream;
+
+    const localVideo = document.getElementById('stream-local-video');
+    if (localVideo) localVideo.srcObject = stream;
+    _renderTab();
+
+    const iceServers = await fetchIceServers();
+    const pc = new RTCPeerConnection({ iceServers });
+    _state.publisherPc = pc;
+    stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    await _waitForIce(pc);
+
+    _setStatus(t('streamConnecting'), 'waiting');
+    const res = await fetch(`${getStreamBase()}/room/${roomCode}/whip`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: pc.localDescription.sdp,
+    });
+    if (!res.ok) throw new Error(`WHIP ${res.status}`);
+    await pc.setRemoteDescription({ type: 'answer', sdp: await res.text() });
+
+    _state.isStreaming = true;
+    _deps.setStreamingActive(true);
+    sendPresenceHello();
+    _setLiveDot(true);
+    _setStatus(t('streamStatusLive'), 'ok');
+    _renderTab();
+
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        stopBroadcast();
+      }
+    };
+  } catch (e) {
+    _setStatus(`${t('streamError')}: ${e.message}`, 'err');
+    _cleanupBroadcast();
+    _renderTab();
+  }
+}
+
+export function stopBroadcast() {
+  const { sendPresenceHello, setStreamingActive } = _deps;
+  _cleanupBroadcast();
+  _state.isStreaming = false;
+  setStreamingActive(false);
+  sendPresenceHello();
+  _setLiveDot(!!_state.activeStreamerNickname);
+  _setStatus('', '');
+  _renderTab();
+}
+
+// ── WHEP — view ───────────────────────────────────────────────────────────────
+
+export async function startWatch() {
+  if (_state.isWatching || _state.isStreaming) return;
+  const { t, fetchIceServers, getStreamBase, getActiveRoomCode } = _deps;
+  const roomCode = getActiveRoomCode();
+  if (!roomCode) return;
+
+  try {
+    _setStatus(t('streamConnectingViewer'), 'waiting');
+    const iceServers = await fetchIceServers();
+    const pc = new RTCPeerConnection({ iceServers });
+    _state.viewerPc = pc;
+
+    pc.addTransceiver('video', { direction: 'recvonly' });
+    pc.addTransceiver('audio', { direction: 'recvonly' });
+
+    const remoteVideo = document.getElementById('stream-remote-video');
+    pc.ontrack = e => {
+      if (remoteVideo && e.streams[0]) remoteVideo.srcObject = e.streams[0];
+    };
+
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    await _waitForIce(pc);
+
+    const res = await fetch(`${getStreamBase()}/room/${roomCode}/whep`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: pc.localDescription.sdp,
+    });
+    if (!res.ok) throw new Error(`WHEP ${res.status}`);
+    await pc.setRemoteDescription({ type: 'answer', sdp: await res.text() });
+
+    _state.isWatching = true;
+    _setStatus(t('streamStatusViewing'), 'ok');
+    _renderTab();
+
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        stopWatch();
+      }
+    };
+  } catch (e) {
+    _setStatus(`${t('streamError')}: ${e.message}`, 'err');
+    _cleanupViewer();
+    _renderTab();
+  }
+}
+
+export function stopWatch() {
+  _cleanupViewer();
+  _state.isWatching = false;
+  _setStatus('', '');
+  _renderTab();
+}
+
+// ── Cleanup helpers ───────────────────────────────────────────────────────────
+
+function _cleanupBroadcast() {
+  _state.localStream?.getTracks().forEach(t => t.stop());
+  _state.localStream = null;
+  _state.publisherPc?.close();
+  _state.publisherPc = null;
+  const v = document.getElementById('stream-local-video');
+  if (v) v.srcObject = null;
+}
+
+function _cleanupViewer() {
+  _state.viewerPc?.close();
+  _state.viewerPc = null;
+  const v = document.getElementById('stream-remote-video');
+  if (v) { v.srcObject = null; v.pause(); }
+}
+
+// ── ICE gathering ─────────────────────────────────────────────────────────────
+
+function _waitForIce(pc) {
+  return new Promise(resolve => {
+    if (pc.iceGatheringState === 'complete') { resolve(); return; }
+    const check = () => {
+      if (pc.iceGatheringState === 'complete') {
+        pc.removeEventListener('icegatheringstatechange', check);
+        resolve();
+      }
+    };
+    pc.addEventListener('icegatheringstatechange', check);
+    setTimeout(resolve, 4000); // fallback timeout
+  });
+}
+
+// ── UI helpers ────────────────────────────────────────────────────────────────
+
+function _setLiveDot(show) {
+  const dot = document.getElementById('tab-live-dot');
+  if (!dot) return;
+  dot.hidden = !show;
+}
+
+function _setStatus(msg, cls = '') {
+  const el = document.getElementById('stream-status');
+  if (!el) return;
+  el.textContent = msg;
+  el.className = `status${cls ? ' ' + cls : ''}`;
+}
+
+export function renderStreamTab() {
+  _renderTab();
+}
+
+function _renderTab() {
+  const startBtn     = document.getElementById('stream-start-btn');
+  const stopBtn      = document.getElementById('stream-stop-btn');
+  const watchBtn     = document.getElementById('stream-watch-btn');
+  const leaveBtn     = document.getElementById('stream-leave-btn');
+  const localVideo   = document.getElementById('stream-local-video');
+  const remoteVideo  = document.getElementById('stream-remote-video');
+  const watchSection = document.getElementById('stream-watch-section');
+  const whoEl        = document.getElementById('stream-who');
+  if (!startBtn) return;
+
+  const { t, getActiveRoomCode } = _deps;
+  const hasStreamer = !!_state.activeStreamerNickname;
+  const noRoom     = !getActiveRoomCode();
+
+  // Broadcast controls
+  startBtn.style.display = (_state.isStreaming || _state.isWatching) ? 'none' : '';
+  startBtn.disabled      = noRoom || hasStreamer;
+  startBtn.title         = noRoom ? t('streamNoRoom') : (hasStreamer ? t('streamAlreadyLive') : '');
+  stopBtn.style.display  = _state.isStreaming ? '' : 'none';
+  if (localVideo) localVideo.style.display = _state.isStreaming ? 'block' : 'none';
+
+  // Viewer section
+  if (_state.isWatching) {
+    watchSection.style.display = '';
+    if (watchBtn) watchBtn.style.display = 'none';
+    leaveBtn.style.display = '';
+    if (remoteVideo) remoteVideo.style.display = 'block';
+  } else if (!_state.isStreaming && hasStreamer) {
+    watchSection.style.display = '';
+    if (watchBtn) watchBtn.style.display = '';
+    leaveBtn.style.display = 'none';
+    if (remoteVideo) remoteVideo.style.display = 'none';
+  } else {
+    watchSection.style.display = 'none';
+    if (remoteVideo) remoteVideo.style.display = 'none';
+  }
+
+  if (whoEl) {
+    if (hasStreamer) {
+      whoEl.textContent = t('streamFrom')(_state.activeStreamerNickname);
+      whoEl.style.display = '';
+    } else {
+      whoEl.style.display = 'none';
+    }
+  }
+}
+
+// Cleanup on page unload
+export function cleanupStream() {
+  if (_state.isStreaming) stopBroadcast();
+  if (_state.isWatching) stopWatch();
+}

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -59,6 +59,10 @@
     <button class="tab active" data-tab="send">📤 <span data-ja>送信</span><span data-en>Send</span></button>
     <button class="tab" data-tab="receive">📥 <span data-ja>受信</span><span data-en>Receive</span></button>
     <button class="tab" data-tab="text">📝 <span data-ja>テキスト</span><span data-en>Text</span></button>
+    <button class="tab" data-tab="stream">
+      📹 <span data-ja>配信</span><span data-en>Stream</span>
+      <span class="tab-live-dot" id="tab-live-dot" hidden></span>
+    </button>
   </div>
 
   <!-- ── Send ── -->
@@ -257,6 +261,42 @@
     </div>
     <div id="txt-history"></div>
   </div>
+
+  <!-- ── Stream ── -->
+  <div class="tab-panel" id="tab-stream">
+    <div class="stream-panel">
+
+      <!-- Broadcaster controls -->
+      <div class="stream-broadcast">
+        <video id="stream-local-video" class="stream-video stream-video-local" autoplay muted playsinline style="display:none"></video>
+        <div class="btn-row" style="margin-top:0">
+          <button class="btn btn-primary" id="stream-start-btn" onclick="startBroadcast()">
+            <span data-ja>配信開始</span><span data-en>Go Live</span>
+          </button>
+          <button class="btn btn-stream-stop" id="stream-stop-btn" onclick="stopBroadcast()" style="display:none">
+            <span data-ja>配信停止</span><span data-en>Stop</span>
+          </button>
+        </div>
+        <div class="status" id="stream-status"></div>
+      </div>
+
+      <!-- Viewer section (shown when someone in the room is streaming) -->
+      <div id="stream-watch-section" style="display:none">
+        <div class="stream-who" id="stream-who"></div>
+        <video id="stream-remote-video" class="stream-video" autoplay playsinline controls style="display:none"></video>
+        <div class="btn-row" style="margin-top:12px">
+          <button class="btn btn-primary" id="stream-watch-btn" onclick="startWatch()" style="display:none">
+            <span data-ja>視聴する</span><span data-en>Watch</span>
+          </button>
+          <button class="btn btn-ghost" id="stream-leave-btn" onclick="stopWatch()" style="display:none">
+            <span data-ja>視聴終了</span><span data-en>Leave</span>
+          </button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
 </main>
 
 <footer>

--- a/mediamtx/mediamtx.yml
+++ b/mediamtx/mediamtx.yml
@@ -1,0 +1,46 @@
+logLevel: info
+logDestinations: [stdout]
+
+# 未使用プロトコルを無効化
+rtsp: no
+rtmp: no
+hls: no
+srt: no
+
+###############################################################################
+# WebRTC (WHIP / WHEP)
+###############################################################################
+webrtc: yes
+webrtcAddress: :8889
+
+# ICE 用 UDP リスナー (ホスト側ポートと合わせること)
+webrtcLocalUDPAddress: :8189
+webrtcLocalTCPAddress: ""
+
+# コンテナ NIC の IP を ICE 候補として自動収集
+webrtcIPsFromInterfaces: yes
+webrtcIPsFromInterfacesList: []
+
+# 公開サーバーの実 IP を ICE 候補に追加する場合は
+# .env に MEDIAMTX_EXTERNAL_IP=<サーバーの公開IP> を設定すること
+# docker-compose.yml 側で MTX_WEBRTCADDITIONALHOSTS に渡している
+webrtcAdditionalHosts: []
+
+# CORS — nginx で絞っているので * で問題なし
+webrtcAllowOrigins: ["*"]
+
+# STUN サーバー (公開 IP 検出用)
+webrtcICEServers2:
+  - url: stun:stun.l.google.com:19302
+
+###############################################################################
+# Control API (presence サーバー連携で使用)
+###############################################################################
+api: yes
+apiAddress: :9997
+
+###############################################################################
+# パス設定 — room/{6文字英数字} のみ受け付ける
+###############################################################################
+paths:
+  "~regex:^room/[a-z0-9\\-]{1,24}$": {}


### PR DESCRIPTION
- mediamtx サービスを docker-compose に追加 (WebRTC WHIP/WHEP)
- nginx /stream/ → mediamtx:8889 プロキシを設定
- pipe/index.html に「配信」タブを追加
  - 配信者: WHIP で映像をサーバーへ送信、ローカルプレビュー表示
  - 視聴者: WHEP でルームの配信を受信、入室時に自動視聴開始
  - 他タブにいても配信中を示す赤ランプ (tab-live-dot) を表示
- presence サーバーにストリーミング状態 (streaming: bool) を追加
  - hello メッセージで配信状態を通知、peers リストに反映
- stream.js モジュールを新規作成 (WHIP/WHEP, ICE, ライフサイクル管理)
- ローカル開発用に docker-compose.local.yml に 8889/9997 ポートを追加

https://claude.ai/code/session_01Nh9wMyLhtNXyRZAe7KfzHx