### PR TITLE
Simplify privacy policy page for Scene Sync service

### DIFF
--- a/html/scenesync/privacy/index.html
+++ b/html/scenesync/privacy/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scene Sync プライバシーポリシー - afjk.jp</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html {
+      font-size: 16px;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: #fff;
+    }
+
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+      margin-top: 0;
+    }
+
+    h2 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin-top: 32px;
+      margin-bottom: 12px;
+      color: #222;
+    }
+
+    p {
+      margin-bottom: 12px;
+      color: #555;
+    }
+
+    ul {
+      margin-left: 1.5em;
+      margin-bottom: 12px;
+      color: #555;
+    }
+
+    li {
+      margin-bottom: 8px;
+    }
+
+    a {
+      color: #0066cc;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    .updated {
+      font-size: 0.9rem;
+      color: #888;
+      margin-bottom: 32px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Scene Sync プライバシーポリシー</h1>
+    <p class="updated">最終更新日: 2026-04-29</p>
+
+    <p>Scene Sync（以下「本サービス」）は個人開発の実験的サービスです。本ポリシーは現時点での運用方針を示すもので、予告なく変更される場合があります。</p>
+
+    <h2>取得する情報</h2>
+    <p>本サービスは、機能提供に必要な範囲で次の情報を取り扱います。</p>
+    <ul>
+      <li>ペアリングコード、認証トークン（linkToken / sessionId）</li>
+      <li>ルーム識別子（roomId）、ブラウザが生成するランダム ID（userId）</li>
+      <li>利用者が GPT またはブラウザを通じて送信するシーン操作データ、アップロードファイル、スクリーンショット</li>
+      <li>アクセスログ等の運用上必要な情報</li>
+    </ul>
+    <p>氏名・メールアドレス等、利用者を直接特定する情報は本サービスから能動的には取得しません。ChatGPT 上での会話内容の取扱いは OpenAI のポリシーに従います。</p>
+
+    <h2>利用目的</h2>
+    <p>取得した情報は本サービスの提供および運用のために利用します。</p>
+
+    <h2>保管</h2>
+    <p>トークン・アップロードファイル等は機能上必要な期間サーバーに保持され、その後順次削除されます。具体的な保持期間は予告なく変更される場合があります。</p>
+
+    <h2>第三者提供</h2>
+    <p>法令に基づく場合を除き、第三者への提供は行いません。</p>
+
+    <h2>利用者の操作</h2>
+    <p>「リンク解除」操作によりトークンを無効化できます。ブラウザの localStorage をクリアすることで端末内に保存された情報を削除できます。</p>
+
+    <h2>免責</h2>
+    <p>本サービスは現状有姿で提供されます。本サービスの利用または利用不能により生じたいかなる損害についても、運営者は責任を負いません。</p>
+
+    <h2>お問い合わせ</h2>
+    <p>GitHub Issues: <a href="https://github.com/afjk/afjk.jp/issues" target="_blank" rel="noopener">https://github.com/afjk/afjk.jp/issues</a></p>
+    <p>公開を望まない内容については、Issue 内でその旨をお知らせください。</p>
+
+    <h2>改定</h2>
+    <p>本ポリシーは予告なく改定される場合があります。最新版は本ページに掲載されます。</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Completely redesigned the privacy policy page to focus on the "Scene Sync" service instead of the previous "pipe" file transfer tool. The page has been simplified with a cleaner, lighter design and more concise content.

## Key Changes
- **Service Update**: Changed from "pipe" (P2P file transfer) to "Scene Sync" (scene operation/collaboration service)
- **Design Overhaul**: 
  - Removed dark theme (dark background with accent colors) in favor of light theme (white background, dark text)
  - Eliminated navigation bar and language toggle functionality
  - Simplified CSS significantly (from ~150 lines to ~70 lines)
  - Removed footer and JavaScript language switching logic
- **Content Restructuring**:
  - Reduced from 8 sections to 7 more concise sections
  - Updated privacy policy to reflect Scene Sync's actual data handling (pairing codes, tokens, room IDs, scene operation data, file uploads)
  - Removed Google Drive/OAuth-specific content
  - Added information about token invalidation and localStorage management
  - Changed contact method from Twitter to GitHub Issues
- **Metadata Updates**:
  - Simplified meta tags (removed favicon references, description)
  - Changed charset from UTF-8 to utf-8
  - Updated title to Japanese-only format
  - Updated last modified date to 2026-04-29

## Implementation Details
- Single-language Japanese content (removed bilingual support)
- Removed all interactive elements (language toggle buttons)
- Streamlined styling with standard web colors (#333, #555, #0066cc) instead of CSS variables
- Maintained responsive design with max-width constraint and padding

https://claude.ai/code/session_01YY6evkNV4UAbgFLoRDgPza