### PR TITLE
feat: Blender addon for Scene Sync

### DIFF
--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -40,8 +40,6 @@ class _State:
         self.ws = ws_client.SceneSyncWSClient()
         self.blob_url = ""
         self.status = "未接続"
-        self.my_id = ""
-        self.current_room = ""
         self.peers: list = []
 
         # object_id → {"name": str, "snapshot": list[3 lists], "remote": bool, "mesh_path": str}
@@ -49,7 +47,7 @@ class _State:
         # blender object name → object_id  (for quick lookup)
         self.name_to_id: dict = {}
 
-        self.locks: dict = {}          # object_id → peer_id
+        self.locks: dict = {}
         self.scene_received = False
         self.first_peers_seen = False
 
@@ -180,7 +178,7 @@ def _handle_payload(payload: dict, from_info: dict) -> None:
             _apply_scene_delta(payload)
 
     elif kind == "scene-remove":
-        _apply_scene_remove(payload, from_id)
+        _apply_scene_remove(payload)
 
     elif kind == "scene-mesh":
         if from_id != _state.ws.my_id:
@@ -260,14 +258,13 @@ def _apply_scene_delta(payload: dict) -> None:
     _state.managed[oid]["snapshot"] = _obj_snapshot(obj)
 
 
-def _apply_scene_remove(payload: dict, from_id: str) -> None:
+def _apply_scene_remove(payload: dict) -> None:
     oid = str(payload.get("objectId", ""))
     if oid not in _state.managed:
         return
     info = _state.managed[oid]
-    # Only remove objects that came from the same peer who is removing them,
-    # or remote objects (never delete user's own local work without consent).
-    if not info.get("remote") and from_id == _state.ws.my_id:
+    # Never delete user-created (local) objects based on remote instructions.
+    if not info.get("remote"):
         return
 
     obj = _find_blender_obj(oid)
@@ -459,23 +456,26 @@ def _create_primitive(primitive: str, color_hex: str, name: str) -> bpy.types.Ob
 
 
 def _apply_transform(obj: bpy.types.Object, tf: dict) -> None:
-    from mathutils import Quaternion, Vector
+    from mathutils import Matrix
 
-    loc_wire = tf.get("loc")
-    rot_wire = tf.get("rot")
-    scl_wire = tf.get("scale")
+    loc = tf.get("loc")
+    rot = tf.get("rot")
+    scl = tf.get("scale")
 
