### PR TITLE
Add initial Scene Sync and Loom implementation plans

### DIFF
--- a/docs/plans/loom/001-scenesync-integration.md
+++ b/docs/plans/loom/001-scenesync-integration.md
@@ -1,0 +1,107 @@
+# Loom Scene Sync Integration
+
+## 概要
+
+Loom と Scene Sync の接続方針を整理し、どちらの repo に何を置くか、同期、競合、責務分担を明確にするための初期 plan です。  
+この task では `loom/` を変更せず、`afjk.jp` 側の計画文書だけを追加します。
+
+## 背景
+
+- Loom と Scene Sync を接続すると、object movement、animation、graph-driven changes の責務が曖昧になりやすい
+- cross-repo で並列実装するには、`afjk.jp` 側責務と `loom/` 側責務の線引きが必要
+- 同じ object に対して Scene Sync update と Loom 側 change が競合したときの source of truth を先に決めておきたい
+- staging で実験しながら育てる前提でも、実装順序は早めに共有しておくほうが安全
+
+## 対象repo
+
+- `afjk.jp`
+
+## 対象area
+
+- `loom`
+- `scenesync`
+
+## 目的
+
+- `afjk.jp` side responsibility を明確にする
+- `loom/` side responsibility を明確にする
+- ownership と source of truth の原則を決める
+- cross-repo implementation order を整理する
+- staging で確認すべき接続面を先に定義する
+
+## 想定するユーザー体験
+
+- 開発者が、どの変更を `afjk.jp` に入れるべきか、どの変更を `loom/` に入れるべきか迷いにくい
+- graph-driven changes が Scene Sync に反映されるとき、どこで正規化し、どこで衝突を扱うかが分かる
+- 人間が staging で Scene Sync と Loom の接続結果を確認し、追加指示を出しやすい
+
+## 実装方針
+
+- `afjk.jp` は Scene Sync 側の受け口、可視化、staging 検証導線を担当する
+- `loom/` は graph / runtime / orchestration の責務を主に持つ
+- object movement や animation の最終反映点は Scene Sync 側に寄せつつ、変更の生成源が Loom なのか user 操作なのかを追えるようにする
+- source of truth は object 種別や更新種類ごとに分けるのではなく、まずは「どの mutation が最終適用権を持つか」をシンプルに決める
+- conflict が起きたら、silent overwrite ではなく検出可能な形を優先する
+
+## 段階的な実装ステップ
+
+1. 責務分担を固定する
+   - `afjk.jp` 側の API / viewer / developer tool responsibility
+   - `loom/` 側の graph execution / scheduling responsibility
+2. 最小 integration を定義する
+   - Loom が Scene Sync mutation を発行する最小経路
+   - object movement と simple property update のみ対象にする
+3. ownership ルールを決める
+   - user 操作起点
+   - Loom 起点
+   - conflict 時の優先順位
+4. staging 検証ケースを作る
+   - graph-driven changes が反映されること
+   - Scene Sync 直接更新と競合したときの挙動確認
+5. cross-repo 拡張に進む
+   - animation
+   - 複数 object 更新
+   - richer event / diff handling
+
+## acceptance criteria
+
+- [ ] `afjk.jp` と `loom/` の責務分担が書かれている
+- [ ] object movement / animation / graph-driven changes の扱い方針がある
+- [ ] ownership / source of truth の原則が書かれている
+- [ ] conflict 時の基本方針が書かれている
+- [ ] cross-repo implementation order が書かれている
+- [ ] staging での確認方法が書かれている
+
+## out of scope
+
+- この task 内での `loom/` repo 実装変更
+- 完全な競合解決アルゴリズムの確定
+- FileTransfer との接続計画
+- production 運用フローの設計
+
+## staging確認方法
+
+- `afjk.jp` 側に最小 integration UI / log / developer tool を出す
+- Loom 起点の mutation が Scene Sync に反映される流れを staging で確認する
+- Scene Sync 側から同じ object を更新した場合の衝突検知を確認する
+- before / after snapshot または log で source の違いが追えるか確認する
+
+## リスク
+
+- repo 境界が曖昧なまま進めると、並列実装時に責務重複が起きる
+- conflict 方針を後回しにすると、animation や graph-driven update で挙動が不安定になる
+- `afjk.jp` 側の staging 確認導線が弱いと、統合後の不具合切り分けが難しい
+
+## follow-up tasks
+
+- `loom/` 側に置く integration task の切り出し
+- Scene Sync AI tool contract との接続点整理
+- graph-driven changes の event schema 下書き
+- conflict 表示方法の検討
+
+## agent向け注意
+
+- この task では `loom/` repo を変更しない
+- cross-repo 作業に進むときは、どちらを先に変えるかを明示する
+- Scene Sync 側の developer tool や snapshot 導線を先に作ると検証しやすい
+- issue 作成は必須ではなく、branch / PR 先行でもよい

