### PR TITLE
Add ISSUE/PR templates, AGENTS guide, and planning docs; update .gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,31 +4,31 @@ about: Report a bug found during review or staging
 labels: [type:bug]
 ---
 
-## Summary
+## 概要
 
 ## Area
 - scenesync | loom | file-transfer | platform | docs
 
-## Steps to reproduce
+## 再現手順
 1. 
 2. 
 3. 
 
-## Expected behavior
+## 期待される挙動
 
-## Actual behavior
+## 実際の挙動
 
-## Environment
+## 環境
 - Commit/branch:
 - Environment (local/staging/prod):
 - Browser/runtime/device:
 
-## Screenshots or logs
+## スクリーンショットまたはログ
 
-## Severity
+## 重大度
 - low | medium | high | critical
 
-## Workaround
+## 回避策
 
 ## Release blocker?
 - [ ] Yes

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug found during review or staging
+labels: [type:bug]
+---
+
+## Summary
+
+## Area
+- scenesync | loom | file-transfer | platform | docs
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+- Commit/branch:
+- Environment (local/staging/prod):
+- Browser/runtime/device:
+
+## Screenshots or logs
+
+## Severity
+- low | medium | high | critical
+
+## Workaround
+
+## Release blocker?
+- [ ] Yes
+- [ ] No

--- a/.github/ISSUE_TEMPLATE/follow-up-task.md
+++ b/.github/ISSUE_TEMPLATE/follow-up-task.md
@@ -1,0 +1,31 @@
+---
+name: Follow-up Task
+about: Task discovered during implementation that should be tracked separately
+labels: [type:follow-up]
+---
+
+## Summary
+
+## Discovered while working on
+- Issue/PR: #
+
+## Area
+- scenesync | loom | file-transfer | platform | docs
+
+## Type
+- follow-up | blocker | bug | refactor | new-idea
+
+## Why this should not be included in the current PR
+
+## Suggested priority
+- now | next | later
+
+## Related files
+- 
+
+## Blocking status
+- [ ] Blocking current task
+- [ ] Not blocking current task
+
+## Acceptance criteria
+- [ ]

--- a/.github/ISSUE_TEMPLATE/follow-up-task.md
+++ b/.github/ISSUE_TEMPLATE/follow-up-task.md
@@ -4,9 +4,9 @@ about: Task discovered during implementation that should be tracked separately
 labels: [type:follow-up]
 ---
 
-## Summary
+## 概要
 
-## Discovered while working on
+## どの作業中に見つかったか
 - Issue/PR: #
 
 ## Area
@@ -15,12 +15,12 @@ labels: [type:follow-up]
 ## Type
 - follow-up | blocker | bug | refactor | new-idea
 
-## Why this should not be included in the current PR
+## 今回のPRに含めない理由
 
-## Suggested priority
+## 優先度（提案）
 - now | next | later
 
-## Related files
+## 関連ファイル
 - 
 
 ## Blocking status

--- a/.github/ISSUE_TEMPLATE/implementation-task.md
+++ b/.github/ISSUE_TEMPLATE/implementation-task.md
@@ -1,0 +1,32 @@
+---
+name: Implementation Task
+about: Planned implementation work
+labels: [agent:needs-plan]
+---
+
+## Summary
+
+## Area
+- scenesync | loom | file-transfer | platform | docs
+
+## Type
+- feature | bug | refactor | platform
+
+## Related plan
+- `docs/plans/...`
+
+## Background
+
+## Requirements
+
+## Acceptance criteria
+- [ ]
+
+## Out of scope
+
+## Suggested files
+- 
+
+## Test plan
+
+## Risks

--- a/.github/ISSUE_TEMPLATE/implementation-task.md
+++ b/.github/ISSUE_TEMPLATE/implementation-task.md
@@ -4,7 +4,7 @@ about: Planned implementation work
 labels: [agent:needs-plan]
 ---
 
-## Summary
+## 概要
 
 ## Area
 - scenesync | loom | file-transfer | platform | docs
@@ -12,21 +12,21 @@ labels: [agent:needs-plan]
 ## Type
 - feature | bug | refactor | platform
 
-## Related plan
+## 関連プラン
 - `docs/plans/...`
 
-## Background
+## 背景
 
-## Requirements
+## 要件
 
 ## Acceptance criteria
 - [ ]
 
 ## Out of scope
 
-## Suggested files
+## 変更候補ファイル
 - 
 
-## Test plan
+## テスト計画
 
-## Risks
+## リスク

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,43 @@
-## Summary
+## 概要
 