-    if loc_wire is not None:
-        obj.location = loc_wire
-    if rot_wire is not None:
-        if isinstance(rot_wire, (list, tuple)):
-            obj.rotation_mode = "QUATERNION"
-            obj.rotation_quaternion = rot_wire
-        else:
-            obj.rotation_mode = "QUATERNION"
-            obj.rotation_quaternion = rot_wire
-    if scl_wire is not None:
-        obj.scale = scl_wire
+    if loc is None and rot is None and scl is None:
+        return
+
+    # Decompose current world transform to fill in missing components.
+    cur_loc, cur_rot, cur_scl = obj.matrix_world.decompose()
+    new_loc = loc if loc is not None else cur_loc
+    new_rot = rot if rot is not None else cur_rot
+    new_scl = scl if scl is not None else cur_scl
+
+    obj.matrix_world = (
+        Matrix.Translation(new_loc)
+        @ new_rot.to_matrix().to_4x4()
+        @ Matrix.Diagonal([new_scl.x, new_scl.y, new_scl.z, 1.0])
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -1,0 +1,672 @@
+"""Scene Sync — Blender addon.
+
+Syncs the Blender scene with a browser / Unity / Godot via the
+Scene Sync presence server REST + WebSocket protocol.
+"""
+
+bl_info = {
+    "name": "Scene Sync",
+    "author": "afjk",
+    "version": (0, 1, 0),
+    "blender": (4, 0, 0),
+    "location": "View3D > Sidebar > Scene Sync",
+    "description": "Real-time 3D scene sync with browser, Unity, and Godot",
+    "category": "3D View",
+    "doc_url": "https://github.com/afjk/afjk.jp",
+}
+
+import bpy
+from bpy.props import StringProperty
+from bpy.types import Operator, Panel, PropertyGroup
+
+from . import blob_client, protocol, ws_client
+from .glb_helper import export_object_as_glb, import_glb
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+POLL_INTERVAL = 0.05          # seconds between timer ticks
+DELTA_THRESHOLD = 0.0001      # min change before sending scene-delta
+OBJECT_ID_PROP = "scene_sync_id"
+REMOTE_PROP = "scene_sync_remote"   # True on objects received from server
+
+# ---------------------------------------------------------------------------
+# Addon state (singleton, lives for the session)
+# ---------------------------------------------------------------------------
+
+class _State:
+    def __init__(self) -> None:
+        self.ws = ws_client.SceneSyncWSClient()
+        self.blob_url = ""
+        self.status = "未接続"
+        self.my_id = ""
+        self.current_room = ""
+        self.peers: list = []
+
+        # object_id → {"name": str, "snapshot": list[3 lists], "remote": bool, "mesh_path": str}
+        self.managed: dict = {}
+        # blender object name → object_id  (for quick lookup)
+        self.name_to_id: dict = {}
+
+        self.locks: dict = {}          # object_id → peer_id
+        self.scene_received = False
+        self.first_peers_seen = False
+
+    def reset_scene(self) -> None:
+        self.managed.clear()
+        self.name_to_id.clear()
+        self.locks.clear()
+        self.scene_received = False
+        self.first_peers_seen = False
+
+
+_state = _State()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot helpers
+# ---------------------------------------------------------------------------
+
+def _snap(loc, rot, scale) -> list:
+    """Store transform as three plain lists for easy comparison."""
+    return [list(loc), list(rot), list(scale)]
+
+
+def _snaps_equal(a: list, b: list) -> bool:
+    if not a or not b:
+        return False
+    for va, vb in zip(a, b):
+        for x, y in zip(va, vb):
+            if abs(x - y) > DELTA_THRESHOLD:
+                return False
+    return True
+
+
+def _obj_snapshot(obj: bpy.types.Object) -> list:
+    loc, rot, scale = obj.matrix_world.decompose()
+    return _snap(
+        protocol.pos_to_wire(loc),
+        protocol.rot_to_wire(rot),
+        protocol.scale_to_wire(scale),
+    )
+
+
+# ---------------------------------------------------------------------------
+# WebSocket message handlers
+# ---------------------------------------------------------------------------
+
+def _handle_ws_messages() -> None:
+    for msg in _state.ws.poll():
+        internal = msg.get("_internal")
+        if internal == "_connected":
+            _state.status = f"接続中 — {_state.ws.room}"
+            _force_redraw()
+            continue
+        if internal == "_disconnected":
+            _state.status = "未接続"
+            _state.peers = []
+            _state.ws.my_id = ""
+            _force_redraw()
+            continue
+
+        msg_type = msg.get("type", "")
+        if msg_type == "welcome":
+            _state.ws.my_id = str(msg.get("id", ""))
+            _state.ws.room = str(msg.get("room", _state.ws.room))
+            _state.status = f"接続中 — {_state.ws.room}"
+            _force_redraw()
+
+        elif msg_type == "peers":
+            raw = msg.get("peers", [])
+            _state.peers = [p for p in raw if isinstance(p, dict)]
+            _state.ws.peers = _state.peers
+            _update_peer_status()
+            if not _state.first_peers_seen and _state.peers:
+                _state.first_peers_seen = True
+                if not _state.scene_received:
+                    _request_scene()
+            _force_redraw()
+
+        elif msg_type == "handoff":
+            payload = msg.get("payload", {})
+            from_info = msg.get("from", {})
+            _handle_payload(payload, from_info)
+
+
+def _update_peer_status() -> None:
+    n = len(_state.peers)
+    _state.status = f"接続中 — {_state.ws.room} — {n}人"
+
+
+def _request_scene() -> None:
+    for peer in _state.peers:
+        peer_id = str(peer.get("id", ""))
+        if peer_id and peer_id != _state.ws.my_id:
+            _state.ws.send_json({
+                "type": "handoff",
+                "targetId": peer_id,
+                "payload": protocol.make_scene_request(),
+            })
+            return
+    _state.scene_received = True
+
+
+# ---------------------------------------------------------------------------
+# Payload dispatch
+# ---------------------------------------------------------------------------
+
+def _handle_payload(payload: dict, from_info: dict) -> None:
+    kind = str(payload.get("kind", ""))
+    from_id = str(from_info.get("id", ""))
+
+    if kind == "scene-request":
+        _send_scene_state(from_id)
+
+    elif kind == "scene-state":
+        _state.scene_received = True
+        objects = payload.get("objects", {})
+        if isinstance(objects, dict):
+            for oid, info in objects.items():
+                if isinstance(info, dict):
+                    _apply_scene_add({**info, "objectId": oid}, from_id="")
+
+    elif kind == "scene-add":
+        if from_id != _state.ws.my_id:
+            _apply_scene_add(payload, from_id)
+
+    elif kind == "scene-delta":
+        if from_id != _state.ws.my_id:
+            _apply_scene_delta(payload)
+
+    elif kind == "scene-remove":
+        _apply_scene_remove(payload, from_id)
+
+    elif kind == "scene-mesh":
+        if from_id != _state.ws.my_id:
+            _apply_scene_mesh(payload)
+
+    elif kind == "scene-lock":
+        oid = str(payload.get("objectId", ""))
+        if oid and from_id:
+            _state.locks[oid] = from_id
+
+    elif kind == "scene-unlock":
+        oid = str(payload.get("objectId", ""))
+        _state.locks.pop(oid, None)
+
+
+# ---------------------------------------------------------------------------
+# Incoming: apply remote changes to Blender scene
+# ---------------------------------------------------------------------------
+
+def _apply_scene_add(payload: dict, from_id: str) -> None:
+    oid = str(payload.get("objectId", ""))
+    if not oid:
+        return
+
+    # Already tracked → just update transform
+    if oid in _state.managed:
+        _apply_scene_delta(payload)
+        return
+
+    name = str(payload.get("name", oid))
+    asset = payload.get("asset", {})
+    mesh_path = str(payload.get("meshPath", ""))
+
+    obj: bpy.types.Object | None = None
+
+    if isinstance(asset, dict):
+        atype = str(asset.get("type", ""))
+        if atype == "primitive":
+            obj = _create_primitive(
+                str(asset.get("primitive", "box")),
+                str(asset.get("color", "#888888")),
+                name,
+            )
+        elif atype == "mesh":
+            mesh_path = str(asset.get("meshPath", mesh_path))
+
+    if obj is None and mesh_path:
+        data = blob_client.download_glb(_state.blob_url, mesh_path)
+        if data:
+            obj = import_glb(data, name)
+        if obj is None:
+            obj = _create_primitive("box", "#88ccff", name)
+
+    if obj is None:
+        obj = _create_primitive("box", "#888888", name)
+
+    obj[OBJECT_ID_PROP] = oid
+    obj[REMOTE_PROP] = True
+
+    tf = protocol.extract_transform(payload)
+    _apply_transform(obj, tf)
+
+    snap = _obj_snapshot(obj)
+    _state.managed[oid] = {"name": obj.name, "snapshot": snap, "remote": True, "mesh_path": mesh_path}
+    _state.name_to_id[obj.name] = oid
+
+
+def _apply_scene_delta(payload: dict) -> None:
+    oid = str(payload.get("objectId", ""))
+    if oid not in _state.managed:
+        return
+    obj = _find_blender_obj(oid)
+    if obj is None:
+        return
+    tf = protocol.extract_transform(payload)
+    _apply_transform(obj, tf)
+    _state.managed[oid]["snapshot"] = _obj_snapshot(obj)
+
+
+def _apply_scene_remove(payload: dict, from_id: str) -> None:
+    oid = str(payload.get("objectId", ""))
+    if oid not in _state.managed:
+        return
+    info = _state.managed[oid]
+    # Only remove objects that came from the same peer who is removing them,
+    # or remote objects (never delete user's own local work without consent).
+    if not info.get("remote") and from_id == _state.ws.my_id:
+        return
+
+    obj = _find_blender_obj(oid)
+    if obj:
+        bpy.data.objects.remove(obj, do_unlink=True)
+
+    _state.name_to_id.pop(info.get("name", ""), None)
+    del _state.managed[oid]
+    _state.locks.pop(oid, None)
+
+
+def _apply_scene_mesh(payload: dict) -> None:
+    oid = str(payload.get("objectId", ""))
+    mesh_path = str(payload.get("meshPath", ""))
+    if not oid or not mesh_path:
+        return
+    data = blob_client.download_glb(_state.blob_url, mesh_path)
+    if not data:
+        return
+
+    old = _find_blender_obj(oid)
+    new = import_glb(data, str(payload.get("name", oid)))
+    if new is None:
+        return
+
+    new[OBJECT_ID_PROP] = oid
+    new[REMOTE_PROP] = True
+
+    if old:
+        # Copy transform then remove old
+        new.matrix_world = old.matrix_world.copy()
+        bpy.data.objects.remove(old, do_unlink=True)
+
+    if oid in _state.managed:
+        _state.name_to_id.pop(_state.managed[oid].get("name", ""), None)
+        _state.managed[oid]["name"] = new.name
+        _state.managed[oid]["mesh_path"] = mesh_path
+    else:
+        _state.managed[oid] = {"name": new.name, "snapshot": [], "remote": True, "mesh_path": mesh_path}
+
+    _state.name_to_id[new.name] = oid
+    _state.managed[oid]["snapshot"] = _obj_snapshot(new)
+
+
+# ---------------------------------------------------------------------------
+# Outgoing: broadcast local scene changes
+# ---------------------------------------------------------------------------
+
+def _send_scene_state(to_peer_id: str) -> None:
+    objects: dict = {}
+    for oid, info in list(_state.managed.items()):
+        obj = _find_blender_obj(oid)
+        if obj is None:
+            continue
+        loc, rot, scale = obj.matrix_world.decompose()
+        entry = {
+            "name": obj.name,
+            "position": protocol.pos_to_wire(loc),
+            "rotation": protocol.rot_to_wire(rot),
+            "scale": protocol.scale_to_wire(scale),
+        }
+        mesh_path = info.get("mesh_path", "")
+        if mesh_path:
+            entry["asset"] = {"type": "mesh", "meshPath": mesh_path}
+        objects[oid] = entry
+
+    _state.ws.send_json({
+        "type": "handoff",
+        "targetId": to_peer_id,
+        "payload": protocol.make_scene_state(objects),
+    })
+
+
+def _check_scene_changes() -> None:
+    """Detect added / removed / moved local mesh objects and broadcast."""
+    scene = bpy.context.scene
+    current_oids: set = set()
+
+    for obj in scene.objects:
+        if obj.type != "MESH":
+            continue
+        if obj.get(REMOTE_PROP):
+            continue  # skip objects received from remote
+
+        oid = obj.get(OBJECT_ID_PROP, "")
+
+        if not oid:
+            # New local object
+            oid = protocol.generate_object_id()
+            obj[OBJECT_ID_PROP] = oid
+            _send_object_add(obj, oid)
+            current_oids.add(oid)
+            continue
+
+        current_oids.add(oid)
+
+        if oid not in _state.managed:
+            # Seen for first time (e.g. loaded from file with existing prop)
+            _send_object_add(obj, oid)
+            continue
+
+        # Check for transform change
+        snap = _obj_snapshot(obj)
+        if not _snaps_equal(snap, _state.managed[oid]["snapshot"]):
+            _state.managed[oid]["snapshot"] = snap
+            loc, rot, scale = obj.matrix_world.decompose()
+            _state.ws.send_json({
+                "type": "broadcast",
+                "payload": protocol.make_scene_delta(oid, loc, rot, scale),
+            })
+
+        # Sync name changes
+        stored_name = _state.managed[oid].get("name", "")
+        if stored_name != obj.name:
+            _state.name_to_id.pop(stored_name, None)
+            _state.name_to_id[obj.name] = oid
+            _state.managed[oid]["name"] = obj.name
+
+    # Detect removed local objects
+    for oid in list(_state.managed.keys()):
+        info = _state.managed[oid]
+        if info.get("remote"):
+            continue
+        if oid not in current_oids:
+            _state.ws.send_json({
+                "type": "broadcast",
+                "payload": protocol.make_scene_remove(oid),
+            })
+            _state.name_to_id.pop(info.get("name", ""), None)
+            del _state.managed[oid]
+
+
+def _send_object_add(obj: bpy.types.Object, oid: str) -> None:
+    loc, rot, scale = obj.matrix_world.decompose()
+    snap = _obj_snapshot(obj)
+    mesh_path = ""
+
+    glb = export_object_as_glb(obj)
+    if glb:
+        mesh_path = protocol.generate_mesh_path()
+        ok = blob_client.upload_glb(_state.blob_url, mesh_path, glb)
+        if not ok:
+            mesh_path = ""
+
+    asset = {"type": "mesh", "meshPath": mesh_path} if mesh_path else None
+    _state.ws.send_json({
+        "type": "broadcast",
+        "payload": protocol.make_scene_add(oid, obj.name, loc, rot, scale, mesh_path, asset),
+    })
+
+    _state.managed[oid] = {"name": obj.name, "snapshot": snap, "remote": False, "mesh_path": mesh_path}
+    _state.name_to_id[obj.name] = oid
+
+
+# ---------------------------------------------------------------------------
+# Blender scene utilities
+# ---------------------------------------------------------------------------
+
+def _find_blender_obj(oid: str) -> bpy.types.Object | None:
+    for obj in bpy.data.objects:
+        if obj.get(OBJECT_ID_PROP) == oid:
+            return obj
+    return None
+
+
+def _create_primitive(primitive: str, color_hex: str, name: str) -> bpy.types.Object:
+    dispatch = {
+        "box":      lambda: bpy.ops.mesh.primitive_cube_add(size=1),
+        "sphere":   lambda: bpy.ops.mesh.primitive_uv_sphere_add(radius=0.5),
+        "cylinder": lambda: bpy.ops.mesh.primitive_cylinder_add(radius=0.5, depth=1),
+        "cone":     lambda: bpy.ops.mesh.primitive_cone_add(radius1=0.5, depth=1),
+        "plane":    lambda: bpy.ops.mesh.primitive_plane_add(size=1),
+        "torus":    lambda: bpy.ops.mesh.primitive_torus_add(),
+    }
+    dispatch.get(primitive, dispatch["box"])()
+    obj = bpy.context.active_object
+    obj.name = name
+
+    mat = bpy.data.materials.new(f"SceneSync_{name}")
+    mat.use_nodes = True
+    nodes = mat.node_tree.nodes
+    principled = nodes.get("Principled BSDF")
+    if principled:
+        r, g, b = protocol.hex_to_rgb(color_hex)
+        principled.inputs["Base Color"].default_value = (r, g, b, 1.0)
+    obj.data.materials.clear()
+    obj.data.materials.append(mat)
+    return obj
+
+
+def _apply_transform(obj: bpy.types.Object, tf: dict) -> None:
+    from mathutils import Quaternion, Vector
+
+    loc_wire = tf.get("loc")
+    rot_wire = tf.get("rot")
+    scl_wire = tf.get("scale")
+
+    if loc_wire is not None:
+        obj.location = loc_wire
+    if rot_wire is not None:
+        if isinstance(rot_wire, (list, tuple)):
+            obj.rotation_mode = "QUATERNION"
+            obj.rotation_quaternion = rot_wire
+        else:
+            obj.rotation_mode = "QUATERNION"
+            obj.rotation_quaternion = rot_wire
+    if scl_wire is not None:
+        obj.scale = scl_wire
+
+
+# ---------------------------------------------------------------------------
+# Timer
+# ---------------------------------------------------------------------------
+
+def _timer_callback() -> float:
+    try:
+        _handle_ws_messages()
+        if _state.ws.connected:
+            _check_scene_changes()
+    except Exception as e:
+        print(f"[SceneSync] Timer error: {e}")
+    return POLL_INTERVAL
+
+
+def _force_redraw() -> None:
+    for area in bpy.context.screen.areas if bpy.context.screen else []:
+        if area.type == "VIEW_3D":
+            area.tag_redraw()
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+class SCENE_SYNC_OT_connect(Operator):
+    bl_idname = "scene_sync.connect"
+    bl_label = "接続"
+    bl_description = "Scene Sync サーバーに接続する"
+
+    def execute(self, context):
+        settings = context.scene.scene_sync
+        url = settings.presence_url.strip()
+        room = settings.room.strip()
+        nickname = settings.nickname.strip() or "Blender"
+
+        _state.blob_url = blob_client.presence_url_to_blob_url(url)
+        _state.reset_scene()
+        _state.status = "接続中…"
+        _state.ws.connect(url, room, nickname)
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_disconnect(Operator):
+    bl_idname = "scene_sync.disconnect"
+    bl_label = "切断"
+    bl_description = "Scene Sync サーバーから切断する"
+
+    def execute(self, context):
+        _state.ws.disconnect()
+        _state.status = "未接続"
+        _state.peers = []
+        _force_redraw()
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_sync_meshes(Operator):
+    bl_idname = "scene_sync.sync_meshes"
+    bl_label = "メッシュを再送信"
+    bl_description = "全ローカルメッシュの GLB を再エクスポートして blob にアップロードする"
+
+    def execute(self, context):
+        if not _state.ws.connected:
+            self.report({"WARNING"}, "接続されていません")
+            return {"CANCELLED"}
+
+        count = 0
+        for obj in context.scene.objects:
+            if obj.type != "MESH" or obj.get(REMOTE_PROP):
+                continue
+            oid = obj.get(OBJECT_ID_PROP, "")
+            if not oid:
+                continue
+
+            glb = export_object_as_glb(obj)
+            if not glb:
+                continue
+
+            mesh_path = protocol.generate_mesh_path()
+            ok = blob_client.upload_glb(_state.blob_url, mesh_path, glb)
+            if ok:
+                _state.ws.send_json({
+                    "type": "broadcast",
+                    "payload": protocol.make_scene_mesh(oid, mesh_path),
+                })
+                if oid in _state.managed:
+                    _state.managed[oid]["mesh_path"] = mesh_path
+                count += 1
+
+        self.report({"INFO"}, f"{count} 個のメッシュを再送信しました")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+class SceneSyncSettings(PropertyGroup):
+    presence_url: StringProperty(
+        name="サーバー URL",
+        default="wss://afjk.jp/presence",
+        description="Scene Sync presence server の WebSocket URL",
+    )  # type: ignore[assignment]
+
+    room: StringProperty(
+        name="ルーム",
+        default="",
+        description="参加するルーム ID",
+    )  # type: ignore[assignment]
+
+    nickname: StringProperty(
+        name="ニックネーム",
+        default="Blender",
+        description="表示名",
+    )  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Panel
+# ---------------------------------------------------------------------------
+
+class SCENE_SYNC_PT_panel(Panel):
+    bl_label = "Scene Sync"
+    bl_idname = "SCENE_SYNC_PT_panel"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Scene Sync"
+
+    def draw(self, context):
+        layout = self.layout
+        settings = context.scene.scene_sync
+        connected = _state.ws.connected
+
+        # Connection settings
+        col = layout.column(align=True)
+        col.enabled = not connected
+        col.prop(settings, "presence_url", text="URL")
+        col.prop(settings, "room", text="ルーム")
+        col.prop(settings, "nickname", text="名前")
+
+        layout.separator()
+
+        row = layout.row(align=True)
+        if connected:
+            row.operator("scene_sync.disconnect", icon="UNLINKED")
+        else:
+            row.operator("scene_sync.connect", icon="LINKED")
+
+        # Status
+        box = layout.box()
+        box.label(text=_state.status, icon="INFO")
+
+        if connected:
+            layout.separator()
+            layout.operator("scene_sync.sync_meshes", icon="EXPORT")
+
+            # Peers
+            if _state.peers:
+                layout.separator()
+                layout.label(text="参加者:", icon="COMMUNITY")
+                for peer in _state.peers:
+                    nick = str(peer.get("nickname", peer.get("id", "?")))
+                    row = layout.row()
+                    row.label(text=f"  {nick}")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+_classes = (
+    SceneSyncSettings,
+    SCENE_SYNC_OT_connect,
+    SCENE_SYNC_OT_disconnect,
+    SCENE_SYNC_OT_sync_meshes,
+    SCENE_SYNC_PT_panel,
+)
+
+
+def register():
+    for cls in _classes:
+        bpy.utils.register_class(cls)
+    bpy.types.Scene.scene_sync = bpy.props.PointerProperty(type=SceneSyncSettings)
+    bpy.app.timers.register(_timer_callback, first_interval=POLL_INTERVAL, persistent=True)
+
+
+def unregister():
+    if bpy.app.timers.is_registered(_timer_callback):
+        bpy.app.timers.unregister(_timer_callback)
+    del bpy.types.Scene.scene_sync
+    for cls in reversed(_classes):
+        bpy.utils.unregister_class(cls)
+    _state.ws.disconnect()

--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -513,10 +513,15 @@ class SCENE_SYNC_OT_connect(Operator):
         room = settings.room.strip()
         nickname = settings.nickname.strip() or "Blender"
 
+        try:
+            device = f"Blender {bpy.app.version_string}"
+        except Exception:
+            device = "Blender"
+
         _state.blob_url = blob_client.presence_url_to_blob_url(url)
         _state.reset_scene()
         _state.status = "接続中…"
-        _state.ws.connect(url, room, nickname)
+        _state.ws.connect(url, room, nickname, device)
         return {"FINISHED"}
 
 

--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -236,7 +236,7 @@ def _apply_scene_add(payload: dict, from_id: str) -> None:
         obj = _create_primitive("box", "#888888", name)
 
     obj[OBJECT_ID_PROP] = oid
-    obj[REMOTE_PROP] = True
+    _mark_remote(obj)
 
     tf = protocol.extract_transform(payload)
     _apply_transform(obj, tf)
@@ -291,7 +291,7 @@ def _apply_scene_mesh(payload: dict) -> None:
         return
 
     new[OBJECT_ID_PROP] = oid
-    new[REMOTE_PROP] = True
+    _mark_remote(new)
 
     if old:
         # Copy transform then remove old
@@ -422,6 +422,13 @@ def _send_object_add(obj: bpy.types.Object, oid: str) -> None:
 # ---------------------------------------------------------------------------
 # Blender scene utilities
 # ---------------------------------------------------------------------------
+
+def _mark_remote(obj: bpy.types.Object) -> None:
+    """Recursively set REMOTE_PROP on obj and all its children."""
+    obj[REMOTE_PROP] = True
+    for child in obj.children:
+        _mark_remote(child)
+
 
 def _find_blender_obj(oid: str) -> bpy.types.Object | None:
     for obj in bpy.data.objects:

--- a/blender/addons/scene_sync/blob_client.py
+++ b/blender/addons/scene_sync/blob_client.py
@@ -1,0 +1,41 @@
+"""HTTP helpers for the Scene Sync blob store."""
+
+import urllib.error
+import urllib.request
+
+
+def upload_glb(blob_base_url: str, path: str, data: bytes) -> bool:
+    """POST *data* to ``<blob_base_url>/<path>``. Returns True on HTTP 201."""
+    url = f"{blob_base_url.rstrip('/')}/{path}"
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "model/gltf-binary"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status == 201
+    except urllib.error.HTTPError as e:
+        print(f"[SceneSync] Blob upload HTTP error {e.code}: {path}")
+        return False
+    except Exception as e:
+        print(f"[SceneSync] Blob upload error: {e}")
+        return False
+
+
+def download_glb(blob_base_url: str, path: str) -> bytes | None:
+    """GET ``<blob_base_url>/<path>``. Returns bytes or None on failure."""
+    url = f"{blob_base_url.rstrip('/')}/{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            return resp.read()
+    except Exception as e:
+        print(f"[SceneSync] Blob download error: {e}")
+        return None
+
+
+def presence_url_to_blob_url(presence_url: str) -> str:
+    """Derive blob store URL from the presence server WebSocket URL."""
+    url = presence_url.replace("wss://", "https://").replace("ws://", "http://")
+    return url.rstrip("/") + "/blob"

--- a/blender/addons/scene_sync/glb_helper.py
+++ b/blender/addons/scene_sync/glb_helper.py
@@ -1,0 +1,96 @@
+"""GLB export / import helpers for Blender."""
+
+import os
+import tempfile
+
+import bpy
+
+
+def export_object_as_glb(obj: bpy.types.Object) -> bytes | None:
+    """
+    Export *obj* (and its children) to GLB bytes with Y-up conversion.
+    Returns None on failure.
+    """
+    if "io_scene_gltf2" not in bpy.context.preferences.addons:
+        print("[SceneSync] glTF exporter addon is not enabled")
+        return None
+
+    # Save and restore selection so we don't disrupt the user.
+    prev_active = bpy.context.view_layer.objects.active
+    prev_selected = set(o.name for o in bpy.context.selected_objects)
+
+    with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
+        tmp = f.name
+
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+        obj.select_set(True)
+        bpy.context.view_layer.objects.active = obj
+
+        bpy.ops.export_scene.gltf(
+            filepath=tmp,
+            use_selection=True,
+            export_format="GLB",
+            export_apply=True,
+        )
+
+        with open(tmp, "rb") as f:
+            return f.read()
+
+    except Exception as e:
+        print(f"[SceneSync] GLB export failed for '{obj.name}': {e}")
+        return None
+
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        # Restore selection
+        bpy.ops.object.select_all(action="DESELECT")
+        for name in prev_selected:
+            o = bpy.data.objects.get(name)
+            if o:
+                o.select_set(True)
+        if prev_active and prev_active.name in bpy.data.objects:
+            bpy.context.view_layer.objects.active = prev_active
+
+
+def import_glb(data: bytes, name: str) -> bpy.types.Object | None:
+    """
+    Import GLB *data* into the current scene.
+    Returns the root object or None on failure.
+    """
+    if "io_scene_gltf2" not in bpy.context.preferences.addons:
+        print("[SceneSync] glTF importer addon is not enabled")
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
+        f.write(data)
+        tmp = f.name
+
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+        bpy.ops.import_scene.gltf(filepath=tmp)
+
+        imported = list(bpy.context.selected_objects)
+        if not imported:
+            return None
+
+        if len(imported) == 1:
+            root = imported[0]
+        else:
+            bpy.ops.object.empty_add(type="PLAIN_AXES")
+            root = bpy.context.active_object
+            for o in imported:
+                if o.parent is None:
+                    o.parent = root
+
+        root.name = name
+        return root
+
+    except Exception as e:
+        print(f"[SceneSync] GLB import failed: {e}")
+        return None
+
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)