--- a/docs/plans/scenesync/001-dev-tool-command-console.md
+++ b/docs/plans/scenesync/001-dev-tool-command-console.md
@@ -1,0 +1,110 @@
+# Scene Sync Dev Tool Command Console
+
+## 概要
+
+Scene Sync の開発・検証をしやすくするために、web 上からシーン操作コマンドを入力、送信、確認できる developer tool を整備するための初期 plan です。  
+この task では実装は行わず、experimental に staging で育てる前提の実装方針を整理します。
+
+## 背景
+
+- 現状の Scene Sync 検証は、個別の script や ad-hoc な手動操作に寄りやすい
+- AI agent が送る payload を人間が目視確認しにくい
+- シーンの object create / update / delete を素早く試せる UI があると、開発速度と切り戻し判断が上がる
+- staging でそのまま触って確認できる developer-facing な画面があると、branch push 後の確認が簡単になる
+
+## 対象repo
+
+- `afjk.jp`
+
+## 対象area
+
+- `scenesync`
+
+## 目的
+
+- plain text command から Scene Sync 操作を試せるようにする
+- 送信前に JSON payload preview を確認できるようにする
+- command history と validation error を見える化する
+- AI agent が生成した command / payload を staging 上で人間が検証しやすくする
+
+## 想定するユーザー体験
+
+- 開発者が staging の developer tool を開く
+- plain text command か helper UI で操作内容を作る
+- 生成される JSON payload preview を見て送信する
+- response、validation error、scene snapshot の変化を同じ画面で確認する
+- 同じ command を history から再実行して比較する
+
+## 実装方針
+
+- Scene Sync の既存 endpoint / command 送信経路を再利用し、別仕様を増やしすぎない
+- 入力 UI はまず plain text command を中心にし、object create / update / delete helper を補助として載せる
+- JSON payload preview は送信前に必ず見える位置に置く
+- scene snapshot fetch を明示的な action として用意し、before / after 比較に使えるようにする
+- focus / screenshot helper が既存機能で使えるなら UI に薄く載せる
+- validation error と transport error は分けて表示する
+- staging で確認しやすいように、1画面で入力、preview、response、history が見える構成を優先する
+
+## 段階的な実装ステップ
+
+1. 最小 UI を用意する
+   - plain text command input
+   - send action
+   - response 表示
+2. payload preview を追加する
+   - command から生成される JSON を送信前に確認
+   - basic validation error を表示
+3. helper 群を追加する
+   - object create / update / delete helper
+   - scene snapshot fetch
+4. 検証体験を強化する
+   - command history
+   - before / after の snapshot 比較
+   - focus / screenshot helper の接続可否確認
+5. AI agent 向け確認導線を整える
+   - agent が生成した payload の貼り付け確認
+   - command と payload のズレを見つけやすい表示
+
+## acceptance criteria
+
+- [ ] plain text command を入力して Scene Sync 操作を送信できる
+- [ ] 送信前に JSON payload preview を確認できる
+- [ ] validation error を UI 上で判別できる
+- [ ] command history から再実行または再利用できる
+- [ ] scene snapshot fetch を使って状態確認できる
+- [ ] staging 上で人間が agent payload を確認しやすい画面になっている
+
+## out of scope
+
+- Scene Sync protocol 自体の大幅な再設計
+- production 向けの権限制御や本格監査 UI
+- FileTransfer 関連の developer tool
+- この task 内での実装、deploy 動作変更、`loom/` repo 変更
+
+## staging確認方法
+
+- `codex/**` branch で UI を staging に出す
+- command input から単純な object create / update / delete を試す
+- payload preview と response が一致しているか確認する
+- scene snapshot fetch を before / after で実行して差分確認する
+- AI agent が生成した payload を貼り付け、validation error や表示の分かりやすさを確認する
+
+## リスク
+
+- command 入力形式を先に固めすぎると、後続の AI tool contract と齟齬が出る
+- preview、response、snapshot を1画面に載せすぎると UI が散らかる
+- helper を増やしすぎると、かえって protocol の理解が薄れる
+
+## follow-up tasks
+
+- command grammar の最小仕様整理
+- snapshot diff の見せ方改善
+- focus / screenshot helper の既存機能調査
+- Scene Sync AI tool contract との用語統一
+
+## agent向け注意
+
+- この文書は実装着手用の plan であり、仕様を固定しすぎない
+- staging で早く触れる最小構成から入る
+- product behavior の変更と developer tool の変更を同じ branch に混ぜすぎない
+- issue 作成は必須ではなく、branch / PR 先行で進めてよい

