### PR TITLE
Enable staging deploy from experimental branches

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,9 +31,9 @@ jobs:
           script: |
             DEPLOY_BRANCH='${{ github.ref_name }}'
             cd ~/github/afjk.jp
-            git fetch origin "${DEPLOY_BRANCH}"
-            git checkout -B "${DEPLOY_BRANCH}" "origin/${DEPLOY_BRANCH}"
-            git reset --hard "origin/${DEPLOY_BRANCH}"
+            git fetch origin "+refs/heads/${DEPLOY_BRANCH}:refs/remotes/origin/${DEPLOY_BRANCH}"
+            git checkout -B "${DEPLOY_BRANCH}" "refs/remotes/origin/${DEPLOY_BRANCH}"
+            git reset --hard "refs/remotes/origin/${DEPLOY_BRANCH}"
             docker compose up -d --build presence-server
             docker compose up -d mediamtx
             docker compose up -d --force-recreate https-portal

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+      - codex/**
+      - experiment/**
+  workflow_dispatch:
+
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -22,9 +29,11 @@ jobs:
           password: ${{ secrets.SERVER_PASSWORD }}
           timeout: 120s
           script: |
+            DEPLOY_BRANCH='${{ github.ref_name }}'
             cd ~/github/afjk.jp
-            git fetch origin
-            git reset --hard origin/main
+            git fetch origin "${DEPLOY_BRANCH}"
+            git checkout -B "${DEPLOY_BRANCH}" "origin/${DEPLOY_BRANCH}"
+            git reset --hard "origin/${DEPLOY_BRANCH}"
             docker compose up -d --build presence-server
             docker compose up -d mediamtx
             docker compose up -d --force-recreate https-portal


### PR DESCRIPTION
概要:
`codex/**` と `experiment/**` branch への push で staging deploy が走るようにします。

変更内容:
- `main`, `codex/**`, `experiment/**` push で staging workflow を起動
- `workflow_dispatch` を追加
- staging deploy の concurrency を追加
- deploy対象を固定の `origin/main` から `github.ref_name` ベースに変更
- remote-tracking ref を明示的に fetch / checkout / reset するように変更

変更していないこと:
- production deploy workflow は変更していません
- アプリケーションロジックは変更していません
- `loom/` は変更していません

確認:
- YAML load check
- staging workflow diff確認
- production deploy workflowが未変更であることを確認

リスク:
- staging は最新にdeployされた experimental branch で上書きされます。
- この変更が main に入った後、`codex/**` push によって staging deploy が走ります。