### PR TITLE
Add in-scene Scene Sync inspector panel

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -54,6 +54,9 @@ const environmentManager = createEnvironmentManager({
   dom,
   showToast,
 });
+dom.envSelect?.addEventListener('change', () => {
+  scheduleSceneInspectorRefresh();
+});
 
 setupXrButtons({
   renderer,
@@ -815,6 +818,7 @@ function sendSelectedDelta() {
     rotation: rot,
     scale: scl,
   });
+  scheduleSceneInspectorRefresh();
 }
 
 // ── サンプルオブジェクト ──────────────────────────────────
@@ -1161,6 +1165,7 @@ function selectManagedObject(obj) {
   showToolbar();
   updateToolbarActive(transformCtrl.mode);
   updatePeersList();
+  scheduleSceneInspectorRefresh();
 }
 
 function selectObjectAt(clientX, clientY) {
@@ -1196,6 +1201,7 @@ function selectObjectAt(clientX, clientY) {
     transformCtrl.detach();
     hideToolbar();
     updatePeersList();
+    scheduleSceneInspectorRefresh();
   }
 }
 
@@ -1329,6 +1335,7 @@ function deleteSelectedObject() {
     );
 
     broadcast({ kind: 'scene-remove', objectId: deleteId });
+    scheduleSceneInspectorRefresh();
   }
 }
 
