### PR TITLE
Keep glB loading overlay at fixed size regardless of target scale

### DIFF
--- a/html/assets/js/pipe/scene.js
+++ b/html/assets/js/pipe/scene.js
@@ -358,8 +358,6 @@ function addLoadingOverlay(objectId, name, info) {
   group.add(label);
 
   if (info?.position) group.position.fromArray(info.position);
-  if (info?.rotation) group.quaternion.fromArray(info.rotation);
-  if (info?.scale) group.scale.fromArray(info.scale);
 
   scene.add(group);
   loadingOverlays.set(objectId, { group, placeholder });


### PR DESCRIPTION
## Summary
- `addLoadingOverlay` でターゲットオブジェクトの rotation / scale を group に適用していたため、スケールが大きいオブジェクトだとローディング表示が極端に巨大・歪みになり読みづらくなっていた
- position のみ反映し、placeholder と label は常に固定サイズで表示

## Test plan
- [ ] scale (10,10,10) のオブジェクトを受信してもローディング表示が 1m キューブのまま表示される
- [ ] scale (0.1,0.1,0.1) のオブジェクトでも同じ大きさで表示される
- [ ] ロード完了でオーバーレイが除去されることを確認

https://claude.ai/code/session_01536VbF4jvuZqMeTbfhkFhn