### PR TITLE
Add asset delta support for object color and metadata sync

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2118,6 +2118,9 @@ function handleHandoff(data) {
       if (payload.position) obj.position.fromArray(payload.position);
       if (payload.rotation) obj.quaternion.fromArray(payload.rotation);
       if (payload.scale) obj.scale.fromArray(payload.scale);
+      if (payload.asset) {
+        applyAssetDelta(obj, payload.asset);
+      }
       if (shouldTrackHistory && isOnBehalfOf) {
         const afterPos = obj.position.toArray();
         const afterRot = obj.quaternion.toArray();
@@ -2648,6 +2651,42 @@ function applyTransform(obj, info) {
   if (info.scale) obj.scale.fromArray(info.scale);
 }
 
+function applyObjectColor(obj, color) {
+  if (!obj || !color) return;
+
+  obj.traverse((child) => {
+    if (!child.isMesh || !child.material) return;
+
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map((material) => {
+        const cloned = material.clone();
+        if (cloned.color) cloned.color.set(color);
+        cloned.needsUpdate = true;
+        return cloned;
+      });
+      return;
+    }
+
+    const cloned = child.material.clone();
+    if (cloned.color) cloned.color.set(color);
+    cloned.needsUpdate = true;
+    child.material = cloned;
+  });
+}
+
+function applyAssetDelta(obj, asset) {
+  if (!obj || !asset || typeof asset !== 'object') return;
+
+  obj.userData.asset = {
+    ...(obj.userData.asset || {}),
+    ...structuredClone(asset),
+  };
+
+  if (asset.color) {
+    applyObjectColor(obj, asset.color);
+  }
+}
+
 // ── Undo/Redo 処理 ──────────────────────────────────────
 
 function performUndo() {
@@ -2694,6 +2733,9 @@ function applyOperationToScene(operation) {
       const obj = managedObjects.get(operation.objectId);
       if (obj) {
         applyTransform(obj, operation);
+        if (operation.asset) {
+          applyAssetDelta(obj, operation.asset);
+        }
       }
       break;
     }

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -487,6 +487,7 @@ server.registerTool(
 
       return successResult({
         objectId,
+        primitive,
         color: finalColor
       })
     } catch (e) {


### PR DESCRIPTION
## Summary
This PR adds support for syncing asset metadata and color properties across scene objects during handoff and undo/redo operations. It introduces new functions to apply asset deltas and handle object color updates with proper material cloning.

## Key Changes
- **Asset delta handling in handoff**: Added `applyAssetDelta()` call in `handleHandoff()` to process asset payload data when objects are synchronized
- **Asset delta in undo/redo**: Extended `applyOperationToScene()` to apply asset deltas during operation replay
- **New `applyAssetDelta()` function**: Merges asset metadata into object's userData and triggers color updates when present
- **New `applyObjectColor()` function**: Traverses object hierarchy and applies color to all meshes by cloning materials and setting `needsUpdate` flag
- **Server-side return value**: Updated the scene-sync-mcp server tool to return the `primitive` field alongside color in responses

## Implementation Details
- Material cloning is performed to avoid shared material mutations across objects
- The `applyObjectColor()` function handles both single materials and material arrays
- Asset metadata is merged using spread operator with `structuredClone()` to prevent reference issues
- Color application only occurs if the asset object contains a color property

https://claude.ai/code/session_01L1UyHZvyfF2wBgYkvF7nrW