### PR TITLE
SceneSync に Loom グラフプロトコルを統合

### DIFF
--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -133,22 +133,36 @@ function isValidScope(scope) {
 }
 
 function validateSceneGraphMessage(msg) {
-  if (!msg || typeof msg !== 'object') return false;
-  if (typeof msg.type !== 'string') return false;
-  if (!SCENE_GRAPH_MESSAGE_TYPES.has(msg.type)) return false;
+  if (!msg || typeof msg !== 'object') {
+    return { ok: false, error: 'message must be an object' };
+  }
+  if (typeof msg.type !== 'string') {
+    return { ok: false, error: 'type must be a string' };
+  }
+  if (!SCENE_GRAPH_MESSAGE_TYPES.has(msg.type)) {
+    return { ok: false, error: 'unsupported scene-graph message type' };
+  }
 
-  if (!isValidScope(msg.scope)) return false;
+  if (!isValidScope(msg.scope)) {
+    return { ok: false, error: 'invalid scope' };
+  }
 
   if (msg.type === 'scene-graph-set' || msg.type === 'scene-graph-patch') {
-    if (!msg.graph || typeof msg.graph !== 'object') return false;
-    if (!Array.isArray(msg.graph.nodes) || !Array.isArray(msg.graph.edges)) return false;
+    if (!msg.graph || typeof msg.graph !== 'object') {
+      return { ok: false, error: 'graph is required' };
+    }
+    if (!Array.isArray(msg.graph.nodes) || !Array.isArray(msg.graph.edges)) {
+      return { ok: false, error: 'graph.nodes and graph.edges must be arrays' };
+    }
   }
 
   if (msg.type === 'scene-graph-input') {
-    if (typeof msg.ref !== 'string') return false;
+    if (typeof msg.ref !== 'string') {
+      return { ok: false, error: 'ref must be a string' };
+    }
   }
 
-  return true;
+  return { ok: true };
 }
 
 function logSceneGraphMessage(msg) {
@@ -658,10 +672,11 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
   }
 
   if (nextPayload?.type && SCENE_GRAPH_MESSAGE_TYPES.has(nextPayload.type)) {
-    if (!validateSceneGraphMessage(nextPayload)) {
+    const validation = validateSceneGraphMessage(nextPayload);
+    if (!validation.ok) {
       return {
         status: 400,
-        body: { error: 'invalid scene-graph message' }
+        body: { error: 'invalid scene-graph message', details: validation.error }
       };
     }
 
@@ -1327,6 +1342,30 @@ function createPresenceServer() {
           break;
         case 'broadcast':
           if (data.payload) {
+            // Validate scene-graph-* messages
+            if (SCENE_GRAPH_MESSAGE_TYPES.has(data.payload.type)) {
+              const validation = validateSceneGraphMessage(data.payload);
+              if (!validation.ok) {
+                safeSend(conn, {
+                  type: 'error',
+                  error: 'invalid scene-graph message',
+                  details: validation.error
+                });
+                return;
+              }
+
+              const msgSize = JSON.stringify(data.payload).length;
+              if (msgSize > SCENE_GRAPH_MAX_SIZE) {
+                safeSend(conn, {
+                  type: 'error',
+                  error: 'scene-graph message too large'
+                });
+                return;
+              }
+
+              logSceneGraphMessage(data.payload);
+            }
+
             broadcastHandoff(client, data);
           }
           break;
@@ -1334,10 +1373,6 @@ function createPresenceServer() {
           safeSend(conn, { type: 'pong', at: Date.now() });
           break;
         default:
-          // Handle scene-graph-* messages via broadcast type
-          if (data.type === 'broadcast' && data.payload && SCENE_GRAPH_MESSAGE_TYPES.has(data.payload.type)) {
-            broadcastHandoff(client, { payload: data.payload });
-          }
           break;
       }
     };

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -12,6 +12,15 @@ const MAX_MESSAGE_SIZE = 131072; // 128 KB max WebSocket message
 const STATS_FILE = process.env.STATS_FILE || '/data/stats.json';
 const STATS_ARCHIVE_DIR = process.env.STATS_ARCHIVE_DIR || '/data/archive';
 
+// ── Scene Graph Protocol ────────────────────────────────────────────────────
+const SCENE_GRAPH_MESSAGE_TYPES = new Set([
+  'scene-graph-set',
+  'scene-graph-clear',
+  'scene-graph-patch',
+  'scene-graph-input'
+]);
+const SCENE_GRAPH_MAX_SIZE = 64 * 1024; // 64 KB for graph payloads
+
 const rooms = new Map(); // roomId -> Map<clientId, Client>
 const pendingSceneRequests = new Map(); // apiRequestId -> { resolve, timer }
 const pendingAiCommandResults = new Map(); // apiRequestId -> { resolve, timer }
@@ -113,6 +122,51 @@ function inferRoomFromReq(req) {
     return `${parts[0]}.${parts[1]}.${parts[2]}.x`;
   }
   return ip || 'global';
+}
+
+function isValidScope(scope) {
+  if (scope === 'scene') return true;
+  if (typeof scope === 'object' && scope !== null && !Array.isArray(scope)) {
+    return typeof scope.object === 'string' && scope.object.length > 0;
+  }
+  return false;
+}
+
+function validateSceneGraphMessage(msg) {
+  if (!msg || typeof msg !== 'object') return false;
+  if (typeof msg.type !== 'string') return false;
+  if (!SCENE_GRAPH_MESSAGE_TYPES.has(msg.type)) return false;
+
+  if (!isValidScope(msg.scope)) return false;
+
+  if (msg.type === 'scene-graph-set' || msg.type === 'scene-graph-patch') {
+    if (!msg.graph || typeof msg.graph !== 'object') return false;
+    if (!Array.isArray(msg.graph.nodes) || !Array.isArray(msg.graph.edges)) return false;
+  }
+
+  if (msg.type === 'scene-graph-input') {
+    if (typeof msg.ref !== 'string') return false;
+  }
+
+  return true;
+}
+
+function logSceneGraphMessage(msg) {
+  const scopeStr = msg.scope === 'scene' ? 'scene' : JSON.stringify(msg.scope);
+  switch (msg.type) {
+    case 'scene-graph-set':
+      log('[SceneSync] scene-graph-set scope=' + scopeStr + ' nodes=' + msg.graph.nodes.length + ' edges=' + msg.graph.edges.length);
+      break;
+    case 'scene-graph-clear':
+      log('[SceneSync] scene-graph-clear scope=' + scopeStr);
+      break;
+    case 'scene-graph-patch':
+      log('[SceneSync] scene-graph-patch scope=' + scopeStr + (msg.graph ? ' nodes=' + msg.graph.nodes.length + ' edges=' + msg.graph.edges.length : ''));
+      break;
+    case 'scene-graph-input':
+      log('[SceneSync] scene-graph-input scope=' + scopeStr + ' ref=' + msg.ref);
+      break;
+  }
 }
 
 function getRequestUrl(req) {
@@ -601,6 +655,38 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
       payload: nextPayload,
       sender,
     });
