### PR TITLE
Add AI pairing and history tracking for onBehalfOf operations

### DIFF
--- a/apps/presence-server/src/link-token.mjs
+++ b/apps/presence-server/src/link-token.mjs
@@ -1,0 +1,152 @@
+import { createHmac, randomUUID } from 'node:crypto';
+
+const LINK_TOKEN_SECRET = process.env.LINK_TOKEN_SECRET || 'dev-secret-key-change-in-production';
+const LINK_TOKEN_TTL_MS = 30 * 24 * 3600 * 1000; // 30 days
+const PAIRING_CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const PAIRING_CODE_LENGTH = 6;
+
+// In-memory storage for pairing codes and revoked tokens
+// In production, use Redis or persistent store
+export const pairingCodes = new Map(); // code -> { roomId, userId, expiresAt }
+export const revokedTokens = new Map(); // linkId -> { revokedAt, reason }
+
+function generatePairingCode() {
+  let code = '';
+  for (let i = 0; i < PAIRING_CODE_LENGTH; i++) {
+    code += Math.floor(Math.random() * 10);
+  }
+  return code;
+}
+
+function base64urlEncode(data) {
+  return Buffer.from(data).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function base64urlDecode(str) {
+  const padded = str + '=='.substring(0, (4 - (str.length % 4)) % 4);
+  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+export function createLinkToken(linkId, userId, roomId) {
+  const now = Date.now();
+  const exp = now + LINK_TOKEN_TTL_MS;
+
+  const payload = {
+    linkId,
+    userId,
+    roomId,
+    iat: now,
+    exp
+  };
+
+  const payloadStr = JSON.stringify(payload);
+  const payloadB64 = base64urlEncode(payloadStr);
+
+  const hmac = createHmac('sha256', LINK_TOKEN_SECRET);
+  hmac.update(payloadB64);
+  const signatureB64 = base64urlEncode(hmac.digest());
+
+  return {
+    linkToken: `${payloadB64}.${signatureB64}`,
+    linkId,
+    roomId,
+    expiresAt: exp
+  };
+}
+
+export function verifyLinkToken(token) {
+  try {
+    const [payloadB64, signatureB64] = token.split('.');
+    if (!payloadB64 || !signatureB64) {
+      return { valid: false, error: 'invalid format' };
+    }
+
+    const hmac = createHmac('sha256', LINK_TOKEN_SECRET);
+    hmac.update(payloadB64);
+    const expectedSig = base64urlEncode(hmac.digest());
+
+    if (signatureB64 !== expectedSig) {
+      return { valid: false, error: 'invalid signature' };
+    }
+
+    const payloadStr = base64urlDecode(payloadB64).toString('utf8');
+    const payload = JSON.parse(payloadStr);
+
+    if (payload.exp < Date.now()) {
+      return { valid: false, error: 'token expired' };
+    }
+
+    if (revokedTokens.has(payload.linkId)) {
+      return { valid: false, error: 'token revoked' };
+    }
+
+    return { valid: true, payload };
+  } catch (err) {
+    return { valid: false, error: err.message };
+  }
+}
+
+export function initiatePairingCode(roomId, userId) {
+  const code = generatePairingCode();
+  const expiresAt = Date.now() + PAIRING_CODE_TTL_MS;
+
+  pairingCodes.set(code, {
+    roomId,
+    userId,
+    expiresAt,
+    redeemed: false
+  });
+
+  return {
+    code,
+    expiresAt
+  };
+}
+
+export function redeemPairingCode(code) {
+  const entry = pairingCodes.get(code);
+
+  if (!entry) {
+    return { ok: false, error: 'not found' };
+  }
+
+  if (Date.now() > entry.expiresAt) {
+    pairingCodes.delete(code);
+    return { ok: false, error: 'expired' };
+  }
+
+  if (entry.redeemed) {
+    return { ok: false, error: 'already redeemed' };
+  }
+
+  // Mark as redeemed (keep in map until expiry for idempotency)
+  entry.redeemed = true;
+
+  const linkId = `lnk-${randomUUID()}`;
+  const tokenData = createLinkToken(linkId, entry.userId, entry.roomId);
+
+  return { ok: true, ...tokenData };
+}
+
+export function revokeLinkToken(linkId) {
+  revokedTokens.set(linkId, {
+    revokedAt: Date.now(),
+    reason: 'user-revoked'
+  });
+}
+
+// Cleanup expired pairing codes periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [code, entry] of pairingCodes) {
+    if (now > entry.expiresAt) {
+      pairingCodes.delete(code);
+    }
+  }
+  // Cleanup revoked tokens older than their original TTL
+  for (const [linkId, revoked] of revokedTokens) {
+    if (now > revoked.revokedAt + LINK_TOKEN_TTL_MS) {
+      revokedTokens.delete(linkId);
+    }
+  }
+}, 60000); // Every minute

--- a/apps/presence-server/src/link-token.mjs
+++ b/apps/presence-server/src/link-token.mjs
@@ -1,6 +1,10 @@
 import { createHmac, randomUUID } from 'node:crypto';
 
 const LINK_TOKEN_SECRET = process.env.LINK_TOKEN_SECRET || 'dev-secret-key-change-in-production';
+
+if (!process.env.LINK_TOKEN_SECRET) {
+  console.warn('[link-token] LINK_TOKEN_SECRET not set; using insecure default. Set this env var in production.');
+}
 const LINK_TOKEN_TTL_MS = 30 * 24 * 3600 * 1000; // 30 days
 const PAIRING_CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const PAIRING_CODE_LENGTH = 6;

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -2,6 +2,7 @@ import { createServer } from 'node:http';
 import { createHash, randomUUID } from 'node:crypto';
 import { URL, pathToFileURL } from 'node:url';
 import { readFileSync, writeFileSync, mkdirSync, unlinkSync, createReadStream } from 'node:fs';
