### PR TITLE
Add Scene Sync link from pipe room section

### DIFF
--- a/html/assets/css/pipe.css
+++ b/html/assets/css/pipe.css
@@ -205,6 +205,9 @@
       font-family: inherit;
       transition: all .15s;
       white-space: nowrap;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
     }
     .room-btn:hover { border-color: var(--accent); color: var(--accent); }
     .room-btn.danger:hover { border-color: #f87171; color: #f87171; }

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -90,6 +90,8 @@ const I18N = {
     roomJoinPlaceholder: 'コードを入力',
     roomJoin:     '参加',
     roomUrlCopied:'コピー済 ✓',
+    sceneSyncOpen:'🎬 Scene Sync',
+    sceneSyncOpenTitle: 'この部屋を Scene Sync で開く',
     sendToAll:         n      => `全員に送信 (${n}人)`,
     broadcastSending:  n      => `${n}台に送信中…`,
     broadcastProgress: (d, n) => `${d}/${n} 完了…`,
@@ -200,6 +202,8 @@ const I18N = {
     roomJoinPlaceholder: 'Enter code',
     roomJoin:     'Join',
     roomUrlCopied:'Copied ✓',
+    sceneSyncOpen:'🎬 Scene Sync',
+    sceneSyncOpenTitle: 'Open this room in Scene Sync',
     sendToAll:         n      => `Send to All (${n})`,
     broadcastSending:  n      => `Sending to ${n} devices…`,
     broadcastProgress: (d, n) => `${d}/${n} done…`,
@@ -1220,6 +1224,12 @@ function roomUrl(code) {
   return u.toString();
 }
 
+function sceneSyncUrl(code) {
+  const u = new URL('/scenesync/', location.href);
+  if (code) u.searchParams.set('room', code);
+  return u.toString();
+}
+
 function applyRoomCode(code) {
   activeRoomCode = code;
   // Sync URL so reloading stays in the same room
@@ -1307,6 +1317,13 @@ function renderRoomSection() {
     clearBtn.addEventListener('click', clearRoom);
     row.appendChild(clearBtn);
 
+    const sceneLink = document.createElement('a');
+    sceneLink.className = 'room-btn';
+    sceneLink.href = sceneSyncUrl(activeRoomCode);
+    sceneLink.textContent = t('sceneSyncOpen');
+    sceneLink.title = t('sceneSyncOpenTitle');
+    row.appendChild(sceneLink);
+
     wrap.appendChild(row);
   } else {
     const row = document.createElement('div');
@@ -1317,6 +1334,14 @@ function renderRoomSection() {
     genBtn.textContent = t('roomGenerate');
     genBtn.addEventListener('click', generateRoom);
     row.appendChild(genBtn);
+
+    const sceneLink = document.createElement('a');
+    sceneLink.className = 'room-btn';
+    sceneLink.href = sceneSyncUrl(null);
+    sceneLink.textContent = t('sceneSyncOpen');
+    sceneLink.title = t('sceneSyncOpenTitle');
+    row.appendChild(sceneLink);
+
     wrap.appendChild(row);
 
     const joinRow = document.createElement('div');


### PR DESCRIPTION
## Summary
- pipe のルームセクションに `🎬 Scene Sync` chip リンクを追加。アクティブルームがあればその code を `?room=` で引き継ぎ、無ければ IP ベースの ambient ルームで Scene Sync を開く
- `.room-btn` を `<a>` でも崩れないように `text-decoration: none; display: inline-flex; align-items: center;` を追加
- JA / EN 両方に `sceneSyncOpen` / `sceneSyncOpenTitle` を追加

## Test plan
- [ ] `/pipe/` を開き、ルーム未設定の状態で「作成」ボタン横に `🎬 Scene Sync` が出る
- [ ] そのリンクをクリックすると `/scenesync/` が開く
- [ ] 「作成」でルームに入り、アクティブルームのチップ横に `🎬 Scene Sync` が出る
- [ ] そのリンクで `/scenesync/?room=<code>` が開き、Scene Sync が同じルームに入る
- [ ] JA/EN 切り替えでラベルが追従する

https://claude.ai/code/session_01536VbF4jvuZqMeTbfhkFhn