+  }
+
+  if (nextPayload?.type && SCENE_GRAPH_MESSAGE_TYPES.has(nextPayload.type)) {
+    if (!validateSceneGraphMessage(nextPayload)) {
+      return {
+        status: 400,
+        body: { error: 'invalid scene-graph message' }
+      };
+    }
+
+    const msgSize = JSON.stringify(nextPayload).length;
+    if (msgSize > SCENE_GRAPH_MAX_SIZE) {
+      return {
+        status: 413,
+        body: { error: 'scene-graph message too large' }
+      };
+    }
+
+    logSceneGraphMessage(nextPayload);
+
+    const message = {
+      type: 'handoff',
+      from: sender,
+      payload: nextPayload
+    };
+    peers.forEach(client => safeSend(client.conn, message));
+
+    const userPresent = Boolean(onBehalfOfUserId) && peers.some(client => client.userId === onBehalfOfUserId);
+    return {
+      status: 200,
+      body: createBroadcastResponse(roomId, peers, userPresent),
+    };
   }
 
   const message = {
@@ -1147,7 +1233,8 @@ function createPresenceServer() {
           return;
         }
 
-        if (payload && typeof payload === 'object' && payload.payload && typeof payload.payload === 'object') {
+        // For scene-graph-* messages, don't unwrap payload
+        if (payload && typeof payload === 'object' && payload.payload && typeof payload.payload === 'object' && !SCENE_GRAPH_MESSAGE_TYPES.has(payload.type)) {
           payload = payload.payload;
         }
 
@@ -1247,6 +1334,10 @@ function createPresenceServer() {
           safeSend(conn, { type: 'pong', at: Date.now() });
           break;
         default:
+          // Handle scene-graph-* messages via broadcast type
+          if (data.type === 'broadcast' && data.payload && SCENE_GRAPH_MESSAGE_TYPES.has(data.payload.type)) {
+            broadcastHandoff(client, { payload: data.payload });
+          }
           break;
       }
     };

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -825,6 +825,72 @@ describe('scene-graph protocol', () => {
       await closeClient(ws);
     }
   });
+
+  it('does not relay WebSocket scene-graph-set with invalid scope', async () => {
+    const sender = await connectClient('graph-ws-invalid-room', 'Sender');
+    const receiver = await connectClient('graph-ws-invalid-room', 'Receiver');
+    try {
+      // Try to wait for a relayed message from sender (should not arrive)
+      const noRelayPromise = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-set',
+        200  // short timeout
+      );
+
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          type: 'scene-graph-set',
+          scope: { target: 'cube1' },  // invalid scope
+          graph: { nodes: [], edges: [] }
+        }
+      }));
+
+      let relayedToReceiver = false;
+      try {
+        await noRelayPromise;
+        relayedToReceiver = true;
+      } catch (e) {
+        // Expected: timeout because message should not be relayed
+      }
+
+      assert.equal(relayedToReceiver, false, 'Invalid message should not be relayed to receiver');
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
+    }
+  });
+
+  it('does not relay WebSocket scene-graph-set without graph', async () => {
+    const sender = await connectClient('graph-ws-no-graph-room', 'Sender');
+    const receiver = await connectClient('graph-ws-no-graph-room', 'Receiver');
+    try {
+      // Try to wait for a relayed message (should not arrive)
+      const noRelayPromise = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-set',
+        200  // short timeout
+      );
+
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          type: 'scene-graph-set',
+          scope: 'scene'
+          // missing graph
+        }
+      }));
+
+      let relayedToReceiver = false;
+      try {
+        await noRelayPromise;
+        relayedToReceiver = true;
+      } catch (e) {
+        // Expected: timeout
+      }
+
+      assert.equal(relayedToReceiver, false, 'Invalid message should not be relayed to receiver');
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
+    }
+  });
 });
 
 describe('presence GPT wrapper API', () => {

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -643,6 +643,190 @@ describe('presence AI link API', () => {
   });
 });
 
