### PR TITLE
fix: Hotfix WSS connection failure from PR #78

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1407,14 +1407,6 @@ btnRedo?.addEventListener('click', () => {
   }
 });
 
-// 履歴状態が変わったときにボタンを更新
-presenceState.historyManager.onChange = () => {
-  updateHistoryButtonState();
-};
-
-// 初期状態を反映
-updateHistoryButtonState();
-
 // ── キーボードショートカット ──────────────────────────────
 
 window.addEventListener('keydown', (e) => {
@@ -1661,6 +1653,14 @@ const presenceState = {
   peers: [],
   historyManager: createHistoryManager(),
 };
+
+// 履歴状態が変わったときにボタンを更新
+presenceState.historyManager.onChange = () => {
+  updateHistoryButtonState();
+};
+
+// 初期状態を反映
+updateHistoryButtonState();
 
 const remoteAvatarManager = createRemoteAvatarManager({
   scene,


### PR DESCRIPTION
## 問題

PR #78（Scene Sync Undo/Redo）をマージ後、`https://afjk.jp/scenesync/` および `https://staging.afjk.jp/scenesync/` で WSS 接続が確立されず、ステータスが「接続中…」のまま固まる。

## 原因

PR #78 で追加した以下のコードが `presenceState` 定義前（1411行）で実行されていた：

```javascript
presenceState.historyManager.onChange = () => {
  updateHistoryButtonState();
};
updateHistoryButtonState();
```

`presenceState` は 1655 行で定義されるため、モジュール初期化時に `ReferenceError` が発生し、以後のコード（WSS 接続など）が実行されない。

## 修正内容

上記の2行をモバイルツールバー部分から削除し、`presenceState` 定義の直後（1656行）に移動。

```javascript
const presenceState = { ... };

// ✅ ここから先は presenceState が初期化済み
presenceState.historyManager.onChange = () => {
  updateHistoryButtonState();
};
updateHistoryButtonState();
```

クリックハンドラ（`btnUndo?.addEventListener(...)` 等）はコールバック内での参照なので、元の位置で問題なし。

## テスト

- [x] 構文チェック：OK
- [ ] WSS 接続確立を確認
- [ ] Undo/Redo 機能の動作確認

## コミット

- `dab20d9` fix: move historyManager.onChange registration after presenceState init

---

**関連:** PR #78 の副次効果を修正するホットフィックス


---
_Generated by [Claude Code](https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ)_