### PR TITLE
Scene Sync: Undo/Redo history management & mobile buttons

### DIFF
--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -1,8 +1,9 @@
 export class HistoryManager {
-  constructor() {
+  constructor(maxHistorySize = 100) {
     this.undoStack = [];
     this.redoStack = [];
-    this.maxHistorySize = 100;
+    this.maxHistorySize = maxHistorySize;
+    this.onChange = null;
   }
 
   push(entry) {
@@ -13,6 +14,8 @@ export class HistoryManager {
     if (this.undoStack.length > this.maxHistorySize) {
       this.undoStack.shift();
     }
+
+    this._notifyChange();
   }
 
   canUndo() {
@@ -27,6 +30,7 @@ export class HistoryManager {
     if (!this.canUndo()) return null;
     const entry = this.undoStack.pop();
     this.redoStack.push(entry);
+    this._notifyChange();
     return entry.backward;
   }
 
@@ -34,12 +38,25 @@ export class HistoryManager {
     if (!this.canRedo()) return null;
     const entry = this.redoStack.pop();
     this.undoStack.push(entry);
+    this._notifyChange();
     return entry.forward;
   }
 
   clear() {
     this.undoStack = [];
     this.redoStack = [];
+    this._notifyChange();
+  }
+
+  _notifyChange() {
+    if (typeof this.onChange === 'function') {
+      this.onChange({
+        canUndo: this.canUndo(),
+        canRedo: this.canRedo(),
+        undoSize: this.undoStack.length,
+        redoSize: this.redoStack.length,
+      });
+    }
   }
 
   getHistory(count = 10) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1332,6 +1332,8 @@ function deleteSelectedObject() {
 // ── モバイルツールバー ──────────────────────────────────
 
 const toolbar = document.getElementById('mobile-toolbar');
+const btnUndo = document.getElementById('btn-undo');
+const btnRedo = document.getElementById('btn-redo');
 const btnMove = document.getElementById('btn-move');
 const btnRotate = document.getElementById('btn-rotate');
 const btnScale = document.getElementById('btn-scale');
@@ -1382,6 +1384,36 @@ btnDeselect?.addEventListener('click', () => {
 btnDelete?.addEventListener('click', () => {
   deleteSelectedObject();
 });
+
+// ── Undo/Redo ボタン ──────────────────────────────────────
+
+function updateHistoryButtonState() {
+  const canUndo = presenceState.historyManager.canUndo();
+  const canRedo = presenceState.historyManager.canRedo();
+
+  if (btnUndo) btnUndo.disabled = !canUndo;
+  if (btnRedo) btnRedo.disabled = !canRedo;
+}
+
+btnUndo?.addEventListener('click', () => {
+  if (presenceState.historyManager.canUndo()) {
+    performUndo();
+  }
+});
+
+btnRedo?.addEventListener('click', () => {
+  if (presenceState.historyManager.canRedo()) {
+    performRedo();
+  }
+});
+
+// 履歴状態が変わったときにボタンを更新
+presenceState.historyManager.onChange = () => {
+  updateHistoryButtonState();
+};
+
+// 初期状態を反映
+updateHistoryButtonState();
 
 // ── キーボードショートカット ──────────────────────────────
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -205,6 +205,13 @@
     .tb-btn.btn-danger:hover {
       background: rgba(255,60,60,0.7);
     }
+    .tb-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .tb-btn:disabled:hover {
+      background: rgba(255,255,255,0.15);
+    }
     #peers-panel {
       position: fixed;
       top: 48px;
@@ -309,6 +316,8 @@
   <div id="mode">W: 移動 &nbsp; E: 回転 &nbsp; R: スケール</div>
   <div id="toast"></div>
   <div id="mobile-toolbar" style="display:none;">
+    <button id="btn-undo" class="tb-btn" title="取り消す (Ctrl+Z)">↶</button>
+    <button id="btn-redo" class="tb-btn" title="やり直す (Ctrl+Y)">↷</button>
     <button id="btn-move" class="tb-btn active" title="移動">☩</button>
     <button id="btn-rotate" class="tb-btn" title="回転">↻</button>
     <button id="btn-scale" class="tb-btn" title="スケール">⤡</button>


### PR DESCRIPTION
## 概要

Scene Sync に Undo/Redo 履歴管理システムを実装し、ローカルの操作取り消し・やり直し機能とモバイル向けUIボタンを追加しました。

## Phase 1: ローカル Undo/Redo 履歴管理

**新規モジュール:**
- `HistoryManager` - undoStack/redoStack 管理（最大100エントリ）
- `UserManager` - userId 永続管理（localStorage、usr-UUID形式）

**機能:**
- scene-add / scene-remove / scene-delta / scene-env / scene-batch の履歴追跡
- Ctrl+Z (Cmd+Z) / Ctrl+Y (Cmd+Shift+Z) のキーバインド
- TransformControls ドラッグを1履歴エントリとして記録
- ドラッグ中の Undo/Redo を無効化（状態破損防止）

## Phase 2: scene-batch サポート

複数操作をまとめて1つの履歴エントリとしたり、原子的に送信可能に。

## PR #77 レビュー修正

- ✅ UserManager を userId のみに制限（既存の pipe.deviceName を使用）
- ✅ scene-batch 逆操作（scene-delta）を修正
- ✅ HistoryManager static メソッド（createAddEntry等）で統一

## モバイル向け Undo/Redo ボタン

**追加機能:**
- モバイルツールバーに ↶/↷ ボタンを追加
- HistoryManager に onChange コールバック機構
- ボタン状態（disabled）を自動同期
- CSS で disabled 状態（opacity 0.4）をサポート

## テスト項目

- [x] 構文チェック：OK
- [ ] シナリオ A-H（動作確認待ち）

## ファイル変更

```
 html/assets/js/scenesync/core/environment.js       |  15 +-
 html/assets/js/scenesync/history/history-manager.js | 173 ++++++++++
 html/assets/js/scenesync/scene.js                  | 228 ++++++++++++++--
 html/assets/js/scenesync/user/user-manager.js      |  33 +++
 html/scenesync/index.html                          |   9 +
 5 files changed, 443 insertions(+), 15 deletions(-)
```

## コミット一覧

1. Phase 1: ローカル Undo/Redo 履歴管理実装
2. Phase 2: scene-batch サポート
3. PR #77 レビュー修正：責務制限・逆操作修正・ドラッグ中無効化・static メソッド統一
4. モバイル向け Undo/Redo ボタン追加

---

**次フェーズ（Phase 3）:** AI ペアリング機構（サーバー側 linkToken、onBehalfOf）

---
_Generated by [Claude Code](https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ)_