### PR TITLE
feat(scene-sync): add IBL environment light presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# afjk.jp — Claude Code ガイド
+
+## Scene Sync
+
+ブラウザ / Unity / Godot 間で 3D シーンをリアルタイム共有するシステム。
+
+- ビューア: `html/scenesync/index.html` + `html/assets/js/scenesync/scene.js`
+- サーバー: `apps/presence-server/src/server.mjs`
+- テスト: `apps/presence-server/tests/api.test.mjs`
+- 仕様: `docs/scene-sync-spec.md`
+
+### REST API
+
+```bash
+# シーンにオブジェクトを追加
+curl -s -X POST "http://localhost:8787/api/room/{room}/broadcast?name=Claude" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"scene-add","objectId":"box-1","asset":{"type":"primitive","primitive":"box","color":"#4488ff"},"position":[0,0.5,0],"rotation":[0,0,0,1],"scale":[1,1,1]}'
+
+# 現在のシーン状態を取得
+curl -s "http://localhost:8787/api/room/{room}/scene?name=Claude"
+```
+
+### broadcast メッセージ種別
+
+#### scene-add
+```json
+{
+  "kind": "scene-add",
+  "objectId": "box-1",
+  "name": "My Box",
+  "position": [0, 0.5, 0],
+  "rotation": [0, 0, 0, 1],
+  "scale": [1, 1, 1],
+  "asset": { "type": "primitive", "primitive": "box", "color": "#4488ff" }
+}
+```
+
+asset.primitive の選択肢: `box`, `sphere`, `cylinder`, `cone`, `plane`, `torus`
+
+#### scene-delta
+```json
+{
+  "kind": "scene-delta",
+  "objectId": "box-1",
+  "position": [1, 0.5, 0],
+  "rotation": [0, 0, 0, 1],
+  "scale": [1, 1, 1]
+}
+```
+
+#### scene-remove
+```json
+{ "kind": "scene-remove", "objectId": "box-1" }
+```
+
+#### scene-env（環境光の切り替え）
+```json
+{
+  "kind": "scene-env",
+  "envId": "studio | outdoor_day | outdoor_sunset | outdoor_night | indoor_warm"
+}
+```
+
+broadcast すると全クライアントが HDRI 環境光を切り替える。
+`scene-state` にも `envId` を含めるため、後から参加したクライアントにも反映される。
+
+HDRI ファイルは Poly Haven（CC0）から取得し `html/assets/hdri/{envId}.hdr` に配置。
+
+```bash
+curl -s -X POST "http://localhost:8787/api/room/ai-test/broadcast?name=Claude" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"scene-env","envId":"outdoor_night"}'
+```
+
+### テスト実行
+
+```bash
+cd apps/presence-server && node --test tests/api.test.mjs
+```

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -200,6 +200,31 @@ describe('presence REST broadcast API', () => {
       await Promise.all([closeClient(ws1), closeClient(ws2)]);
     }
   });
