### PR TITLE
fix: Safari バックグラウンド復帰時の WebSocket 再接続遅延を修正

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2997,6 +2997,34 @@ nicknameChip?.addEventListener('click', editNickname);
 updateNicknameLabel();
 renderRoomSection();
 connectPresence();
+
+// Safari / iOS: バックグラウンドから復帰時に即再接続（3秒タイマーを待たない）
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') return;
+  const ws = presenceState.ws;
+  if (ws && ws.readyState === WebSocket.OPEN) return;
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
+  if (ws && presenceState.ws === ws) {
+    presenceState.ws = null;
+    try { ws.close(); } catch {}
+  }
+  connectPresence();
+});
+
+// Safari BFCache 復元時の再接続
+window.addEventListener('pageshow', (e) => {
+  if (!e.persisted) return;
+  const ws = presenceState.ws;
+  if (ws && ws.readyState === WebSocket.OPEN) return;
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
+  if (ws && presenceState.ws === ws) {
+    presenceState.ws = null;
+    try { ws.close(); } catch {}
+  }
+  connectPresence();
+});
 environmentManager.loadEnvironment('outdoor_day', {
   source: 'init',
   broadcastChange: false,


### PR DESCRIPTION
## 概要

iPhone Safari で GPTs などの他アプリに切り替えた後に戻ると「再接続中…」が表示され、接続が回復するまで数秒かかる問題を修正。

## 原因

- Safari がバックグラウンドになると WebSocket への pong 応答が止まる
- サーバー側は 30〜60 秒後に死んだ接続を切断
- Safari に戻るまで `onclose` が処理されないため、復帰後に 3 秒の再接続タイマーが走る

## 修正内容

`html/assets/js/scenesync/scene.js` に以下を追加:

- **`visibilitychange`**: ページが visible になったとき、WebSocket が OPEN でなければ即座に再接続（3 秒タイマー不要）
- **`pageshow` (persisted)**: Safari の BFCache 復元時も同様に即再接続

## テスト方法

1. Safari で Scene Sync を開く
2. GPTs など別アプリに切り替え、数十秒待つ
3. Safari に戻る → 「再接続中…」がほぼ瞬時に解消されることを確認

https://claude.ai/code/session_01834JdnELnwAVxap8jbDjcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01834JdnELnwAVxap8jbDjcj)_