### PR TITLE
Add camera pose, history, undo/redo, and GLB model loading tools

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2423,6 +2423,15 @@ async function uploadGlbFromUrl(url, params = {}) {
     : new THREE.Vector3(0, 0, 0);
 
   const model = await glbLoader.loadFromFile(file, position, scene);
+
+  if (Array.isArray(params.rotation) && params.rotation.length === 4) {
+    model.quaternion.fromArray(params.rotation);
+  }
+
+  if (Array.isArray(params.scale) && params.scale.length === 3) {
+    model.scale.fromArray(params.scale);
+  }
+
   model.userData.objectId = objectId;
   model.userData.name = file.name;
   managedObjects.set(model.userData.objectId, model);

--- a/packages/scene-sync-mcp/README.md
+++ b/packages/scene-sync-mcp/README.md
@@ -4,7 +4,9 @@ An MCP server for controlling [afjk.jp](https://afjk.jp) Scene Sync from Claude 
 
 Scene Sync is a real-time 3D scene synchronization system. This MCP server lets AI models:
 - Redeem pairing codes to link to a user's Scene Sync room
-- Add and manipulate 3D objects (boxes, spheres, etc.)
+- Add and manipulate 3D objects (boxes, spheres, primitives, and GLB/glTF models from URL)
+- Get and manipulate camera pose
+- Access browser operation history (undo/redo)
 - Focus the camera on objects
 - Take screenshots
 - Manage the link session
@@ -128,6 +130,56 @@ Input:
 
 日本語: `primitive` は必須です。種類が不明な場合は、先に `scene_sync_get_scene` で対象 object の `asset.primitive` を確認してください。
 
+### scene_sync_add_glb_from_url
+Add a GLB/glTF model from a publicly fetchable URL.
+
+Input:
+```json
+{
+  "url": "https://example.com/model.glb",
+  "objectId": "ai-model-1",
+  "name": "Example Model",
+  "position": [0, 0, 0],
+  "rotation": [0, 0, 0, 1],
+  "scale": [1, 1, 1]
+}
+```
+
+Notes:
+- The URL must be accessible from the browser.
+- CORS headers may be required depending on the hosting site.
+- Local file paths are not supported by this tool.
+- For local files, drag & drop them into the Scene Sync browser UI instead.
+
+### scene_sync_get_camera_pose
+Get the current browser camera position and quaternion.
+
+Input: `{}`
+
+Returns camera position and quaternion.
+
+### scene_sync_get_history
+Get recent Scene Sync operation history.
+
+Input:
+```json
+{
+  "count": 10
+}
+```
+
+Returns the last N history entries from the browser.
+
+### scene_sync_undo
+Undo the last operation recorded in the Scene Sync history.
+
+Input: `{}`
+
+### scene_sync_redo
+Redo the last undone operation.
+
+Input: `{}`
+
 ### scene_sync_focus_object
 Focus the browser camera on an object (requires objectId).
 
@@ -171,6 +223,29 @@ If `true`, enables the `scene_sync_raw_broadcast` developer tool. Use only for a
 ```bash
 export SCENE_SYNC_ENABLE_RAW_TOOLS=true
 ```
+
+## Browser AI Command parity
+
+Browser AI commands in `html/assets/js/scenesync/scene.js` should stay in sync with MCP tools.
+
+| Browser AI Command | MCP Tool | Status |
+|---|---|---|
+| `getCameraPose` | `scene_sync_get_camera_pose` | supported |
+| `focusObject` | `scene_sync_focus_object` | supported |
+| `screenshot` | `scene_sync_screenshot` | supported |
+| `uploadGlbFromUrl` | `scene_sync_add_glb_from_url` | supported |
+| `getHistory` | `scene_sync_get_history` | supported |
+| `undo` | `scene_sync_undo` | supported |
+| `redo` | `scene_sync_redo` | supported |
+
+When adding a new browser AI command:
+
+- Add command handling in `handleAiCommand()`
+- Add matching MCP tool in `packages/scene-sync-mcp/src/server.mjs`
+- Add README documentation for the MCP tool
+- Update this parity table
+- Confirm tool responses do not expose `sessionId`
+- Confirm errors are handled by `assertAiCommandOk()`
 
 ## Behavior Policy
 

--- a/packages/scene-sync-mcp/README.md
+++ b/packages/scene-sync-mcp/README.md
@@ -5,7 +5,7 @@ An MCP server for controlling [afjk.jp](https://afjk.jp) Scene Sync from Claude 
 Scene Sync is a real-time 3D scene synchronization system. This MCP server lets AI models:
 - Redeem pairing codes to link to a user's Scene Sync room
 - Add and manipulate 3D objects (boxes, spheres, primitives, and GLB/glTF models from URL)
-- Get and manipulate camera pose
+- Inspect camera pose
 - Access browser operation history (undo/redo)
 - Focus the camera on objects
 - Take screenshots
@@ -179,6 +179,8 @@ Input: `{}`
 Redo the last undone operation.
 
 Input: `{}`
+
+Note: Undo/Redo operates on the browser-side Scene Sync history. Some operations may not be undoable if they were not recorded in the browser history.
 
 ### scene_sync_focus_object
 Focus the browser camera on an object (requires objectId).

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -50,10 +50,29 @@ function assertAiCommandOk(response) {
     throw new Error(response.result.error)
   }
 
+  if (response?.result?.ok === false) {
+    throw new Error('AI command failed')
+  }
+
   if (response?.error) {
     throw new Error(response.error)
   }
 
+  return response
+}
+
+// Helper to run AI commands
+async function runAiCommand(action, params = {}, options = {}) {
+  const session = getSession()
+  const response = await client.aiCommand(
+    session.roomId,
+    session.sessionId,
+    action,
+    params,
+    options
+  )
+
+  assertAiCommandOk(response)
   return response
 }
 
@@ -341,6 +360,70 @@ server.registerTool(
   }
 )
 
+// scene_sync_add_glb_from_url
+server.registerTool(
+  'scene_sync_add_glb_from_url',
+  {
+    title: 'Add a GLB model from URL',
+    description: 'Add a GLB/glTF model to the Scene Sync scene from a publicly fetchable HTTP(S) URL. The URL must be fetchable by the browser and may require CORS headers.',
+    inputSchema: z.object({
+      url: z.string()
+        .url()
+        .refine((value) => /^https?:\/\//i.test(value), {
+          message: 'url must be an HTTP(S) URL'
+        })
+        .describe('Publicly fetchable GLB/glTF URL. Must be accessible from the browser.'),
+      objectId: z.string().optional().describe('Unique object ID. Auto-generated if omitted.'),
+      name: z.string().optional().describe('Display name. If omitted, browser may infer from URL filename.'),
+      position: z.array(z.number()).length(3).optional().describe('[x, y, z] position in meters'),
+      rotation: z.array(z.number()).length(4).optional().describe('[x, y, z, w] quaternion'),
+      scale: z.array(z.number()).length(3).optional().describe('[x, y, z] scale')
+    }),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  },
+  async ({ url, objectId, name, position, rotation, scale }) => {
+    try {
+      const finalObjectId = objectId || makeObjectId('ai-model')
+      assertObjectId(finalObjectId)
+
+      const params = {
+        url,
+        objectId: finalObjectId,
+        position: normalizeVec3(position),
+        rotation: normalizeQuat(rotation),
+        scale: normalizeScale(scale)
+      }
+
+      if (name) {
+        params.name = normalizeName(name, 'GLB Model')
+      }
+
+      const response = await runAiCommand(
+        'uploadGlbFromUrl',
+        params,
+        { timeout: 60000 }
+      )
+
+      return jsonResult({
+        ok: true,
+        objectId: finalObjectId,
+        action: 'uploadGlbFromUrl',
+        result: response.result
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e.message)
+      }
+      return errorResult(formatApiError(e))
+    }
+  }
+)
+
 // scene_sync_move_object
 server.registerTool(
   'scene_sync_move_object',
@@ -558,6 +641,152 @@ server.registerTool(
       return jsonResult({
         ok: true,
         ...sanitized
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e.message)
+      }
+      return errorResult(formatApiError(e))
+    }
+  }
+)
+
+// scene_sync_get_camera_pose
+server.registerTool(
+  'scene_sync_get_camera_pose',
+  {
+    title: 'Get camera pose',
+    description: 'Get the current browser camera position and quaternion.',
+    inputSchema: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async () => {
+    try {
+      const response = await runAiCommand(
+        'getCameraPose',
+        {},
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ok: true,
+        action: 'getCameraPose',
+        result: response.result
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e.message)
+      }
+      return errorResult(formatApiError(e))
+    }
+  }
+)
+
+// scene_sync_get_history
+server.registerTool(
+  'scene_sync_get_history',
+  {
+    title: 'Get Scene Sync history',
+    description: 'Get recent Scene Sync operation history from the browser.',
+    inputSchema: z.object({
+      count: z.number().int().min(1).max(50).optional().describe('Number of history entries to return, default 10')
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async ({ count }) => {
+    try {
+      const response = await runAiCommand(
+        'getHistory',
+        { count: count || 10 },
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ok: true,
+        action: 'getHistory',
+        result: response.result
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e.message)
+      }
+      return errorResult(formatApiError(e))
+    }
+  }
+)
+
+// scene_sync_undo
+server.registerTool(
+  'scene_sync_undo',
+  {
+    title: 'Undo last Scene Sync operation',
+    description: 'Undo the last operation recorded in the browser Scene Sync history.',
+    inputSchema: z.object({}),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false
+    }
+  },
+  async () => {
+    try {
+      const response = await runAiCommand(
+        'undo',
+        {},
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ok: true,
+        action: 'undo',
+        result: response.result
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e.message)
+      }
+      return errorResult(formatApiError(e))
+    }
+  }
+)
+
+// scene_sync_redo
+server.registerTool(
+  'scene_sync_redo',
+  {
+    title: 'Redo Scene Sync operation',
+    description: 'Redo the last undone operation recorded in the browser Scene Sync history.',
+    inputSchema: z.object({}),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false
+    }
+  },
+  async () => {
+    try {
+      const response = await runAiCommand(
+        'redo',
+        {},
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ok: true,
+        action: 'redo',
+        result: response.result
       })
     } catch (e) {
       if (e instanceof ValidationError) {

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -51,7 +51,7 @@ function assertAiCommandOk(response) {
   }
 
   if (response?.result?.ok === false) {
-    throw new Error('AI command failed')
+    throw new Error(response.result.error || response.result.message || 'AI command failed')
   }
 
   if (response?.error) {
@@ -394,7 +394,7 @@ server.registerTool(
       const params = {
         url,
         objectId: finalObjectId,
-        position: normalizeVec3(position),
+        position: normalizeVec3(position, [0, 0, 0]),
         rotation: normalizeQuat(rotation),
         scale: normalizeScale(scale)
       }


### PR DESCRIPTION
## Summary
This PR adds five new MCP tools to Scene Sync for enhanced scene manipulation and inspection capabilities: camera pose retrieval, operation history access, undo/redo functionality, and GLB/glTF model loading from URLs.

## Key Changes

- **Enhanced error handling**: Added explicit check for `response?.result?.ok === false` in `assertAiCommandOk()` to catch failed AI commands
- **New helper function**: Introduced `runAiCommand()` to reduce boilerplate when executing AI commands with consistent error handling and timeout management
- **New MCP tools**:
  - `scene_sync_add_glb_from_url`: Load GLB/glTF 3D models from publicly accessible URLs with optional position, rotation, and scale parameters
  - `scene_sync_get_camera_pose`: Retrieve current browser camera position and quaternion
  - `scene_sync_get_history`: Access recent Scene Sync operation history (configurable count, max 50)
  - `scene_sync_undo`: Undo the last recorded operation
  - `scene_sync_redo`: Redo the last undone operation
- **Browser-side GLB loading enhancement**: Updated `uploadGlbFromUrl()` in scene.js to apply rotation (quaternion) and scale parameters to loaded models
- **Documentation**: Updated README with new tool descriptions, usage examples, and added a browser AI command parity table for tracking sync between browser commands and MCP tools

## Implementation Details

- All new tools follow the existing pattern: input validation, AI command execution via `runAiCommand()`, and consistent error handling
- Camera and history tools are read-only with appropriate annotations
- Undo/redo tools are marked as destructive but not idempotent
- GLB loading tool supports optional objectId generation and name normalization
- 60-second timeout for GLB loading, 10-second timeout for other operations
- Parity table added to README to help maintain sync between browser AI commands and MCP tools

https://claude.ai/code/session_011uQtReTfTZgy5DsHd8DWzM