### PR TITLE
Add Scene Sync dev tool command console MVP

### DIFF
--- a/html/assets/css/scenesync-dev-tool.css
+++ b/html/assets/css/scenesync-dev-tool.css
@@ -1,0 +1,310 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --bg-elevated: #161b22;
+  --bg-console: #05080d;
+  --border: #263042;
+  --text: #e6edf3;
+  --muted: #8b98a9;
+  --accent: #4cc9b0;
+  --accent-strong: #84f5e2;
+  --warning: #ffb86c;
+  --danger: #ff7b72;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(76, 201, 176, 0.15), transparent 30%),
+    radial-gradient(circle at top right, rgba(132, 245, 226, 0.08), transparent 22%),
+    linear-gradient(180deg, #0d1117 0%, #111827 100%);
+  color: var(--text);
+  font: 14px/1.5 "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+a {
+  color: var(--accent-strong);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button,
+input,
+textarea,
+.status-card,
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+}
+
+button,
+input,
+textarea {
+  color: var(--text);
+  background: rgba(13, 17, 23, 0.9);
+}
+
+button {
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 140ms ease, background 140ms ease;
+}
+
+button:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 12px 14px;
+}
+
+textarea {
+  min-height: 420px;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus,
+button:focus {
+  outline: 2px solid rgba(76, 201, 176, 0.35);
+  outline-offset: 2px;
+}
+
+.page {
+  width: min(1400px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.hero,
+.panel,
+.status-card {
+  background: rgba(22, 27, 34, 0.9);
+  backdrop-filter: blur(8px);
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.hero h1,
+.panel h2 {
+  margin: 0;
+  font-weight: 600;
+}
+
+.lede {
+  max-width: 68ch;
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.hero-links {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.panel {
+  padding: 18px;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.panel-grid label,
+.status-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.panel-grid span,
+.status-label,
+.route-bar span {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.inline-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.status-card {
+  padding: 16px;
+}
+
+.status-card strong {
+  font-size: 16px;
+}
+
+.status-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 20px;
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stack {
+  display: grid;
+  gap: 20px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.route-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(5, 8, 13, 0.65);
+}
+
+.console {
+  margin: 0;
+  min-height: 164px;
+  padding: 14px;
+  border-radius: 14px;
+  background: var(--bg-console);
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+}
+
+.console-warning {
+  color: var(--warning);
+}
+
+.console-error {
+  color: var(--danger);
+}
+
+.history-panel {
+  margin-top: 20px;
+}
+
+.history-list {
+  display: grid;
+  gap: 12px;
+}
+
+.history-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(5, 8, 13, 0.45);
+}
+
+.history-item p {
+  margin: 0;
+}
+
+.history-item .meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.history-item .history-actions {
+  display: flex;
+  gap: 8px;
+  align-items: start;
+}
+
+.history-empty {
+  color: var(--muted);
+}
+
+@media (max-width: 1120px) {
+  .panel-grid,
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    width: min(100vw - 20px, 100%);
+    padding-top: 10px;
+  }
+
+  .hero,
+  .panel {
+    padding: 16px;
+  }
+
+  .hero,
+  .panel-head,
+  .history-item {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions,
+  .hero-links,
+  .history-item .history-actions {
+    width: 100%;
+  }
+}

--- a/html/assets/js/scenesync/dev-tool-console.js
+++ b/html/assets/js/scenesync/dev-tool-console.js
@@ -1,0 +1,385 @@
+const API_BASE_URL = `${window.location.origin}/presence/api/ai`;
+const STORAGE_KEYS = {
+  roomId: 'scenesync.devtool.roomId',
+  sessionId: 'scenesync.devtool.sessionId',
+  expiresAt: 'scenesync.devtool.expiresAt',
+  history: 'scenesync.devtool.history',
+};
+const MAX_HISTORY = 8;
+const DEFAULT_PAYLOAD = {
+  kind: 'scene-add',
+  objectId: 'dev-cube-1',
+  name: 'Dev Cube',
+  position: [0, 0.5, 0],
+  rotation: [0, 0, 0, 1],
+  scale: [1, 1, 1],
+  asset: {
+    type: 'primitive',
+    primitive: 'box',
+    color: '#ff8800',
+  },
+};
+
+const elements = {
+  roomId: document.querySelector('#roomId'),
+  sessionId: document.querySelector('#sessionId'),
+  pairCode: document.querySelector('#pairCode'),
+  sessionStatus: document.querySelector('#sessionStatus'),
+  sessionMeta: document.querySelector('#sessionMeta'),
+  payloadInput: document.querySelector('#payloadInput'),
+  previewOutput: document.querySelector('#previewOutput'),
+  validationOutput: document.querySelector('#validationOutput'),
+  responseOutput: document.querySelector('#responseOutput'),
+  resolvedRoute: document.querySelector('#resolvedRoute'),
+  redeemButton: document.querySelector('#redeemButton'),
+  formatButton: document.querySelector('#formatButton'),
+  sendButton: document.querySelector('#sendButton'),
+  snapshotButton: document.querySelector('#snapshotButton'),
+  clearHistoryButton: document.querySelector('#clearHistoryButton'),
+  historyList: document.querySelector('#historyList'),
+};
+
+function loadJson(key, fallback) {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveJson(key, value) {
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function getHistory() {
+  return loadJson(STORAGE_KEYS.history, []);
+}
+
+function setHistory(history) {
+  saveJson(STORAGE_KEYS.history, history.slice(0, MAX_HISTORY));
+}
+
+function saveSession() {
+  window.localStorage.setItem(STORAGE_KEYS.roomId, elements.roomId.value.trim());
+  window.localStorage.setItem(STORAGE_KEYS.sessionId, elements.sessionId.value.trim());
+}
+
+function setStoredExpiry(expiresAt) {
+  if (expiresAt) {
+    window.localStorage.setItem(STORAGE_KEYS.expiresAt, String(expiresAt));
+  } else {
+    window.localStorage.removeItem(STORAGE_KEYS.expiresAt);
+  }
+}
+
+function hydrateSession() {
+  const params = new URLSearchParams(window.location.search);
+  elements.roomId.value = params.get('room') || window.localStorage.getItem(STORAGE_KEYS.roomId) || '';
+  elements.sessionId.value = params.get('sessionId') || window.localStorage.getItem(STORAGE_KEYS.sessionId) || '';
+  updateSessionStatus();
+}
+
+function hydratePayload() {
+  elements.payloadInput.value = JSON.stringify(DEFAULT_PAYLOAD, null, 2);
+  syncPayloadState();
+}
+
+function updateSessionStatus() {
+  const roomId = elements.roomId.value.trim();
+  const sessionId = elements.sessionId.value.trim();
+  const expiresAt = Number(window.localStorage.getItem(STORAGE_KEYS.expiresAt) || 0);
+
+  if (!roomId || !sessionId) {
+    elements.sessionStatus.textContent = 'No stored session';
+    elements.sessionMeta.textContent = 'Redeem a 6-digit code or paste room and session values.';
+    return;
+  }
+
+  elements.sessionStatus.textContent = 'Ready';
+  elements.sessionMeta.textContent = expiresAt > 0
+    ? `Room ${roomId} • expires ${new Date(expiresAt).toLocaleString()}`
+    : `Room ${roomId} • expiry unknown`;
+}
+
+function renderValidation(errors) {
+  if (!errors.length) {
+    elements.validationOutput.textContent = 'No validation errors.';
+    elements.validationOutput.classList.remove('console-error');
+    elements.validationOutput.classList.add('console-warning');
+    return;
+  }
+
+  elements.validationOutput.textContent = errors.join('\n');
+  elements.validationOutput.classList.remove('console-warning');
+  elements.validationOutput.classList.add('console-error');
+}
+
+function validatePayload(value) {
+  const errors = [];
+  let parsed = null;
+  let route = 'broadcast';
+
+  if (!value.trim()) {
+    errors.push('Payload JSON is required.');
+    return { errors, parsed, route };
+  }
+
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    errors.push(`Invalid JSON: ${error.message}`);
+    return { errors, parsed, route };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    errors.push('Payload must be a JSON object.');
+    return { errors, parsed, route };
+  }
+
+  if (parsed.kind === 'ai-command') {
+    route = 'ai-command';
+    if (typeof parsed.action !== 'string' || !parsed.action.trim()) {
+      errors.push('ai-command requires action.');
+    }
+    if (parsed.params !== undefined && (typeof parsed.params !== 'object' || parsed.params === null || Array.isArray(parsed.params))) {
+      errors.push('ai-command params must be an object when provided.');
+    }
+    if (parsed.action === 'focusObject' && typeof parsed.params?.objectId !== 'string') {
+      errors.push('focusObject requires params.objectId.');
+    }
+    if (parsed.action === 'uploadGlbFromUrl' && typeof parsed.params?.url !== 'string') {
+      errors.push('uploadGlbFromUrl requires params.url.');
+    }
+  } else {
+    if (typeof parsed.kind !== 'string' || !parsed.kind.trim()) {
+      errors.push('payload.kind is required.');
+    }
+    if (parsed.kind === 'scene-add' && parsed.asset?.type === 'primitive') {
+      if (typeof parsed.asset.primitive !== 'string' || !parsed.asset.primitive) {
+        errors.push('primitive scene-add requires payload.asset.primitive.');
+      }
+      if (typeof parsed.asset.color !== 'string' || !parsed.asset.color) {
+        errors.push('primitive scene-add requires payload.asset.color.');
+      }
+    }
+  }
+
+  return { errors, parsed, route };
+}
+
+function syncPayloadState() {
+  const { errors, parsed, route } = validatePayload(elements.payloadInput.value);
+  renderValidation(errors);
+  elements.resolvedRoute.textContent = route;
+  elements.previewOutput.textContent = parsed ? JSON.stringify(parsed, null, 2) : 'Preview unavailable.';
+  elements.sendButton.disabled = errors.length > 0;
+  return { errors, parsed, route };
+}
+
+function renderResult(target, value, isError = false) {
+  target.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  target.classList.toggle('console-error', isError);
+}
+
+async function postJson(path, body) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(data?.error || `HTTP ${response.status}`);
+  }
+  return data;
+}
+
+function storeHistoryEntry(route, payload) {
+  const entry = {
+    id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    route,
+    roomId: elements.roomId.value.trim(),
+    sessionId: elements.sessionId.value.trim(),
+    payload,
+    createdAt: new Date().toISOString(),
+  };
+  const history = [entry, ...getHistory()];
+  setHistory(history);
+  renderHistory();
+}
+
+function renderHistory() {
+  const history = getHistory();
+  if (!history.length) {
+    elements.historyList.innerHTML = '<p class="history-empty">No payload history yet.</p>';
+    return;
+  }
+
+  elements.historyList.innerHTML = history.map((entry) => {
+    const preview = JSON.stringify(entry.payload);
+    return `
+      <article class="history-item">
+        <div>
+          <p><strong>${escapeHtml(entry.route)}</strong></p>
+          <p class="meta">${escapeHtml(entry.roomId)} • ${escapeHtml(new Date(entry.createdAt).toLocaleString())}</p>
+          <p>${escapeHtml(preview.length > 140 ? `${preview.slice(0, 140)}...` : preview)}</p>
+        </div>
+        <div class="history-actions">
+          <button type="button" data-history-action="reuse" data-history-id="${escapeHtml(entry.id)}">Reuse</button>
+          <button type="button" data-history-action="send" data-history-id="${escapeHtml(entry.id)}">Send Again</button>
+        </div>
+      </article>
+    `;
+  }).join('');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function requireRoomAndSession() {
+  const roomId = elements.roomId.value.trim();
+  const sessionId = elements.sessionId.value.trim();
+  const errors = [];
+  if (!roomId) errors.push('roomId is required.');
+  if (!sessionId) errors.push('sessionId is required.');
+  if (errors.length) {
+    renderValidation(errors);
+    throw new Error('Missing roomId or sessionId.');
+  }
+  return { roomId, sessionId };
+}
+
+async function handleRedeem() {
+  const code = elements.pairCode.value.trim();
+  if (!/^\d{6}$/.test(code)) {
+    renderValidation(['Pairing code must be a 6-digit string.']);
+    return;
+  }
+
+  try {
+    renderResult(elements.responseOutput, 'Redeeming pairing code...');
+    const result = await postJson('/link/redeem', { code });
+    elements.roomId.value = result.roomId || '';
+    elements.sessionId.value = result.sessionId || '';
+    saveSession();
+    setStoredExpiry(result.expiresAt || null);
+    updateSessionStatus();
+    renderResult(elements.responseOutput, result);
+  } catch (error) {
+    renderResult(elements.responseOutput, error.message, true);
+  }
+}
+
+async function handleSend(entryOverride = null) {
+  try {
+    const { roomId, sessionId } = requireRoomAndSession();
+    const payloadState = entryOverride
+      ? validatePayload(JSON.stringify(entryOverride.payload))
+      : syncPayloadState();
+    if (payloadState.errors.length) {
+      return;
+    }
+
+    saveSession();
+    const { parsed, route } = payloadState;
+    renderResult(elements.responseOutput, 'Sending request...');
+
+    const result = route === 'ai-command'
+      ? await postJson(`/room/${encodeURIComponent(roomId)}/ai-command`, {
+        sessionId,
+        action: parsed.action,
+        params: parsed.params || {},
+        requestId: parsed.requestId,
+        targetPeerId: parsed.targetPeerId,
+      })
+      : await postJson(`/room/${encodeURIComponent(roomId)}/broadcast`, {
+        sessionId,
+        payload: parsed,
+      });
+
+    if (!entryOverride) {
+      storeHistoryEntry(route, parsed);
+    }
+    renderResult(elements.responseOutput, result);
+  } catch (error) {
+    renderResult(elements.responseOutput, error.message, true);
+  }
+}
+
+async function handleSnapshot() {
+  try {
+    const { roomId, sessionId } = requireRoomAndSession();
+    saveSession();
+    renderResult(elements.responseOutput, 'Fetching scene snapshot...');
+    const result = await postJson(`/room/${encodeURIComponent(roomId)}/scene`, { sessionId });
+    renderResult(elements.responseOutput, result);
+  } catch (error) {
+    renderResult(elements.responseOutput, error.message, true);
+  }
+}
+
+function reuseHistoryEntry(entry) {
+  elements.roomId.value = entry.roomId || '';
+  elements.sessionId.value = entry.sessionId || '';
+  elements.payloadInput.value = JSON.stringify(entry.payload, null, 2);
+  saveSession();
+  updateSessionStatus();
+  syncPayloadState();
+}
+
+function bindEvents() {
+  elements.roomId.addEventListener('input', () => {
+    saveSession();
+    updateSessionStatus();
+  });
+  elements.sessionId.addEventListener('input', () => {
+    saveSession();
+    updateSessionStatus();
+  });
+  elements.payloadInput.addEventListener('input', syncPayloadState);
+  elements.redeemButton.addEventListener('click', handleRedeem);
+  elements.formatButton.addEventListener('click', () => {
+    const { parsed } = syncPayloadState();
+    if (parsed) {
+      elements.payloadInput.value = JSON.stringify(parsed, null, 2);
+      syncPayloadState();
+    }
+  });
+  elements.sendButton.addEventListener('click', () => handleSend());
+  elements.snapshotButton.addEventListener('click', handleSnapshot);
+  elements.clearHistoryButton.addEventListener('click', () => {
+    setHistory([]);
+    renderHistory();
+  });
+  elements.historyList.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-history-id]');
+    if (!button) return;
+
+    const history = getHistory();
+    const entry = history.find((item) => item.id === button.dataset.historyId);
+    if (!entry) return;
+
+    if (button.dataset.historyAction === 'reuse') {
+      reuseHistoryEntry(entry);
+      return;
+    }
+
+    reuseHistoryEntry(entry);
+    await handleSend(entry);
+  });
+}
+
+hydrateSession();
+hydratePayload();
+renderHistory();
+bindEvents();

--- a/html/scenesync/dev-tool/index.html
+++ b/html/scenesync/dev-tool/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scene Sync Dev Tool - afjk.jp</title>
+  <meta name="description" content="Developer console for sending Scene Sync payloads, fetching snapshots, and validating AI wrapper requests.">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/assets/css/scenesync-dev-tool.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Scene Sync</p>
+        <h1>Dev Tool Command Console</h1>
+        <p class="lede">Validate JSON, send it through the existing AI wrapper path, inspect the response, and keep a short local history.</p>
+      </div>
+      <div class="hero-links">
+        <a href="/scenesync/">Open Scene Sync</a>
+      </div>
+    </header>
+
+    <section class="panel panel-grid">
+      <label>
+        <span>Room ID</span>
+        <input id="roomId" type="text" autocomplete="off" spellcheck="false" placeholder="abc123">
+      </label>
+      <label>
+        <span>Session ID</span>
+        <input id="sessionId" type="text" autocomplete="off" spellcheck="false" placeholder="v1....">
+      </label>
+      <label>
+        <span>Pairing Code</span>
+        <div class="inline-field">
+          <input id="pairCode" type="text" inputmode="numeric" autocomplete="one-time-code" spellcheck="false" placeholder="123456" maxlength="6">
+          <button id="redeemButton" type="button">Redeem</button>
+        </div>
+      </label>
+      <div class="status-card">
+        <span class="status-label">Session</span>
+        <strong id="sessionStatus">No stored session</strong>
+        <p id="sessionMeta">Redeem a 6-digit code or paste room and session values.</p>
+      </div>
+    </section>
+
+    <section class="workspace">
+      <div class="panel composer">
+        <div class="panel-head">
+          <h2>Payload</h2>
+          <div class="actions">
+            <button id="formatButton" type="button">Format</button>
+            <button id="sendButton" type="button">Send</button>
+            <button id="snapshotButton" type="button">Fetch Snapshot</button>
+          </div>
+        </div>
+        <textarea id="payloadInput" spellcheck="false" aria-label="Scene Sync JSON payload"></textarea>
+        <div class="route-bar">
+          <span>Resolved route</span>
+          <code id="resolvedRoute">broadcast</code>
+        </div>
+      </div>
+
+      <div class="stack">
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Validation</h2>
+          </div>
+          <pre id="validationOutput" class="console console-warning">No validation errors.</pre>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Preview</h2>
+          </div>
+          <pre id="previewOutput" class="console">{
+  "kind": "scene-add",
+  "objectId": "dev-cube-1",
+  "name": "Dev Cube",
+  "position": [0, 0.5, 0],
+  "rotation": [0, 0, 0, 1],
+  "scale": [1, 1, 1],
+  "asset": {
+    "type": "primitive",
+    "primitive": "box",
+    "color": "#ff8800"
+  }
+}</pre>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Response / Error</h2>
+          </div>
+          <pre id="responseOutput" class="console">No request sent yet.</pre>
+        </section>
+      </div>
+    </section>
+
+    <section class="panel history-panel">
+      <div class="panel-head">
+        <h2>Recent Payloads</h2>
+        <button id="clearHistoryButton" type="button">Clear History</button>
+      </div>
+      <div id="historyList" class="history-list"></div>
+    </section>
+  </main>
+
+  <script type="module" src="/assets/js/scenesync/dev-tool-console.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone Scene Sync developer tool page under `/scenesync/dev-tool/`
- add JSON payload validation, route resolution, response/error display, snapshot fetch, and short local payload history
- support redeeming a 6-digit pairing code to hydrate `roomId` and `sessionId`

## Testing
- `node --check html/assets/js/scenesync/dev-tool-console.js`
- `npm test` in `apps/presence-server` currently fails locally because `ws` is not installed in this worktree (`ERR_MODULE_NOT_FOUND`)