+describe('scene-graph protocol', () => {
+  it('broadcasts scene-graph-set via REST API', async () => {
+    const ws = await connectClient('graph-test-room');
+    try {
+      const messagePromise = waitForMessage(ws, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-set'
+      );
+
+      const graph = {
+        nodes: [
+          { id: 'clock', type: 'serverClock' },
+          { id: 'sine', type: 'sine', params: { freq: 1, amplitude: 50 } }
+        ],
+        edges: [{ from: 'clock.t', to: 'sine.t' }]
+      };
+
+      const response = await fetch(`${baseUrl}/api/room/graph-test-room/broadcast?name=TestGraph`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'scene-graph-set',
+          scope: 'scene',
+          graph
+        }),
+      });
+
+      const [resBody, message] = await Promise.all([
+        response.json(),
+        messagePromise,
+      ]);
+
+      assert.equal(response.status, 200);
+      assert.equal(resBody.ok, true);
+      assert.equal(message.type, 'handoff');
+      assert.equal(message.payload.type, 'scene-graph-set');
+      assert.equal(message.payload.scope, 'scene');
+      assert.deepEqual(message.payload.graph, graph);
+    } finally {
+      await closeClient(ws);
+    }
+  });
+
+  it('broadcasts scene-graph-clear via REST API', async () => {
+    const ws = await connectClient('graph-clear-room');
+    try {
+      const messagePromise = waitForMessage(ws, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-clear'
+      );
+
+      const response = await fetch(`${baseUrl}/api/room/graph-clear-room/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'scene-graph-clear',
+          scope: 'scene'
+        }),
+      });
+
+      const [resBody, message] = await Promise.all([
+        response.json(),
+        messagePromise,
+      ]);
+
+      assert.equal(response.status, 200);
+      assert.equal(resBody.ok, true);
+      assert.equal(message.payload.type, 'scene-graph-clear');
+      assert.equal(message.payload.scope, 'scene');
+    } finally {
+      await closeClient(ws);
+    }
+  });
+
+  it('accepts object-scoped scene-graph messages', async () => {
+    const ws = await connectClient('graph-object-room');
+    try {
+      const messagePromise = waitForMessage(ws, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-set'
+      );
+
+      const graph = { nodes: [], edges: [] };
+      const response = await fetch(`${baseUrl}/api/room/graph-object-room/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'scene-graph-set',
+          scope: { object: 'cube1' },
+          graph
+        }),
+      });
+
+      const message = await messagePromise;
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(message.payload.scope, { object: 'cube1' });
+    } finally {
+      await closeClient(ws);
+    }
+  });
+
+  it('rejects scene-graph message with invalid scope', async () => {
+    const response = await fetch(`${baseUrl}/api/room/graph-invalid-room/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'scene-graph-set',
+        scope: { target: 'cube1' },
+        graph: { nodes: [], edges: [] }
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error, 'invalid scene-graph message');
+  });
+
+  it('rejects scene-graph-set without graph', async () => {
+    const response = await fetch(`${baseUrl}/api/room/graph-no-graph-room/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'scene-graph-set',
+        scope: 'scene'
+      }),
+    });
+
+    assert.equal(response.status, 400);
+  });
+
+  it('broadcasts scene-graph-patch via WebSocket', async () => {
+    const sender = await connectClient('graph-patch-room', 'Sender');
+    const receiver = await connectClient('graph-patch-room', 'Receiver');
+    try {
+      const messagePromise = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-patch'
+      );
+
+      const graph = { nodes: [{ id: 'n1', type: 'test' }], edges: [] };
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          type: 'scene-graph-patch',
+          scope: 'scene',
+          graph
+        }
+      }));
+
+      const message = await messagePromise;
+
+      assert.equal(message.payload.type, 'scene-graph-patch');
+      assert.deepEqual(message.payload.graph, graph);
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
+    }
+  });
+
+  it('broadcasts scene-graph-input for future use', async () => {
+    const ws = await connectClient('graph-input-room');
+    try {
+      const messagePromise = waitForMessage(ws, message =>
+        message.type === 'handoff' && message.payload?.type === 'scene-graph-input'
+      );
+
+      const response = await fetch(`${baseUrl}/api/room/graph-input-room/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'scene-graph-input',
+          scope: 'scene',
+          ref: 'click.event',
+          payload: { x: 100, y: 200 }
+        }),
+      });
+
+      const message = await messagePromise;
+
+      assert.equal(response.status, 200);
+      assert.equal(message.payload.type, 'scene-graph-input');
+      assert.equal(message.payload.ref, 'click.event');
+    } finally {
+      await closeClient(ws);
+    }
+  });
+});
+
 describe('presence GPT wrapper API', () => {
   it('redeems pairing code and returns sessionId', async () => {
     const userId = 'usr-gpt-redeem';

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -732,7 +732,9 @@ afjk.jp 側は Loom グラフを評価せず、ステートレスなメッセー
 
 #### `scene-graph-patch`（グラフの差分更新）
 
-第一実装では `graph` を含む場合、`scene-graph-set` と同等に扱う。
+afjk.jp 側では `scene-graph-patch` も他の scene-graph メッセージと同様に中継するのみ。
+受信側の LoomSceneSync が `graph` を含む `scene-graph-patch` を `scene-graph-set` 相当として扱うか、
+本来の差分パッチとして処理するかは、クライアント側の実装に任せる。
 
 ```json
 {
@@ -767,23 +769,17 @@ Phase 1 では予約扱い。現在は受信・中継のみで、サーバー側
 
 ### クライアント側の実装
 
+afjk.jp 側は scene-graph メッセージを中継するのみで、評価責任はクライアント側にある。
+
 ```javascript
 // メッセージ受信
 function handleSceneGraphMessage(msg) {
-  switch (msg.type) {
-    case 'scene-graph-set':
-      // LoomSceneSync に渡す
-      loomSync.setGraph(msg.scope, msg.graph);
-      break;
-    case 'scene-graph-clear':
-      loomSync.clearGraph(msg.scope);
-      break;
-    case 'scene-graph-patch':
-      loomSync.patchGraph(msg.scope, msg.graph);
-      break;
-    case 'scene-graph-input':
-      // 将来用
-      break;
+  // afjk.jp 側では中継のみを行う。実際の評価は LoomSceneSync に委ねる。
+  if (typeof loomSceneSync?.handleMessage === 'function') {
+    loomSceneSync.handleMessage(msg);
+  } else {
+    // Loom がまだ統合されていない場合
+    console.log('[SceneSync] received Loom graph message', msg);
   }
 }
 

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -690,6 +690,123 @@ Pose に加えて：
 
 ---
 
+## Loom グラフプロトコル（`scene-graph-*`）
+
+Loom（リアルタイムグラフプロセッシング）との連携を実現するグラフメッセージプロトコル。  
+afjk.jp 側は Loom グラフを評価せず、ステートレスなメッセージとしてルーム内で中継する。評価責任はクライアント側にある。
+
+### メッセージタイプ
+
+#### `scene-graph-set`（グラフの全置換）
+
+```json
+{
+  "type": "scene-graph-set",
+  "scope": "scene",
+  "graph": {
+    "nodes": [
+      { "id": "clock", "type": "serverClock" },
+      { "id": "sine", "type": "sine", "params": { "freq": 1, "amplitude": 50 } },
+      { "id": "pos", "type": "sceneSetPosition", "params": { "target": "cube1" } }
+    ],
+    "edges": [
+      { "from": "clock.t", "to": "sine.t" },
+      { "from": "sine.out", "to": "pos.x" }
+    ]
+  }
+}
+```
+
+`scope` は以下のいずれかのみ許可：
+- `"scene"`：全シーンに適用
+- `{ "object": "cube1" }`：特定オブジェクトに適用
+
+#### `scene-graph-clear`（グラフをクリア）
+
+```json
+{
+  "type": "scene-graph-clear",
+  "scope": "scene"
+}
+```
+
+#### `scene-graph-patch`（グラフの差分更新）
+
+第一実装では `graph` を含む場合、`scene-graph-set` と同等に扱う。
+
+```json
+{
+  "type": "scene-graph-patch",
+  "scope": "scene",
+  "graph": {
+    "nodes": [...],
+    "edges": [...]
+  }
+}
+```
+
+#### `scene-graph-input`（入力イベント）
+
+Phase 1 では予約扱い。現在は受信・中継のみで、サーバー側での処理なし。
+
+```json
+{
+  "type": "scene-graph-input",
+  "scope": "scene",
+  "ref": "click.event",
+  "payload": { "x": 100, "y": 200 }
+}
+```
+
+### サーバー側の動作
+
+- **検証**: `type`, `scope`, `graph` の基本的な JSON 形式を検証
+- **サイズ制限**: メッセージサイズが 64 KB を超える場合は 413 を返す
+- **中継**: 同一ルーム内の全クライアントへ handoff 形式で配信
+- **評価なし**: グラフの内容は解析しない
+
+### クライアント側の実装
+
+```javascript
+// メッセージ受信
+function handleSceneGraphMessage(msg) {
+  switch (msg.type) {
+    case 'scene-graph-set':
+      // LoomSceneSync に渡す
+      loomSync.setGraph(msg.scope, msg.graph);
+      break;
+    case 'scene-graph-clear':
+      loomSync.clearGraph(msg.scope);
+      break;
+    case 'scene-graph-patch':
+      loomSync.patchGraph(msg.scope, msg.graph);
+      break;
+    case 'scene-graph-input':
+      // 将来用
+      break;
+  }
+}
+
+// メッセージ送信
+function broadcastSceneGraph(type, scope, graph = null) {
+  const payload = {
+    type,
+    scope,
+  };
+  if (graph) {
+    payload.graph = graph;
+  }
+  broadcast({ ...payload });
+}
+```
+
+### デモ
+
+`html/scenesync-loom-demo.html` で scene-graph-* メッセージの送受信を確認できる。  
+ブラウザで複数タブを開き、別々のクライアントとして接続するだけで、メッセージの配信を確認可能。
+
+---
+
 ## 実装ガイドライン
 
 ### WebXR クライアント（`scene.js`）

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2081,7 +2081,16 @@ async function respondToSceneRequest(from) {
 
 function handleHandoff(data) {
   const payload = data.payload;
-  if (!payload || !payload.kind) return;
+  if (!payload) return;
+
+  // Handle scene-graph-* protocol messages (Loom graph protocol)
+  const sceneGraphTypes = new Set(['scene-graph-set', 'scene-graph-clear', 'scene-graph-patch', 'scene-graph-input']);
+  if (sceneGraphTypes.has(payload.type)) {
+    handleSceneGraphMessage(payload);
+    return;
+  }
+
+  if (!payload.kind) return;
 
   // 操作が自分またはAIが代理している場合、履歴に追加するか判定
   const isOwn = data.from.id === presenceState.id;
@@ -2289,6 +2298,24 @@ function handleHandoff(data) {
       break;
     }
     default:
+      break;
+  }
+}
+
+function handleSceneGraphMessage(msg) {
+  const scopeStr = msg.scope === 'scene' ? 'scene' : JSON.stringify(msg.scope);
+  switch (msg.type) {
+    case 'scene-graph-set':
+      console.log('[SceneSync] Received scene-graph-set scope=' + scopeStr + ' nodes=' + (msg.graph?.nodes?.length || 0) + ' edges=' + (msg.graph?.edges?.length || 0));
+      break;
+    case 'scene-graph-clear':
+      console.log('[SceneSync] Received scene-graph-clear scope=' + scopeStr);
+      break;
+    case 'scene-graph-patch':
+      console.log('[SceneSync] Received scene-graph-patch scope=' + scopeStr + (msg.graph ? ' nodes=' + msg.graph.nodes.length + ' edges=' + msg.graph.edges.length : ''));
+      break;
+    case 'scene-graph-input':
+      console.log('[SceneSync] Received scene-graph-input scope=' + scopeStr + ' ref=' + msg.ref);
       break;
   }
 }

--- a/html/scenesync-loom-demo.html
+++ b/html/scenesync-loom-demo.html
@@ -1,0 +1,531 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SceneSync Loom Graph Protocol Demo</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: #0a0e27;
+      color: #e0e0e0;
+      padding: 20px;
+    }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    h1 {
+      color: #64b5f6;
+      margin-bottom: 20px;
+      font-size: 24px;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+      margin-bottom: 20px;
+    }
+    .panel {
+      background: #1a1f3a;
+      border: 1px solid #2c3e50;
+      border-radius: 8px;
+      padding: 20px;
+    }
+    .panel h2 {
+      color: #64b5f6;
+      font-size: 16px;
+      margin-bottom: 15px;
+      border-bottom: 1px solid #2c3e50;
+      padding-bottom: 10px;
+    }
+    .control-group {
+      margin-bottom: 15px;
+    }
+    label {
+      display: block;
+      font-size: 12px;
+      color: #90caf9;
+      margin-bottom: 5px;
+      font-weight: 500;
+    }
+    input[type="text"],
+    input[type="number"],
+    textarea,
+    select {
+      width: 100%;
+      padding: 8px;
+      background: #0f1629;
+      border: 1px solid #2c3e50;
+      color: #e0e0e0;
+      border-radius: 4px;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 12px;
+    }
+    textarea {
+      min-height: 100px;
+      resize: vertical;
+    }
+    button {
+      background: #2196f3;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s;
+      width: 100%;
+    }
+    button:hover {
+      background: #1976d2;
+    }
+    button:disabled {
+      background: #424242;
+      cursor: not-allowed;
+    }
+    .button-group {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+    .log {
+      background: #0f1629;
+      border: 1px solid #2c3e50;
+      border-radius: 4px;
+      padding: 10px;
+      max-height: 400px;
+      overflow-y: auto;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 11px;
+      line-height: 1.4;
+    }
+    .log-entry {
+      padding: 4px 0;
+      border-bottom: 1px solid #1a2332;
+    }
+    .log-entry:last-child {
+      border-bottom: none;
+    }
+    .log-time {
+      color: #4db8ff;
+    }
+    .log-type {
+      color: #81c784;
+      font-weight: 600;
+    }
+    .log-scope {
+      color: #ffb74d;
+    }
+    .log-payload {
+      color: #b39ddb;
+    }
+    .status-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 15px;
+      background: #1a1f3a;
+      border: 1px solid #2c3e50;
+      border-radius: 4px;
+      margin-bottom: 20px;
+      font-size: 12px;
+    }
+    .status-indicator {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      margin-right: 6px;
+    }
+    .status-indicator.connected {
+      background: #81c784;
+    }
+    .status-indicator.disconnected {
+      background: #e57373;
+    }
+    .full-width {
+      grid-column: 1 / -1;
+    }
+    .info-box {
+      background: #0f1629;
+      border: 1px solid #2c3e50;
+      border-radius: 4px;
+      padding: 10px;
+      margin-top: 10px;
+      font-size: 11px;
+      color: #90caf9;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🔗 SceneSync Loom Graph Protocol Demo</h1>
+
+    <div class="status-bar">
+      <div>
+        <span class="status-indicator disconnected" id="status-indicator"></span>
+        <span id="status-text">Not connected</span>
+      </div>
+      <div id="peer-count">0 peers</div>
+    </div>
+
+    <div class="layout">
+      <div class="panel">
+        <h2>Room Connection</h2>
+        <div class="control-group">
+          <label>Room ID:</label>
+          <input type="text" id="roomId" value="loom-demo" placeholder="Enter room ID">
+        </div>
+        <div class="control-group">
+          <label>Nickname:</label>
+          <input type="text" id="nickname" value="DemoUser" placeholder="Your name">
+        </div>
+        <button id="connectBtn" onclick="toggleConnection()">Connect</button>
+        <div class="info-box">
+          Room ID is sanitized to lowercase alphanumeric + hyphens, max 32 chars.
+        </div>
+      </div>
+
+      <div class="panel">
+        <h2>Message Log (Received)</h2>
+        <div class="log" id="log"></div>
+        <button onclick="clearLog()" style="margin-top: 10px;">Clear Log</button>
+      </div>
+
+      <div class="panel full-width">
+        <h2>Send scene-graph-set</h2>
+        <div class="control-group">
+          <label>Scope:</label>
+          <select id="setScope">
+            <option value="scene">scene</option>
+            <option value="object">{ object: "cube1" }</option>
+            <option value="object2">{ object: "custom" }</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Nodes (JSON array):</label>
+          <textarea id="setNodes">[
+  { "id": "clock", "type": "serverClock" },
+  { "id": "sine", "type": "sine", "params": { "freq": 1, "amplitude": 50 } },
+  { "id": "pos", "type": "sceneSetPosition", "params": { "target": "cube1" } }
+]</textarea>
+        </div>
+        <div class="control-group">
+          <label>Edges (JSON array):</label>
+          <textarea id="setEdges">[
+  { "from": "clock.t", "to": "sine.t" },
+  { "from": "sine.out", "to": "pos.x" }
+]</textarea>
+        </div>
+        <button id="sendSetBtn" onclick="sendSceneGraphSet()" disabled>Send scene-graph-set</button>
+      </div>
+
+      <div class="panel full-width">
+        <h2>Send scene-graph-clear</h2>
+        <div class="control-group">
+          <label>Scope:</label>
+          <select id="clearScope">
+            <option value="scene">scene</option>
+            <option value="object">{ object: "cube1" }</option>
+          </select>
+        </div>
+        <button id="sendClearBtn" onclick="sendSceneGraphClear()" disabled>Send scene-graph-clear</button>
+      </div>
+
+      <div class="panel full-width">
+        <h2>Send scene-graph-patch</h2>
+        <div class="control-group">
+          <label>Scope:</label>
+          <select id="patchScope">
+            <option value="scene">scene</option>
+            <option value="object">{ object: "cube1" }</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Nodes (JSON array):</label>
+          <textarea id="patchNodes">[
+  { "id": "n1", "type": "test", "params": { "value": 1 } }
+]</textarea>
+        </div>
+        <div class="control-group">
+          <label>Edges (JSON array):</label>
+          <textarea id="patchEdges">[]</textarea>
+        </div>
+        <button id="sendPatchBtn" onclick="sendSceneGraphPatch()" disabled>Send scene-graph-patch</button>
+      </div>
+
+      <div class="panel full-width">
+        <h2>Send scene-graph-input</h2>
+        <div class="control-group">
+          <label>Scope:</label>
+          <select id="inputScope">
+            <option value="scene">scene</option>
+            <option value="object">{ object: "cube1" }</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label>Ref (string):</label>
+          <input type="text" id="inputRef" value="click.event" placeholder="e.g., click.event">
+        </div>
+        <div class="control-group">
+          <label>Payload (JSON):</label>
+          <textarea id="inputPayload">{ "x": 100, "y": 200 }</textarea>
+        </div>
+        <button id="sendInputBtn" onclick="sendSceneGraphInput()" disabled>Send scene-graph-input</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let ws = null;
+    let connected = false;
+
+    function sanitizeRoom(raw) {
+      if (!raw) return '';
+      return raw.toLowerCase().replace(/[^a-z0-9\-]/g, '').slice(0, 32);
+    }
+
+    function updateUI() {
+      const btns = ['sendSetBtn', 'sendClearBtn', 'sendPatchBtn', 'sendInputBtn'];
+      btns.forEach(id => {
+        document.getElementById(id).disabled = !connected;
+      });
+
+      const indicator = document.getElementById('status-indicator');
+      const text = document.getElementById('status-text');
+      if (connected) {
+        indicator.className = 'status-indicator connected';
+        text.textContent = 'Connected to ' + sanitizeRoom(document.getElementById('roomId').value);
+        document.getElementById('connectBtn').textContent = 'Disconnect';
+      } else {
+        indicator.className = 'status-indicator disconnected';
+        text.textContent = 'Not connected';
+        document.getElementById('connectBtn').textContent = 'Connect';
+      }
+    }
+
+    function addLogEntry(type, scope, details = '') {
+      const log = document.getElementById('log');
+      const entry = document.createElement('div');
+      entry.className = 'log-entry';
+      const time = new Date().toLocaleTimeString();
+      const scopeStr = typeof scope === 'string' ? scope : JSON.stringify(scope);
+      entry.innerHTML = `<span class="log-time">${time}</span> <span class="log-type">[${type}]</span> <span class="log-scope">scope=${scopeStr}</span> ${details}`;
+      log.appendChild(entry);
+      log.scrollTop = log.scrollHeight;
+
+      // Keep only last 100 entries
+      const entries = log.querySelectorAll('.log-entry');
+      if (entries.length > 100) {
+        entries[0].remove();
+      }
+    }
+
+    function clearLog() {
+      document.getElementById('log').innerHTML = '';
+    }
+
+    function toggleConnection() {
+      if (connected) {
+        disconnect();
+      } else {
+        connect();
+      }
+    }
+
+    function connect() {
+      const roomId = sanitizeRoom(document.getElementById('roomId').value);
+      const nickname = document.getElementById('nickname').value || 'DemoUser';
+
+      if (!roomId) {
+        alert('Please enter a room ID');
+        return;
+      }
+
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const wsUrl = `${protocol}//${window.location.host}/ws?room=${encodeURIComponent(roomId)}`;
+
+      ws = new WebSocket(wsUrl);
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify({
+          type: 'hello',
+          nickname,
+          device: 'Browser Demo',
+        }));
+      };
+
+      ws.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data);
+          handleMessage(msg);
+        } catch (err) {
+          console.error('Failed to parse message:', err);
+        }
+      };
+
+      ws.onclose = () => {
+        connected = false;
+        updateUI();
+      };
+
+      ws.onerror = (err) => {
+        console.error('WebSocket error:', err);
+        alert('Connection error. Check console.');
+      };
+    }
+
+    function disconnect() {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+      connected = false;
+      updateUI();
+    }
+
+    function handleMessage(msg) {
+      if (msg.type === 'welcome') {
+        connected = true;
+        updateUI();
+        addLogEntry('WELCOME', 'system', `id=${msg.id}`);
+      } else if (msg.type === 'peers') {
+        document.getElementById('peer-count').textContent = (msg.peers?.length || 0) + ' peers';
+      } else if (msg.type === 'handoff' && msg.payload) {
+        const payload = msg.payload;
+        if (payload.type && payload.type.startsWith('scene-graph-')) {
+          const scopeStr = typeof payload.scope === 'string' ? payload.scope : JSON.stringify(payload.scope);
+          switch (payload.type) {
+            case 'scene-graph-set':
+              addLogEntry('SET', payload.scope, `nodes=${payload.graph?.nodes?.length || 0} edges=${payload.graph?.edges?.length || 0}`);
+              break;
+            case 'scene-graph-clear':
+              addLogEntry('CLEAR', payload.scope);
+              break;
+            case 'scene-graph-patch':
+              addLogEntry('PATCH', payload.scope, `nodes=${payload.graph?.nodes?.length || 0} edges=${payload.graph?.edges?.length || 0}`);
+              break;
+            case 'scene-graph-input':
+              addLogEntry('INPUT', payload.scope, `ref=${payload.ref}`);
+              break;
+          }
+        }
+      }
+    }
+
+    function parseScope(scopeStr) {
+      if (scopeStr === 'scene') return 'scene';
+      if (scopeStr === 'object') return { object: 'cube1' };
+      if (scopeStr === 'object2') return { object: 'custom' };
+      return 'scene';
+    }
+
+    function sendSceneGraphSet() {
+      if (!connected || !ws) {
+        alert('Not connected');
+        return;
+      }
+
+      try {
+        const scope = parseScope(document.getElementById('setScope').value);
+        const nodes = JSON.parse(document.getElementById('setNodes').value);
+        const edges = JSON.parse(document.getElementById('setEdges').value);
+
+        const msg = {
+          type: 'broadcast',
+          payload: {
+            type: 'scene-graph-set',
+            scope,
+            graph: { nodes, edges }
+          }
+        };
+
+        ws.send(JSON.stringify(msg));
+        addLogEntry('SET (sent)', scope, `nodes=${nodes.length} edges=${edges.length}`);
+      } catch (err) {
+        alert('Invalid JSON: ' + err.message);
+      }
+    }
+
+    function sendSceneGraphClear() {
+      if (!connected || !ws) {
+        alert('Not connected');
+        return;
+      }
+
+      const scope = parseScope(document.getElementById('clearScope').value);
+      const msg = {
+        type: 'broadcast',
+        payload: {
+          type: 'scene-graph-clear',
+          scope
+        }
+      };
+
+      ws.send(JSON.stringify(msg));
+      addLogEntry('CLEAR (sent)', scope);
+    }
+
+    function sendSceneGraphPatch() {
+      if (!connected || !ws) {
+        alert('Not connected');
+        return;
+      }
+
+      try {
+        const scope = parseScope(document.getElementById('patchScope').value);
+        const nodes = JSON.parse(document.getElementById('patchNodes').value);
+        const edges = JSON.parse(document.getElementById('patchEdges').value);
+
+        const msg = {
+          type: 'broadcast',
+          payload: {
+            type: 'scene-graph-patch',
+            scope,
+            graph: { nodes, edges }
+          }
+        };
+
+        ws.send(JSON.stringify(msg));
+        addLogEntry('PATCH (sent)', scope, `nodes=${nodes.length} edges=${edges.length}`);
+      } catch (err) {
+        alert('Invalid JSON: ' + err.message);
+      }
+    }
+
+    function sendSceneGraphInput() {
+      if (!connected || !ws) {
+        alert('Not connected');
+        return;
+      }
+
+      try {
+        const scope = parseScope(document.getElementById('inputScope').value);
+        const ref = document.getElementById('inputRef').value;
+        const payload = JSON.parse(document.getElementById('inputPayload').value);
+
+        const msg = {
+          type: 'broadcast',
+          payload: {
+            type: 'scene-graph-input',
+            scope,
+            ref,
+            payload
+          }
+        };
+
+        ws.send(JSON.stringify(msg));
+        addLogEntry('INPUT (sent)', scope, `ref=${ref}`);
+      } catch (err) {
+        alert('Invalid JSON: ' + err.message);
+      }
+    }
+
+    // Initialize
+    updateUI();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