-## Related issue
+## 関連Issue
 - Closes #
 
-## Related plan
+## 関連プラン
 - `docs/plans/...`
 
-## Area
+## 対象エリア
 - [ ] scenesync
 - [ ] loom
 - [ ] file-transfer
 - [ ] platform
 - [ ] docs
 
-## Type of change
+## 変更種別
 - [ ] feature
 - [ ] bug fix
 - [ ] refactor
 - [ ] docs
 - [ ] workflow/platform
 
-## What changed
+## 変更内容
 
-## What was intentionally not changed
+## 意図的に変更していないこと
 
-## How to test
+## テスト方法
 
-## Test results
+## テスト結果
 
-## Screenshots or videos (if UI-related)
+## UI変更がある場合のスクリーンショット/動画
 
-## Risks
+## リスク
 
 ## Follow-up tasks
 - #
 
-## Checklist
-- [ ] This PR does not include unrelated changes.
-- [ ] This PR follows the related plan.
-- [ ] I documented any follow-up tasks.
-- [ ] I ran relevant tests or explained why they could not be run.
-- [ ] I updated docs if behavior changed.
+## チェックリスト
+- [ ] この PR に無関係な変更を含めていない。
+- [ ] この PR は関連 plan に沿っている。
+- [ ] 必要な follow-up tasks を記録した。
+- [ ] 関連 tests を実行した、または実行できない理由を記載した。
+- [ ] 挙動変更がある場合は docs を更新した。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Summary
+
+## Related issue
+- Closes #
+
+## Related plan
+- `docs/plans/...`
+
+## Area
+- [ ] scenesync
+- [ ] loom
+- [ ] file-transfer
+- [ ] platform
+- [ ] docs
+
+## Type of change
+- [ ] feature
+- [ ] bug fix
+- [ ] refactor
+- [ ] docs
+- [ ] workflow/platform
+
+## What changed
+
+## What was intentionally not changed
+
+## How to test
+
+## Test results
+
+## Screenshots or videos (if UI-related)
+
+## Risks
+
+## Follow-up tasks
+- #
+
+## Checklist
+- [ ] This PR does not include unrelated changes.
+- [ ] This PR follows the related plan.
+- [ ] I documented any follow-up tasks.
+- [ ] I ran relevant tests or explained why they could not be run.
+- [ ] I updated docs if behavior changed.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ verdaccio/
 
 node_modules/
 plans/
+
+# Track repository planning docs under docs/plans/
+!docs/plans/
+!docs/plans/**/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS Guide
+
+## Repository purpose
+This repository hosts afjk.jp platform and related tooling for real-time scene synchronization, Loom runtime integration, FileTransfer capabilities, and supporting platform workflows (CI, staging, release, deployment, and agent operations).
+
+## Important project areas
+- **Scene Sync**: scene state synchronization, scene object operations, AI-accessible scene control, and Scene Dev Tool work.
+- **Loom integration**: logic graph/runtime behavior and integration boundaries with Scene Sync.
+- **FileTransfer**: room-based file transfer, fallback transport paths, and file sharing UX.
+- **Platform / deployment / tooling**: CI, release, staging, deployment, repo workflow, and agent workflow support.
+
+## Scope discipline
+- Follow **one task = one issue = one PR**.
+- Do not mix unrelated changes in the same PR.
+- Do not add speculative refactors.
+- Do not silently expand scope beyond the issue and plan.
+- Keep PRs small, reviewable, and easy to revert.
+
+## New task handling
+- If you discover new work while implementing, record it as a **follow-up task**.
+- Include new work in the current PR only when required to meet current acceptance criteria.
+- Do not add unrelated improvements to the current PR.
+
+## PR requirements
+Each PR should include:
+- Related issue
+- Related plan document
+- Summary
+- What changed
+- What was intentionally not changed
+- Tests/checks run (or why not run)
+- Risks
+- Follow-up tasks
+
+## Testing expectations
+- Run relevant tests/checks for the changed area when available.
+- If tests/checks cannot run, explain why in the PR.
+
+## Documentation expectations
+- Update documentation when behavior, public usage, or workflow changes.
+
+## Safety rules
+- Avoid touching unrelated areas.
+- Avoid broad formatting-only changes.
+- Avoid adding dependencies unless necessary.
+- Avoid modifying application logic in repository bootstrap tasks.
+- Keep changes easy to review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,46 @@
-# AGENTS Guide
+# AGENTS ガイド
 
