### PR TITLE
feat(scene-sync): IBL 環境光プリセットを追加

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -36,7 +36,7 @@ scene.add(new THREE.GridHelper(20, 20, 0x888888, 0x666666));
 
 // ── IBL 環境光 ───────────────────────────────────────────
 
-let currentEnvId = 'studio';
+let currentEnvId = 'outdoor_day';
 const envSelect = document.getElementById('env-select');
 
 function loadEnvironment(envId) {
@@ -1628,4 +1628,4 @@ nicknameChip?.addEventListener('click', editNickname);
 updateNicknameLabel();
 renderRoomSection();
 connectPresence();
-loadEnvironment('studio');
+loadEnvironment('outdoor_day');

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -261,11 +261,11 @@
     </div>
     <div class="row">
       <select id="env-select" class="chip" title="環境光">
-        <option value="studio">Studio</option>
         <option value="outdoor_day">屋外 昼</option>
         <option value="outdoor_sunset">屋外 夕方</option>
         <option value="outdoor_night">屋外 夜</option>
         <option value="indoor_warm">室内 暖色</option>
+        <option value="studio">Studio</option>
       </select>
     </div>
     <div class="row" id="room-section"></div>


### PR DESCRIPTION
## 概要

Scene Sync に HDRI ベースの環境光（IBL）プリセット機能を追加。ブラウザ UI と REST API の両方から切り替え可能。

## 変更内容

### `html/assets/js/scenesync/scene.js`
- `RGBELoader` + `PMREMGenerator` で HDRI を IBL として適用
- `loadEnvironment(envId)` / `updateEnvSelector()` 関数を追加
- デフォルト環境を `outdoor_day`（屋外 昼）に設定
- `#env-select` の change イベントで環境切り替え + broadcast
- `handleHandoff` に `scene-env` case 追加
- `scene-state` 受信・送信に `envId` を含め、後から参加したクライアントにも反映
- `AmbientLight` 0.6→0.3、`DirectionalLight` 0.8→0.5（IBL 補助として残す）
- `GridHelper` 色を明るめに調整（HDRI 背景で視認しやすく）

### `html/scenesync/index.html`
- `select.chip` スタイル追加
- `#env-select` セレクタ（屋外昼 / 屋外夕方 / 屋外夜 / 室内暖色 / Studio）を設定パネルに追加

### `apps/presence-server/tests/api.test.mjs`
- `broadcasts scene-env to change environment` テスト追加（全 10 テスト通過）

### `docs/scene-sync-spec.md`
- `scene-env` セクション追加

### `CLAUDE.md`（新規作成）
- Scene Sync REST API ガイドと scene-env の使い方を記載

## 注意

HDRI ファイル（`html/assets/hdri/*.hdr`）はネットワーク制限のため未配置。Poly Haven（CC0）から手動でダウンロードが必要：
- `studio.hdr` ← `studio_small_09_1k`
- `outdoor_day.hdr` ← `kloofendal_48d_partly_cloudy_puresky_1k`
- `outdoor_sunset.hdr` ← `venice_sunset_1k`
- `outdoor_night.hdr` ← `moonlit_golf_1k`
- `indoor_warm.hdr` ← `brown_photostudio_02_1k`

---
_Generated by [Claude Code](https://claude.ai/code/session_014ArtscbPTkwSJW8Lwm87eh)_