### PR TITLE
Fix 180 degree Y rotation mismatch between local glB add and scene reload

### DIFF
--- a/html/assets/js/pipe/scene.js
+++ b/html/assets/js/pipe/scene.js
@@ -1181,9 +1181,10 @@ async function handleAddMeshFile(file) {
 
   gltfLoader.load(blobUrl, async (gltf) => {
     removeLoadingOverlay(objectId);
-    const model = gltf.scene;
+    const model = new THREE.Group();
     model.userData.objectId = objectId;
     model.userData.name = file.name;
+    attachImportedGlb(model, gltf);
 
     // center offset は行わない（glB の原点をそのまま使用）
     // Unity 側との座標整合性を保つため


### PR DESCRIPTION
## Summary
- ローカル追加 (`handleAddMeshFile`) と再読込 / 他ピア受信 (`addOrUpdateObject`, `scene-mesh`) の glB 取り込み経路で Y 軸 180° の handedness 補正の有無が食い違っていたため、シーン再読込後にオブジェクトが 180° 回転して見えていた
- ローカル追加側も `attachImportedGlb` (Group ラップ + `rotateY(Math.PI)`) を通すよう統一

## Test plan
- [ ] ローカルで glB を drag-and-drop で配置
- [ ] 同じクライアントでページ再読込し、同じ向きで表示されることを確認
- [ ] 別クライアントから参加し、向きが一致することを確認

https://claude.ai/code/session_01536VbF4jvuZqMeTbfhkFhn