### PR TITLE
feat: MediaMTX 配信通信量をトップページに表示

### DIFF
--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -334,6 +334,26 @@ const CORS = {
   'access-control-allow-headers': 'content-type',
 };
 
+const MEDIAMTX_API = process.env.MEDIAMTX_API_URL || 'http://mediamtx:9997';
+
+async function fetchStreamStats() {
+  try {
+    const res = await globalThis.fetch(MEDIAMTX_API + '/v3/paths/list');
+    if (!res.ok) return { sessions: 0, bytes: 0 };
+    const data = await res.json();
+    const items = data.items || [];
+    let sessions = 0;
+    let bytes = 0;
+    for (const path of items) {
+      if (path.source) sessions += 1;
+      bytes += (path.inboundBytes || 0) + (path.outboundBytes || 0);
+    }
+    return { sessions, bytes };
+  } catch {
+    return { sessions: 0, bytes: 0 };
+  }
+}
+
 function buildTurnServers() {
   const raw = process.env.TURN_URLS || process.env.TURN_URL || '';
   const username = process.env.TURN_USERNAME || '';
@@ -369,7 +389,7 @@ function recordTransfer(entry) {
   saveStats(stats);
 }
 
-const server = createServer((req, res) => {
+const server = createServer(async (req, res) => {
   const path = req.url.split('?')[0].replace(/\/+/g, '/');
 
   // CORS preflight
@@ -398,8 +418,10 @@ const server = createServer((req, res) => {
          .end(header + rows);
       return;
     }
+    const streamStats = await fetchStreamStats();
     const payload = {
       summary: stats.summary,
+      stream: streamStats,
       logs,
     };
     res.writeHead(200, { 'content-type': 'application/json', ...CORS })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - TURN_URL=${TURN_URL:-}
       - TURN_USERNAME=${TURN_USERNAME:-pipe}
       - TURN_CREDENTIAL=${TURN_CREDENTIAL:-pipe}
+      - MEDIAMTX_API_URL=http://mediamtx:9997
     volumes:
       - presence-stats:/data
 

--- a/html/assets/js/main.js
+++ b/html/assets/js/main.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
       relay: '#stat-relay',
       torrent: '#stat-torrent',
       bytes: '#stat-bytes',
+      stream: '#stat-stream',
     }
   });
   stats.run();

--- a/html/assets/js/statsFetcher.js
+++ b/html/assets/js/statsFetcher.js
@@ -20,6 +20,7 @@ export class StatsFetcher {
     const p2p = summary.p2p || { count: 0, bytes: 0 };
     const pipe = summary.pipe || { count: 0, bytes: 0 };
     const torrent = summary.torrent || { count: 0, bytes: 0 };
+    const stream = data.stream || { sessions: 0, bytes: 0 };
     const total = p2p.count + pipe.count + torrent.count;
     const totalBytes = (p2p.bytes || 0) + (pipe.bytes || 0) + (torrent.bytes || 0);
 
@@ -28,6 +29,7 @@ export class StatsFetcher {
     this.setText(this.selectors.relay, this.formatNumber(pipe.count));
     this.setText(this.selectors.torrent, this.formatNumber(torrent.count));
     this.setText(this.selectors.bytes, this.formatBytes(totalBytes));
+    this.setText(this.selectors.stream, this.formatBytes(stream.bytes));
   }
 
   setText(selector, value) {

--- a/html/index.html
+++ b/html/index.html
@@ -408,6 +408,14 @@
           <span data-en>All transfers</span>
         </div>
       </div>
+      <div class="stat-card">
+        <div class="stat-value" id="stat-stream">—</div>
+        <div class="stat-label">
+          <span data-ja>配信</span>
+          <span data-en>Stream</span>
+        </div>
+        <div class="stat-sub">MediaMTX</div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
- presence-server に fetchStreamStats() を追加して MediaMTX Control API から配信通信量を取得
- GET /stats レスポンスに stream フィールド（sessions, bytes）を追加
- html に配信カード（#stat-stream）を追加
- StatsFetcher で stream.bytes をバイト数表示する

これにより afjk.jp/pipe の配信通信量がトップページ「転送の記録」セクションに表示される。