### PR TITLE
Update WebSocket endpoint from /ws to /presence

### DIFF
--- a/html/scenesync-loom-demo.html
+++ b/html/scenesync-loom-demo.html
@@ -346,7 +346,7 @@
       }
 
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = `${protocol}//${window.location.host}/ws?room=${encodeURIComponent(roomId)}`;
+      const wsUrl = `${protocol}//${window.location.host}/presence?room=${encodeURIComponent(roomId)}`;
 
       ws = new WebSocket(wsUrl);
 


### PR DESCRIPTION
## Summary
Updated the WebSocket connection endpoint in the scenesync-loom-demo to use the `/presence` route instead of `/ws`.

## Changes
- Changed WebSocket URL endpoint from `/ws` to `/presence` while maintaining the existing room query parameter
- This allows the demo to connect to the presence service instead of the generic WebSocket service

## Implementation Details
The WebSocket URL construction remains the same, with only the path segment being updated. The room ID parameter is still properly encoded and passed through as before.

https://claude.ai/code/session_01CKYY11TijZ8BqyXYmpQ5sh