-## Repository purpose
-This repository hosts afjk.jp platform and related tooling for real-time scene synchronization, Loom runtime integration, FileTransfer capabilities, and supporting platform workflows (CI, staging, release, deployment, and agent operations).
+## リポジトリの目的
+このリポジトリは、afjk.jp の基盤と関連ツールを管理します。主に Scene Sync、Loom 連携、FileTransfer、そして CI / staging / release / deployment / agent 運用を対象にします。
 
-## Important project areas
-- **Scene Sync**: scene state synchronization, scene object operations, AI-accessible scene control, and Scene Dev Tool work.
-- **Loom integration**: logic graph/runtime behavior and integration boundaries with Scene Sync.
-- **FileTransfer**: room-based file transfer, fallback transport paths, and file sharing UX.
-- **Platform / deployment / tooling**: CI, release, staging, deployment, repo workflow, and agent workflow support.
+## 主要エリア
+- **Scene Sync**: シーン状態同期、オブジェクト操作、AI からのシーン制御、Scene Dev Tool 関連。
+- **Loom**: ロジックグラフ / ランタイム挙動、Scene Sync との連携境界。
+- **FileTransfer**: ルームベースのファイル転送、fallback 経路、共有 UX。
+- **Platform**: CI、release、staging、deployment、リポジトリ運用、agent workflow。
 
-## Scope discipline
-- Follow **one task = one issue = one PR**.
-- Do not mix unrelated changes in the same PR.
-- Do not add speculative refactors.
-- Do not silently expand scope beyond the issue and plan.
-- Keep PRs small, reviewable, and easy to revert.
+## スコープ管理
+- **one task = one issue = one PR** を厳守してください。
+- 無関係な変更を同じ PR に混ぜないでください。Do not mix unrelated changes.
+- 推測ベースの先回りリファクタは避けてください。
+- scope を黙って拡張しないでください。
+- PR は小さく、レビューしやすく、必要なら revert しやすく保ってください。
 
-## New task handling
-- If you discover new work while implementing, record it as a **follow-up task**.
-- Include new work in the current PR only when required to meet current acceptance criteria.
-- Do not add unrelated improvements to the current PR.
+## 追加タスクの扱い
+- 実装中に新しい作業を見つけたら **follow-up task** として記録してください。
+- 現在の **acceptance criteria** を満たすために必須な場合のみ、現在の PR に含めてください。
+- それ以外は別 issue / 別 PR に分離してください。
 
-## PR requirements
-Each PR should include:
-- Related issue
-- Related plan document
-- Summary
-- What changed
-- What was intentionally not changed
-- Tests/checks run (or why not run)
-- Risks
-- Follow-up tasks
+## PR に必ず書くこと
+- **related issue**
+- **related plan**
+- 概要（summary）
+- 変更内容（what changed）
+- 意図的に変更していないこと（out of scope を含む）
+- **tests**（実行内容、または実行できない理由）
+- **risks**
+- follow-up tasks
 
-## Testing expectations
-- Run relevant tests/checks for the changed area when available.
-- If tests/checks cannot run, explain why in the PR.
+## テスト方針
+- 変更対象エリアに関連する tests / checks があれば実行してください。
+- 実行できない場合は、理由を PR に明記してください。
 
-## Documentation expectations
-- Update documentation when behavior, public usage, or workflow changes.
+## ドキュメント更新方針
+- 挙動、公開利用方法、運用フローに変更がある場合は関連ドキュメントを更新してください。
 
-## Safety rules
-- Avoid touching unrelated areas.
-- Avoid broad formatting-only changes.
-- Avoid adding dependencies unless necessary.
-- Avoid modifying application logic in repository bootstrap tasks.
-- Keep changes easy to review.
+## 安全ルール
+- 無関係な領域への変更を避ける。
+- 大量の formatting-only 変更を避ける。
+- 必要性が明確でない依存追加を避ける。
+- repository bootstrap タスクで application logic を変更しない。
+- 常に「小さく、明確で、レビューしやすい差分」を優先する。

--- a/docs/plans/000-roadmap.md
+++ b/docs/plans/000-roadmap.md
@@ -1,25 +1,25 @@
-# afjk.jp Roadmap
+# afjk.jp ロードマップ
 
 ## 1) Primary Track: Scene Sync + Loom
