### PR TITLE
bug fix

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,4 +9,17 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  # WHIP/WHEP WebRTC endpoints for /pipe streaming.
+  # Keep this here as a fallback even though production https-portal also
+  # proxies /stream/, so requests never fall through to static file handling.
+  location /stream/ {
+    proxy_pass http://mediamtx:8889/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600s;
+  }
+
 }


### PR DESCRIPTION
This pull request adds a new proxy configuration to the `nginx/default.conf` file to support WebRTC streaming endpoints. The main change is the introduction of a `/stream/` location block that proxies requests to the `mediamtx` service, which is important for enabling WHIP/WHEP WebRTC streaming functionality.

**WebRTC streaming configuration:**

* Added a `location /stream/` block in `nginx/default.conf` to proxy requests to `http://mediamtx:8889/`, including appropriate headers and a long read timeout, to support WHIP/WHEP WebRTC endpoints for `/pipe` streaming.