### PR TITLE
feat(stream): 画面共有配信機能を追加

### DIFF
--- a/html/assets/css/pipe.css
+++ b/html/assets/css/pipe.css
@@ -320,6 +320,20 @@
       transition: background .15s, border-color .15s;
     }
     .btn-stream-stop:hover { background: #4a1414; border-color: #c0392b; }
+    .btn-stream-screen {
+      background: #0a1a2e;
+      border: 1px solid #1a4a7a;
+      color: #60a5fa;
+      padding: 11px 22px;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: inherit;
+      transition: background .15s, border-color .15s;
+    }
+    .btn-stream-screen:hover { background: #0f2440; border-color: #2563eb; }
+    .btn-stream-screen:disabled { opacity: 0.45; cursor: not-allowed; }
 
     /* ── Camera selector row ── */
     .stream-camera-row {

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -17,12 +17,13 @@ import {
   onStreamTabEntered,
   startBroadcast,
   stopBroadcast,
+  startScreenShare,
   startWatch,
   stopWatch,
   flipCamera,
   selectCamera,
   cleanupStream,
-} from './stream.js?v=2';
+} from './stream.js?v=3';
 
 // ── i18n ──────────────────────────────────────────────────────────────────────
 const I18N = {
@@ -133,6 +134,8 @@ const I18N = {
     streamFrom:    name => `${name} が配信中`,
     streamNoCameras:         'カメラが見つかりません',
     streamCameraLabel:       'カメラ',
+    streamGettingDisplay:    '画面共有を開始中…',
+    streamNoDisplayMedia:    '画面共有はこのブラウザでは利用できません',
   },
   en: {
     copying:            'Copied ✓',
@@ -241,6 +244,8 @@ const I18N = {
     streamFrom:    name => `${name} is live`,
     streamNoCameras:         'No cameras found',
     streamCameraLabel:       'Camera',
+    streamGettingDisplay:    'Starting screen share…',
+    streamNoDisplayMedia:    'Screen sharing is not available in this browser',
   }
 };
 
@@ -3239,6 +3244,7 @@ Object.assign(window, {
   closePreviewModal,
   startBroadcast,
   stopBroadcast,
+  startScreenShare,
   startWatch,
   stopWatch,
   flipCamera,

--- a/html/assets/js/pipe/stream.js
+++ b/html/assets/js/pipe/stream.js
@@ -13,6 +13,7 @@ const _state = {
   facingMode: null,      // 'user' | 'environment' | null
   deviceId: null,        // deviceId string | null
   isMobile: navigator.maxTouchPoints > 0,
+  broadcastMode: null,   // 'camera' | 'screen' | null
 };
 
 export function initStreamModule(deps) {
@@ -162,14 +163,47 @@ export async function selectCamera(deviceId) {
 
 // ── WHIP — publish ────────────────────────────────────────────────────────────
 
-export async function startBroadcast() {
-  if (_state.isStreaming || _state.isWatching) return;
+// Shared WHIP publish logic (used by both camera and screen share)
+async function _doPublish(stream) {
   const { t, fetchIceServers, getStreamBase, getActiveRoomCode, sendPresenceHello } = _deps;
   const roomCode = getActiveRoomCode();
-  if (!roomCode) {
-    _setStatus(t('streamNoRoom'), 'err');
-    return;
-  }
+
+  const iceServers = await fetchIceServers();
+  const pc = new RTCPeerConnection({ iceServers });
+  _state.publisherPc = pc;
+  stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  await _waitForIce(pc);
+
+  _setStatus(t('streamConnecting'), 'waiting');
+  const res = await fetch(`${getStreamBase()}/room/${roomCode}/whip`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/sdp' },
+    body: pc.localDescription.sdp,
+  });
+  if (!res.ok) throw new Error(`WHIP ${res.status}`);
+  await pc.setRemoteDescription({ type: 'answer', sdp: await res.text() });
+
+  _state.isStreaming = true;
+  _deps.setStreamingActive(true);
+  sendPresenceHello();
+  _setLiveDot(true);
+  _setStatus(t('streamStatusLive'), 'ok');
+  _renderTab();
+
+  pc.onconnectionstatechange = () => {
+    if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+      stopBroadcast();
+    }
+  };
+}
+
+export async function startBroadcast() {
+  if (_state.isStreaming || _state.isWatching) return;
+  const { t, getActiveRoomCode } = _deps;
+  if (!getActiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
 
   try {
     _setStatus(t('streamGettingMedia'), 'waiting');
@@ -178,47 +212,58 @@ export async function startBroadcast() {
       audio: true,
     });
     _state.localStream = stream;
+    _state.broadcastMode = 'camera';
 
     const localVideo = document.getElementById('stream-local-video');
     if (localVideo) localVideo.srcObject = stream;
 
-    // Update camera list & select after permission granted (labels now available)
     await _loadCameras();
     _renderTab();
+    await _doPublish(stream);
+  } catch (e) {
+    _setStatus(`${_deps.t('streamError')}: ${e.message}`, 'err');
+    _cleanupBroadcast();
+    _state.broadcastMode = null;
+    _renderTab();
+  }
+}
 
-    const iceServers = await fetchIceServers();
-    const pc = new RTCPeerConnection({ iceServers });
-    _state.publisherPc = pc;
-    stream.getTracks().forEach(track => pc.addTrack(track, stream));
+export async function startScreenShare() {
+  if (_state.isStreaming || _state.isWatching) return;
+  const { t, getActiveRoomCode } = _deps;
+  if (!getActiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    _setStatus(t('streamNoDisplayMedia'), 'err');
+    return;
+  }
 
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
-    await _waitForIce(pc);
+  try {
+    _setStatus(t('streamGettingDisplay'), 'waiting');
+    const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
 
-    _setStatus(t('streamConnecting'), 'waiting');
-    const res = await fetch(`${getStreamBase()}/room/${roomCode}/whip`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/sdp' },
-      body: pc.localDescription.sdp,
-    });
-    if (!res.ok) throw new Error(`WHIP ${res.status}`);
-    await pc.setRemoteDescription({ type: 'answer', sdp: await res.text() });
+    // Add mic if display stream has no audio (e.g. iOS, some desktop configs)
+    if (stream.getAudioTracks().length === 0) {
+      try {
+        const mic = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        mic.getAudioTracks().forEach(t => stream.addTrack(t));
+      } catch { /* no mic available, proceed without audio */ }
+    }
 
-    _state.isStreaming = true;
-    _deps.setStreamingActive(true);
-    sendPresenceHello();
-    _setLiveDot(true);
-    _setStatus(t('streamStatusLive'), 'ok');
+    _state.localStream = stream;
+    _state.broadcastMode = 'screen';
+
+    const localVideo = document.getElementById('stream-local-video');
+    if (localVideo) localVideo.srcObject = stream;
     _renderTab();
 
-    pc.onconnectionstatechange = () => {
-      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
-        stopBroadcast();
-      }
-    };
+    // Auto-stop when user ends share via OS/browser UI
+    stream.getVideoTracks()[0].onended = () => stopBroadcast();
+
+    await _doPublish(stream);
   } catch (e) {
-    _setStatus(`${t('streamError')}: ${e.message}`, 'err');
+    _setStatus(`${_deps.t('streamError')}: ${e.message}`, 'err');
     _cleanupBroadcast();
+    _state.broadcastMode = null;
     _renderTab();
   }
 }
@@ -227,6 +272,7 @@ export function stopBroadcast() {
   const { sendPresenceHello, setStreamingActive } = _deps;
   _cleanupBroadcast();
   _state.isStreaming = false;
+  _state.broadcastMode = null;
   setStreamingActive(false);
   sendPresenceHello();
   _setLiveDot(!!_state.activeStreamerNickname);
@@ -346,6 +392,7 @@ export function renderStreamTab() {
 
 function _renderTab() {
   const startBtn     = document.getElementById('stream-start-btn');
+  const screenBtn    = document.getElementById('stream-screen-btn');
   const stopBtn      = document.getElementById('stream-stop-btn');
   const watchBtn     = document.getElementById('stream-watch-btn');
   const leaveBtn     = document.getElementById('stream-leave-btn');
@@ -361,18 +408,25 @@ function _renderTab() {
   const hasStreamer = !!_state.activeStreamerNickname;
   const noRoom     = !getActiveRoomCode();
   const broadcasting = _state.isStreaming || _state.isWatching;
+  const isScreen   = _state.broadcastMode === 'screen';
 
-  // Camera row: visible in broadcast section when not watching
-  if (cameraRow) cameraRow.style.display = _state.isWatching ? 'none' : '';
+  // Camera row: hide when watching or screen sharing
+  if (cameraRow) cameraRow.style.display = (_state.isWatching || isScreen) ? 'none' : '';
 
-  // Flip button: only when streaming (camera already acquired)
+  // Flip button: only when camera-streaming with ≥2 cameras
   if (flipBtn) flipBtn.style.display =
-    (_state.isStreaming && _state.cameras.length >= 2) ? '' : 'none';
+    (_state.isStreaming && !isScreen && _state.cameras.length >= 2) ? '' : 'none';
 
   // Broadcast controls
+  const btnTitle = noRoom ? t('streamNoRoom') : (hasStreamer ? t('streamAlreadyLive') : '');
   startBtn.style.display = broadcasting ? 'none' : '';
   startBtn.disabled      = noRoom || hasStreamer;
-  startBtn.title         = noRoom ? t('streamNoRoom') : (hasStreamer ? t('streamAlreadyLive') : '');
+  startBtn.title         = btnTitle;
+  if (screenBtn) {
+    screenBtn.style.display = broadcasting ? 'none' : '';
+    screenBtn.disabled      = noRoom || hasStreamer;
+    screenBtn.title         = btnTitle;
+  }
   stopBtn.style.display  = _state.isStreaming ? '' : 'none';
   if (localVideo) localVideo.style.display = _state.isStreaming ? 'block' : 'none';
 

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -280,7 +280,10 @@
 
         <div class="btn-row" style="margin-top:12px">
           <button class="btn btn-primary" id="stream-start-btn" onclick="startBroadcast()">
-            <span data-ja>配信開始</span><span data-en>Go Live</span>
+            📹 <span data-ja>カメラ配信</span><span data-en>Camera</span>
+          </button>
+          <button class="btn btn-stream-screen" id="stream-screen-btn" onclick="startScreenShare()">
+            🖥 <span data-ja>画面共有</span><span data-en>Screen</span>
           </button>
           <button class="btn btn-stream-stop" id="stream-stop-btn" onclick="stopBroadcast()" style="display:none">
             <span data-ja>配信停止</span><span data-en>Stop</span>
@@ -313,7 +316,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-  <script type="module" src="/assets/js/pipe/app.js?v=2"></script>
+  <script type="module" src="/assets/js/pipe/app.js?v=3"></script>
 
 
 <!-- ── Preview Modal ── -->


### PR DESCRIPTION
- 🖥 画面共有ボタンを配信タブに追加 (カメラ配信と並列表示)
- getDisplayMedia で画面キャプチャ、WHIPでサーバーに送信
- 音声: まずシステム音声を要求し、なければマイクにフォールバック
- OS/ブラウザの「共有停止」ボタンで自動的に配信停止
- 画面共有中はカメラ行(セレクト・フリップ)を非表示に
- _doPublish() を共通ヘルパーとして分離し、カメラ/画面共有の両方から利用
- stream.js?v=3 でキャッシュバスター更新

https://claude.ai/code/session_01Nh9wMyLhtNXyRZAe7KfzHx