### PR TITLE
Integrate loom scenesync 2

### DIFF
--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -839,6 +839,60 @@ Phase 1 では予約扱い。現在は受信・中継のみで、サーバー側
 }
 ```
 
+### scene-state への loomGraphs 復元
+
+**途中参加者向けグラフ復元**
+
+`scene-state` には Loom graph 状態を含める場合があります。room に途中参加したクライアントが既存の Loom animation を復元するためです。
+
+#### スキーマ
+
+```json
+{
+  "kind": "scene-state",
+  "objects": {
+    "cube1": {
+      "name": "cube1",
+      "position": [0, 0.5, 0],
+      "rotation": [0, 0, 0, 1],
+      "scale": [1, 1, 1],
+      "asset": { "type": "primitive", "primitive": "box", "color": "#4488ff" }
+    }
+  },
+  "loomGraphs": {
+    "scene": null,
+    "objects": {
+      "cube1": {
+        "nodes": [
+          { "id": "clock", "type": "serverClock" },
+          { "id": "sine", "type": "sine", "params": { "freq": 0.2, "amplitude": 2, "offset": 0 } },
+          { "id": "pos", "type": "sceneSetPosition", "params": { "y": 0.5, "z": 0 } }
+        ],
+        "edges": [
+          { "from": "clock.t", "to": "sine.t" },
+          { "from": "sine.out", "to": "pos.x" }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### 仕様
+
+- `loomGraphs` は optional フィールド。Loom graph がない場合は省略可能
+- `loomGraphs.scene`: scene scope の Loom graph（null または graph 定義）
+- `loomGraphs.objects`: objectId ごとの object scope Loom graph（オブジェクト）
+- **途中参加者復元**：`scene-state` を受信したクライアントが存在する graph を自動復元する
+  - objects の復元後に graph を import する（target object が存在することを保証）
+  - import 失敗時も viewer は動作継続（warning log と toast）
+- **object 削除時**：object scope の Loom graph も同時に削除される
+  - remote `scene-remove` を受信した時点で object scope graph を stop/cleanup
+  - 途中参加者が `scene-state` を再取得した時点で存在しない object graph は復元されない
+- **サーバー責務なし**：presence-server は `loomGraphs` を保持・管理しない
+  - room 内の既存クライアントが `scene-state` を返すときに自身の graph 状態を含める
+  - サーバーはそのまま中継するのみ
+
 ---
 
 ## 実装ガイドライン

--- a/html/assets/js/scenesync/loom/loom-integration.js
+++ b/html/assets/js/scenesync/loom/loom-integration.js
@@ -51,6 +51,9 @@ export function createSceneSyncLoomIntegration({
 
   return {
     handlePayload,
+    exportState: () => adapter.exportState(),
+    importState: (state) => adapter.importState(state),
+    clearObjectGraph: (objectId) => adapter.clearObjectGraph(objectId),
     dispose,
     adapter,
   };

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -391,6 +391,8 @@ export class LoomSceneSync {
   dispose() {
     this.stop();
     this._objectGraphs.clear();
+    this._objectGraphDefinitions.clear();
+    this._sceneGraphDefinition = null;
     adapterRegistry.delete(this.adapterId);
   }
 

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -43,6 +43,10 @@ export class LoomSceneSync {
     // 実行状態
     this._started = false;
 
+    // Export 用 graph definition の保持
+    this._sceneGraphDefinition = null;
+    this._objectGraphDefinitions = new Map();
+
     // ノード型登録（冪等性を保証）
     this._registerNodeTypes();
   }
@@ -297,12 +301,17 @@ export class LoomSceneSync {
     }
 
     this._validateSceneSyncGraphNodeTypes(msg.graph);
+
+    // Export 用に元の graph を保存（deep clone）
+    const graphDefinition = JSON.parse(JSON.stringify(msg.graph));
+
     const injectedGraph = this._injectAdapterId(msg.graph, msg.scope);
 
     if (typeof msg.scope === "string" && msg.scope === "scene") {
       // シーングラフの置き換え
       this._sceneGraph.stop();
       this._sceneGraph = new this.LoomClass(injectedGraph);
+      this._sceneGraphDefinition = graphDefinition;
       if (this._started) {
         this._sceneGraph.start();
       }
@@ -314,6 +323,7 @@ export class LoomSceneSync {
       }
       const engine = new this.LoomClass(injectedGraph);
       this._objectGraphs.set(targetId, engine);
+      this._objectGraphDefinitions.set(targetId, graphDefinition);
       if (this._started) {
         engine.start();
       }
@@ -327,6 +337,7 @@ export class LoomSceneSync {
       // シーングラフをクリア
       this._sceneGraph.stop();
       this._sceneGraph = new this.LoomClass({ nodes: [], edges: [] });
+      this._sceneGraphDefinition = null;
       if (this._started) {
         this._sceneGraph.start();
       }
@@ -337,6 +348,7 @@ export class LoomSceneSync {
         this._objectGraphs.get(targetId).stop();
         this._objectGraphs.delete(targetId);
       }
+      this._objectGraphDefinitions.delete(targetId);
     }
   }
 
@@ -380,6 +392,64 @@ export class LoomSceneSync {
     this.stop();
     this._objectGraphs.clear();
     adapterRegistry.delete(this.adapterId);
+  }
+
+  exportState() {
+    const state = {
+      scene: this._sceneGraphDefinition ? JSON.parse(JSON.stringify(this._sceneGraphDefinition)) : null,
+      objects: {}
+    };
+
+    for (const [objectId, definition] of this._objectGraphDefinitions) {
+      if (definition) {
+        state.objects[objectId] = JSON.parse(JSON.stringify(definition));
+      }
+    }
+
+    return state;
+  }
+
+  importState(state) {
+    if (!state || typeof state !== 'object') return;
+
+    if (state.scene) {
+      try {
+        this.handleMessage({
+          type: 'scene-graph-set',
+          scope: 'scene',
+          graph: JSON.parse(JSON.stringify(state.scene)),
+        });
+      } catch (err) {
+        console.warn('[loom] failed to import scene graph:', err);
+      }
+    }
+
+    if (state.objects && typeof state.objects === 'object') {
+      for (const [objectId, graph] of Object.entries(state.objects)) {
+        if (!graph) continue;
+        try {
+          this.handleMessage({
+            type: 'scene-graph-set',
+            scope: { object: objectId },
+            graph: JSON.parse(JSON.stringify(graph)),
+          });
+        } catch (err) {
+          console.warn(`[loom] failed to import object graph for ${objectId}:`, err);
+        }
+      }
+    }
+  }
+
+  clearObjectGraph(objectId) {
+    if (!objectId) return;
+
+    const graph = this._objectGraphs.get(objectId);
+    if (graph) {
+      graph.stop();
+      this._objectGraphs.delete(objectId);
+    }
+
+    this._objectGraphDefinitions.delete(objectId);
   }
 
   sendGraph(scope, graph) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2096,10 +2096,18 @@ async function respondToSceneRequest(from) {
 
   const ws = presenceState.ws;
   if (ws && ws.readyState === WebSocket.OPEN) {
+    const payload = { kind: 'scene-state', envId: environmentManager.getCurrentEnvId(), objects };
+
+    // Loom graph state を含める
+    const loomGraphState = loomIntegration.exportState();
+    if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
+      payload.loomGraphs = loomGraphState;
+    }
+
     ws.send(JSON.stringify({
       type: 'handoff',
       targetId: from.id,
-      payload: { kind: 'scene-state', envId: environmentManager.getCurrentEnvId(), objects },
+      payload,
     }));
   }
 }
@@ -2137,6 +2145,16 @@ function handleHandoff(data) {
       const objects = payload.objects || {};
       for (const [objectId, info] of Object.entries(objects)) {
         addOrUpdateObject(objectId, info);
+      }
+
+      // Loom graph 状態を復元
+      if (payload.loomGraphs) {
+        try {
+          loomIntegration.importState(payload.loomGraphs);
+        } catch (error) {
+          console.warn('[loom] failed to import loomGraphs from scene-state:', error);
+          showToast?.('Loom graph restore failed');
+        }
       }
       break;
     }
@@ -2213,6 +2231,8 @@ function handleHandoff(data) {
         scene.remove(obj);
         managedObjects.delete(objectId);
       }
+      // Loom object graph をクリーンアップ
+      loomIntegration.clearObjectGraph(objectId);
       break;
     }
     case 'scene-mesh': {
@@ -2776,6 +2796,8 @@ function applyOperationToScene(operation) {
         scene.remove(obj);
         managedObjects.delete(operation.objectId);
       }
+      // Loom object graph をクリーンアップ
+      loomIntegration.clearObjectGraph(operation.objectId);
       break;
     }
     case 'scene-delta': {


### PR DESCRIPTION
This pull request implements support for exporting and restoring Loom graph states as part of the scene synchronization process, enabling late-joining clients to recover ongoing Loom animations. The changes include updates to both the documentation/spec and the implementation to handle exporting, importing, and cleanup of per-object and scene-wide Loom graphs during scene state handoff and object removal.

**Scene state export/import and restoration:**

- Added support for including `loomGraphs` (scene and per-object Loom graph definitions) in the `scene-state` payload, allowing late joiners to restore ongoing Loom animations. The documentation/spec (`docs/scene-sync-spec.md`) was updated to describe the schema and behavior for restoring graphs, handling missing graphs, and cleaning up on object removal.
- Modified the scene sync implementation (`scene.js`) to export Loom graph state when responding to scene requests and to import and restore Loom graphs when receiving a `scene-state` payload. Error handling and user feedback (toast/warning) are provided on import failure. [[1]](diffhunk://#diff-bbe7f6ff90c1f285925a4e5d27e11b3e00af6647ad4774b3db215e7c33bd165eR2099-R2110) [[2]](diffhunk://#diff-bbe7f6ff90c1f285925a4e5d27e11b3e00af6647ad4774b3db215e7c33bd165eR2149-R2158)

**Loom integration API enhancements:**

- Extended the Loom integration API (`loom-integration.js`, `loom-scenesync.js`) with `exportState`, `importState`, and `clearObjectGraph` methods to support exporting the current graph state, restoring it from a payload, and cleaning up object graphs when objects are removed. [[1]](diffhunk://#diff-31b882d78acfbd564a67d9ac71c5ea640c6ea5ede6d7e85a59982511fa2dde91R54-R56) [[2]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R394-R456)

**Graph state management and cleanup:**

- Ensured that Loom graph definitions are tracked and deep-cloned for export/import, and are properly cleared when objects are removed or the integration is disposed. This prevents stale graphs from persisting and ensures accurate restoration for late joiners. [[1]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R46-R49) [[2]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R304-R314) [[3]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R326) [[4]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R340) [[5]](diffhunk://#diff-c920c352584e14b25b4f68ff8ab1f13ea4a92fc15ccb6bad19c2c4b0bc003d51R351) [[6]](diffhunk://#diff-bbe7f6ff90c1f285925a4e5d27e11b3e00af6647ad4774b3db215e7c33bd165eR2234-R2235) [[7]](diffhunk://#diff-bbe7f6ff90c1f285925a4e5d27e11b3e00af6647ad4774b3db215e7c33bd165eR2799-R2800)