-- **Purpose**: Deliver stable scene synchronization and runtime logic integration for core experiences.
-- **Example tasks**: Scene object sync reliability, Scene Sync APIs for agents, Loom runtime integration points, authoring/runtime boundary fixes.
-- **Current priority**: **Now (highest)**.
-- **Do not mix into this track**: FileTransfer feature work, broad CI/deployment changes unless directly required.
+- **目的**: コア体験に必要なシーン同期とランタイム連携を安定提供する。
+- **タスク例**: Scene object 同期の信頼性向上、agent 向け Scene Sync API、Loom 連携ポイント整備、authoring/runtime 境界修正。
+- **優先度**: **Now (最優先)**
+- **この track に混ぜないもの**: FileTransfer 機能、直接必要でない CI / deployment の広範な変更。
 
 ## 2) Adjacent Track: FileTransfer
-- **Purpose**: Support reliable room-based file sharing with fallback transport paths and practical UX.
-- **Example tasks**: transfer session lifecycle, WebRTC/piping fallback handling, upload/share progress and error states.
-- **Current priority**: **Next (parallel but separate)**.
-- **Do not mix into this track**: Scene Sync + Loom runtime behavior changes, unrelated platform refactors.
+- **目的**: ルームベースのファイル共有を、fallback を含めて信頼性高く提供する。
+- **タスク例**: 転送セッション制御、WebRTC/piping fallback、進捗表示・再試行・エラー UX。
+- **優先度**: **Next (並行だが分離)**
+- **この track に混ぜないもの**: Scene Sync + Loom のランタイム機能、無関係な platform リファクタ。
 
-## 3) Platform Track: Release, CI, Staging, Agent Workflow
-- **Purpose**: Keep delivery pipelines, staging validation, and repo workflow predictable for human + agent collaboration.
-- **Example tasks**: CI workflow hardening, staging deploy checks, release checklists, issue/PR templates, agent operation docs.
-- **Current priority**: **Now (enabler)**.
-- **Do not mix into this track**: Product feature implementation unrelated to workflow/platform support.
+## 3) Platform Track: Release / CI / Staging / Agent Workflow
+- **目的**: 人間と agent の両方が安全に継続開発できる運用基盤を整える。
+- **タスク例**: CI 安定化、staging デプロイ検証、release チェックリスト、Issue/PR template、agent 運用ドキュメント。
+- **優先度**: **Now (開発基盤として重要)**
+- **この track に混ぜないもの**: workflow 支援と無関係な product 機能実装。
 
-## 4) Future Track: Advanced Authoring + AI Tooling
-- **Purpose**: Expand editor capabilities and advanced tooling after core tracks stabilize.
-- **Example tasks**: richer editor UI, node graph editor UX, advanced AI-assisted scene tooling.
-- **Current priority**: **Later**.
-- **Do not mix into this track**: Immediate delivery blockers from primary/adjacent/platform tracks.
+## 4) Future Track: Rich Editor UI / Node Graph Editor / Advanced AI Tooling
+- **目的**: コア安定後に、より高度な編集体験と AI ツール支援を拡張する。
+- **タスク例**: リッチ editor UI、node graph editor UX、高度な AI 支援ツール。
+- **優先度**: **Later**
+- **この track に混ぜないもの**: 直近 release を妨げる primary/adjacent/platform の課題。

--- a/docs/plans/000-roadmap.md
+++ b/docs/plans/000-roadmap.md
@@ -1,0 +1,25 @@
+# afjk.jp Roadmap
+
+## 1) Primary Track: Scene Sync + Loom
+- **Purpose**: Deliver stable scene synchronization and runtime logic integration for core experiences.
+- **Example tasks**: Scene object sync reliability, Scene Sync APIs for agents, Loom runtime integration points, authoring/runtime boundary fixes.
+- **Current priority**: **Now (highest)**.
+- **Do not mix into this track**: FileTransfer feature work, broad CI/deployment changes unless directly required.
+
+## 2) Adjacent Track: FileTransfer
+- **Purpose**: Support reliable room-based file sharing with fallback transport paths and practical UX.
+- **Example tasks**: transfer session lifecycle, WebRTC/piping fallback handling, upload/share progress and error states.
+- **Current priority**: **Next (parallel but separate)**.
+- **Do not mix into this track**: Scene Sync + Loom runtime behavior changes, unrelated platform refactors.
+
+## 3) Platform Track: Release, CI, Staging, Agent Workflow
+- **Purpose**: Keep delivery pipelines, staging validation, and repo workflow predictable for human + agent collaboration.
+- **Example tasks**: CI workflow hardening, staging deploy checks, release checklists, issue/PR templates, agent operation docs.
+- **Current priority**: **Now (enabler)**.
+- **Do not mix into this track**: Product feature implementation unrelated to workflow/platform support.
+
+## 4) Future Track: Advanced Authoring + AI Tooling
+- **Purpose**: Expand editor capabilities and advanced tooling after core tracks stabilize.
+- **Example tasks**: richer editor UI, node graph editor UX, advanced AI-assisted scene tooling.
+- **Current priority**: **Later**.
+- **Do not mix into this track**: Immediate delivery blockers from primary/adjacent/platform tracks.