@@ -1382,6 +1389,7 @@ btnDeselect?.addEventListener('click', () => {
   }
   transformCtrl.detach();
   hideToolbar();
+  scheduleSceneInspectorRefresh();
 });
 
 btnDelete?.addEventListener('click', () => {
@@ -1573,6 +1581,13 @@ const dotEl = statusEl.querySelector('.dot');
 const nicknameLabel = document.getElementById('nickname-label');
 const nicknameChip = document.getElementById('nickname-chip');
 const roomSectionEl = document.getElementById('room-section');
+const sceneInspectorToggleBtn = document.getElementById('scene-inspector-toggle');
+const sceneInspectorPanel = document.getElementById('scene-inspector-panel');
+const sceneInspectorCloseBtn = document.getElementById('scene-inspector-close');
+const sceneInspectorRefreshBtn = document.getElementById('scene-inspector-refresh');
+const sceneInspectorCopyBtn = document.getElementById('scene-inspector-copy');
+const sceneInspectorSummaryEl = document.getElementById('scene-inspector-summary');
+const sceneInspectorOutputEl = document.getElementById('scene-inspector-output');
 
 function resolvePresenceUrl() {
   const params = new URLSearchParams(location.search);
@@ -1691,6 +1706,10 @@ let sceneReceived = false;
 let sceneRequestTimer = null;
 let sceneRequestAttempt = 0;
 let reconnectTimer = null;
+const sceneInspectorState = {
+  isOpen: false,
+  refreshTimer: null,
+};
 
 // ── Loom 統合初期化 ──────────────────────────────────
 const loomIntegration = createSceneSyncLoomIntegration({
@@ -1806,6 +1825,7 @@ function applyRoomCode(code) {
   u.searchParams.set('room', cleaned);
   history.replaceState(null, '', u.toString());
   reconnectPresence();
+  scheduleSceneInspectorRefresh();
 }
 
 function generateRoom() {
@@ -1822,6 +1842,7 @@ function clearRoom() {
   u.searchParams.delete('room');
   history.replaceState(null, '', u.toString());
   reconnectPresence();
+  scheduleSceneInspectorRefresh();
 }
 
 function copyRoomUrl() {
@@ -1936,6 +1957,7 @@ function connectPresence() {
         presenceState.room = data.room;
         updateStatus(true);
         updatePeersList();
+        scheduleSceneInspectorRefresh();
         break;
 
       case 'peers': {
@@ -1961,6 +1983,7 @@ function connectPresence() {
         if (isFirstPeers && !sceneReceived) {
           requestSceneFromPeer();
         }
+        scheduleSceneInspectorRefresh();
         break;
       }
 
@@ -1977,6 +2000,7 @@ function connectPresence() {
     updateStatus(false);
     remoteAvatarManager.disposeAllRemoteAvatars();
     updatePeersList();
+    scheduleSceneInspectorRefresh();
     clearTimeout(reconnectTimer);
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
@@ -2002,6 +2026,7 @@ function updateStatus(connected) {
     dotEl.className = 'dot off';
     statusEl.innerHTML = '<span class="dot off"></span>再接続中…';
   }
+  scheduleSceneInspectorRefresh();
 }
 
 // ── シーンリクエスト（後から参加したクライアント用） ───────
@@ -2156,6 +2181,7 @@ function handleHandoff(data) {
           showToast?.('Loom graph restore failed');
         }
       }
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-request': {
@@ -2191,6 +2217,7 @@ function handleHandoff(data) {
         );
         presenceState.historyManager.push(historyEntry);
       }
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-add': {
@@ -2208,6 +2235,7 @@ function handleHandoff(data) {
         );
         presenceState.historyManager.push(historyEntry);
       }
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-remove': {
@@ -2233,6 +2261,7 @@ function handleHandoff(data) {
       }
       // Loom object graph をクリーンアップ
       loomIntegration.clearObjectGraph(objectId);
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-mesh': {
@@ -2286,12 +2315,14 @@ function handleHandoff(data) {
       locks.set(payload.objectId, data.from);
       addLockOverlay(payload.objectId, data.from);
       updatePeersList();
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-unlock': {
       locks.delete(payload.objectId);
       removeLockOverlay(payload.objectId);
       updatePeersList();
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-env': {
@@ -2306,6 +2337,7 @@ function handleHandoff(data) {
           presenceState.historyManager.push(historyEntry);
         }
       }
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-avatar': {
@@ -2496,6 +2528,7 @@ async function uploadGlbFromUrl(url, params = {}) {
   model.userData.name = file.name;
   managedObjects.set(model.userData.objectId, model);
   selectManagedObject(model);
+  scheduleSceneInspectorRefresh();
 
   const arrayBuffer = await blob.arrayBuffer();
   await uploadAndBroadcast(
@@ -2638,7 +2671,9 @@ function loadMeshObject(objectId, info, meshPath, existing) {
     console.warn('Failed to load mesh for', objectId, ':', err);
     if (!existing) {
       replaceManagedObject(objectId, buildDefaultBoxObject(objectId, info, 0xff4444), info);
+      return;
     }
+    scheduleSceneInspectorRefresh();
   });
 }
 
@@ -2654,6 +2689,7 @@ function replaceManagedObject(objectId, nextObject, info) {
   applyTransform(nextObject, info);
   scene.add(nextObject);
   managedObjects.set(objectId, nextObject);
+  scheduleSceneInspectorRefresh();
 }
 
 function buildDefaultBoxObject(objectId, info, color = 0x4488ff) {
@@ -2754,6 +2790,7 @@ function applyAssetDelta(obj, asset) {
   if (asset.color) {
     applyObjectColor(obj, asset.color);
   }
+  scheduleSceneInspectorRefresh();
 }
 
 // ── Undo/Redo 処理 ──────────────────────────────────────
@@ -2798,6 +2835,7 @@ function applyOperationToScene(operation) {
       }
       // Loom object graph をクリーンアップ
       loomIntegration.clearObjectGraph(operation.objectId);
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-delta': {
@@ -2815,10 +2853,12 @@ function applyOperationToScene(operation) {
         source: 'undo-redo',
         broadcastChange: false,
       });
+      scheduleSceneInspectorRefresh();
       break;
     }
     case 'scene-batch': {
       operation.actions?.forEach(action => applyOperationToScene(action));
+      scheduleSceneInspectorRefresh();
       break;
     }
   }
@@ -2874,6 +2914,7 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       actualMeshPath
     );
     presenceState.historyManager.push(historyEntry);
+    scheduleSceneInspectorRefresh();
 
     broadcast({
       kind: 'scene-add',
@@ -2910,6 +2951,7 @@ const dragDropManager = new DragDropManager({
   onLoaded: async (model, file) => {
     managedObjects.set(model.userData.objectId, model);
     selectManagedObject(model);
+    scheduleSceneInspectorRefresh();
 
     const arrayBuffer = await file.arrayBuffer();
     await uploadAndBroadcast(
@@ -2992,6 +3034,102 @@ async function copyText(text, successMessage = 'コピーしました') {
 
 function copyPairingCode() {
   return copyText(pairingCode?.textContent?.trim(), 'AIリンクコードをコピーしました');
+}
+
+function buildSceneInspectorSnapshot() {
+  const objects = {};
+  const sortedEntries = Array.from(managedObjects.entries())
+    .sort(([leftId], [rightId]) => leftId.localeCompare(rightId));
+
+  for (const [objectId, obj] of sortedEntries) {
+    const entry = {
+      name: obj.userData?.name || obj.name || objectId,
+      type: obj.type,
+      position: obj.position.toArray(),
+      rotation: obj.quaternion.toArray(),
+      scale: obj.scale.toArray(),
+      visible: obj.visible !== false,
+      childCount: obj.children?.length || 0,
+    };
+
+    if (obj.userData?.meshPath) {
+      entry.meshPath = obj.userData.meshPath;
+    }
+    if (obj.userData?.asset) {
+      entry.asset = structuredClone(obj.userData.asset);
+    }
+    if (locks.has(objectId)) {
+      const lockInfo = locks.get(objectId);
+      entry.lockedBy = {
+        id: lockInfo?.id || null,
+        nickname: lockInfo?.nickname || null,
+      };
+    }
+
+    objects[objectId] = entry;
+  }
+
+  const snapshot = {
+    kind: 'scene-inspector',
+    room: presenceState.room || activeRoomCode || null,
+    connection: {
+      connected: presenceState.ws?.readyState === WebSocket.OPEN,
+      peerId: presenceState.id,
+      userId: presenceState.userId,
+      sceneReceived,
+    },
+    environment: {
+      currentEnvId: environmentManager.getCurrentEnvId?.() || null,
+      appliedEnvId: environmentManager.getAppliedEnvId?.() || null,
+    },
+    selection: {
+      objectId: transformCtrl.object?.userData?.objectId || null,
+    },
+    objectCount: sortedEntries.length,
+    objects,
+    generatedAt: new Date().toISOString(),
+  };
+
+  const loomGraphState = loomIntegration.exportState();
+  if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
+    snapshot.loomGraphs = loomGraphState;
+  }
+
+  return snapshot;
+}
+
+function refreshSceneInspector() {
+  const snapshot = buildSceneInspectorSnapshot();
+  const roomLabel = snapshot.room || 'no-room';
+  const selectedLabel = snapshot.selection.objectId || 'none';
+  if (sceneInspectorSummaryEl) {
+    sceneInspectorSummaryEl.textContent =
+      `Room ${roomLabel} | ${snapshot.objectCount} objects | selected ${selectedLabel} | ${new Date().toLocaleTimeString()}`;
+  }
+  if (sceneInspectorOutputEl) {
+    sceneInspectorOutputEl.textContent = JSON.stringify(snapshot, null, 2);
+  }
+}
+
+function scheduleSceneInspectorRefresh() {
+  if (!sceneInspectorState.isOpen) return;
+  if (sceneInspectorState.refreshTimer) return;
+  sceneInspectorState.refreshTimer = setTimeout(() => {
+    sceneInspectorState.refreshTimer = null;
+    refreshSceneInspector();
+  }, 80);
+}
+
+function setSceneInspectorOpen(nextOpen) {
+  sceneInspectorState.isOpen = nextOpen;
+  sceneInspectorPanel?.classList.toggle('open', nextOpen);
+  sceneInspectorToggleBtn?.classList.toggle('active', nextOpen);
+  if (sceneInspectorToggleBtn) {
+    sceneInspectorToggleBtn.title = nextOpen ? 'Scene Inspector を閉じる' : 'Scene Inspector を開く';
+  }
+  if (nextOpen) {
+    refreshSceneInspector();
+  }
 }
 
 function showPairingDialogLinked(expiresAtMs) {
@@ -3078,6 +3216,16 @@ btnCancelPairing?.addEventListener('click', cancelPairing);
 btnRevokeLink?.addEventListener('click', revokeLink);
 btnCopyPairingCode?.addEventListener('click', copyPairingCode);
 pairingCode?.addEventListener('click', copyPairingCode);
+sceneInspectorToggleBtn?.addEventListener('click', () => {
+  setSceneInspectorOpen(!sceneInspectorState.isOpen);
+});
+sceneInspectorCloseBtn?.addEventListener('click', () => {
+  setSceneInspectorOpen(false);
+});
+sceneInspectorRefreshBtn?.addEventListener('click', refreshSceneInspector);
+sceneInspectorCopyBtn?.addEventListener('click', () => {
+  copyText(sceneInspectorOutputEl?.textContent?.trim(), 'Scene JSON をコピーしました');
+});
 pairingDialog?.addEventListener('click', (event) => {
   if (event.target === pairingDialog) {
     cancelPairing();
@@ -3086,12 +3234,18 @@ pairingDialog?.addEventListener('click', (event) => {
 document.addEventListener('keydown', (event) => {
   if (event.key === 'Escape' && pairingDialog?.style.display === 'flex') {
     cancelPairing();
+    return;
+  }
+  if (event.key === 'Escape' && sceneInspectorState.isOpen) {
+    setSceneInspectorOpen(false);
   }
 });
 
 presenceState.linkManager.onStatusChange = () => {
   updateLinkButtonState();
 };
+
+setSceneInspectorOpen(false);
 
 if (sceneSyncOperatorLink) {
   if (SCENE_SYNC_OPERATOR_URL) {

--- a/html/scenesync/dev-tool/index.html
+++ b/html/scenesync/dev-tool/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Scene Sync Dev Tool - afjk.jp</title>
-  <meta name="description" content="Developer console for sending Scene Sync payloads, fetching snapshots, and validating AI wrapper requests.">
+  <title>Scene Sync Payload Tester - afjk.jp</title>
+  <meta name="description" content="Standalone payload tester for Scene Sync AI wrapper requests, snapshots, and JSON validation.">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="stylesheet" href="/assets/css/scenesync-dev-tool.css">
 </head>
@@ -13,8 +13,8 @@
     <header class="hero">
       <div>
         <p class="eyebrow">Scene Sync</p>
-        <h1>Dev Tool Command Console</h1>
-        <p class="lede">Validate JSON, send it through the existing AI wrapper path, inspect the response, and keep a short local history.</p>
+        <h1>Payload Tester</h1>
+        <p class="lede">Use this standalone page for API payload testing. The primary developer inspector now lives inside the main Scene Sync screen.</p>
       </div>
       <div class="hero-links">
         <a href="/scenesync/">Open Scene Sync</a>

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -277,6 +277,77 @@
       margin-left: auto;
       flex-shrink: 0;
     }
+    #scene-inspector-panel {
+      position: fixed;
+      top: 96px;
+      right: 12px;
+      width: min(420px, calc(100vw - 24px));
+      max-height: calc(100vh - 120px);
+      display: none;
+      flex-direction: column;
+      gap: 10px;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.78);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      color: #fff;
+      z-index: 80;
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      font: 12px/1.5 monospace;
+    }
+    #scene-inspector-panel.open {
+      display: flex;
+    }
+    .scene-inspector-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 10px;
+    }
+    .scene-inspector-header h2 {
+      font-size: 16px;
+      line-height: 1.2;
+    }
+    .scene-inspector-eyebrow {
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.55);
+      margin-bottom: 4px;
+    }
+    .scene-inspector-summary {
+      color: rgba(255,255,255,0.72);
+    }
+    .scene-inspector-actions {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .scene-inspector-actions .chip {
+      justify-content: center;
+    }
+    #scene-inspector-output {
+      margin: 0;
+      padding: 12px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.08);
+      color: #dce7ff;
+      overflow: auto;
+      white-space: pre;
+      word-break: normal;
+      min-height: 180px;
+      flex: 1;
+    }
+    @media (max-width: 720px) {
+      #scene-inspector-panel {
+        top: auto;
+        bottom: 84px;
+        right: 12px;
+        max-height: min(52vh, 420px);
+      }
+    }
 
     /* WebXR ボタン用余白確保 */
     #add-btn.xr-available {
@@ -410,6 +481,12 @@
         <span id="link-label">AIにリンク</span>
       </button>
     </div>
+    <div class="row">
+      <button id="scene-inspector-toggle" class="chip" type="button" title="Scene Inspector を開く">
+        <span>🛠</span>
+        <span>Dev</span>
+      </button>
+    </div>
     <div id="pairing-dialog" class="pairing-dialog" style="display:none;">
       <div class="pairing-content">
         <h3>AI ペアリング</h3>
@@ -443,6 +520,24 @@
   <div id="peers-panel">
     <div id="peers-list"></div>
   </div>
+  <aside id="scene-inspector-panel" aria-live="polite" aria-label="Scene Inspector">
+    <div class="scene-inspector-header">
+      <div>
+        <p class="scene-inspector-eyebrow">Development Tool</p>
+        <h2>Scene Inspector</h2>
+      </div>
+      <button id="scene-inspector-close" class="chip" type="button" title="閉じる">✕</button>
+    </div>
+    <p id="scene-inspector-summary" class="scene-inspector-summary">Scene state is not loaded yet.</p>
+    <div class="scene-inspector-actions">
+      <button id="scene-inspector-refresh" class="chip" type="button">Refresh</button>
+      <button id="scene-inspector-copy" class="chip" type="button">Copy JSON</button>
+      <a class="chip" href="/scenesync/dev-tool/">Payload Tester</a>
+    </div>
+    <pre id="scene-inspector-output">{
+  "status": "waiting-for-scene"
+}</pre>
+  </aside>
   <button id="add-btn" title="GLB を追加">＋</button>
   <input type="file" id="file-input" accept=".glb" style="display:none">
   <div id="drop-overlay">GLB をドロップして追加</div>


### PR DESCRIPTION
## Summary
- add an in-scene Scene Inspector panel to `/scenesync/`
- keep the standalone `/scenesync/dev-tool/` page and relabel it as a payload tester
- expose current scene state, selection, environment, and lock context as copyable JSON

## Checks
- `git diff -- .github/workflows`
- `git diff --check`
- `git status --short --branch`
- browser ESM syntax could not be validated with `node --check` because this file uses browser module imports (`three`) that are not resolvable in the shell environment
