### PR TITLE
fix: stream.js キャッシュ不整合によるiPhone表示崩れを修正

### DIFF
--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -22,7 +22,7 @@ import {
   flipCamera,
   selectCamera,
   cleanupStream,
-} from './stream.js';
+} from './stream.js?v=2';
 
 // ── i18n ──────────────────────────────────────────────────────────────────────
 const I18N = {

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -313,7 +313,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-  <script type="module" src="/assets/js/pipe/app.js"></script>
+  <script type="module" src="/assets/js/pipe/app.js?v=2"></script>
 
 
 <!-- ── Preview Modal ── -->


### PR DESCRIPTION
カメラ機能追加でstream.jsの公開APIが変更されたが、
iOSサファリが古いstream.jsをキャッシュしていた場合に
import失敗→モジュール全体未実行→言語表示・タップ不動作の不具合。

app.jsのimportとscriptタグにキャッシュバスター(?v=2)を付与し
旧キャッシュを強制的に無効化する。

https://claude.ai/code/session_01Nh9wMyLhtNXyRZAe7KfzHx