--- a/docs/plans/001-agent-workflow.md
+++ b/docs/plans/001-agent-workflow.md
@@ -1,34 +1,34 @@
 # Agent-Driven Development Workflow
 
-## Development flow
-1. **Plan**: Add/update a concise plan in `docs/plans/...`.
-2. **Issue**: Create one GitHub issue for one implementation task.
-3. **Branch**: Create a focused branch for that single issue.
-4. **PR**: Open one PR scoped to the issue and plan.
-5. **CI**: Run required checks and resolve failures.
-6. **Staging**: Deploy to staging when applicable.
-7. **Human verification**: Human reviewer validates behavior on staging as needed.
-8. **Follow-up**: Record discovered non-scope tasks as follow-up issues.
+## 開発フロー
+1. **plan**: `docs/plans/...` に簡潔な計画を追加/更新。
+2. **issue**: 1 実装タスクにつき 1 issue を作成。
+3. **branch**: issue 単位で専用 branch を作成。
+4. **PR**: issue と plan に対応する 1 PR を作成。
+5. **CI**: 必要な checks を実行し、失敗を解消。
+6. **staging**: 必要に応じて staging へ反映。
+7. **human verification**: 人間レビュアーが挙動を確認。
+8. **follow-up**: スコープ外で見つかった作業を follow-up issue 化。
 
-## Handling additional tasks found during implementation
-- Log newly discovered work immediately in a follow-up issue.
-- Keep the current PR focused on its acceptance criteria.
-- Pull in extra work only when it is required to complete current acceptance criteria.
+## 実装中に追加タスクを見つけた場合
+- 発見した時点で follow-up issue を作成する。
+- 現在 PR は current acceptance criteria に集中する。
+- 追加作業を現在 PR に入れるのは、acceptance criteria 達成に必須な場合のみ。
 
-## Task classification
-- **bug**: Incorrect behavior vs expected behavior.
-- **blocker**: Prevents progress on the current task.
-- **follow-up**: Needed improvement not required for current acceptance criteria.
-- **new idea**: Potential enhancement not yet prioritized.
-- **refactor**: Structural/code-quality improvement without intended behavior change.
+## タスク分類
+- **bug**: 期待挙動との差異がある不具合。
+- **blocker**: 現在タスクの進行を止める問題。
+- **follow-up**: 今の acceptance criteria には不要だが必要な改善。
+- **new idea**: 将来検討する拡張案。
+- **refactor**: 挙動変更を意図しない構造改善。
 
-## Interruption rules
-- Include additional work in current PR **only if required** by current acceptance criteria.
-- Create a **follow-up issue** for non-blocking improvements.
-- Create a **blocker issue** for work that prevents current progress.
-- Mark **release blocker** when unresolved work should stop release.
+## 割り込みルール
+- 現在 PR へ追加できるのは「現在の acceptance criteria に必須な作業」のみ。
+- 非 blocking な改善は follow-up issue を作る。
+- 進行不能にする課題は blocker issue を作る。
+- release を止めるべき課題は release-blocker を付与する。
 
-## Suggested labels
+## 推奨ラベル
 - `area:scenesync`
 - `area:loom`
 - `area:file-transfer`