`scene-graph-*` メッセージ型を afjk.jp 側 SceneSync に追加し、Loom のグラフプロトコルに対応しました。
サーバー側は Loom グラフを評価せず、ステートレスなメッセージとしてルーム内で中継します。評価責任は各クライアントにあります。

## 対応メッセージ

- `scene-graph-set` - グラフの全置換
- `scene-graph-clear` - グラフをクリア
- `scene-graph-patch` - グラフの差分更新（現在は set と同等）
- `scene-graph-input` - 入力イベント（予約扱い）

## 仕様メモ

### Scope

メッセージの適用範囲を指定:
- `scope: "scene"` - 全シーン
- `scope: { object: "cube1" }` - 特定オブジェクト

### Validation

サーバー側で以下を検証:
- `type` が有効な scene-graph-* メッセージ型
- `scope` が "scene" または `{ object: "..." }`
- `scene-graph-set` / `scene-graph-patch` では `graph.nodes` と `graph.edges` が配列
- メッセージサイズが 64 KB 以下

### 中継

- 同一ルーム内の全クライアントへ handoff 形式で配信
- REST API `/api/room/{room}/broadcast` で送信可能
- WebSocket 経由でもクライアント送信可能

## 実装内容

### サーバー側

1. **定数と検証関数**
   - `SCENE_GRAPH_MESSAGE_TYPES` - メッセージ型のセット
   - `SCENE_GRAPH_MAX_SIZE` - 64 KB の制限
   - `isValidScope()` - scope の検証
   - `validateSceneGraphMessage()` - メッセージ全体の検証
   - `logSceneGraphMessage()` - デバッグログ出力

