### PR TITLE
fix: statsFetcher が data.summary を参照するよう修正し転送量を全経路合計に変更

### DIFF
--- a/html/assets/js/statsFetcher.js
+++ b/html/assets/js/statsFetcher.js
@@ -16,16 +16,18 @@ export class StatsFetcher {
   }
 
   update(data = {}) {
-    const p2p = data.p2p || { count: 0, bytes: 0 };
-    const pipe = data.pipe || { count: 0, bytes: 0 };
-    const torrent = data.torrent || { count: 0, bytes: 0 };
+    const summary = data.summary || {};
+    const p2p = summary.p2p || { count: 0, bytes: 0 };
+    const pipe = summary.pipe || { count: 0, bytes: 0 };
+    const torrent = summary.torrent || { count: 0, bytes: 0 };
     const total = p2p.count + pipe.count + torrent.count;
+    const totalBytes = (p2p.bytes || 0) + (pipe.bytes || 0) + (torrent.bytes || 0);
 
     this.setText(this.selectors.total, this.formatNumber(total));
     this.setText(this.selectors.p2p, this.formatNumber(p2p.count));
     this.setText(this.selectors.relay, this.formatNumber(pipe.count));
     this.setText(this.selectors.torrent, this.formatNumber(torrent.count));
-    this.setText(this.selectors.bytes, this.formatBytes(pipe.bytes));
+    this.setText(this.selectors.bytes, this.formatBytes(totalBytes));
   }
 
   setText(selector, value) {

--- a/html/index.html
+++ b/html/index.html
@@ -404,8 +404,8 @@
           <span data-en>Data relayed</span>
         </div>
         <div class="stat-sub">
-          <span data-ja>中継経由</span>
-          <span data-en>via relay</span>
+          <span data-ja>全経路合計</span>
+          <span data-en>All transfers</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
トップページの「転送の記録」セクションで全カードが 0 のままになっていた問題を修正。
/presence/stats のレスポンスは data.summary 配下にネストされているが、 statsFetcher.js が data.p2p 等を直接参照していたため undefined になっていた。 あわせて転送量表示を中継のみから P2P + Torrent + 中継の全経路合計に変更した。

https://claude.ai/code/session_01WhEAsDjzeSqmJwWjwMYqoX