--- a/docs/plans/001-agent-workflow.md
+++ b/docs/plans/001-agent-workflow.md
@@ -1,0 +1,49 @@
+# Agent-Driven Development Workflow
+
+## Development flow
+1. **Plan**: Add/update a concise plan in `docs/plans/...`.
+2. **Issue**: Create one GitHub issue for one implementation task.
+3. **Branch**: Create a focused branch for that single issue.
+4. **PR**: Open one PR scoped to the issue and plan.
+5. **CI**: Run required checks and resolve failures.
+6. **Staging**: Deploy to staging when applicable.
+7. **Human verification**: Human reviewer validates behavior on staging as needed.
+8. **Follow-up**: Record discovered non-scope tasks as follow-up issues.
+
+## Handling additional tasks found during implementation
+- Log newly discovered work immediately in a follow-up issue.
+- Keep the current PR focused on its acceptance criteria.
+- Pull in extra work only when it is required to complete current acceptance criteria.
+
+## Task classification
+- **bug**: Incorrect behavior vs expected behavior.
+- **blocker**: Prevents progress on the current task.
+- **follow-up**: Needed improvement not required for current acceptance criteria.
+- **new idea**: Potential enhancement not yet prioritized.
+- **refactor**: Structural/code-quality improvement without intended behavior change.
+
+## Interruption rules
+- Include additional work in current PR **only if required** by current acceptance criteria.
+- Create a **follow-up issue** for non-blocking improvements.
+- Create a **blocker issue** for work that prevents current progress.
+- Mark **release blocker** when unresolved work should stop release.
+
+## Suggested labels
+- `area:scenesync`
+- `area:loom`
+- `area:file-transfer`
+- `area:platform`
+- `area:docs`
+- `type:bug`
+- `type:blocker`
+- `type:follow-up`
+- `type:new-idea`
+- `type:refactor`
+- `priority:now`
+- `priority:next`
+- `priority:later`
+- `agent:ready`
+- `agent:needs-plan`
+- `agent:blocked`
+- `needs-human`
+- `release-blocker`

--- a/docs/plans/file-transfer/000-overview.md
+++ b/docs/plans/file-transfer/000-overview.md
@@ -1,23 +1,23 @@
 # FileTransfer Area Overview
 
-## Purpose
-Own room-based file exchange capabilities including transport fallback and sharing UX.
+## 目的
+ルームベースの file exchange、transport fallback、sharing UX を担当する。
 
-## What belongs in this area
-- File transfer session/control flow.
-- Transport strategy (WebRTC/piping fallback).
-- Sharing UX states (progress, retry, error handling).
-- Reliability and observability for transfer flows.
+## この area に含めるもの
+- file transfer のセッション制御。
+- transport strategy（WebRTC/piping fallback）。
+- 進捗表示・再試行・エラー処理など sharing UX。
+- 転送信頼性と観測性。
 
-## What does not belong in this area
-- Scene Sync + Loom primary runtime features.
-- Broad platform/release workflow changes not needed for FileTransfer.
+## この area に含めないもの
+- Scene Sync + Loom の primary runtime 機能。
+- FileTransfer 提供に不要な platform/release 変更。
 
-## Example implementation plans to add later
-- Room-based transfer protocol hardening.
-- Fallback transport retry strategy.
-- File sharing UX validation and staging test checklist.
+## 今後追加しうる implementation plan 例
+- room-based transfer protocol の堅牢化。
+- fallback retry strategy の整備。
+- staging 向け file sharing UX 検証チェックリスト。
 
 ## Notes for agents
-- FileTransfer is an adjacent track, not part of the primary Scene Sync + Loom track.
-- Keep cross-track dependencies explicit in issues and PR descriptions.
+- FileTransfer は adjacent track（primary track とは分離）。
+- cross-track 依存は issue / PR に明示する。

--- a/docs/plans/file-transfer/000-overview.md
+++ b/docs/plans/file-transfer/000-overview.md
@@ -1,0 +1,23 @@
+# FileTransfer Area Overview
+
+## Purpose
+Own room-based file exchange capabilities including transport fallback and sharing UX.
+
+## What belongs in this area
+- File transfer session/control flow.
+- Transport strategy (WebRTC/piping fallback).
+- Sharing UX states (progress, retry, error handling).
+- Reliability and observability for transfer flows.
+
+## What does not belong in this area
+- Scene Sync + Loom primary runtime features.
+- Broad platform/release workflow changes not needed for FileTransfer.
+
+## Example implementation plans to add later
+- Room-based transfer protocol hardening.
+- Fallback transport retry strategy.
+- File sharing UX validation and staging test checklist.
+
+## Notes for agents
+- FileTransfer is an adjacent track, not part of the primary Scene Sync + Loom track.
+- Keep cross-track dependencies explicit in issues and PR descriptions.

--- a/docs/plans/loom/000-overview.md
+++ b/docs/plans/loom/000-overview.md
@@ -1,0 +1,24 @@
+# Loom Area Overview
+
+## Purpose
+Own Loom logic graph/runtime behavior and integration with Scene Sync at clear boundaries.
+
+## What belongs in this area
+- Loom runtime execution model and node behavior.
+- Logic graph evaluation flow.
+- Contracted integration points with Scene Sync.
+- Runtime-authoring boundary rules.
+
+## What does not belong in this area
+- Scene Sync internals outside integration contracts.
+- FileTransfer feature work.
+- Platform pipeline/process changes unless Loom delivery requires them.
+
+## Example implementation plans to add later
+- Loom runtime lifecycle and scheduling improvements.
+- Scene Sync integration contract hardening.
+- Runtime-authoring boundary validation.
+
+## Notes for agents
+- Treat Loom and Scene Sync as related but separate.
+- Capture contract changes explicitly and avoid silent cross-area scope growth.