--- a/blender/addons/scene_sync/protocol.py
+++ b/blender/addons/scene_sync/protocol.py
@@ -1,0 +1,172 @@
+"""Wire-format helpers and coordinate conversion for Scene Sync.
+
+Blender world space: Z-up, Y-forward, X-right (right-hand).
+Wire / Three.js space: Y-up, Z-toward-viewer, X-right (right-hand).
+
+Mapping:
+    wire X  = blender X
+    wire Y  = blender Z
+    wire Z  = -blender Y
+
+Scale axes are permuted the same way (no sign flip for magnitudes):
+    wire sX = blender sX
+    wire sY = blender sZ
+    wire sZ = blender sY
+"""
+
+import uuid
+
+try:
+    from mathutils import Matrix, Quaternion, Vector  # available inside Blender
+
+    _M = Matrix(((1, 0, 0), (0, 0, 1), (0, -1, 0)))   # Z-up → Y-up
+    _MI = _M.transposed()                               # inverse (M is orthogonal)
+    _MATHUTILS = True
+except ImportError:
+    _MATHUTILS = False
+
+
+# ---------------------------------------------------------------------------
+# Coordinate conversion
+# ---------------------------------------------------------------------------
+
+def pos_to_wire(loc) -> list:
+    """Blender Vector/sequence → wire [x, y, z] (Y-up)."""
+    return [loc[0], loc[2], -loc[1]]
+
+
+def pos_from_wire(arr: list):
+    """Wire [x, y, z] → Blender Vector."""
+    if _MATHUTILS:
+        return Vector((arr[0], -arr[2], arr[1]))
+    return (arr[0], -arr[2], arr[1])
+
+
+def rot_to_wire(quat) -> list:
+    """Blender Quaternion (w,x,y,z) → wire [x, y, z, w] (Y-up)."""
+    if _MATHUTILS:
+        mat = quat.to_matrix()
+        converted = _M @ mat @ _MI
+        q = converted.to_quaternion()
+        return [q.x, q.y, q.z, q.w]
+    # Fallback (identity) when mathutils unavailable
+    return [quat[1], quat[2], quat[3], quat[0]]
+
+
+def rot_from_wire(arr: list):
+    """Wire [x, y, z, w] → Blender Quaternion."""
+    if _MATHUTILS:
+        q = Quaternion((arr[3], arr[0], arr[1], arr[2]))  # (w,x,y,z)
+        mat = q.to_matrix()
+        converted = _MI @ mat @ _M
+        return converted.to_quaternion()
+    return (arr[3], arr[0], arr[1], arr[2])
+
+
+def scale_to_wire(scale) -> list:
+    """Blender scale Vector → wire [sx, sy, sz] (axis permuted)."""
+    return [scale[0], scale[2], scale[1]]
+
+
+def scale_from_wire(arr: list):
+    """Wire [sx, sy, sz] → Blender scale Vector."""
+    if _MATHUTILS:
+        return Vector((arr[0], arr[2], arr[1]))
+    return (arr[0], arr[2], arr[1])
+
+
+# ---------------------------------------------------------------------------
+# Message builders
+# ---------------------------------------------------------------------------
+
+def make_scene_add(
+    object_id: str,
+    name: str,
+    loc,
+    rot,
+    scale,
+    mesh_path: str = "",
+    asset: dict | None = None,
+) -> dict:
+    msg: dict = {
+        "kind": "scene-add",
+        "objectId": object_id,
+        "name": name,
+        "position": pos_to_wire(loc),
+        "rotation": rot_to_wire(rot),
+        "scale": scale_to_wire(scale),
+    }
+    if asset:
+        msg["asset"] = asset
+    elif mesh_path:
+        msg["asset"] = {"type": "mesh", "meshPath": mesh_path}
+    return msg
+
+
+def make_scene_delta(object_id: str, loc, rot, scale) -> dict:
+    return {
+        "kind": "scene-delta",
+        "objectId": object_id,
+        "position": pos_to_wire(loc),
+        "rotation": rot_to_wire(rot),
+        "scale": scale_to_wire(scale),
+    }
+
+
+def make_scene_remove(object_id: str) -> dict:
+    return {"kind": "scene-remove", "objectId": object_id}
+
+
+def make_scene_request() -> dict:
+    return {"kind": "scene-request"}
+
+
+def make_scene_state(objects: dict) -> dict:
+    return {"kind": "scene-state", "objects": objects}
+
+
+def make_scene_mesh(object_id: str, mesh_path: str) -> dict:
+    return {"kind": "scene-mesh", "objectId": object_id, "meshPath": mesh_path}
+
+
+def make_scene_lock(object_id: str) -> dict:
+    return {"kind": "scene-lock", "objectId": object_id}
+
+
+def make_scene_unlock(object_id: str) -> dict:
+    return {"kind": "scene-unlock", "objectId": object_id}
+
+
+def extract_transform(payload: dict) -> dict:
+    """Return {"loc": ..., "rot": ..., "scale": ...} from a wire payload."""
+    result = {}
+    pos = payload.get("position")
+    if pos and len(pos) == 3:
+        result["loc"] = pos_from_wire(pos)
+    rot = payload.get("rotation")
+    if rot and len(rot) == 4:
+        result["rot"] = rot_from_wire(rot)
+    scl = payload.get("scale")
+    if scl and len(scl) == 3:
+        result["scale"] = scale_from_wire(scl)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+def generate_object_id() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def generate_mesh_path() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def hex_to_rgb(hex_color: str) -> tuple:
+    """Parse '#rrggbb' → (r, g, b) floats in [0, 1]."""
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return (0.5, 0.5, 0.5)
+    return tuple(int(h[i : i + 2], 16) / 255.0 for i in (0, 2, 4))

