### PR TITLE
Show pipe link in Scene Sync when no room, align labels to pipe

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -875,7 +875,7 @@ function renderRoomSection() {
     const copyBtn = document.createElement('button');
     copyBtn.type = 'button';
     copyBtn.className = 'chip';
-    copyBtn.textContent = '🔗 コピー';
+    copyBtn.textContent = 'URL コピー';
     copyBtn.title = 'ルーム URL をコピー';
     copyBtn.addEventListener('click', copyRoomUrl);
     roomSectionEl.appendChild(copyBtn);
@@ -896,16 +896,23 @@ function renderRoomSection() {
   } else {
     const noRoomChip = document.createElement('div');
     noRoomChip.className = 'chip';
-    noRoomChip.innerHTML = '🏠 <span style="opacity:0.6">ルーム未設定</span>';
+    noRoomChip.innerHTML = '🏠 <span style="opacity:0.6">未設定</span>';
     roomSectionEl.appendChild(noRoomChip);
 
     const genBtn = document.createElement('button');
     genBtn.type = 'button';
     genBtn.className = 'chip primary';
-    genBtn.textContent = '＋ 作成';
+    genBtn.textContent = '作成';
     genBtn.title = '新しいルームを作成';
     genBtn.addEventListener('click', generateRoom);
     roomSectionEl.appendChild(genBtn);
+
+    const pipeLink = document.createElement('a');
+    pipeLink.className = 'chip';
+    pipeLink.href = pipeUrlForRoom(null);
+    pipeLink.textContent = '📥 pipe';
+    pipeLink.title = 'pipe を開く';
+    roomSectionEl.appendChild(pipeLink);
 
     const input = document.createElement('input');
     input.type = 'text';


### PR DESCRIPTION
## Summary
- Scene Sync のルーム未設定状態にも `📥 pipe` chip を追加し、pipe への動線を確保
- ラベルを pipe の文言に寄せる:
  - `🔗 コピー` → `URL コピー`
  - `＋ 作成` → `作成`
  - `🏠 ルーム未設定` → `🏠 未設定`
- レイアウト（左上に浮かぶ chip パネル）は変更なし

## Test plan
- [ ] `/scenesync/` をルーム未設定で開くと `📥 pipe` chip が出て `/pipe/` に飛べる
- [ ] アクティブルーム状態での `📥 pipe` は従来どおり `/pipe/?room=<code>` に遷移
- [ ] 各ボタンのラベルが pipe 側と同じ（`作成` / `URL コピー` / `参加` / `退場`）

https://claude.ai/code/session_01536VbF4jvuZqMeTbfhkFhn