### PR TITLE
ci: デプロイ時に mediamtx と https-portal も更新する

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,4 +26,6 @@ jobs:
             git fetch origin
             git reset --hard origin/main
             docker compose up -d --build presence-server
+            docker compose up -d mediamtx
+            docker compose up -d --force-recreate https-portal
             docker compose -p afjkjp-staging -f docker-compose.staging.yml up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,3 +25,5 @@ jobs:
             git fetch origin
             git reset --hard origin/main
             docker compose up -d --build presence-server
+            docker compose up -d mediamtx
+            docker compose up -d --force-recreate https-portal


### PR DESCRIPTION
presence-server のみビルドしていたが、mediamtx.yml や
docker-compose.yml の変更が反映されない問題があった。
mediamtx を起動してから https-portal を再作成する順序で実行する。