2. **REST API 拡張** (`/api/room/{room}/broadcast`)
   - scene-graph-* メッセージの受け入れ
   - 検証後、ルーム内全クライアントに配信

3. **WebSocket クライアント処理**
   - `broadcast` タイプのメッセージで scene-graph-* をサポート

### クライアント側

1. **メッセージハンドラ** (`scene.js`)
   - `handleSceneGraphMessage()` - 受信したグラフメッセージの処理
   - console.log でメッセージを出力（デモ・デバッグ用）

2. **デモページ** (`html/scenesync-loom-demo.html`)
   - ブラウザベースのテスト UI
   - 複数タブで複数クライアント接続可能
   - 各メッセージ型をインタラクティブに送信
   - 受信メッセージをリアルタイムログ表示

## テスト

以下の 9 つのテストを追加し、全て成功しました:

1. ✅ REST API で scene-graph-set を broadcast
2. ✅ REST API で scene-graph-clear を broadcast
3. ✅ object-scoped メッセージ対応
4. ✅ 無効な scope を reject
5. ✅ scene-graph-set without graph を reject
6. ✅ WebSocket で scene-graph-patch を broadcast
7. ✅ scene-graph-input を broadcast
8. ✅ WebSocket invalid scope は中継されない
9. ✅ WebSocket graph 欠落は中継されない