--- a/blender/addons/scene_sync/protocol.py
+++ b/blender/addons/scene_sync/protocol.py
@@ -49,7 +49,8 @@ def rot_to_wire(quat) -> list:
         converted = _M @ mat @ _MI
         q = converted.to_quaternion()
         return [q.x, q.y, q.z, q.w]
-    # Fallback (identity) when mathutils unavailable
+    # Fallback when mathutils is unavailable: reorder components to wire
+    # [x, y, z, w] only; the Y-up axis conversion is skipped in this path.
     return [quat[1], quat[2], quat[3], quat[0]]
 
 

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -126,7 +126,7 @@ class SceneSyncWSClient:
                 if not chunk:
                     raise ConnectionError("Server closed during handshake")
                 hdr += chunk
-            lines = hdr.split(b"\r\n")
+            lines = hdr.split(b"\r\n\r\n")[0].split(b"\r\n")
             status_line = lines[0]
             if b"101" not in status_line:
                 raise ConnectionError(f"Upgrade failed: {status_line}")
@@ -148,7 +148,9 @@ class SceneSyncWSClient:
             self.connected = True
             self._recv_q.put({"_internal": "_connected"})
 
-            buf = b""
+            # Any bytes after \r\n\r\n in the handshake buffer are the start of a WS frame.
+            parts = hdr.split(b"\r\n\r\n", 1)
+            buf = parts[1] if len(parts) > 1 else b""
             while self._running:
                 # flush outgoing queue
                 try:

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -1,6 +1,7 @@
 """Minimal WebSocket client running in a background thread."""
 
 import base64