--- a/docs/plans/loom/000-overview.md
+++ b/docs/plans/loom/000-overview.md
@@ -1,24 +1,24 @@
 # Loom Area Overview
 
-## Purpose
-Own Loom logic graph/runtime behavior and integration with Scene Sync at clear boundaries.
+## 目的
+Loom の logic graph / runtime behavior と、Scene Sync との integration boundary を担当する。
 
-## What belongs in this area
-- Loom runtime execution model and node behavior.
-- Logic graph evaluation flow.
-- Contracted integration points with Scene Sync.
-- Runtime-authoring boundary rules.
+## この area に含めるもの
+- Loom runtime execution model。
+- Logic graph evaluation flow。
+- Scene Sync との契約済み integration point。
+- runtime-authoring boundary のルール。
 
-## What does not belong in this area
-- Scene Sync internals outside integration contracts.
-- FileTransfer feature work.
-- Platform pipeline/process changes unless Loom delivery requires them.
+## この area に含めないもの
+- integration contract 外の Scene Sync 内部実装。
+- FileTransfer 機能。
+- Loom 提供に不要な platform 運用変更。
 
-## Example implementation plans to add later
-- Loom runtime lifecycle and scheduling improvements.
-- Scene Sync integration contract hardening.
-- Runtime-authoring boundary validation.
+## 今後追加しうる implementation plan 例
+- Loom runtime lifecycle / scheduling 改善。
+- Scene Sync integration contract の強化。
+- runtime-authoring boundary の検証整備。
 
 ## Notes for agents
-- Treat Loom and Scene Sync as related but separate.
-- Capture contract changes explicitly and avoid silent cross-area scope growth.
+- Loom と Scene Sync は「関連あり・責務分離」で扱う。
+- contract 変更は明示し、暗黙の scope 拡張を避ける。

--- a/docs/plans/platform/000-overview.md
+++ b/docs/plans/platform/000-overview.md
@@ -1,24 +1,24 @@
 # Platform Area Overview
 
-## Purpose
-Own repository workflow, CI, release, staging, deployment, and agent operation support.
+## 目的
+repository workflow、CI、release、staging、deployment、agent operation support を担当する。
 
-## What belongs in this area
-- CI workflow and automation reliability.
-- Release/staging/deployment process improvements.
-- Issue/PR templates and planning structure.
-- Agent workflow docs and operational guardrails.
+## この area に含めるもの
+- CI workflow と自動化の安定化。
+- release/staging/deployment プロセス改善。
+- Issue/PR template と planning structure。
+- agent workflow ドキュメントと運用ガードレール。
 
-## What does not belong in this area
-- Direct Scene Sync feature implementation.
-- Loom runtime feature implementation.
-- FileTransfer feature implementation unless required for platform operability.
+## この area に含めないもの
+- Scene Sync の直接的な機能実装。
+- Loom runtime の機能実装。
+- platform 運用に不要な FileTransfer 機能実装。
 
-## Example implementation plans to add later
-- CI matrix and flaky test management.
-- Staging verification checklist automation.
-- Agent-ready workflow quality gates.
+## 今後追加しうる implementation plan 例
+- CI matrix と flaky test 対策。
+- staging verification checklist の自動化。
+- agent-ready quality gate の整備。
 
 ## Notes for agents
-- Keep platform PRs focused on process/tooling, not product behavior.
-- If platform work reveals product fixes, log them as follow-up issues.
+- platform PR は process/tooling に集中し、product behavior を混在させない。
+- product 側修正が見つかった場合は follow-up issue として分離する。

--- a/docs/plans/platform/000-overview.md
+++ b/docs/plans/platform/000-overview.md
@@ -1,0 +1,24 @@
+# Platform Area Overview
+
+## Purpose
+Own repository workflow, CI, release, staging, deployment, and agent operation support.
+
+## What belongs in this area
+- CI workflow and automation reliability.
+- Release/staging/deployment process improvements.
+- Issue/PR templates and planning structure.
+- Agent workflow docs and operational guardrails.
+
+## What does not belong in this area
+- Direct Scene Sync feature implementation.
+- Loom runtime feature implementation.
+- FileTransfer feature implementation unless required for platform operability.
+
+## Example implementation plans to add later
+- CI matrix and flaky test management.
+- Staging verification checklist automation.
+- Agent-ready workflow quality gates.
+
+## Notes for agents
+- Keep platform PRs focused on process/tooling, not product behavior.
+- If platform work reveals product fixes, log them as follow-up issues.

