### PR TITLE
fix(scenesync): make sessionstart handler async to support await

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -667,7 +667,7 @@ function applyFloorOffset(floorY) {
 // ── XR セッション開始/終了 ─────────────────────────────
 let xrSavedBackground = null;
 
-renderer.xr.addEventListener('sessionstart', () => {
+renderer.xr.addEventListener('sessionstart', async () => {
   xrState.active = true;
   const session = renderer.xr.getSession();
   // セッションモード判定（mode プロパティが無い実装もあるので blendMode で AR を推定）


### PR DESCRIPTION
The sessionstart handler uses 'await' for hit-test source requests but was not declared as async, causing SyntaxError. Added async keyword to handler function.