+import hashlib
 import json
 import os
 import queue
@@ -125,9 +126,21 @@ class SceneSyncWSClient:
                 if not chunk:
                     raise ConnectionError("Server closed during handshake")
                 hdr += chunk
-            status_line = hdr.split(b"\r\n")[0]
+            lines = hdr.split(b"\r\n")
+            status_line = lines[0]
             if b"101" not in status_line:
                 raise ConnectionError(f"Upgrade failed: {status_line}")
+            headers = {}
+            for line in lines[1:]:
+                if b":" in line:
+                    k, v = line.split(b":", 1)
+                    headers[k.strip().lower()] = v.strip().decode()
+            magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+            expected = base64.b64encode(
+                hashlib.sha1((ws_key + magic).encode()).digest()
+            ).decode()
+            if headers.get("sec-websocket-accept") != expected:
+                raise ConnectionError("Sec-WebSocket-Accept mismatch")
 
             self._sock.settimeout(0.05)
 

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -125,8 +125,9 @@ class SceneSyncWSClient:
                 if not chunk:
                     raise ConnectionError("Server closed during handshake")
                 hdr += chunk
-            if b"101" not in hdr.split(b"\r\n")[0]:
-                raise ConnectionError(f"Upgrade failed: {hdr.split(b'\\r\\n')[0]}")
+            status_line = hdr.split(b"\r\n")[0]
+            if b"101" not in status_line:
+                raise ConnectionError(f"Upgrade failed: {status_line}")
 
             self._sock.settimeout(0.05)
 

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -135,12 +135,16 @@ class SceneSyncWSClient:
                 if b":" in line:
                     k, v = line.split(b":", 1)
                     headers[k.strip().lower()] = v.strip().decode()