+
+  it('broadcasts scene-env to change environment', async () => {
+    const ws = await connectClient('env-test-room');
+    try {
+      const messagePromise = waitForMessage(ws, message => message.type === 'handoff');
+      const response = await fetch(`${baseUrl}/api/room/env-test-room/broadcast?name=Claude`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind: 'scene-env', envId: 'outdoor_night' }),
+      });
+
+      const [body, message] = await Promise.all([
+        response.json(),
+        messagePromise,
+      ]);
+
+      assert.equal(response.status, 200);
+      assert.equal(body.ok, true);
+      assert.equal(message.type, 'handoff');
+      assert.equal(message.payload.kind, 'scene-env');
+      assert.equal(message.payload.envId, 'outdoor_night');
+    } finally {
+      await closeClient(ws);
+    }
+  });
 });
 
 describe('presence REST scene API', () => {

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -540,3 +540,46 @@ Last-Writer-Wins を採用。同一オブジェクトの同時編集は後着が
 - `scene-add` の Undo -> `scene-remove`
 - `scene-remove` の Undo -> `scene-add`（元データを保持）
 - `scene-delta` の Undo -> 変更前の Transform で `scene-delta`
+
+---
+
+## scene-env（環境光の切り替え）
+
+HDRI ベースの環境光（IBL）をプリセットから切り替える。
+
+### メッセージ形式
+
+```json
+{
+  "kind": "scene-env",
+  "envId": "outdoor_night"
+}
+```
+
+### envId 選択肢
+
+| envId          | 用途           | ファイル                                |
+|----------------|---------------|-----------------------------------------|
+| studio         | スタジオ / 展示 | `/assets/hdri/studio.hdr`              |
+| outdoor_day    | 屋外 昼        | `/assets/hdri/outdoor_day.hdr`         |
+| outdoor_sunset | 屋外 夕方      | `/assets/hdri/outdoor_sunset.hdr`      |
+| outdoor_night  | 屋外 夜        | `/assets/hdri/outdoor_night.hdr`       |
+| indoor_warm    | 室内 暖色      | `/assets/hdri/indoor_warm.hdr`         |
+
+### 動作
+
+- broadcast すると全クライアントが環境光を切り替える
+- `scene-state` にも `envId` を含め、後から参加したクライアントにも反映される
+- ブラウザ UI の `#env-select` セレクタからも切り替え可能
+
+### HDRI ファイル
+
+Poly Haven（CC0 ライセンス）から取得。ファイル配置: `html/assets/hdri/{envId}.hdr`
+
+### curl での確認
+
+```bash
+curl -s -X POST "http://localhost:8787/api/room/ai-test/broadcast?name=Claude" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"scene-env","envId":"outdoor_night"}'
+```

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6,6 +6,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 
 // ── Three.js 基本セットアップ ────────────────────────────
 
@@ -22,14 +23,43 @@ renderer.setPixelRatio(devicePixelRatio);
 renderer.setSize(innerWidth, innerHeight);
 document.body.appendChild(renderer.domElement);
 
-// ライト
-scene.add(new THREE.AmbientLight(0xffffff, 0.6));
-const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+const pmremGenerator = new THREE.PMREMGenerator(renderer);
+
+// ライト（IBL 補助として残す）
+scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
 dirLight.position.set(5, 10, 7);
 scene.add(dirLight);
 
-// グリッド
-scene.add(new THREE.GridHelper(20, 20, 0x444444, 0x333333));
+// グリッド（HDRI 背景でも視認できるよう明るめに）
+scene.add(new THREE.GridHelper(20, 20, 0x888888, 0x666666));
+
+// ── IBL 環境光 ───────────────────────────────────────────
+
+let currentEnvId = 'studio';
+const envSelect = document.getElementById('env-select');
+
+function loadEnvironment(envId) {
+  const url = '/assets/hdri/' + envId + '.hdr';
+  new RGBELoader().load(url, (texture) => {
+    const envMap = pmremGenerator.fromEquirectangular(texture).texture;
+    scene.environment = envMap;
+    scene.background = envMap;
+    texture.dispose();
+    currentEnvId = envId;
+    updateEnvSelector();
+  });
+}
+
+function updateEnvSelector() {
+  if (envSelect) envSelect.value = currentEnvId;
+}
+
+envSelect?.addEventListener('change', (e) => {
+  const envId = e.target.value;
+  loadEnvironment(envId);
+  broadcast({ kind: 'scene-env', envId });
+});
 
 // glB ローダー
 const gltfLoader = new GLTFLoader();
@@ -1176,7 +1206,7 @@ async function respondToSceneRequest(from) {
     ws.send(JSON.stringify({
       type: 'handoff',
       targetId: from.id,
-      payload: { kind: 'scene-state', objects },
+      payload: { kind: 'scene-state', envId: currentEnvId, objects },
     }));
   }
 }
@@ -1191,6 +1221,9 @@ function handleHandoff(data) {
     case 'scene-state': {
       sceneReceived = true;
       clearTimeout(sceneRequestTimer);
+      if (payload.envId) {
+        loadEnvironment(payload.envId);
+      }
       const objects = payload.objects || {};
       for (const [objectId, info] of Object.entries(objects)) {
         addOrUpdateObject(objectId, info);
@@ -1279,6 +1312,12 @@ function handleHandoff(data) {
       locks.delete(payload.objectId);
       removeLockOverlay(payload.objectId);
       updatePeersList();
+      break;
+    }
+    case 'scene-env': {
+      if (payload.envId) {
+        loadEnvironment(payload.envId);
+      }
       break;
     }
     default:
@@ -1589,3 +1628,4 @@ nicknameChip?.addEventListener('click', editNickname);
 updateNicknameLabel();
 renderRoomSection();
 connectPresence();
+loadEnvironment('studio');

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -36,6 +36,16 @@
     .chip.danger:hover { background: rgba(255,60,60,0.7); }
     .chip.primary { background: rgba(68,136,255,0.55); }
     .chip.primary:hover { background: rgba(68,136,255,0.8); }
+    select.chip {
+      appearance: auto;
+      cursor: pointer;
+      background: rgba(0,0,0,0.55);
+      color: #fff;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 6px;
+      font: 13px/1.4 monospace;
+    }
 
     #status {
       position: fixed;
@@ -248,6 +258,15 @@
         <span id="nickname-label">—</span>
         <span class="chip-edit">✏️</span>
       </button>
+    </div>
+    <div class="row">
+      <select id="env-select" class="chip" title="環境光">
+        <option value="studio">Studio</option>
+        <option value="outdoor_day">屋外 昼</option>
+        <option value="outdoor_sunset">屋外 夕方</option>
+        <option value="outdoor_night">屋外 夜</option>
+        <option value="indoor_warm">室内 暖色</option>
+      </select>
     </div>
     <div class="row" id="room-section"></div>
   </div>


### PR DESCRIPTION
- Add RGBELoader + PMREMGenerator for HDRI-based IBL
- Add loadEnvironment(envId) to apply HDRI as scene.environment and scene.background
- Add scene-env Kind to handleHandoff for real-time environment switching
- Include envId in scene-state so late-joining clients receive current environment
- Reduce AmbientLight 0.6→0.3 and DirectionalLight 0.8→0.5 (IBL supplements)
- Brighten GridHelper 0x444444/0x333333→0x888888/0x666666 for HDRI backgrounds
- Add #env-select UI in settings panel with 5 presets (studio, outdoor_day, outdoor_sunset, outdoor_night, indoor_warm)
- Add select.chip CSS style to index.html
- Add broadcasts scene-env test to api.test.mjs
- Document scene-env in docs/scene-sync-spec.md
- Create CLAUDE.md with Scene Sync REST API and scene-env usage guide

HDRI files (html/assets/hdri/*.hdr) must be placed manually from Poly Haven (CC0):
  studio_small_09_1k, kloofendal_48d_partly_cloudy_puresky_1k,
  venice_sunset_1k, moonlit_golf_1k, brown_photostudio_02_1k

https://claude.ai/code/session_014ArtscbPTkwSJW8Lwm87eh