### PR TITLE
Fix UPM publish by setting version from release tag

### DIFF
--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -20,4 +20,7 @@ jobs:
           UPM_TOKEN: ${{ secrets.UPM_TOKEN }}
         run: |
           echo "//upm.afjk.jp/:_authToken=${UPM_TOKEN}" > ~/.npmrc
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          npm version "$VERSION" --no-git-tag-version
           npm publish --registry https://upm.afjk.jp


### PR DESCRIPTION
package.json had a hardcoded version (0.1.0), causing npm publish to fail on every release after the first because the version was already registered. Now the workflow extracts the version from the git tag (e.g. v0.10.5 → 0.10.5) and applies it with `npm version` before publishing.

https://claude.ai/code/session_01NkS556BHeSirHRJvpu9t3w