--- a/docs/plans/scenesync/002-ai-tool-contract.md
+++ b/docs/plans/scenesync/002-ai-tool-contract.md
@@ -1,0 +1,112 @@
+# Scene Sync AI Tool Contract
+
+## 概要
+
+GPTs / MCP / Codex / other agents が Scene Sync を確実に操作できるように、AI 向けの操作契約、payload 方針、失敗時の扱いを整理するための初期 plan です。  
+自然言語だけに依存しない stable な contract を目指します。
+
+## 背景
+
+- AI agent に Scene Sync を触らせる場合、曖昧な自然言語指示だけでは再現性が低い
+- action 名、required params、response 期待値が不安定だと、agent ごとの差が大きくなる
+- scene snapshot の before / after を含めた確認導線があると、失敗検知と retry 方針を作りやすい
+- 今後の MCP / GPTs integration を考えると、早い段階で tool-like な contract を揃えておきたい
+
+## 対象repo
+
+- `afjk.jp`
+
+## 対象area
+
+- `scenesync`
+
+## 目的
+
+- stable action names を定義する
+- required params と optional params の境界を明確にする
+- response expectations と error handling をそろえる
+- scene snapshot before / after を使った確認フローを標準化する
+- future MCP / GPTs integration に流用できる形にする
+
+## 想定するユーザー体験
+
+- agent 実装者が、曖昧な prompt ではなく定義済み action を使って Scene Sync を操作する
+- action ごとに必要な params と返り値の期待が明確で、失敗時の扱いも判断しやすい
+- 人間が payload と response を見れば、agent の誤動作か backend 側の問題かを切り分けやすい
+
+## 実装方針
+
+- operation は tool-like な単位で定義し、stable action names を優先する
+- action ごとに required params、optional params、成功時 response、失敗時 error shape を決める
+- object create / update / delete、scene snapshot fetch など、主要操作から先に揃える
+- response には、可能なら scene state 参照用の情報を含める
+- agent が自然言語のみで直接 state を推測しないよう、snapshot fetch を標準導線に入れる
+- example は concise に保ち、長い narrative ではなく最小の request / response を示す
+
+## 段階的な実装ステップ
+
+1. 最小 operation セットを定義する
+   - `create_object`
+   - `update_object`
+   - `delete_object`
+   - `get_scene_snapshot`
+2. action schema をそろえる
+   - stable action names
+   - required params
+   - optional params
+   - response shape
+3. error handling 方針を決める
+   - validation error
+   - not found
+   - conflict
+   - transport / internal error
+4. snapshot ベースの確認フローを定義する
+   - before snapshot
+   - mutation
+   - after snapshot
+5. future integration へ展開する
+   - MCP tool 定義への写像
+   - GPTs / Codex 向け prompt contract の最小例
+
+## acceptance criteria
+
+- [ ] 主要 action の stable name が定義されている
+- [ ] 各 action に required params と response expectations がある
+- [ ] error handling の分類が定義されている
+- [ ] scene snapshot before / after を使う標準フローが書かれている
+- [ ] concise な request / response 例が含まれている
+- [ ] future MCP / GPTs integration への接続方針が書かれている
+
+## out of scope
+
+- この task 内での MCP server 実装
+- 完全な protocol 仕様書の完成
+- production 向け SLA や権限モデルの策定
+- FileTransfer への横展開
+
+## staging確認方法
+
+- `codex/**` branch で contract に沿った最小実装または developer tool を staging に出す
+- action 名と payload 形式が UI / log / response で一致するか確認する
+- before / after snapshot の流れで object 操作が追えるか確認する
+- validation error と conflict の見分けがつくか確認する
+
+## リスク
+
+- contract を早く固定しすぎると、実装側の学びを取り込みにくい
+- action 粒度が粗すぎると agent 側の判断が増え、細かすぎると運用コストが増える
+- response に情報を盛りすぎると、安定性より利便性優先の設計になりやすい
+
+## follow-up tasks
+
+- action schema のサンプル JSON 追加
+- Scene Sync developer tool との整合確認
+- MCP tool 定義ドラフト作成
+- snapshot diff ルールの簡略化
+
+## agent向け注意
+
+- 自然言語のみで state を推測せず、必要なら snapshot を取りに行く前提で考える
+- action 名は branch ごとに揺らさない
+- 実装時は concise な example を先に通し、拡張は後から行う
+- issue 作成は必須ではなく、experimental branch で先に検証してよい


