### PR TITLE
fix: keep undo/redo buttons visible & fix glb loading overlay

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2434,6 +2434,9 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
     model.userData.meshPath = meshPath;
   } catch (err) {
     console.warn('POST failed:', err);
+    removeLoadingOverlay(objectId);
+    showToast('GLB アップロード失敗: ' + err.message);
+    return;
   }
 
   // 履歴に追加
@@ -2461,6 +2464,9 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
     scale: model.scale.toArray(),
     meshPath: actualMeshPath,
   });
+
+  // ローディングオーバーレイを解除
+  removeLoadingOverlay(objectId);
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -181,6 +181,14 @@
       gap: 8px;
       z-index: 50;
     }
+    #history-toolbar {
+      position: fixed;
+      bottom: 24px;
+      left: 12px;
+      display: flex;
+      gap: 8px;
+      z-index: 50;
+    }
     .tb-btn {
       width: 44px;
       height: 44px;
@@ -315,9 +323,11 @@
   <div id="drop-overlay">GLB をドロップして追加</div>
   <div id="mode">W: 移動 &nbsp; E: 回転 &nbsp; R: スケール</div>
   <div id="toast"></div>
-  <div id="mobile-toolbar" style="display:none;">
+  <div id="history-toolbar">
     <button id="btn-undo" class="tb-btn" title="取り消す (Ctrl+Z)">↶</button>
     <button id="btn-redo" class="tb-btn" title="やり直す (Ctrl+Y)">↷</button>
+  </div>
+  <div id="mobile-toolbar" style="display:none;">
     <button id="btn-move" class="tb-btn active" title="移動">☩</button>
     <button id="btn-rotate" class="tb-btn" title="回転">↻</button>
     <button id="btn-scale" class="tb-btn" title="スケール">⤡</button>


### PR DESCRIPTION
## 概要

動作確認で見つかった2つの問題を修正：

1. **Undo/Redo ボタンの常時表示化** — モバイルツールバーから独立させ、常時表示
2. **GLB インポート後のローディング解除** — loadingOverlay が消えない問題を修正

## 問題 1: Undo/Redo ボタンが選択時しか表示されない

### 症状
`#mobile-toolbar` はオブジェクト選択中のみ `display: flex` で、未選択時は非表示。
そのため Undo/Redo ボタンも非表示になり、未選択時に履歴操作ができない。

### 修正
- `#history-toolbar` という独立したコンテナを新設
- 位置: 左下（`bottom: 24px; left: 12px;`）常時表示
- モバイルにも親指の届きやすい配置

**レイアウト変更:**
```
Before: [btn-undo] [btn-redo] [btn-move] [btn-rotate] ...  (選択時のみ表示)
After:  [btn-undo] [btn-redo]  (常時)  +  [btn-move] ... (選択時のみ)
        左下                           中央下
```

## 問題 2: GLB インポート後に「読み込み中」が消えない

### 症状
GLB ファイルドラッグ&ドロップ → 「読み込み中」表示 → オブジェクト配置
しかし読み込み中表示が残ったまま消えない。

### 原因
`uploadAndBroadcast()` 関数で `removeLoadingOverlay(objectId)` が呼ばれていなかった。
broadcast 送信後にオーバーレイを削除する処理が欠落。

### 修正
- try/catch 構造を整理
- 成功時: `removeLoadingOverlay(objectId)` を必ず呼ぶ
- 失敗時: `removeLoadingOverlay(objectId)` + エラートースト表示
- early return で失敗時の broadcast を防止

```javascript
async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
  try {
    await fetch(BLOB_BASE + '/' + meshPath, ...);
    // ...
  } catch (err) {
    removeLoadingOverlay(objectId);  // ← 追加
    showToast('GLB アップロード失敗: ' + err.message);  // ← 追加
    return;  // ← early return で以後の処理を中止
  }
  
  // 成功時の処理
  presenceState.historyManager.push(...);
  broadcast(...);
  removeLoadingOverlay(objectId);  // ← 追加
}
```

## テスト項目

- [x] 構文チェック：OK
- [ ] モバイル未選択時に ↶/↷ ボタンが見える
- [ ] GLB ドラッグ&ドロップで読み込み中が消える
- [ ] Undo/Redo が動く
- [ ] ボタンの disabled 状態が履歴に応じて切り替わる

## ファイル変更

```
 html/assets/js/scenesync/scene.js | 10 +++++++++-
 html/scenesync/index.html         |  7 +++++++
 2 files changed, 16 insertions(+), 1 deletion(-)
```

## コミット

- `cd84420` fix: keep undo/redo buttons always visible and clear loading overlay after glb import

---

**関連:** PR #78（Undo/Redo 履歴管理実装）の副次効果を修正


---
_Generated by [Claude Code](https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ)_