### PR TITLE
fix(stream): ルーム未参加でもローカル配信できるように変更

### DIFF
--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -23,7 +23,7 @@ import {
   flipCamera,
   selectCamera,
   cleanupStream,
-} from './stream.js?v=3';
+} from './stream.js?v=4';
 
 // ── i18n ──────────────────────────────────────────────────────────────────────
 const I18N = {
@@ -485,6 +485,7 @@ const peerGrid         = document.getElementById('peer-grid');
 let pairedIds = new Set();
 // activeRoomCode: currently connected room (from URL param, generated, or joined)
 let activeRoomCode = ROOM_CODE;
+let presenceRoomId = null; // room ID assigned by presence server (IP-based or explicit)
 let _pairingDb = null;  // IDBDatabase handle
 
 // ── IndexedDB helpers ─────────────────────────────────────────────────────────
@@ -799,6 +800,7 @@ function handlePresenceMessage(ev) {
         presenceState.id = data.id;
         updateLocalSwarmOwner(prevId, data.id);
       }
+      presenceRoomId = data.room || null;
       updateRoomLabel(data.room);
       sendPresenceHello();
       break;
@@ -3201,6 +3203,7 @@ initStreamModule({
   fetchIceServers,
   getStreamBase: () => STREAM_BASE,
   getActiveRoomCode: () => activeRoomCode,
+  getPresenceRoom: () => presenceRoomId,
   sendPresenceHello,
   setStreamingActive,
 });

--- a/html/assets/js/pipe/stream.js
+++ b/html/assets/js/pipe/stream.js
@@ -161,12 +161,24 @@ export async function selectCamera(deviceId) {
   }
 }
 
+// ── Room resolution ───────────────────────────────────────────────────────────
+
+// Returns the room code to use for WHIP/WHEP.
+// Falls back to the presence server's IP-based room (sanitized for the path regex).
+function _effectiveRoomCode() {
+  const explicit = _deps.getActiveRoomCode();
+  if (explicit) return explicit;
+  const presence = _deps.getPresenceRoom?.();
+  if (!presence) return null;
+  return presence.replace(/\./g, '-').replace(/[^a-z0-9-]/g, '').slice(0, 24) || null;
+}
+
 // ── WHIP — publish ────────────────────────────────────────────────────────────
 
 // Shared WHIP publish logic (used by both camera and screen share)
 async function _doPublish(stream) {
-  const { t, fetchIceServers, getStreamBase, getActiveRoomCode, sendPresenceHello } = _deps;
-  const roomCode = getActiveRoomCode();
+  const { t, fetchIceServers, getStreamBase, sendPresenceHello } = _deps;
+  const roomCode = _effectiveRoomCode();
 
   const iceServers = await fetchIceServers();
   const pc = new RTCPeerConnection({ iceServers });
@@ -202,8 +214,8 @@ async function _doPublish(stream) {
 
 export async function startBroadcast() {
   if (_state.isStreaming || _state.isWatching) return;
-  const { t, getActiveRoomCode } = _deps;
-  if (!getActiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
+  const { t } = _deps;
+  if (!_effectiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
 
   try {
     _setStatus(t('streamGettingMedia'), 'waiting');
@@ -230,8 +242,8 @@ export async function startBroadcast() {
 
 export async function startScreenShare() {
   if (_state.isStreaming || _state.isWatching) return;
-  const { t, getActiveRoomCode } = _deps;
-  if (!getActiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
+  const { t } = _deps;
+  if (!_effectiveRoomCode()) { _setStatus(t('streamNoRoom'), 'err'); return; }
   if (!navigator.mediaDevices?.getDisplayMedia) {
     _setStatus(t('streamNoDisplayMedia'), 'err');
     return;
@@ -284,8 +296,8 @@ export function stopBroadcast() {
 
 export async function startWatch() {
   if (_state.isWatching || _state.isStreaming) return;
-  const { t, fetchIceServers, getStreamBase, getActiveRoomCode } = _deps;
-  const roomCode = getActiveRoomCode();
+  const { t, fetchIceServers, getStreamBase } = _deps;
+  const roomCode = _effectiveRoomCode();
   if (!roomCode) return;
 
   try {
@@ -404,9 +416,8 @@ function _renderTab() {
   const flipBtn      = document.getElementById('stream-flip-btn');
   if (!startBtn) return;
 
-  const { t, getActiveRoomCode } = _deps;
+  const { t } = _deps;
   const hasStreamer = !!_state.activeStreamerNickname;
-  const noRoom     = !getActiveRoomCode();
   const broadcasting = _state.isStreaming || _state.isWatching;
   const isScreen   = _state.broadcastMode === 'screen';
 
@@ -417,14 +428,14 @@ function _renderTab() {
   if (flipBtn) flipBtn.style.display =
     (_state.isStreaming && !isScreen && _state.cameras.length >= 2) ? '' : 'none';
 
-  // Broadcast controls
-  const btnTitle = noRoom ? t('streamNoRoom') : (hasStreamer ? t('streamAlreadyLive') : '');
+  // Broadcast controls — disabled only when someone else is already streaming
+  const btnTitle = hasStreamer ? t('streamAlreadyLive') : '';
   startBtn.style.display = broadcasting ? 'none' : '';
-  startBtn.disabled      = noRoom || hasStreamer;
+  startBtn.disabled      = hasStreamer;
   startBtn.title         = btnTitle;
   if (screenBtn) {
     screenBtn.style.display = broadcasting ? 'none' : '';
-    screenBtn.disabled      = noRoom || hasStreamer;
+    screenBtn.disabled      = hasStreamer;
     screenBtn.title         = btnTitle;
   }
   stopBtn.style.display  = _state.isStreaming ? '' : 'none';

--- a/html/pipe/index.html
+++ b/html/pipe/index.html
@@ -316,7 +316,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-  <script type="module" src="/assets/js/pipe/app.js?v=3"></script>
+  <script type="module" src="/assets/js/pipe/app.js?v=4"></script>
 
 
 <!-- ── Preview Modal ── -->


### PR DESCRIPTION
presenceサーバーのwelcomeメッセージから受け取るIP系ルームID
(例: 192.168.1.x → 192-168-1-x) をフォールバックとして使用し、
明示的なルームコードなしでもWHIP/WHEPを利用可能にする。

- _effectiveRoomCode(): activeRoomCode または sanitized(presenceRoomId)
- startBroadcast/startScreenShare/startWatch でフォールバックを使用
- 配信ボタンをルーム未参加で無効化しない (他ユーザー配信中のみ無効)
- presenceRoomId を welcome メッセージから保存してdepsに追加

https://claude.ai/code/session_01Nh9wMyLhtNXyRZAe7KfzHx