### PR TITLE
Add GitHub Actions workflow to auto-publish Unity package to upm.afjk.jp on release

### DIFF
--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -1,0 +1,23 @@
+name: Publish UPM Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Publish to upm.afjk.jp
+        working-directory: unity/com.afjk.scene-sync
+        env:
+          UPM_TOKEN: ${{ secrets.UPM_TOKEN }}
+        run: |
+          echo "//upm.afjk.jp/:_authToken=${UPM_TOKEN}" > ~/.npmrc
+          npm publish --registry https://upm.afjk.jp


### PR DESCRIPTION
## Summary
- Release published 時に `unity/com.afjk.scene-sync` パッケージを `upm.afjk.jp` へ自動公開するワークフローを追加
- GitHub Secrets の `UPM_TOKEN` を使って Verdaccio へ認証

## Test plan
- [ ] GitHub Secrets に `UPM_TOKEN` が登録済みであること
- [ ] Release を published して `Publish UPM Package` ワークフローが成功すること
- [ ] `https://upm.afjk.jp` でパッケージが公開されていること