テスト実行コマンド:
```bash
cd apps/presence-server && node --test tests/api.test.mjs
```

## 手動確認手順

### デモページで確認（推奨）

1. `html/scenesync-loom-demo.html` をブラウザで開く
2. ローカルサーバーがポート 8787 で起動していることを確認
3. Room ID を入力（デフォルト: `loom-demo`）
4. [Connect] ボタンをクリック
5. **ブラウザBでも同じページを開き、同じ Room ID で接続**
6. ブラウザAから `scene-graph-set` を送信
7. ブラウザBのログに `SET` が表示されることを確認
9. ブラウザBから `scene-graph-clear` を送信
10. ブラウザAのログに `CLEAR` が表示されることを確認

### コマンドラインで確認

```bash
# ローカルサーバーを起動
cd apps/presence-server && npm start &

# ターミナルAでクライアント接続
curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" \
  http://localhost:8787?room=test

# ターミナルBで scene-graph-set を送信
curl -X POST http://localhost:8787/api/room/test/broadcast \
  -H "Content-Type: application/json" \
  -d '{
    "type": "scene-graph-set",
    "scope": "scene",
    "graph": {
      "nodes": [{"id": "n1", "type": "serverClock"}],
      "edges": []
    }
  }'

# ターミナルAで受信メッセージを確認
```

## 未対応事項

- Loom グラフの実際の評価・実行
- Unity クライアント側の scene-graph-* 対応
- 差分 patch の本実装（現在は set と同等）
- scene-graph-input の本実装（予約扱い）
- Loom SDK の完全統合

## 互換性

- 既存の scene-add, scene-delta, scene-remove, scene-env メッセージの動作に影響なし
- scene-script メッセージの意味は変更なし
- 後方互換性を完全に保持

## ドキュメント

`docs/scene-sync-spec.md` に以下を追加:
- Loom グラフプロトコルセクション
- メッセージ型の詳細仕様
- サーバー側の動作
- クライアント側実装例
- デモページの紹介

https://claude.ai/code/session_01SLKpMG4RtxNYG3Y9XQMqjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLKpMG4RtxNYG3Y9XQMqjV)_