--- a/docs/plans/scenesync/000-overview.md
+++ b/docs/plans/scenesync/000-overview.md
@@ -1,0 +1,24 @@
+# Scene Sync Area Overview
+
+## Purpose
+Own scene state synchronization, scene object operations, and AI-accessible scene control behaviors.
+
+## What belongs in this area
+- Scene state sync protocols and consistency behavior.
+- Scene object create/update/delete operations.
+- Agent-facing controls for scene manipulation.
+- Scene Dev Tool capabilities tied to scene synchronization.
+
+## What does not belong in this area
+- Loom runtime logic internals (except defined integration boundaries).
+- FileTransfer transport/UX work.
+- General CI/release workflow changes unless required for Scene Sync delivery.
+
+## Example implementation plans to add later
+- Scene state conflict resolution strategy.
+- Scene object operation audit trail.
+- AI-safe scene command surface and permissions.
+
+## Notes for agents
+- Coordinate integration points with Loom through explicit interface tasks.
+- Keep Scene Sync PRs focused; document cross-area impacts as follow-up tasks.

--- a/docs/plans/scenesync/000-overview.md
+++ b/docs/plans/scenesync/000-overview.md
@@ -1,24 +1,24 @@
 # Scene Sync Area Overview
 
-## Purpose
-Own scene state synchronization, scene object operations, and AI-accessible scene control behaviors.
+## 目的
+Scene state synchronization、scene object operations、AI-accessible scene control を担当する。
 
-## What belongs in this area
-- Scene state sync protocols and consistency behavior.
-- Scene object create/update/delete operations.
-- Agent-facing controls for scene manipulation.
-- Scene Dev Tool capabilities tied to scene synchronization.
+## この area に含めるもの
+- Scene state sync のプロトコルと整合性制御。
+- Scene object の create/update/delete。
+- agent からの scene 操作用インターフェース。
+- Scene Dev Tool のうち同期責務に関わるもの。
 
-## What does not belong in this area
-- Loom runtime logic internals (except defined integration boundaries).
-- FileTransfer transport/UX work.
-- General CI/release workflow changes unless required for Scene Sync delivery.
+## この area に含めないもの
+- Loom ランタイム内部（明示的な連携境界を除く）。
+- FileTransfer の transport / UX。
+- Scene Sync 提供に不要な CI/release 運用変更。
 
-## Example implementation plans to add later
-- Scene state conflict resolution strategy.
-- Scene object operation audit trail.
-- AI-safe scene command surface and permissions.
+## 今後追加しうる implementation plan 例
+- Scene state conflict resolution。
+- Scene object operation の監査ログ。
+- AI-safe な scene command surface。
 
 ## Notes for agents
-- Coordinate integration points with Loom through explicit interface tasks.
-- Keep Scene Sync PRs focused; document cross-area impacts as follow-up tasks.
+- Loom 連携は interface task として明示する。
+- cross-area 影響は黙って混ぜず、必要なら follow-up task として記録する。


### PR DESCRIPTION
### Motivation
- Standardize repository workflow and agent-driven development by adding issue and PR templates and an AGENTS guide.
- Capture project area ownership and roadmaps to keep work scoped to single-task PRs and to surface follow-up work.
- Ensure planning docs under `docs/plans/` are tracked in the repo and visible to agents and reviewers.

### Description
- Add GitHub issue templates: `bug-report.md`, `follow-up-task.md`, and `implementation-task.md` under `.github/ISSUE_TEMPLATE/`.
- Add a PR template `PULL_REQUEST_TEMPLATE.md` to enforce summary, related plan, area, testing, and checklist fields.
- Add `AGENTS.md` with repository purpose, PR requirements, testing expectations, and safety rules for agent-driven workflows.
- Add planning documents under `docs/plans/`: `000-roadmap.md`, `001-agent-workflow.md`, and area overviews for `loom`, `scenesync`, `file-transfer`, and `platform` plus a file-transfer overview.
- Update `.gitignore` to stop ignoring `docs/plans/` and explicitly track `docs/plans/**/*.md`.

### Testing
- No automated unit or integration tests were modified for these documentation and template changes, so no tests were run.
- Standard CI checks will run on PR submission to validate repo hygiene and workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e8cef9b08320a30db2d399bb6b5c)