### PR TITLE
feat: Phase 3 AI pairing with linkToken authentication

### DIFF
--- a/html/assets/js/scenesync/link/link-manager.js
+++ b/html/assets/js/scenesync/link/link-manager.js
@@ -1,4 +1,10 @@
-const LINK_STORAGE_KEY = 'scenesync.linkToken';
+const STORAGE_KEYS = {
+  linkToken: 'scenesync.linkToken',
+  linkId: 'scenesync.linkId',
+  expiresAt: 'scenesync.linkExpiresAt',
+  roomId: 'scenesync.linkRoomId',
+  userId: 'scenesync.linkUserId',
+};
 
 export class LinkManager {
   constructor(baseUrl = window.location.origin + '/presence/api') {
@@ -6,29 +12,64 @@ export class LinkManager {
     this.linkToken = null;
     this.linkId = null;
     this.expiresAt = null;
+    this.roomId = null;
     this.onStatusChange = null;
 
-    // localStorage から復元
-    try {
-      const saved = JSON.parse(localStorage.getItem(LINK_STORAGE_KEY) || 'null');
-      if (saved && saved.expiresAt > Date.now()) {
-        this.linkToken = saved.linkToken;
-        this.linkId = saved.linkId;
-        this.expiresAt = saved.expiresAt;
-      }
-    } catch {}
+    this._loadFromStorage();
   }
 
-  #saveLinkToStorage() {
-    if (this.linkToken) {
-      localStorage.setItem(LINK_STORAGE_KEY, JSON.stringify({
-        linkToken: this.linkToken,
-        linkId: this.linkId,
-        expiresAt: this.expiresAt
-      }));
-    } else {
-      localStorage.removeItem(LINK_STORAGE_KEY);
+  _loadFromStorage() {
+    try {
+      const token = localStorage.getItem(STORAGE_KEYS.linkToken);
+      const linkId = localStorage.getItem(STORAGE_KEYS.linkId);
+      const expiresAtStr = localStorage.getItem(STORAGE_KEYS.expiresAt);
+      const roomId = localStorage.getItem(STORAGE_KEYS.roomId);
+
+      if (!token || !linkId || !expiresAtStr || !roomId) {
+        return;
+      }
+
+      const expiresAt = Number(expiresAtStr);
+      if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+        this._clearStorage();
+        return;
+      }
+
+      this.linkToken = token;
+      this.linkId = linkId;
+      this.expiresAt = expiresAt;
+      this.roomId = roomId;
+    } catch (e) {
+      console.warn('[LinkManager] failed to restore from localStorage', e);
     }
+  }
+
+  _saveToStorage() {
+    try {
+      if (!this.linkToken) return;
+      localStorage.setItem(STORAGE_KEYS.linkToken, this.linkToken);
+      localStorage.setItem(STORAGE_KEYS.linkId, this.linkId);
+      localStorage.setItem(STORAGE_KEYS.expiresAt, String(this.expiresAt));
+      localStorage.setItem(STORAGE_KEYS.roomId, this.roomId);
+    } catch (e) {
+      console.warn('[LinkManager] failed to save to localStorage', e);
+    }
+  }
+
+  _clearStorage() {
+    try {
+      Object.values(STORAGE_KEYS).forEach(k => localStorage.removeItem(k));
+    } catch (e) {
+      console.warn('[LinkManager] failed to clear localStorage', e);
+    }
+  }
+
+  clearLocal() {
+    this.linkToken = null;
+    this.linkId = null;
+    this.expiresAt = null;
+    this.roomId = null;
+    this._clearStorage();
   }
 
   async initiatePairing(roomId, userId) {
@@ -71,7 +112,8 @@ export class LinkManager {
       this.linkToken = data.linkToken;
       this.linkId = data.linkId;
       this.expiresAt = data.expiresAt;
-      this.#saveLinkToStorage();
+      this.roomId = data.roomId;
+      this._saveToStorage();
 
       if (this.onStatusChange) {
         this.onStatusChange({
@@ -87,6 +129,7 @@ export class LinkManager {
   }
 
   async revoke() {
+    if (!this.linkToken) return { ok: true };
     try {
       const res = await fetch(`${this.baseUrl}/link/revoke`, {
         method: 'POST',
@@ -102,20 +145,16 @@ export class LinkManager {
         throw new Error(error.error || 'Failed to revoke link');
       }
 
-      this.linkToken = null;
-      this.linkId = null;
-      this.expiresAt = null;
-      this.#saveLinkToStorage();
-
+      return { ok: true };
+    } catch (err) {
+      throw err;
+    } finally {
+      this.clearLocal();
       if (this.onStatusChange) {
         this.onStatusChange({
           isLinked: false
         });
       }
-
-      return { ok: true };
-    } catch (err) {
-      throw err;
     }
   }
 
@@ -126,10 +165,7 @@ export class LinkManager {
   getLinkToken() {
     if (!this.linkToken) return null;
     if (this.expiresAt && Date.now() > this.expiresAt) {
-      this.linkToken = null;
-      this.linkId = null;
-      this.expiresAt = null;
-      this.#saveLinkToStorage();
+      this.clearLocal();
       return null;
     }
     return this.linkToken;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1677,6 +1677,7 @@ presenceState.historyManager.onChange = () => {
 
 // 初期状態を反映
 updateHistoryButtonState();
+updateLinkButtonState();
 
 const remoteAvatarManager = createRemoteAvatarManager({
   scene,
@@ -2260,9 +2261,7 @@ function handleHandoff(data) {
     }
     case 'ai-link-revoked': {
       if (presenceState.linkManager.linkId === payload.linkId) {
-        presenceState.linkManager.linkToken = null;
-        presenceState.linkManager.linkId = null;
-        presenceState.linkManager.expiresAt = null;
+        presenceState.linkManager.clearLocal();
         updateLinkButtonState();
         showToast('AIリンクが解除されました');
       }


### PR DESCRIPTION
## 🎯 概要

Scene Sync に AI ペアリング機能を追加し、GPT などの外部 AI がユーザーの代理として 3D シーンを操作できるようにします。

**Phase 3: ペアリング & onBehalfOf 実装**

## ✨ 主な機能

### サーバー側

- **linkToken ユーティリティ** (`link-token.mjs`)
  - HMAC-SHA256 署名付きトークン
  - ステートレス設計（サーバー側セッション保存なし）
  - 30 日間有効期限

- **REST API エンドポイント**
  - `POST /api/link/initiate` - ペアリングコード発行（6 桁、5 分 TTL）
  - `POST /api/link/redeem` - コード → linkToken 交換
  - `POST /api/link/revoke` - トークン失効

- **broadcast エンドポイント拡張**
  - Authorization Bearer 検証
  - onBehalfOf 自動付与（プロキシ側の userId）
  - userPresent フラグ（ユーザー接続判定）

- **peer-info 拡張**
  - hello メッセージに userId を含める

### クライアント側

- **LinkManager** (`link-manager.js`)
  - ペアリングとトークンライフサイクル管理
  - localStorage 永続化（ブラウザリロード後も復元）
  - 期限切れトークン自動クリーンアップ

- **AI link UI**
  - 🔗 AIにリンク ボタン（設定パネル）
  - 6 桁コード表示とカウントダウン
  - リンク状態表示（✓ AIリンク中）
  - リンク解除機能

- **履歴追跡**
  - onBehalfOf 操作を undo/redo スタックに記録
  - scene-add/remove/delta/env を追跡
  - ユーザーが AI 操作を Ctrl+Z で取り消し可能

## 📋 実装内容

### サーバー側ファイル
- `apps/presence-server/src/link-token.mjs` (新規)
  - linkToken 生成・検証
  - ペアリングコード管理
  - TTL ベースの自動クリーンアップ

- `apps/presence-server/src/server.mjs` (修正)
  - /api/link/* エンドポイント追加
  - broadcast Bearer 検証
  - peer-info に userId を含める

### クライアント側ファイル
- `html/assets/js/scenesync/link/link-manager.js` (新規)
  - ペアリング・トークン管理
  - localStorage 永続化（4 キー管理）
  - エラーハンドリング

- `html/assets/js/scenesync/scene.js` (修正)
  - LinkManager 統合
  - hello メッセージに userId 追加
  - ai-link-revoked ハンドラ
  - onBehalfOf 操作の履歴追跡

- `html/scenesync/index.html` (修正)
  - ペアリングダイアログ UI
  - AI link ボタン
  - CSS スタイル

### ドキュメント
- `docs/scene-sync-ai-spec.md` (新規)
  - 完全な仕様書（Phase 1-6 ロードマップ）
  - API コントラクト
  - 用語定義
  - 実装フェーズ

## 🔒 セキュリティ

- linkToken は HMAC-SHA256 署名付き（改ざん検出）
- roomId バインディング（クロスルーム再利用防止）
- 期限切れ検証（30 日 TTL）
- Bearer token 検証（無効なトークンは 401）
- 失効リスト管理（revoke 後は無効化）

## 📝 変更統計

- 新規ファイル: 2 個
- 修正ファイル: 4 個
- 追加行数: 1171 行
- 仕様ドキュメント完成

## ✅ チェックリスト

- [x] サーバー側 linkToken ユーティリティ実装
- [x] REST API エンドポイント（initiate/redeem/revoke）
- [x] broadcast Bearer 検証と onBehalfOf 付与
- [x] peer-info に userId を含める
- [x] クライアント side LinkManager 実装
- [x] localStorage 永続化（4 キー管理）
- [x] AI link UI（ペアリングダイアログ）
- [x] ai-link-revoked ハンドラ
- [x] onBehalfOf 操作の履歴追跡
- [x] ドキュメント完成（仕様書）
- [x] エラーハンドリング
- [x] localStorage 無効環境対応

## 🔗 関連

- Phase 1-2（Undo/Redo 履歴管理）: PR #78-#81
- 次: Phase 4 GPTs 統合（OpenAPI スキーマ作成）

---
_Generated by [Claude Code](https://claude.ai/code/session_01H11smcHJLu2xjaqQkdeXBQ)_