### PR TITLE
Show pipe link in Scene Sync when no room, align labels to pipe

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -914,6 +914,9 @@ function renderRoomSection() {
     pipeLink.title = 'pipe を開く';
     roomSectionEl.appendChild(pipeLink);
 
+    const joinGroup = document.createElement('div');
+    joinGroup.className = 'join-group';
+
     const input = document.createElement('input');
     input.type = 'text';
     input.className = 'room-input';
@@ -922,14 +925,16 @@ function renderRoomSection() {
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') joinRoom(input.value);
     });
-    roomSectionEl.appendChild(input);
+    joinGroup.appendChild(input);
 
     const joinBtn = document.createElement('button');
     joinBtn.type = 'button';
     joinBtn.className = 'chip';
     joinBtn.textContent = '参加';
     joinBtn.addEventListener('click', () => joinRoom(input.value));
-    roomSectionEl.appendChild(joinBtn);
+    joinGroup.appendChild(joinBtn);
+
+    roomSectionEl.appendChild(joinGroup);
   }
 }
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -76,6 +76,10 @@
       gap: 6px;
       flex-wrap: wrap;
     }
+    .join-group {
+      display: flex;
+      gap: 6px;
+    }
     .chip-edit { opacity: 0.6; font-size: 11px; }
     #room-code {
       font-weight: bold;


### PR DESCRIPTION
## Summary
- Add pipe link to Scene Sync settings panel (both room-active and no-room states)
- Align chip labels/wording to pipe (`URL コピー`, `作成`, `🏠 未設定`)
- Keep 参加 button on the same row as the room code input via a `.join-group` flex wrapper

## Test plan
- [ ] Open `/scenesync/` with no room → verify `📥 pipe` chip appears and the code input + 参加 button are on one row
- [ ] Create a room, copy URL, leave room — all chip labels render correctly
- [ ] Open the same room from pipe via the `🎬 Scene Sync` link

https://claude.ai/code/session_01536VbF4jvuZqMeTbfhkFhn