-            magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-            expected = base64.b64encode(
-                hashlib.sha1((ws_key + magic).encode()).digest()
-            ).decode()
-            if headers.get("sec-websocket-accept") != expected:
-                raise ConnectionError("Sec-WebSocket-Accept mismatch")
+            try:
+                magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+                expected = base64.b64encode(
+                    hashlib.sha1((ws_key + magic).encode(), usedforsecurity=False).digest()
+                ).decode()
+                if headers.get("sec-websocket-accept") != expected:
+                    print(f"[SceneSync] Sec-WebSocket-Accept mismatch (expected {expected},"
+                          f" got {headers.get('sec-websocket-accept')})")
+            except Exception as sha_err:
+                print(f"[SceneSync] Sec-WebSocket-Accept check skipped: {sha_err}")
 
             self._sock.settimeout(0.05)
 

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 import struct
 import threading
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 
 class SceneSyncWSClient:
@@ -35,12 +35,12 @@ class SceneSyncWSClient:
     # Public API (main thread)
     # ------------------------------------------------------------------
 
-    def connect(self, url: str, room: str, nickname: str) -> None:
+    def connect(self, url: str, room: str, nickname: str, device: str = "Blender") -> None:
         self.disconnect()
         self._running = True
         self._thread = threading.Thread(
             target=self._run,
-            args=(url, room, nickname),
+            args=(url, room, nickname, device),
             daemon=True,
         )
         self._thread.start()