+import { createLinkToken, verifyLinkToken, initiatePairingCode, redeemPairingCode, revokeLinkToken } from './link-token.mjs';
 
 const PORT = Number(process.env.PORT || 8787);
 const HEARTBEAT_MS = 30000;
@@ -284,6 +285,7 @@ function makeClient(conn, roomId) {
     id: randomUUID(),
     conn,
     roomId,
+    userId: null,
     nickname: '',
     device: '',
     streaming: false,
@@ -309,13 +311,19 @@ function listPeers(roomId, excludeId) {
   if (!room) return [];
   return Array.from(room.values())
     .filter(p => p.id !== excludeId)
-    .map(p => ({
-      id: p.id,
-      nickname: p.nickname,
-      device: p.device,
-      streaming: p.streaming,
-      lastSeen: p.lastSeen
-    }));
+    .map(p => {
+      const peerInfo = {
+        id: p.id,
+        nickname: p.nickname,
+        device: p.device,
+        streaming: p.streaming,
+        lastSeen: p.lastSeen
+      };
+      if (p.userId) {
+        peerInfo.userId = p.userId;
+      }
+      return peerInfo;
+    });
 }
 
 function broadcastPeers(roomId) {
@@ -730,6 +738,113 @@ function createPresenceServer() {
     return;
   }
 
+  // ── AI Pairing Endpoints ────────────────────────────────────────────
+  // POST /api/link/initiate
+  if (req.method === 'POST' && path === '/api/link/initiate') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      sendJson(res, 400, { error: 'invalid JSON body' });
+      return;
+    }
+
+    const { roomId, userId } = body;
+    if (!roomId || !userId) {
+      sendJson(res, 400, { error: 'missing roomId or userId' });
+      return;
+    }
+
+    const sanitized = sanitizeRoom(roomId);
+    if (!sanitized) {
+      sendJson(res, 400, { error: 'invalid roomId' });
+      return;
+    }
+
+    const { code, expiresAt } = initiatePairingCode(sanitized, userId);
+    sendJson(res, 200, { code, expiresAt });
+    return;
+  }
+
+  // POST /api/link/redeem
+  if (req.method === 'POST' && path === '/api/link/redeem') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      sendJson(res, 400, { error: 'invalid JSON body' });
+      return;
+    }
+
+    const { code } = body;
+    if (!code) {
+      sendJson(res, 400, { error: 'missing code' });
+      return;
+    }
+
+    const result = redeemPairingCode(code);
+    if (!result.ok) {
+      const statusCode = result.error === 'not found' ? 404 : result.error === 'already redeemed' ? 410 : 400;
+      sendJson(res, statusCode, { error: result.error });
+      return;
+    }
+
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // POST /api/link/revoke
+  if (req.method === 'POST' && path === '/api/link/revoke') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      sendJson(res, 400, { error: 'invalid JSON body' });
+      return;
+    }
+
+    let linkId = body?.linkId;
+    let revokeUserId = null;
+    let revokeRoomId = null;
+
+    // If Authorization Bearer token provided, extract linkId from it
+    const authHeader = req.headers['authorization'] || '';
+    if (authHeader.startsWith('Bearer ')) {
+      const token = authHeader.slice(7);
+      const result = verifyLinkToken(token);
+      if (result.valid) {
+        linkId = result.payload.linkId;
+        revokeUserId = result.payload.userId;
+        revokeRoomId = result.payload.roomId;
+      }
+    }
+
+    if (!linkId) {
+      sendJson(res, 400, { error: 'missing linkId or Authorization header' });
+      return;
+    }
+
+    revokeLinkToken(linkId);
+
+    // Broadcast ai-link-revoked to room if applicable
+    if (revokeRoomId) {
+      const peers = getRoomClients(revokeRoomId);
+      const message = {
+        type: 'handoff',
+        from: { id: `api-revoke-${randomUUID()}`, nickname: 'AI', device: 'REST API' },
+        payload: {
+          kind: 'ai-link-revoked',
+          linkId,
+          reason: 'ai-revoked'
+        }
+      };
+      peers.forEach(client => safeSend(client.conn, message));
+    }
+
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
     const roomApiMatch = path.match(/^\/api\/room\/([^/]+)\/(broadcast|scene)$/);
     if (roomApiMatch) {
       const roomId = sanitizeRoom(roomApiMatch[1]);
@@ -752,6 +867,26 @@ function createPresenceServer() {
           return;
         }
 
+        // Validate linkToken if Authorization Bearer header is present
+        let onBehalfOfUserId = null;
+        const authHeader = req.headers['authorization'] || '';
+        if (authHeader.startsWith('Bearer ')) {
+          const token = authHeader.slice(7);
+          const result = verifyLinkToken(token);
+          if (!result.valid) {
+            sendJson(res, 401, { error: result.error });
+            return;
+          }
+          // Ensure token roomId matches URL roomId
+          if (result.payload.roomId !== roomId) {
+            sendJson(res, 403, { error: 'roomId mismatch' });
+            return;
+          }
+          onBehalfOfUserId = result.payload.userId;
+          // Add onBehalfOf to payload
+          payload = { ...payload, onBehalfOf: onBehalfOfUserId };
+        }
+
         const peers = getRoomClients(roomId);
         const message = {
           type: 'handoff',
@@ -759,7 +894,14 @@ function createPresenceServer() {
           payload
         };
         peers.forEach(client => safeSend(client.conn, message));
-        sendJson(res, 200, { ok: true, room: roomId, peers: peers.length });
+
+        // Calculate userPresent: check if target userId has any connected peer in room
+        let userPresent = false;
+        if (onBehalfOfUserId) {
+          userPresent = peers.some(client => client.userId === onBehalfOfUserId);
+        }
+
+        sendJson(res, 200, { ok: true, room: roomId, peers: peers.length, userPresent });
         return;
       }
 
@@ -820,6 +962,9 @@ function createPresenceServer() {
           client.nickname = sanitizeName(data.nickname);
           client.device = sanitizeDevice(data.device);
           client.streaming = Boolean(data.streaming);
+          if (data.userId) {
+            client.userId = String(data.userId);
+          }
           broadcastPeers(roomId);
           break;
         case 'handoff':

--- a/docs/scene-sync-ai-spec.md
+++ b/docs/scene-sync-ai-spec.md
@@ -1,0 +1,399 @@
+# Scene Sync AI 連携・履歴管理 仕様
+
+## 目的
+
+Scene Sync に Undo/Redo 履歴管理と AI からの代理操作機構を追加する。
+REST API 経由で GPTs などの外部 AI が、ユーザーの代理として 3D シーンを操作できるようにする。
+
+## 核心原則
+
+**人の継続性は AI エージェント側が保持する。**
+
+サーバーはステートレスを維持し、AI が `linkToken` によってユーザーを代理する。
+ブラウザ・タブ・WSS 接続は短命なリソースとして扱い、人（userId）を識別する役割を AI に委ねる。
+
+## 用語
+
+- **peer**: WSS 接続単位。WS 切断で消失する一時的な存在。`peer-{uuid}` 形式。
+- **user**: ブラウザ単位の永続 ID。`scenesync.userId` として localStorage に保存。`usr-{uuid}` 形式。
+  タブ・リロード・ブラウザ再起動を跨いで同一性を保つ。
+- **link**: 特定の userId と特定の room を結ぶ AI の代理権限。`linkToken` で表現。
+- **linkToken**: HMAC 署名付きの代理権限トークン。Bearer として broadcast に添付。
+- **onBehalfOf**: broadcast の `from` フィールドに付与される代理表明。値は userId。
+
+## アーキテクチャ概要
+
+```
+GPT (or any AI)
+   │ HTTPS + Authorization: Bearer <linkToken>
+   ▼
+afjk.jp presence-server
+   ├ /api/link/initiate     (ペアリング開始)
+   ├ /api/link/redeem       (コード→token 交換)
+   ├ /api/link/revoke       (失効)
+   ├ /api/room/{roomId}/broadcast   (linkToken 検証 + onBehalfOf 自動付与)
+   └ /api/room/{roomId}/scene       (シーン取得、既存)
+   │
+   │ WSS broadcast
+   ▼
+ルーム参加者 (Web / Unity / Godot クライアント)
+   │
+   └ HistoryManager (各クライアントが own/proxy 操作のみ履歴化)
+```
+
+## linkToken 設計
+
+### 形式
+
+HMAC-SHA256 による署名付きトークン。サーバー側にセッション保存不要（ステートレス）。
+
+```
+linkToken = base64url(payload) + "." + base64url(hmac_sha256(payload, SECRET))
+
+payload = {
+  linkId: "lnk-{uuid}",
+  userId: "usr-{uuid}",
+  roomId: "abc123",
+  exp: 1735689600000,
+  iat: 1733097600000
+}
+```
+
+### TTL（初期値）
+
+- 30日（`exp = iat + 30 * 24 * 3600 * 1000`）
+- 自動延長は行わない（Phase 5 以降で検討）
+- 失効条件:
+  - 期限到来による自動失効
+  - `/api/link/revoke` 呼び出しによる明示的失効
+  - サーバー側失効リスト（Phase 3 初期はメモリ保持、token 期限まで）
+
+### 短命にしない理由
+
+ブラウザではなく GPT の会話コンテキストが人の継続性を保持するため、
+都度ペアリングは UX を損なう。AI 側のセッション切れ時にのみ再ペアリングが必要。
+
+## ペアリングコード
+
+- 6桁数字（例: `482915`）
+- TTL 5分
+- 1回限り使用（redeem 後は破棄）
+- サーバー内部のメモリマップで管理: `code → { roomId, userId, expiresAt }`
+
+## REST API
+
+### POST /api/link/initiate
+
+ブラウザがペアリングコード発行を要求する。
+
+リクエスト:
+
+```json
+{
+  "roomId": "abc123",
+  "userId": "usr-xxxx-xxxx"
+}
+```
+
+レスポンス（200）:
+
+```json
+{
+  "code": "482915",
+  "expiresAt": 1733097900000
+}
+```
+
+エラー: 400（パラメータ不正）
+
+### POST /api/link/redeem
+
+AI がペアリングコードを linkToken に交換する。
+
+リクエスト:
+
+```json
+{ "code": "482915" }
+```
+
+レスポンス（200）:
+
+```json
+{
+  "linkToken": "eyJsaW5rSWQ...xxxx.yyyy",
+  "linkId": "lnk-xxxx-xxxx",
+  "roomId": "abc123",
+  "expiresAt": 1735689600000
+}
+```
+
+エラー: 400（コード不正）、404（コード未発行 or 期限切れ）、410（既に使用済み）
+
+### POST /api/link/revoke
+
+リンクを明示的に失効する。
+
+リクエスト（どちらか）:
+
+```json
+{ "linkId": "lnk-xxxx-xxxx" }
+```
+
+```
+Authorization: Bearer <linkToken>
+```
+
+レスポンス（200）:
+
+```json
+{ "ok": true }
+```
+
+副作用: ルーム内に `ai-link-revoked` を broadcast。
+
+### POST /api/room/{roomId}/broadcast（拡張）
+
+既存エンドポイントに linkToken 検証を追加。
+
+リクエストヘッダ:
+
+```
+Authorization: Bearer <linkToken>
+```
+
+サーバー側処理:
+
+1. linkToken の HMAC 検証
+2. payload.roomId と URL の roomId が一致することを確認
+3. payload.exp が未来であることを確認
+4. 失効リストに含まれていないことを確認
+5. broadcast の `from` に `onBehalfOf: payload.userId` を自動付与
+
+エラー: 401（token 不正・期限切れ・失効済み）、403（roomId 不一致）
+
+レスポンス（200）に `userPresent` を追加:
+
+```json
+{
+  "ok": true,
+  "room": "abc123",
+  "peers": 3,
+  "userPresent": true
+}
+```
+
+`userPresent` は対象 userId の peer がルームに 1 つ以上接続中なら true。
+GPT が「ユーザーが今いるか」を判断するために利用。
+
+### GET /api/room/{roomId}/scene
+
+既存仕様のまま。linkToken 認証は任意（不要）。
+
+## 新規 Handoff Kind
+
+### ai-link-established
+
+リンク確立時にルーム全体に通知。
+
+```json
+{
+  "kind": "ai-link-established",
+  "linkId": "lnk-xxxx-xxxx",
+  "userId": "usr-xxxx-xxxx",
+  "expiresAt": 1735689600000
+}
+```
+
+### ai-link-revoked
+
+リンク失効時にルーム全体に通知。
+
+```json
+{
+  "kind": "ai-link-revoked",
+  "linkId": "lnk-xxxx-xxxx",
+  "reason": "user-revoked" | "expired" | "ai-revoked"
+}
+```
+
+### scene-batch
+
+複数の操作を 1 つのトランザクションとしてまとめる。Undo/Redo の最小単位として扱う。
+
+```json
+{
+  "kind": "scene-batch",
+  "batchId": "batch-xxxx",
+  "actions": [
+    { "kind": "scene-add", "objectId": "...", ... },
+    { "kind": "scene-delta", "objectId": "...", ... }
+  ]
+}
+```
+
+### ai-command（Web 専用）
+
+ブラウザ固有の操作を AI が依頼する場合に使用。
+
+```json
+{
+  "kind": "ai-command",
+  "requestId": "req-xxxx",
+  "action": "uploadGlbFromUrl" | "screenshot" | "getCameraPose" | "focusObject" | "undo" | "redo" | "getHistory",
+  "params": { ... },
+  "targetPeerId": "peer-xxxx"
+}
+```
+
+`targetPeerId` 未指定時、サーバーが対象 userId の最新接続 peer を補完する。
+
+## 履歴管理
+
+### データ構造
+
+```javascript
+class HistoryManager {
+  undoStack: HistoryEntry[]   // max 100
+  redoStack: HistoryEntry[]   // max 100
+  onChange: (state) => void   // UI 同期コールバック
+}
+
+HistoryEntry = {
+  id: "hist-{timestamp}-{rand}",
+  timestamp: 1733097600000,
+  summary: "Added Cube",      // 表示用
+  forward: BroadcastMessage,  // やり直し時に送信
+  backward: BroadcastMessage  // 取り消し時に送信
+}
+```
+
+### 履歴記録条件
+
+クライアントは以下の broadcast のみ自身の undoStack に push する:
+
+```
+msg.from.id === myPeerId   ||   msg.from.onBehalfOf === myUserId
+```
+
+これにより:
+
+- 自分の操作は履歴に積まれる
+- 自分の代理 AI による操作も履歴に積まれる（ユーザーが自分で Undo できる）
+- 他人の操作は履歴に積まれない（他人の Undo に巻き込まれない）
+
+### 操作と逆操作の対応
+
+| forward | backward |
+|---------|----------|
+| scene-add | scene-remove |
+| scene-remove | scene-add（元データを backward に保存） |
+| scene-delta | scene-delta（変更前 transform を backward に保存） |
+| scene-env | scene-env（変更前 envId を backward に保存） |
+| scene-batch | scene-batch（actions を逆順かつ各要素を逆操作化） |
+
+### redoStack のクリア
+
+新規操作が push されたとき redoStack をクリア。
+他者の broadcast 受信ではクリアしない（自分の redo は他者の操作で無効化されない）。
+
+### 履歴サイズ制限
+
+`MAX_HISTORY = 100`。超過時は最古エントリを shift で破棄。
+
+### 削除済みオブジェクトの Undo 復元
+
+blob store の TTL は 10 分。10 分経過後の `scene-add` Undo（= 削除の取り消し）は
+mesh の再取得に失敗する可能性がある。
+
+Phase 1 の方針: ユーザーに Toast で通知するのみ（オブジェクトは復元失敗）。
+将来的にローカルキャッシュ機構の検討余地あり。
+
+## クライアント実装要件
+
+### Web クライアント
+
+1. `scenesync.userId` を localStorage で永続管理
+2. AI リンク UI:
+   - 「🔗 AIにリンク」ボタンを設定パネルに配置
+   - ボタン押下で `/api/link/initiate` 呼び出し
+   - 6桁コードを画面に表示（5分カウントダウン付き）
+   - リンク中は「✓ AIリンク中」表示と「解除」ボタン
+3. HistoryManager の組み込み（実装済み）
+4. キーバインド: Ctrl+Z / Cmd+Z / Ctrl+Y / Cmd+Shift+Z（実装済み）
+5. モバイルツールバー: ↶ / ↷ ボタン（実装済み）
+6. `ai-command` ハンドラ:
+   - `uploadGlbFromUrl`: 指定 URL から glB を fetch → blob store に POST → scene-add broadcast
+   - `screenshot`: canvas から JPEG エンコード → blob store に POST → URL 返却
+   - `getCameraPose`: 現在のカメラ position/quaternion を返却
+   - `focusObject`: 指定 objectId にカメラを向ける
+   - `undo` / `redo`: HistoryManager 経由で実行
+   - `getHistory`: 直近 N エントリの summary 配列を返却
+
+### Unity / Godot クライアント
+
+- `scenesync.userId` 相当の永続管理（PlayerPrefs / config file）
+- HistoryManager 相当の実装
+- AI リンク UI（簡易でよい）
+- `ai-command` 受信は省略可能（Web 専用機能のため）
+
+## 実装フェーズ
+
+### Phase 1: ローカル Undo/Redo（実装済み）
+
+- HistoryManager クラス実装
+- scene-add / scene-remove / scene-delta / scene-env の履歴記録
+- キーバインドとモバイル UI
+- userId 永続化
+
+### Phase 2: scene-batch 対応（実装済み）
+
+- HistoryManager.createBatchEntry に forward/backward 引数
+- scene-batch の forward/backward 実行ロジック
+
+### Phase 3: ペアリング & onBehalfOf
+
+- presence-server に `/api/link/*` エンドポイント追加
+- broadcast の Bearer 検証と onBehalfOf 自動付与
+- peer-info に userId を含める
+- 受信側で `from.onBehalfOf === myUserId` を履歴条件に追加
+- Web クライアントの AI リンク UI
+
+### Phase 4: GPTs 統合
+
+- OpenAPI 3.x スキーマ作成（getScene, broadcast, link 系）
+- GPT Instructions 作成（座標系、prefer primitive、ロック規則 etc.）
+- 動作テストとサンプル会話
+
+### Phase 5: ai-command 拡充
+
+- uploadGlbFromUrl, screenshot, getCameraPose, focusObject 等の実装
+- 結果取得用エンドポイント or ai-result kind の検討
+
+### Phase 6: Unity / Godot 移植
+
+- 各クライアントへ HistoryManager と userId 永続化を移植
+- ai-command は不要（Web 専用）
+
+## 合意済み原則
+
+- 履歴は自分と自分が代理された AI のみ。他人の操作は積まない。
+- ピア切断で履歴消失（リロード復元は将来検討）。
+- リンクはユーザー主導のコード発行方式。
+- linkToken は長期（30日）、AI 側がユーザー継続性を保持。
+- 部屋一覧 API は提供しない（プライバシー優先）。
+- マジックリンクや QR ペアリングは Phase 5 以降の検討事項。
+
+## 未決定・保留項目
+
+- linkToken の HMAC 署名検証実装詳細（SECRET 管理、ローテーション）
+- 削除オブジェクトの Undo 復元（blob TTL 超過時の挙動）
+- ブラウザリロード時の履歴復元（localStorage 一時保存）
+- 公開 GPTs 化に向けたレートリミットと認可強化
+- room 一覧 API（公開フラグ方式）
+- スナップショット / 名前付き保存機能
+- 自動延長機構（操作ごとに linkToken 期限を延長）
+
+## 関連ドキュメント
+
+- [`docs/scene-sync-spec.md`](./scene-sync-spec.md) — Scene Sync 本体仕様
+- [`docs/pipe-spec.md`](./pipe-spec.md) — Pipe（P2P 通信）仕様

--- a/html/assets/js/scenesync/link/link-manager.js
+++ b/html/assets/js/scenesync/link/link-manager.js
@@ -1,0 +1,114 @@
+export class LinkManager {
+  constructor(baseUrl = window.location.origin + '/presence/api') {
+    this.baseUrl = baseUrl;
+    this.linkToken = null;
+    this.linkId = null;
+    this.expiresAt = null;
+    this.onStatusChange = null;
+  }
+
+  async initiatePairing(roomId, userId) {
+    try {
+      const res = await fetch(`${this.baseUrl}/link/initiate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roomId, userId })
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || 'Failed to initiate pairing');
+      }
+
+      const data = await res.json();
+      return {
+        code: data.code,
+        expiresAt: data.expiresAt
+      };
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async redeemCode(code) {
+    try {
+      const res = await fetch(`${this.baseUrl}/link/redeem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code })
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || 'Failed to redeem code');
+      }
+
+      const data = await res.json();
+      this.linkToken = data.linkToken;
+      this.linkId = data.linkId;
+      this.expiresAt = data.expiresAt;
+
+      if (this.onStatusChange) {
+        this.onStatusChange({
+          isLinked: true,
+          expiresAt: this.expiresAt
+        });
+      }
+
+      return data;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async revoke() {
+    try {
+      const res = await fetch(`${this.baseUrl}/link/revoke`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.linkToken}`
+        },
+        body: JSON.stringify({ linkId: this.linkId })
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || 'Failed to revoke link');
+      }
+
+      this.linkToken = null;
+      this.linkId = null;
+      this.expiresAt = null;
+
+      if (this.onStatusChange) {
+        this.onStatusChange({
+          isLinked: false
+        });
+      }
+
+      return { ok: true };
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  isLinked() {
+    return !!this.linkToken;
+  }
+
+  getLinkToken() {
+    if (!this.linkToken) return null;
+    if (this.expiresAt && Date.now() > this.expiresAt) {
+      this.linkToken = null;
+      this.linkId = null;
+      this.expiresAt = null;
+      return null;
+    }
+    return this.linkToken;
+  }
+}
+
+export function createLinkManager(baseUrl) {
+  return new LinkManager(baseUrl);
+}

--- a/html/assets/js/scenesync/link/link-manager.js
+++ b/html/assets/js/scenesync/link/link-manager.js
@@ -1,3 +1,5 @@
+const LINK_STORAGE_KEY = 'scenesync.linkToken';
+
 export class LinkManager {
   constructor(baseUrl = window.location.origin + '/presence/api') {
     this.baseUrl = baseUrl;
@@ -5,6 +7,28 @@ export class LinkManager {
     this.linkId = null;
     this.expiresAt = null;
     this.onStatusChange = null;
+
+    // localStorage から復元
+    try {
+      const saved = JSON.parse(localStorage.getItem(LINK_STORAGE_KEY) || 'null');
+      if (saved && saved.expiresAt > Date.now()) {
+        this.linkToken = saved.linkToken;
+        this.linkId = saved.linkId;
+        this.expiresAt = saved.expiresAt;
+      }
+    } catch {}
+  }
+
+  #saveLinkToStorage() {
+    if (this.linkToken) {
+      localStorage.setItem(LINK_STORAGE_KEY, JSON.stringify({
+        linkToken: this.linkToken,
+        linkId: this.linkId,
+        expiresAt: this.expiresAt
+      }));
+    } else {
+      localStorage.removeItem(LINK_STORAGE_KEY);
+    }
   }
 
   async initiatePairing(roomId, userId) {
@@ -47,6 +71,7 @@ export class LinkManager {
       this.linkToken = data.linkToken;
       this.linkId = data.linkId;
       this.expiresAt = data.expiresAt;
+      this.#saveLinkToStorage();
 
       if (this.onStatusChange) {
         this.onStatusChange({
@@ -80,6 +105,7 @@ export class LinkManager {
       this.linkToken = null;
       this.linkId = null;
       this.expiresAt = null;
+      this.#saveLinkToStorage();
 
       if (this.onStatusChange) {
         this.onStatusChange({
@@ -103,6 +129,7 @@ export class LinkManager {
       this.linkToken = null;
       this.linkId = null;
       this.expiresAt = null;
+      this.#saveLinkToStorage();
       return null;
     }
     return this.linkToken;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -20,6 +20,7 @@ import { createXrFloorManager } from './xr/xr-floor.js';
 import { createRemoteAvatarManager } from './avatars/remote-avatars.js';
 import { createHistoryManager, HistoryManager } from './history/history-manager.js';
 import { createUserManager } from './user/user-manager.js';
+import { createLinkManager } from './link/link-manager.js';
 
 // ── Three.js 基本セットアップ ────────────────────────────
 
@@ -1644,6 +1645,20 @@ function updatePeersList() {
 
 const userManager = createUserManager();
 
+function getApiBaseUrl() {
+  const params = new URLSearchParams(location.search);
+  const presenceOverride = params.get('presence');
+  if (presenceOverride) {
+    const url = new URL(presenceOverride, window.location.origin);
+    return url.origin + url.pathname + '/api';
+  }
+  const isLocal = location.hostname === 'localhost'
+                 || location.hostname === '127.0.0.1';
+  return isLocal ? 'http://localhost:8787/api' : 'https://afjk.jp/presence/api';
+}
+
+const linkManager = createLinkManager(getApiBaseUrl());
+
 const presenceState = {
   ws: null,
   id: null,
@@ -1652,6 +1667,7 @@ const presenceState = {
   nickname: loadInitialNickname(),
   peers: [],
   historyManager: createHistoryManager(),
+  linkManager,
 };
 
 // 履歴状態が変わったときにボタンを更新
@@ -1695,6 +1711,7 @@ function editNickname() {
       type: 'hello',
       nickname: cleaned,
       device: navigator.userAgent.slice(0, 60),
+      userId: presenceState.userId,
     }));
   }
 }
@@ -1877,6 +1894,7 @@ function connectPresence() {
       type: 'hello',
       nickname: presenceState.nickname,
       device: navigator.userAgent.slice(0, 60),
+      userId: presenceState.userId,
     }));
   };
 
@@ -2064,6 +2082,11 @@ function handleHandoff(data) {
   const payload = data.payload;
   if (!payload || !payload.kind) return;
 
+  // 操作が自分またはAIが代理している場合、履歴に追加するか判定
+  const isOwn = data.from.id === presenceState.id;
+  const isOnBehalfOf = payload.onBehalfOf === presenceState.userId;
+  const shouldTrackHistory = isOwn || isOnBehalfOf;
+
   switch (payload.kind) {
     case 'scene-state': {
       sceneReceived = true;
@@ -2085,24 +2108,66 @@ function handleHandoff(data) {
       break;
     }
     case 'scene-delta': {
-      if (data.from.id === presenceState.id) break; // 自分の echo は無視
+      if (isOwn) break; // 自分の echo は無視
       const obj = managedObjects.get(payload.objectId);
       if (!obj) break;
+      const beforePos = obj.position.toArray();
+      const beforeRot = obj.quaternion.toArray();
+      const beforeScl = obj.scale.toArray();
       if (payload.position) obj.position.fromArray(payload.position);
       if (payload.rotation) obj.quaternion.fromArray(payload.rotation);
       if (payload.scale) obj.scale.fromArray(payload.scale);
+      if (shouldTrackHistory && isOnBehalfOf) {
+        const afterPos = obj.position.toArray();
+        const afterRot = obj.quaternion.toArray();
+        const afterScl = obj.scale.toArray();
+        const historyEntry = HistoryManager.createDeltaEntry(
+          payload.objectId,
+          obj.userData?.name || payload.objectId,
+          beforePos,
+          beforeRot,
+          beforeScl,
+          afterPos,
+          afterRot,
+          afterScl
+        );
+        presenceState.historyManager.push(historyEntry);
+      }
       break;
     }
     case 'scene-add': {
-      if (data.from.id === presenceState.id) break; // 自分の echo は無視
+      if (isOwn) break; // 自分の echo は無視
       addOrUpdateObject(payload.objectId, payload);
+      if (shouldTrackHistory && isOnBehalfOf) {
+        const historyEntry = HistoryManager.createAddEntry(
+          payload.objectId,
+          payload.asset,
+          payload.position || [0, 0, 0],
+          payload.rotation || [0, 0, 0, 1],
+          payload.scale || [1, 1, 1],
+          payload.name || payload.objectId,
+          payload.meshPath
+        );
+        presenceState.historyManager.push(historyEntry);
+      }
       break;
     }
     case 'scene-remove': {
       const objectId = payload.objectId;
+      const obj = managedObjects.get(objectId);
+      if (shouldTrackHistory && isOnBehalfOf && obj) {
+        const historyEntry = HistoryManager.createRemoveEntry(
+          objectId,
+          obj.userData?.name || objectId,
+          obj.userData?.asset || {},
+          obj.position.toArray(),
+          obj.quaternion.toArray(),
+          obj.scale.toArray()
+        );
+        presenceState.historyManager.push(historyEntry);
+      }
       removeLockOverlay(objectId);
       locks.delete(objectId);
-      const obj = managedObjects.get(objectId);
       if (obj) {
         if (transformCtrl.object === obj) { transformCtrl.detach(); hideToolbar(); }
         scene.remove(obj);
@@ -2171,10 +2236,15 @@ function handleHandoff(data) {
     }
     case 'scene-env': {
       if (payload.envId) {
+        const beforeEnvId = environmentManager.getCurrentEnvId?.() || 'outdoor_day';
         environmentManager.loadEnvironment(payload.envId, {
           source: 'remote',
           broadcastChange: false,
         });
+        if (shouldTrackHistory && isOnBehalfOf) {
+          const historyEntry = HistoryManager.createEnvEntry(beforeEnvId, payload.envId);
+          presenceState.historyManager.push(historyEntry);
+        }
       }
       break;
     }
@@ -2500,6 +2570,121 @@ const dragDropManager = new DragDropManager({
     );
   },
 });
+
+// ── AI ペアリング UI ───────────────────────────────────────────────────
+
+const linkBtn = document.getElementById('link-btn');
+const pairingDialog = document.getElementById('pairing-dialog');
+const pairingStepCode = document.getElementById('pairing-step-code');
+const pairingStepLinked = document.getElementById('pairing-step-linked');
+const pairingCode = document.getElementById('pairing-code');
+const pairingTimer = document.getElementById('pairing-timer');
+const pairingError = document.getElementById('pairing-error');
+const btnCancelPairing = document.getElementById('btn-cancel-pairing');
+const btnRevokeLink = document.getElementById('btn-revoke-link');
+const linkIcon = document.getElementById('link-icon');
+const linkLabel = document.getElementById('link-label');
+
+let pairingCountdown = null;
+let pairingExpireTime = null;
+
+function formatTime(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function updatePairingTimer() {
+  if (!pairingExpireTime || !pairingTimer) return;
+  const remaining = pairingExpireTime - Date.now();
+  pairingTimer.textContent = formatTime(remaining);
+  if (remaining <= 0) {
+    cancelPairing();
+  }
+}
+
+async function startPairing() {
+  if (!presenceState.room) {
+    showToast('ルームに接続してからリンクしてください');
+    return;
+  }
+
+  try {
+    pairingError.style.display = 'none';
+    pairingError.textContent = '';
+
+    const result = await presenceState.linkManager.initiatePairing(
+      presenceState.room,
+      presenceState.userId
+    );
+
+    pairingCode.textContent = result.code;
+    pairingExpireTime = result.expiresAt;
+
+    pairingStepCode.style.display = 'block';
+    pairingStepLinked.style.display = 'none';
+    pairingDialog.style.display = 'flex';
+
+    if (pairingCountdown) clearInterval(pairingCountdown);
+    pairingCountdown = setInterval(updatePairingTimer, 100);
+    updatePairingTimer();
+  } catch (err) {
+    pairingError.textContent = err.message;
+    pairingError.style.display = 'block';
+  }
+}
+
+function cancelPairing() {
+  if (pairingCountdown) clearInterval(pairingCountdown);
+  pairingCountdown = null;
+  pairingDialog.style.display = 'none';
+}
+
+async function revokeLink() {
+  try {
+    await presenceState.linkManager.revoke();
+    updateLinkButtonState();
+    showToast('AI リンクを解除しました');
+  } catch (err) {
+    showToast('リンク解除に失敗しました: ' + err.message);
+  }
+}
+
+function updateLinkButtonState() {
+  const isLinked = presenceState.linkManager.isLinked();
+  if (isLinked) {
+    linkIcon.textContent = '✓';
+    linkLabel.textContent = 'AIリンク中';
+    linkBtn.classList.add('active');
+  } else {
+    linkIcon.textContent = '🔗';
+    linkLabel.textContent = 'AIにリンク';
+    linkBtn.classList.remove('active');
+  }
+}
+
+linkBtn?.addEventListener('click', () => {
+  if (presenceState.linkManager.isLinked()) {
+    pairingStepCode.style.display = 'none';
+    pairingStepLinked.style.display = 'block';
+    btnCancelPairing.style.display = 'inline-block';
+    btnRevokeLink.style.display = 'inline-block';
+    const expiresAt = new Date(presenceState.linkManager.expiresAt);
+    document.getElementById('pairing-expires-at').textContent =
+      `有効期限: ${expiresAt.toLocaleDateString()} ${expiresAt.toLocaleTimeString()}`;
+    pairingDialog.style.display = 'flex';
+  } else {
+    startPairing();
+  }
+});
+
+btnCancelPairing?.addEventListener('click', cancelPairing);
+btnRevokeLink?.addEventListener('click', revokeLink);
+
+presenceState.linkManager.onStatusChange = () => {
+  updateLinkButtonState();
+};
 
 // ── 起動 ─────────────────────────────────────────────────
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2258,6 +2258,16 @@ function handleHandoff(data) {
       });
       break;
     }
+    case 'ai-link-revoked': {
+      if (presenceState.linkManager.linkId === payload.linkId) {
+        presenceState.linkManager.linkToken = null;
+        presenceState.linkManager.linkId = null;
+        presenceState.linkManager.expiresAt = null;
+        updateLinkButtonState();
+        showToast('AIリンクが解除されました');
+      }
+      break;
+    }
     default:
       break;
   }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -36,6 +36,8 @@
     .chip.danger:hover { background: rgba(255,60,60,0.7); }
     .chip.primary { background: rgba(68,136,255,0.55); }
     .chip.primary:hover { background: rgba(68,136,255,0.8); }
+    .chip.active { background: rgba(68,136,255,0.7); }
+    .chip.active:hover { background: rgba(68,136,255,0.9); }
     select.chip {
       appearance: auto;
       cursor: pointer;
@@ -291,6 +293,68 @@
     .xr-button-container button:hover {
       background: rgba(68,136,255,0.7) !important;
     }
+    .pairing-dialog {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 300;
+    }
+    .pairing-content {
+      background: rgba(0, 0, 0, 0.9);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 24px;
+      max-width: 320px;
+      color: #fff;
+      font-family: monospace;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+    .pairing-content h3 {
+      font-size: 16px;
+      margin-bottom: 16px;
+      text-align: center;
+    }
+    .pairing-content p {
+      font-size: 13px;
+      margin: 8px 0;
+      color: #aaa;
+    }
+    .pairing-code {
+      font-size: 32px;
+      font-weight: bold;
+      letter-spacing: 0.1em;
+      text-align: center;
+      margin: 16px 0;
+      font-family: monospace;
+      color: #4488ff;
+    }
+    .pairing-timer {
+      font-size: 12px;
+      text-align: center;
+      color: #ff8800;
+      margin-bottom: 16px;
+    }
+    .pairing-error {
+      background: rgba(255, 60, 60, 0.3);
+      border: 1px solid rgba(255, 60, 60, 0.6);
+      border-radius: 6px;
+      padding: 8px;
+      font-size: 12px;
+      color: #ff6666;
+      margin-bottom: 16px;
+    }
+    .pairing-buttons {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+    }
+    .pairing-buttons .chip {
+      flex: 1;
+    }
   </style>
 </head>
 <body>
@@ -310,6 +374,31 @@
         <option value="indoor_warm">室内 暖色</option>
         <option value="studio">Studio</option>
       </select>
+    </div>
+    <div class="row">
+      <button id="link-btn" class="chip" type="button" title="AI とリンク">
+        <span id="link-icon">🔗</span>
+        <span id="link-label">AIにリンク</span>
+      </button>
+    </div>
+    <div id="pairing-dialog" class="pairing-dialog" style="display:none;">
+      <div class="pairing-content">
+        <h3>AI ペアリング</h3>
+        <div id="pairing-step-code">
+          <p>次のコードを AI に入力してください:</p>
+          <div id="pairing-code" class="pairing-code">------</div>
+          <div id="pairing-timer">5:00</div>
+        </div>
+        <div id="pairing-step-linked" style="display:none;">
+          <p>✓ AI とリンクしました</p>
+          <p id="pairing-expires-at"></p>
+        </div>
+        <div id="pairing-error" style="display:none;" class="pairing-error"></div>
+        <div class="pairing-buttons">
+          <button id="btn-cancel-pairing" class="chip">キャンセル</button>
+          <button id="btn-revoke-link" class="chip danger" style="display:none;">リンク解除</button>
+        </div>
+      </div>
     </div>
     <div class="row" id="room-section"></div>
   </div>


### PR DESCRIPTION
## Summary

This PR implements AI pairing functionality and extends history tracking to support operations performed by AI agents on behalf of users. It introduces a linkToken-based authentication system for REST API access, allowing external AI systems (like GPTs) to perform 3D scene operations as a user's proxy while maintaining proper history and audit trails.

## Key Changes

### Server-side (presence-server)
- **New link token module** (`link-token.mjs`): Implements HMAC-SHA256 signed tokens for AI pairing with 30-day TTL
  - `createLinkToken()`: Generates stateless tokens with payload containing linkId, userId, roomId, and expiration
  - `verifyLinkToken()`: Validates token signature and expiration
  - `initiatePairingCode()`: Creates 6-digit pairing codes (5-minute TTL)
  - `redeemPairingCode()`: Exchanges codes for linkTokens
  - `revokeLinkToken()`: Adds tokens to revocation list
  
- **New REST API endpoints**:
  - `POST /api/link/initiate`: Browser initiates pairing code generation
  - `POST /api/link/redeem`: AI redeems code for linkToken
  - `POST /api/link/revoke`: Revokes a link (via linkId or Bearer token)
  
- **Enhanced broadcast endpoint** (`POST /api/room/{roomId}/broadcast`):
  - Validates Bearer token if provided
  - Automatically adds `onBehalfOf` field to payload with userId from token
  - Returns `userPresent` flag indicating if target user has active peer connection
  
- **Peer tracking**: Added `userId` field to client objects and peer info responses

### Client-side (Web)
- **New LinkManager class** (`link-manager.js`): Manages pairing lifecycle
  - `initiatePairing()`: Requests pairing code from server
  - `redeemCode()`: Exchanges code for token (for future AI use)
  - `revoke()`: Revokes active link
  - `isLinked()`: Checks if currently linked
  - `getLinkToken()`: Returns valid token or null if expired
  
- **AI pairing UI**: New dialog and button in settings panel
  - "🔗 AIにリンク" button shows pairing code with 5-minute countdown
  - Displays "✓ AIリンク中" when linked with revoke option
  - Error handling and visual feedback
  
- **Extended history tracking**: Operations now tracked when:
  - Performed by own peer (`from.id === myPeerId`), OR
  - Performed by AI on behalf of user (`onBehalfOf === myUserId`)
  - Applies to scene-add, scene-remove, scene-delta, and scene-env operations
  - Prevents other users' operations from polluting local undo/redo stack
  
- **userId persistence**: Added to hello message and peer info for proper attribution

## Implementation Details

- **Stateless design**: Server maintains no session state for tokens; validation is cryptographic
- **In-memory storage**: Pairing codes and revocation list stored in-memory with automatic cleanup (production should use Redis)
- **Backward compatible**: Existing broadcast API works without Bearer token; linkToken is optional
- **History isolation**: Each user's undo/redo stack only contains their own operations and AI operations performed on their behalf
- **API base URL detection**: Supports both local development (`localhost:8787`) and production (`afjk.jp/presence/api`) with query parameter override

## Related Specification

Implements the "Scene Sync AI 連携・履歴管理 仕様" (Scene Sync AI Integration & History Management Specification) documented in `docs/scene-sync-ai-spec.md`.

https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