### PR TITLE
Phase 1: Implement local Undo/Redo history management

### DIFF
--- a/html/assets/js/scenesync/core/environment.js
+++ b/html/assets/js/scenesync/core/environment.js
@@ -84,14 +84,25 @@ export function createEnvironmentManager(ctx) {
       broadcastChange = source === 'local',
     } = options;
 
+    const previousEnvId = desiredEnvId;
     desiredEnvId = envId;
     updateEnvSelector();
 
     if (broadcastChange) {
-      ctx.broadcast?.({
+      const operation = {
         kind: 'scene-env',
         envId,
-      });
+      };
+
+      // 履歴に追加
+      if (ctx.onBeforeBroadcast) {
+        ctx.onBeforeBroadcast(operation, {
+          beforeEnvId: previousEnvId,
+          afterEnvId: envId,
+        });
+      }
+
+      ctx.broadcast?.(operation);
     }
 
     loadEnvironmentAsset(envId);

--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -49,20 +49,23 @@ export class HistoryManager {
     }));
   }
 
-  static createAddEntry(objectId, asset, position, rotation, scale, name = '') {
+  static createAddEntry(objectId, asset, position, rotation, scale, name = '', meshPath = null) {
+    const forward = {
+      kind: 'scene-add',
+      objectId,
+      name,
+      position,
+      rotation,
+      scale,
+      asset,
+    };
+    if (meshPath) forward.meshPath = meshPath;
+
     return {
       id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       timestamp: Date.now(),
       summary: `Added ${name || objectId}`,
-      forward: {
-        kind: 'scene-add',
-        objectId,
-        name,
-        position,
-        rotation,
-        scale,
-        asset,
-      },
+      forward,
       backward: {
         kind: 'scene-remove',
         objectId,
@@ -129,25 +132,7 @@ export class HistoryManager {
     };
   }
 
-  static createBatchEntry(actions, summary = 'Batch operation') {
-    const reverseActions = [...actions].reverse().map(action => {
-      if (action.kind === 'scene-add') {
-        return { kind: 'scene-remove', objectId: action.objectId };
-      } else if (action.kind === 'scene-remove') {
-        return {
-          kind: 'scene-add',
-          objectId: action.objectId,
-          name: action.name,
-          position: action.position,
-          rotation: action.rotation,
-          scale: action.scale,
-          asset: action.asset,
-        };
-      } else {
-        return action;
-      }
-    });
-
+  static createBatchEntry(forwardActions, backwardActions, summary = 'Batch operation') {
     return {
       id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       timestamp: Date.now(),
@@ -155,12 +140,12 @@ export class HistoryManager {
       forward: {
         kind: 'scene-batch',
         batchId: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        actions,
+        actions: forwardActions,
       },
       backward: {
         kind: 'scene-batch',
         batchId: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        actions: reverseActions,
+        actions: [...backwardActions].reverse(),
       },
     };
   }

--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -1,0 +1,171 @@
+export class HistoryManager {
+  constructor() {
+    this.undoStack = [];
+    this.redoStack = [];
+    this.maxHistorySize = 100;
+  }
+
+  push(entry) {
+    if (!entry || !entry.forward) return;
+    this.undoStack.push(entry);
+    this.redoStack = [];
+
+    if (this.undoStack.length > this.maxHistorySize) {
+      this.undoStack.shift();
+    }
+  }
+
+  canUndo() {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo() {
+    return this.redoStack.length > 0;
+  }
+
+  undo() {
+    if (!this.canUndo()) return null;
+    const entry = this.undoStack.pop();
+    this.redoStack.push(entry);
+    return entry.backward;
+  }
+
+  redo() {
+    if (!this.canRedo()) return null;
+    const entry = this.redoStack.pop();
+    this.undoStack.push(entry);
+    return entry.forward;
+  }
+
+  clear() {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  getHistory(count = 10) {
+    return this.undoStack.slice(-count).map(e => ({
+      timestamp: e.timestamp,
+      summary: e.summary,
+    }));
+  }
+
+  static createAddEntry(objectId, asset, position, rotation, scale, name = '') {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Added ${name || objectId}`,
+      forward: {
+        kind: 'scene-add',
+        objectId,
+        name,
+        position,
+        rotation,
+        scale,
+        asset,
+      },
+      backward: {
+        kind: 'scene-remove',
+        objectId,
+      },
+    };
+  }
+
+  static createRemoveEntry(objectId, name, asset, position, rotation, scale) {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Removed ${name || objectId}`,
+      forward: {
+        kind: 'scene-remove',
+        objectId,
+      },
+      backward: {
+        kind: 'scene-add',
+        objectId,
+        name,
+        position,
+        rotation,
+        scale,
+        asset,
+      },
+    };
+  }
+
+  static createDeltaEntry(objectId, name, beforePos, beforeRot, beforeScl, afterPos, afterRot, afterScl) {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Modified ${name || objectId}`,
+      forward: {
+        kind: 'scene-delta',
+        objectId,
+        position: afterPos,
+        rotation: afterRot,
+        scale: afterScl,
+      },
+      backward: {
+        kind: 'scene-delta',
+        objectId,
+        position: beforePos,
+        rotation: beforeRot,
+        scale: beforeScl,
+      },
+    };
+  }
+
+  static createEnvEntry(beforeEnvId, afterEnvId) {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Environment changed to ${afterEnvId}`,
+      forward: {
+        kind: 'scene-env',
+        envId: afterEnvId,
+      },
+      backward: {
+        kind: 'scene-env',
+        envId: beforeEnvId,
+      },
+    };
+  }
+
+  static createBatchEntry(actions, summary = 'Batch operation') {
+    const reverseActions = [...actions].reverse().map(action => {
+      if (action.kind === 'scene-add') {
+        return { kind: 'scene-remove', objectId: action.objectId };
+      } else if (action.kind === 'scene-remove') {
+        return {
+          kind: 'scene-add',
+          objectId: action.objectId,
+          name: action.name,
+          position: action.position,
+          rotation: action.rotation,
+          scale: action.scale,
+          asset: action.asset,
+        };
+      } else {
+        return action;
+      }
+    });
+
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary,
+      forward: {
+        kind: 'scene-batch',
+        batchId: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        actions,
+      },
+      backward: {
+        kind: 'scene-batch',
+        batchId: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        actions: reverseActions,
+      },
+    };
+  }
+}
+
+export function createHistoryManager() {
+  return new HistoryManager();
+}

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -18,7 +18,7 @@ import { createXrState } from './xr/xr-state.js';
 import { setupXrButtons } from './xr/xr-buttons.js';
 import { createXrFloorManager } from './xr/xr-floor.js';
 import { createRemoteAvatarManager } from './avatars/remote-avatars.js';
-import { createHistoryManager } from './history/history-manager.js';
+import { createHistoryManager, HistoryManager } from './history/history-manager.js';
 import { createUserManager } from './user/user-manager.js';
 
 // ── Three.js 基本セットアップ ────────────────────────────
@@ -38,17 +38,9 @@ const glbLoader = new GLBFileLoader({
 
 const onBeforeBroadcast = (operation, meta) => {
   if (operation.kind === 'scene-env' && meta.beforeEnvId) {
-    const historyEntry = {
-      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      timestamp: Date.now(),
-      summary: `Environment changed to ${operation.envId}`,
-      forward: operation,
-      backward: {
-        kind: 'scene-env',
-        envId: meta.beforeEnvId,
-      },
-    };
-    presenceState.historyManager.push(historyEntry);
+    presenceState.historyManager.push(
+      HistoryManager.createEnvEntry(meta.beforeEnvId, operation.envId)
+    );
   }
 };
 
@@ -780,25 +772,16 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
         if (!arraysEqual(dragStartState.beforePos, afterPos) ||
             !arraysEqual(dragStartState.beforeRot, afterRot) ||
             !arraysEqual(dragStartState.beforeScl, afterScl)) {
-          const historyEntry = {
-            id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            timestamp: Date.now(),
-            summary: `Modified ${dragStartState.name}`,
-            forward: {
-              kind: 'scene-delta',
-              objectId: dragStartState.objectId,
-              position: afterPos,
-              rotation: afterRot,
-              scale: afterScl,
-            },
-            backward: {
-              kind: 'scene-delta',
-              objectId: dragStartState.objectId,
-              position: dragStartState.beforePos,
-              rotation: dragStartState.beforeRot,
-              scale: dragStartState.beforeScl,
-            },
-          };
+          const historyEntry = HistoryManager.createDeltaEntry(
+            dragStartState.objectId,
+            dragStartState.name,
+            dragStartState.beforePos,
+            dragStartState.beforeRot,
+            dragStartState.beforeScl,
+            afterPos,
+            afterRot,
+            afterScl
+          );
           presenceState.historyManager.push(historyEntry);
         }
       }
@@ -1338,25 +1321,9 @@ function deleteSelectedObject() {
     managedObjects.delete(deleteId);
 
     // 履歴に追加
-    const historyEntry = {
-      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      timestamp: Date.now(),
-      summary: `Removed ${name}`,
-      forward: {
-        kind: 'scene-remove',
-        objectId: deleteId,
-      },
-      backward: {
-        kind: 'scene-add',
-        objectId: deleteId,
-        name,
-        position,
-        rotation,
-        scale,
-        asset,
-      },
-    };
-    presenceState.historyManager.push(historyEntry);
+    presenceState.historyManager.push(
+      HistoryManager.createRemoveEntry(deleteId, name, asset, position, rotation, scale)
+    );
 
     broadcast({ kind: 'scene-remove', objectId: deleteId });
   }
@@ -1421,6 +1388,14 @@ btnDelete?.addEventListener('click', () => {
 window.addEventListener('keydown', (e) => {
   // テキスト入力中は無視
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+  // ドラッグ中は Undo/Redo を無効化
+  if (isDragging) {
+    if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'y')) {
+      e.preventDefault();
+      return;
+    }
+  }
 
   // Undo: Ctrl+Z (Cmd+Z on Mac)
   if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
@@ -1650,7 +1625,7 @@ const presenceState = {
   id: null,
   userId: userManager.getUserId(),
   room: null,
-  nickname: loadInitialNickname() || userManager.getNickname(),
+  nickname: loadInitialNickname(),
   peers: [],
   historyManager: createHistoryManager(),
 };
@@ -2415,15 +2390,7 @@ function generateRandomPath() {
 async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
   // blob store に POST（1回だけ）
   const meshPath = generateRandomPath();
-  const operation = {
-    kind: 'scene-add',
-    objectId,
-    name,
-    position: model.position.toArray(),
-    rotation: model.quaternion.toArray(),
-    scale: model.scale.toArray(),
-    meshPath: null,
-  };
+  let actualMeshPath = null;
 
   try {
     await fetch(BLOB_BASE + '/' + meshPath, {
@@ -2431,7 +2398,7 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       headers: { 'Content-Type': 'model/gltf-binary' },
       body: arrayBuffer,
     });
-    operation.meshPath = meshPath;
+    actualMeshPath = meshPath;
     model.userData.meshPath = meshPath;
   } catch (err) {
     console.warn('POST failed:', err);
@@ -2440,21 +2407,28 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
   // 履歴に追加
   const asset = model.userData.asset || {
     type: 'gltf',
-    meshPath: operation.meshPath,
+    meshPath: actualMeshPath,
   };
-  const historyEntry = {
-    id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    timestamp: Date.now(),
-    summary: `Added ${name}`,
-    forward: operation,
-    backward: {
-      kind: 'scene-remove',
-      objectId,
-    },
-  };
+  const historyEntry = HistoryManager.createAddEntry(
+    objectId,
+    asset,
+    model.position.toArray(),
+    model.quaternion.toArray(),
+    model.scale.toArray(),
+    name,
+    actualMeshPath
+  );
   presenceState.historyManager.push(historyEntry);
 
-  broadcast(operation);
+  broadcast({
+    kind: 'scene-add',
+    objectId,
+    name,
+    position: model.position.toArray(),
+    rotation: model.quaternion.toArray(),
+    scale: model.scale.toArray(),
+    meshPath: actualMeshPath,
+  });
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -18,6 +18,8 @@ import { createXrState } from './xr/xr-state.js';
 import { setupXrButtons } from './xr/xr-buttons.js';
 import { createXrFloorManager } from './xr/xr-floor.js';
 import { createRemoteAvatarManager } from './avatars/remote-avatars.js';
+import { createHistoryManager } from './history/history-manager.js';
+import { createUserManager } from './user/user-manager.js';
 
 // ── Three.js 基本セットアップ ────────────────────────────
 
@@ -34,10 +36,27 @@ const glbLoader = new GLBFileLoader({
   maxDimension: 10,
 });
 
+const onBeforeBroadcast = (operation, meta) => {
+  if (operation.kind === 'scene-env' && meta.beforeEnvId) {
+    const historyEntry = {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Environment changed to ${operation.envId}`,
+      forward: operation,
+      backward: {
+        kind: 'scene-env',
+        envId: meta.beforeEnvId,
+      },
+    };
+    presenceState.historyManager.push(historyEntry);
+  }
+};
+
 const environmentManager = createEnvironmentManager({
   scene,
   pmremGenerator,
   broadcast,
+  onBeforeBroadcast,
   dom,
   showToast,
 });
@@ -724,12 +743,23 @@ scene.add(transformCtrl.getHelper());
 
 let isDragging = false;
 let dragIntervalId = null;
+let dragStartState = null;
 
 transformCtrl.addEventListener('dragging-changed', (e) => {
   orbit.enabled = !e.value;
   isDragging = e.value;
 
   if (isDragging) {
+    const obj = transformCtrl.object;
+    if (obj && obj.userData.objectId) {
+      dragStartState = {
+        objectId: obj.userData.objectId,
+        name: obj.userData.name || obj.userData.objectId,
+        beforePos: obj.position.toArray(),
+        beforeRot: obj.quaternion.toArray(),
+        beforeScl: obj.scale.toArray(),
+      };
+    }
     dragIntervalId = setInterval(() => {
       sendSelectedDelta();
     }, 50);
@@ -737,8 +767,50 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
     clearInterval(dragIntervalId);
     dragIntervalId = null;
     sendSelectedDelta();
+
+    // ドラッグ終了時に履歴に追加
+    if (dragStartState) {
+      const obj = transformCtrl.object;
+      if (obj && obj.userData.objectId === dragStartState.objectId) {
+        const afterPos = obj.position.toArray();
+        const afterRot = obj.quaternion.toArray();
+        const afterScl = obj.scale.toArray();
+
+        // 値が変更されている場合のみ履歴に追加
+        if (!arraysEqual(dragStartState.beforePos, afterPos) ||
+            !arraysEqual(dragStartState.beforeRot, afterRot) ||
+            !arraysEqual(dragStartState.beforeScl, afterScl)) {
+          const historyEntry = {
+            id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            timestamp: Date.now(),
+            summary: `Modified ${dragStartState.name}`,
+            forward: {
+              kind: 'scene-delta',
+              objectId: dragStartState.objectId,
+              position: afterPos,
+              rotation: afterRot,
+              scale: afterScl,
+            },
+            backward: {
+              kind: 'scene-delta',
+              objectId: dragStartState.objectId,
+              position: dragStartState.beforePos,
+              rotation: dragStartState.beforeRot,
+              scale: dragStartState.beforeScl,
+            },
+          };
+          presenceState.historyManager.push(historyEntry);
+        }
+      }
+      dragStartState = null;
+    }
   }
 });
+
+function arraysEqual(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((v, i) => Math.abs(v - b[i]) < 0.0001);
+}
 
 function sendSelectedDelta() {
   const obj = transformCtrl.object;
@@ -1245,6 +1317,13 @@ function deleteSelectedObject() {
     removeLockOverlay(deleteId);
     locks.delete(deleteId);
 
+    // 削除前にオブジェクト情報を保存
+    const name = attached.userData.name || deleteId;
+    const position = attached.position.toArray();
+    const rotation = attached.quaternion.toArray();
+    const scale = attached.scale.toArray();
+    const asset = attached.userData.asset || {};
+
     scene.remove(attached);
     attached.traverse(child => {
       if (child.geometry) child.geometry.dispose();
@@ -1257,6 +1336,28 @@ function deleteSelectedObject() {
       }
     });
     managedObjects.delete(deleteId);
+
+    // 履歴に追加
+    const historyEntry = {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Removed ${name}`,
+      forward: {
+        kind: 'scene-remove',
+        objectId: deleteId,
+      },
+      backward: {
+        kind: 'scene-add',
+        objectId: deleteId,
+        name,
+        position,
+        rotation,
+        scale,
+        asset,
+      },
+    };
+    presenceState.historyManager.push(historyEntry);
+
     broadcast({ kind: 'scene-remove', objectId: deleteId });
   }
 }
@@ -1320,6 +1421,20 @@ btnDelete?.addEventListener('click', () => {
 window.addEventListener('keydown', (e) => {
   // テキスト入力中は無視
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+  // Undo: Ctrl+Z (Cmd+Z on Mac)
+  if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+    e.preventDefault();
+    performUndo();
+    return;
+  }
+
+  // Redo: Ctrl+Y or Ctrl+Shift+Z (Cmd+Shift+Z on Mac)
+  if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
+    e.preventDefault();
+    performRedo();
+    return;
+  }
 
   switch (e.key.toLowerCase()) {
     case 'w': transformCtrl.setMode('translate'); break;
@@ -1528,12 +1643,16 @@ function updatePeersList() {
   peersListEl.innerHTML = html;
 }
 
+const userManager = createUserManager();
+
 const presenceState = {
   ws: null,
   id: null,
+  userId: userManager.getUserId(),
   room: null,
-  nickname: loadInitialNickname(),
+  nickname: loadInitialNickname() || userManager.getNickname(),
   peers: [],
+  historyManager: createHistoryManager(),
 };
 
 const remoteAvatarManager = createRemoteAvatarManager({
@@ -2208,6 +2327,69 @@ function applyTransform(obj, info) {
   if (info.scale) obj.scale.fromArray(info.scale);
 }
 
+// ── Undo/Redo 処理 ──────────────────────────────────────
+
+function performUndo() {
+  const historyManager = presenceState.historyManager;
+  if (!historyManager.canUndo()) return;
+
+  const operation = historyManager.undo();
+  if (!operation) return;
+
+  applyOperationToScene(operation);
+  broadcast(operation);
+}
+
+function performRedo() {
+  const historyManager = presenceState.historyManager;
+  if (!historyManager.canRedo()) return;
+
+  const operation = historyManager.redo();
+  if (!operation) return;
+
+  applyOperationToScene(operation);
+  broadcast(operation);
+}
+
+function applyOperationToScene(operation) {
+  switch (operation.kind) {
+    case 'scene-add': {
+      const obj = buildObject(operation);
+      if (obj) {
+        scene.add(obj);
+        managedObjects.set(operation.objectId, obj);
+      }
+      break;
+    }
+    case 'scene-remove': {
+      const obj = managedObjects.get(operation.objectId);
+      if (obj) {
+        scene.remove(obj);
+        managedObjects.delete(operation.objectId);
+      }
+      break;
+    }
+    case 'scene-delta': {
+      const obj = managedObjects.get(operation.objectId);
+      if (obj) {
+        applyTransform(obj, operation);
+      }
+      break;
+    }
+    case 'scene-env': {
+      environmentManager.loadEnvironment(operation.envId, {
+        source: 'undo-redo',
+        broadcastChange: false,
+      });
+      break;
+    }
+    case 'scene-batch': {
+      operation.actions?.forEach(action => applyOperationToScene(action));
+      break;
+    }
+  }
+}
+
 // ── broadcast 送信ヘルパー（次 Step 以降で使用） ─────────
 
 function broadcast(payload) {
@@ -2227,38 +2409,46 @@ function generateRandomPath() {
 async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
   // blob store に POST（1回だけ）
   const meshPath = generateRandomPath();
-  try {
-    await fetch(BLOB_BASE + '/' + meshPath, {
-      method: 'POST',
-      headers: { 'Content-Type': 'model/gltf-binary' },
-      body: arrayBuffer,
-    });
-  } catch (err) {
-    console.warn('POST failed:', err);
-    broadcast({
-      kind: 'scene-add',
-      objectId,
-      name,
-      position: model.position.toArray(),
-      rotation: model.quaternion.toArray(),
-      scale: model.scale.toArray(),
-      meshPath: null,
-    });
-    return;
-  }
-
-  // meshPath をオブジェクトに保存（respondToSceneRequest で再利用）
-  model.userData.meshPath = meshPath;
-
-  broadcast({
+  const operation = {
     kind: 'scene-add',
     objectId,
     name,
     position: model.position.toArray(),
     rotation: model.quaternion.toArray(),
     scale: model.scale.toArray(),
-    meshPath,
-  });
+    meshPath: null,
+  };
+
+  try {
+    await fetch(BLOB_BASE + '/' + meshPath, {
+      method: 'POST',
+      headers: { 'Content-Type': 'model/gltf-binary' },
+      body: arrayBuffer,
+    });
+    operation.meshPath = meshPath;
+    model.userData.meshPath = meshPath;
+  } catch (err) {
+    console.warn('POST failed:', err);
+  }
+
+  // 履歴に追加
+  const asset = model.userData.asset || {
+    type: 'gltf',
+    meshPath: operation.meshPath,
+  };
+  const historyEntry = {
+    id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    summary: `Added ${name}`,
+    forward: operation,
+    backward: {
+      kind: 'scene-remove',
+      objectId,
+    },
+  };
+  presenceState.historyManager.push(historyEntry);
+
+  broadcast(operation);
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2354,16 +2354,16 @@ function performRedo() {
 function applyOperationToScene(operation) {
   switch (operation.kind) {
     case 'scene-add': {
-      const obj = buildObject(operation);
-      if (obj) {
-        scene.add(obj);
-        managedObjects.set(operation.objectId, obj);
-      }
+      addOrUpdateObject(operation.objectId, operation);
       break;
     }
     case 'scene-remove': {
       const obj = managedObjects.get(operation.objectId);
       if (obj) {
+        if (transformCtrl.object === obj) {
+          transformCtrl.detach();
+          hideToolbar();
+        }
         scene.remove(obj);
         managedObjects.delete(operation.objectId);
       }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2174,6 +2174,12 @@ function handleHandoff(data) {
       remoteAvatarManager.handleAvatarMessage(payload);
       break;
     }
+    case 'scene-batch': {
+      payload.actions?.forEach(action => {
+        handleHandoff({ ...data, payload: action });
+      });
+      break;
+    }
     default:
       break;
   }

--- a/html/assets/js/scenesync/user/user-manager.js
+++ b/html/assets/js/scenesync/user/user-manager.js
@@ -1,5 +1,4 @@
 const STORAGE_KEY = 'scenesync.userId';
-const NICKNAME_STORAGE_KEY = 'scenesync.nickname';
 
 function generateUserId() {
   const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
@@ -13,7 +12,6 @@ function generateUserId() {
 export class UserManager {
   constructor() {
     this.userId = this.loadOrCreateUserId();
-    this.nickname = this.loadNickname() || 'Anonymous';
   }
 
   loadOrCreateUserId() {
@@ -25,21 +23,8 @@ export class UserManager {
     return userId;
   }
 
-  loadNickname() {
-    return localStorage.getItem(NICKNAME_STORAGE_KEY);
-  }
-
-  setNickname(nickname) {
-    this.nickname = nickname;
-    localStorage.setItem(NICKNAME_STORAGE_KEY, nickname);
-  }
-
   getUserId() {
     return this.userId;
-  }
-
-  getNickname() {
-    return this.nickname;
   }
 }
 

--- a/html/assets/js/scenesync/user/user-manager.js
+++ b/html/assets/js/scenesync/user/user-manager.js
@@ -1,0 +1,48 @@
+const STORAGE_KEY = 'scenesync.userId';
+const NICKNAME_STORAGE_KEY = 'scenesync.nickname';
+
+function generateUserId() {
+  const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+  return `usr-${uuid}`;
+}
+
+export class UserManager {
+  constructor() {
+    this.userId = this.loadOrCreateUserId();
+    this.nickname = this.loadNickname() || 'Anonymous';
+  }
+
+  loadOrCreateUserId() {
+    let userId = localStorage.getItem(STORAGE_KEY);
+    if (!userId) {
+      userId = generateUserId();
+      localStorage.setItem(STORAGE_KEY, userId);
+    }
+    return userId;
+  }
+
+  loadNickname() {
+    return localStorage.getItem(NICKNAME_STORAGE_KEY);
+  }
+
+  setNickname(nickname) {
+    this.nickname = nickname;
+    localStorage.setItem(NICKNAME_STORAGE_KEY, nickname);
+  }
+
+  getUserId() {
+    return this.userId;
+  }
+
+  getNickname() {
+    return this.nickname;
+  }
+}
+
+export function createUserManager() {
+  return new UserManager();
+}


### PR DESCRIPTION
- Add HistoryManager class for managing undo/redo stacks (max 100 items)
- Add UserManager class to persist userId to localStorage (usr-UUID format)
- Implement Ctrl+Z (Cmd+Z) for undo, Ctrl+Y (Cmd+Shift+Z) for redo
- Track scene-add operations (uploadAndBroadcast)
- Track scene-remove operations (deleteSelectedObject)
- Track scene-delta operations (TransformControls drag) with before/after snapshots
- Track scene-env operations (environment changes)
- Create history entry for each operation with forward/backward (undo) action
- Don't track scene-lock/unlock (temporary state)
- Only track user's own operations (phase 1)

https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