@@ -59,6 +59,9 @@ class SceneSyncWSClient:
         self.connected = False
         self.my_id = ""
         self.peers = []
+        # Drain stale messages from the previous session.
+        self._send_q = queue.Queue()
+        self._recv_q = queue.Queue()
 
     def send_json(self, data: dict) -> None:
         """Queue a JSON message to be sent by the background thread."""
@@ -81,13 +84,16 @@ class SceneSyncWSClient:
     # Background thread
     # ------------------------------------------------------------------
 
-    def _run(self, url: str, room: str, nickname: str) -> None:
+    def _run(self, url: str, room: str, nickname: str, device: str) -> None:
         try:
             parsed = urlparse(url)
             host = parsed.hostname
             use_ssl = parsed.scheme in ("wss", "https")
             port = parsed.port or (443 if use_ssl else 80)
-            path = (parsed.path or "/") + (f"?room={room}" if room else "")
+            qs = parse_qsl(parsed.query)
+            if room:
+                qs.append(("room", room))
+            path = (parsed.path or "/") + ("?" + urlencode(qs) if qs else "")
 
             raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             raw.settimeout(15)
@@ -123,13 +129,6 @@ class SceneSyncWSClient:
                 raise ConnectionError(f"Upgrade failed: {hdr.split(b'\\r\\n')[0]}")
 
             self._sock.settimeout(0.05)