### PR DESCRIPTION
## 概要

Scene Sync と Loom に関する初期 implementation plan documents を追加します。今回は実装は行わず、coding agents が並列で着手しやすい plan の追加に限定します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`
- `loom`

## 変更内容

- `docs/plans/scenesync/001-dev-tool-command-console.md` を追加
- `docs/plans/scenesync/002-ai-tool-contract.md` を追加
- `docs/plans/loom/001-scenesync-integration.md` を追加
- Scene Sync developer tool、AI tool contract、Loom integration の初期実装方針と段階的ステップを整理

## 変更していないこと

- アプリケーションロジックは変更していません
- workflow files は変更していません
- `loom/` repo は変更していません
- FileTransfer plan は追加していません
- `out of scope`: 実装着手、production deploy、repository settings 変更

## staging確認

- 文書追加のみのため、この PR 自体では staging UI 確認は未実施です
- 各 plan には、今後の `codex/**` branch で使う staging 確認方法を記載しています

## テスト/チェック

- plan 3件の required sections が揃っていることをスクリプトで確認
- `git diff -- .github/workflows` で workflow 未変更を確認
- `loom/` repo が未変更であることを確認

## リスク

- 初期 plan のため、実装着手時に粒度や責務分担の調整が入る可能性があります
- Loom integration は cross-repo 前提なので、後続 task で順序の微修正が入る可能性があります

## follow-up tasks

- Scene Sync developer tool の最小 UI task 切り出し
- AI tool contract の sample payload 追加
- `loom/` 側 integration task の分割

## merge方針

- squash merge を想定
- merge 後は remote branch を削除