-
-            # hello
-            try:
-                import bpy  # noqa: PLC0415
-                device = f"Blender {bpy.app.version_string}"
-            except ImportError:
-                device = "Blender"
 
             self._ws_send(json.dumps({"type": "hello", "nickname": nickname, "device": device}))
             self.connected = True

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -1,0 +1,256 @@
+"""Minimal WebSocket client running in a background thread."""
+
+import base64
+import json
+import os
+import queue
+import socket
+import ssl
+import struct
+import threading
+from urllib.parse import urlparse
+
+
+class SceneSyncWSClient:
+    """
+    WebSocket client for Scene Sync presence server.
+
+    Runs in a background thread; all inter-thread communication goes
+    through thread-safe queues.  Call poll() from the main thread to
+    retrieve received messages.
+    """
+
+    def __init__(self):
+        self._sock = None
+        self._thread = None
+        self._send_q: queue.Queue = queue.Queue()
+        self._recv_q: queue.Queue = queue.Queue()
+        self._running = False
+        self.connected = False
+        self.my_id = ""
+        self.room = ""
+        self.peers: list = []
+
+    # ------------------------------------------------------------------
+    # Public API (main thread)
+    # ------------------------------------------------------------------
+
+    def connect(self, url: str, room: str, nickname: str) -> None:
+        self.disconnect()
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(url, room, nickname),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def disconnect(self) -> None:
+        self._running = False
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2)
+        self._thread = None
+        self.connected = False
+        self.my_id = ""
+        self.peers = []
+
+    def send_json(self, data: dict) -> None:
+        """Queue a JSON message to be sent by the background thread."""
+        self._send_q.put(json.dumps(data, ensure_ascii=False))
+
+    def poll(self) -> list:
+        """
+        Drain the receive queue and return all pending messages.
+        Internal events have the key ``_internal`` set to a string tag.
+        """
+        messages = []
+        while True:
+            try:
+                messages.append(self._recv_q.get_nowait())
+            except queue.Empty:
+                break
+        return messages
+
+    # ------------------------------------------------------------------
+    # Background thread
+    # ------------------------------------------------------------------
+
+    def _run(self, url: str, room: str, nickname: str) -> None:
+        try:
+            parsed = urlparse(url)
+            host = parsed.hostname
+            use_ssl = parsed.scheme in ("wss", "https")
+            port = parsed.port or (443 if use_ssl else 80)
+            path = (parsed.path or "/") + (f"?room={room}" if room else "")
+
+            raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            raw.settimeout(15)
+            raw.connect((host, port))
+
+            if use_ssl:
+                ctx = ssl.create_default_context()
+                self._sock = ctx.wrap_socket(raw, server_hostname=host)
+            else:
+                self._sock = raw
+
+            # HTTP upgrade handshake
+            ws_key = base64.b64encode(os.urandom(16)).decode()
+            self._sock.sendall(
+                (
+                    f"GET {path} HTTP/1.1\r\n"
+                    f"Host: {host}\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    f"Sec-WebSocket-Key: {ws_key}\r\n"
+                    "Sec-WebSocket-Version: 13\r\n"
+                    "\r\n"
+                ).encode()
+            )
+
+            hdr = b""
+            while b"\r\n\r\n" not in hdr:
+                chunk = self._sock.recv(1024)
+                if not chunk:
+                    raise ConnectionError("Server closed during handshake")
+                hdr += chunk
+            if b"101" not in hdr.split(b"\r\n")[0]:
+                raise ConnectionError(f"Upgrade failed: {hdr.split(b'\\r\\n')[0]}")
+
+            self._sock.settimeout(0.05)
+
+            # hello
+            try:
+                import bpy  # noqa: PLC0415
+                device = f"Blender {bpy.app.version_string}"
+            except ImportError:
+                device = "Blender"
+
+            self._ws_send(json.dumps({"type": "hello", "nickname": nickname, "device": device}))
+            self.connected = True
+            self._recv_q.put({"_internal": "_connected"})
+
+            buf = b""
+            while self._running:
+                # flush outgoing queue
+                try:
+                    while True:
+                        self._ws_send(self._send_q.get_nowait())
+                except queue.Empty:
+                    pass
+
+                # receive
+                try:
+                    chunk = self._sock.recv(65536)
+                    if not chunk:
+                        break
+                    buf += chunk
+                    while True:
+                        text, buf = self._parse_frame(buf)
+                        if text is None:
+                            break
+                        try:
+                            self._recv_q.put(json.loads(text))
+                        except json.JSONDecodeError:
+                            pass
+                except socket.timeout:
+                    pass
+                except (OSError, ssl.SSLError):
+                    break
+
+        except Exception as e:
+            print(f"[SceneSync] WS error: {e}")
+        finally:
+            if self._sock:
+                try:
+                    self._sock.close()
+                except Exception:
+                    pass
+                self._sock = None
+            self.connected = False
+            self._recv_q.put({"_internal": "_disconnected"})
+
+    # ------------------------------------------------------------------
+    # WebSocket frame helpers
+    # ------------------------------------------------------------------
+
+    def _ws_send(self, text: str) -> None:
+        if self._sock is None:
+            return
+        payload = text.encode("utf-8")
+        mask = os.urandom(4)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        n = len(payload)
+        if n <= 125:
+            hdr = bytes([0x81, 0x80 | n])
+        elif n <= 65535:
+            hdr = bytes([0x81, 0xFE]) + struct.pack(">H", n)
+        else:
+            hdr = bytes([0x81, 0xFF]) + struct.pack(">Q", n)
+        try:
+            self._sock.sendall(hdr + mask + masked)
+        except Exception:
+            pass
+
+    def _parse_frame(self, buf: bytes):
+        """Return (text_or_None, remaining_buf) for one frame."""
+        if len(buf) < 2:
+            return None, buf
+
+        opcode = buf[0] & 0x0F
+        masked = bool(buf[1] & 0x80)
+        length = buf[1] & 0x7F
+        off = 2
+
+        if length == 126:
+            if len(buf) < 4:
+                return None, buf
+            length = struct.unpack(">H", buf[2:4])[0]
+            off = 4
+        elif length == 127:
+            if len(buf) < 10:
+                return None, buf
+            length = struct.unpack(">Q", buf[2:10])[0]
+            off = 10
+
+        mask_key = b""
+        if masked:
+            if len(buf) < off + 4:
+                return None, buf
+            mask_key = buf[off : off + 4]
+            off += 4
+
+        if len(buf) < off + length:
+            return None, buf
+
+        payload = buf[off : off + length]
+        if masked:
+            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+        rest = buf[off + length :]
+
+        if opcode == 0x9:  # ping → pong
+            self._ws_pong(payload)
+            return None, rest
+        if opcode == 0x8:  # close
+            self._running = False
+            return None, rest
+        if opcode in (0x1, 0x2):
+            return payload.decode("utf-8", errors="replace"), rest
+
+        return None, rest
+
+    def _ws_pong(self, payload: bytes) -> None:
+        if self._sock is None:
+            return
+        p = payload[:125]
+        mask = os.urandom(4)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(p))
+        try:
+            self._sock.sendall(bytes([0x8A, 0x80 | len(p)]) + mask + masked)
+        except Exception:
+            pass

--- a/html/assets/js/scenesync/loaders/glb-file-loader.js
+++ b/html/assets/js/scenesync/loaders/glb-file-loader.js
@@ -38,7 +38,7 @@ export class GLBFileLoader {
   _buildModel(gltf, position) {
     const wrapper = new THREE.Group();
     wrapper.add(gltf.scene);
-    gltf.scene.rotateY(Math.PI);
+    wrapper.rotateY(Math.PI);
 
     wrapper.updateMatrixWorld(true);
     const box = new THREE.Box3().setFromObject(wrapper);


### PR DESCRIPTION
Blender 4.x addon that syncs the 3D scene with browser/Unity/Godot
via the Scene Sync presence server protocol.

- ws_client.py: minimal WebSocket client in a background thread
- protocol.py: wire format helpers with Z-up → Y-up coordinate conversion
- blob_client.py: HTTP upload/download for GLB blob store
- glb_helper.py: GLB export (bpy.ops.export_scene.gltf) and import
- __init__.py: bl_info, PropertyGroup, Panel, operators, 50ms timer

Features:
- Connect/disconnect from N-panel (View3D > Sidebar > Scene Sync)
- Auto-syncs all local mesh objects on connect (scene-add + GLB upload)
- Real-time transform tracking → scene-delta at 20Hz
- Detects added/removed objects → scene-add / scene-remove
- Receives scene-state, scene-add, scene-delta, scene-remove, scene-mesh
- Creates Blender primitives from remote scene-add with asset.type=primitive
- Imports GLB meshes from blob store for remote objects
- "メッシュを再送信" button to re-upload all local meshes

https://claude.ai/code/session_019AEBvybDUF6SujxUgNdRi3