### PR TITLE
Add backlog tracks for parallel agent development

### DIFF
--- a/docs/plans/architecture/asset-carrier-glb-decision.md
+++ b/docs/plans/architecture/asset-carrier-glb-decision.md
@@ -1,0 +1,83 @@
+# Asset Carrier GLB Decision
+
+## 決定
+
+Scene Sync の同期インターフェースは、当面 GLB / carrier GLB を compatibility と placement の共通レイヤとして維持します。  
+shader / splat / video / webpage / text / VFX / AssetBundle などの特殊 runtime asset も、可能な限り carrier GLB fallback を持つ方針を優先します。
+
+## なぜこの方向か
+
+- Scene Sync は placement、selection、transform sync を既に 3D object ベースで扱っている
+- asset type ごとに sync interface を増やすと protocol、viewer、editor、transfer の複雑さが急増する
+- GLB / meshPath を compatibility layer に残すと、非対応 runtime でも fallback 表示しやすい
+- runtime-specific renderer は metadata を見て carrier を置き換えるか augment する方式にしやすい
+
+## Preferred Model
+
+- placement layer:
+  - object transform
+  - object identity
+  - fallback geometry
+  - default selection target
+- carrier layer:
+  - GLB or carrier GLB
+  - `meshPath` or equivalent asset reference
+- runtime augmentation layer:
+  - metadata
+  - referenced blobs
+  - renderer-specific parameters
+
+## Asset Type Guidance
+
+- image:
+  - texture plane carrier GLB
+  - original image blob reference in metadata
+- video:
+  - poster plane carrier GLB
+  - video URL / blob reference in metadata
+- webpage:
+  - placeholder plane or proxy mesh carrier
+  - URL metadata
+- text:
+  - text plane carrier
+  - text content / style metadata
+- shader:
+  - carrier mesh or plane
+  - shader source / uniforms in metadata or blobs
+- Gaussian Splat:
+  - carrier GLB fallback
+  - splat blob / URL metadata
+- VFX / AssetBundle:
+  - placeholder or proxy carrier
+  - runtime payload references in metadata
+
+## Rejected Direction For Now
+
+- `asset.type: "shader"` のような special type を sync primitive として直接増やし、GLSL source と uniforms を protocol 本体で常に同期する案
+
+### 理由
+
+- sync interface が asset-specialized になりやすい
+- fallback が弱くなり、非対応 runtime で placement すら表現しにくい
+- blob size、validation、security、compatibility 問題が一気に増える
+
+## Tradeoffs
+
+- carrier GLB 方針は、最短では回り道に見える
+- ただし protocol と placement の安定性を保ちやすく、後から runtime-specific renderer を増やしやすい
+- perfect fidelity より interoperability と staged rollout を優先する決定
+
+## Open Questions
+
+- carrier metadata の canonical schema をどこまで protocol に含めるか
+- browser-side conversion と server-side conversion の境界をどう切るか
+- large shader code や splat payload の blob lifecycle をどう管理するか
+- metadata 参照の signed URL / assetId strategy をどう security track と接続するか
+- carrier replacement と carrier augmentation を runtime ごとにどう分けるか
+
+## Follow-Up
+
+- backlog の Asset Pipeline / Carrier GLB track で asset class matrix を具体化する
+- Shader / Generative Runtime track で shader metadata と blob threshold を整理する
+- Advanced Rendering track で splat fallback strategy を詰める
+

--- a/docs/plans/backlog/000-index.md
+++ b/docs/plans/backlog/000-index.md
@@ -1,0 +1,62 @@
+# Backlog Tracks Index
+
+## 目的
+
+今後増えていく Scene Sync / Loom / AI / asset / rendering / refactoring 系の開発アイデアを、coding agents と subagents が並列で扱いやすい track 単位に整理するための index です。
+
+## Product Positioning
+
+- 短い表現: クリエイティブツールのためのリアルタイム空間データブリッジ
+- 外向き説明: Web / Unity / Blender / TouchDesigner をつなぐリアルタイム3Dシーン同期ツール
+- 内部アーキテクチャ視点: Adapter / Codec / Transport を差し替えられるリアルタイム空間データプラットフォーム
+- 表の顔: すぐ使える3Dシーン同期ツール
+- 裏の顔: 対応先を増やしやすいリアルタイム空間データプラットフォーム
+
+詳細は [product-positioning.md](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/product-positioning.md) を参照。
+
+## Track 一覧
+
+- [Scene Sync Dev Tool / IDE](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/scenesync-dev-tool-ide.md)
+- [Loom Language / Node Graph](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/loom-language-node-graph.md)
+- [AI Integration](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/ai-integration.md)
+- [Asset Pipeline / Carrier GLB](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/asset-pipeline-carrier-glb.md)
+- [Shader / Generative Runtime](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/shader-generative-runtime.md)
+- [Advanced Rendering](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/advanced-rendering.md)
+- [WebAR Snapshot Viewer](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/webar-snapshot-viewer.md)
+- [Refactoring / Packages](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/refactoring-packages.md)
+- [Enterprise / Security](/Users/afjk/github/SceneSyncWork/afjk.jp/docs/plans/backlog/enterprise-security.md)
+
+## Near-Term Waves
+
+### Wave 1
+
+- In-scene Scene Sync Inspector panel follow-up
+- AI contract / runtime response alignment
+- Loom conflict / ownership refinement
+
+### Wave 2
+
+- Asset pipeline / carrier GLB design follow-up
+- WebAR USDZ export feasibility
+- Scene Sync protocol extraction plan
+
+### Wave 3
+
+- Shader runtime Web MVP
+- image-to-plane / image-to-GLB pipeline
+- Loom code editor / graph prototype
+
+## Parallelization Rules
+
+- 並列化してよいのは、別 repo、別 track、または明確に別 file set を触る task
+- 同じ route / component / store / protocol consumer を複数 agent が同時に触る task は避ける
+- schema producer / consumer を両側で変える task は、片側 PR を先に landing させる
+- 並列実装時は git worktree を使い、各 agent に branch ownership を持たせる
+- parent agent が PR を確認し、安全なものだけ one-by-one で squash merge する
+
+## Agent Notes
+
+- backlog doc の更新と runtime 実装を同じ branch に混ぜすぎない
+- first PR を小さくし、track 境界を壊さない
+- cross-track task は、どの track を primary とみなすかを最初に明示する
+

--- a/docs/plans/backlog/advanced-rendering.md
+++ b/docs/plans/backlog/advanced-rendering.md
@@ -1,0 +1,64 @@
+# Advanced Rendering
+
+## purpose
+
+Gaussian Splat などの advanced rendering asset を Scene Sync に持ち込むための format、fallback、performance research を整理する track です。
+
+## included ideas
+
+- Gaussian Splat support
+- `.ply`
+- `.splat`
+- `.ksplat`
+- `.spz`
+- carrier GLB + splat blob / URL
+- runtime-specific renderer
+- performance research
+- import / capture workflow
+- fallback strategy
+
+## out of scope
+
+- first-party renderer の即時完成
+- all devices での parity
+- enterprise controls
+
+## near-term implementation tasks
+
+- format matrix を作る
+- carrier GLB fallback の形を整理する
+- runtime-specific renderer ownership を切り分ける
+- performance test axes を定義する
+
+## later tasks
+
+- Web runtime feasibility test
+- import / capture workflow prototype
+- splat snapshot export flow
+- fallback rendering QA
+
+## dependencies
+
+- Asset Pipeline / Carrier GLB
+- Advanced device test environment
+- WebAR Snapshot Viewer for playback reuse
+
+## risks
+
+- splat native path に寄りすぎると sync / placement の互換性が落ちる
+- performance budget を定義しないと viewer regressions が読めない
+
+## parallelization notes
+
+- format research、fallback design、performance test planning は並列化可能
+- renderer implementation と protocol change は同じ PR に混ぜない
+
+## suggested first PR
+
+- supported format matrix and fallback note
+
+## agent notes
+
+- first implementation path は always fallback-aware にする
+- placement / sync / playback を一度に解こうとしない
+

--- a/docs/plans/backlog/ai-integration.md
+++ b/docs/plans/backlog/ai-integration.md
@@ -1,0 +1,61 @@
+# AI Integration
+
+## purpose
+
+Scene Sync と Loom を AI から再現性高く扱うために、stable action schema、response shape、scene context injection、Dev Tool integration を整理する track です。
+
+## included ideas
+
+- AI tool contract
+- stable action schema
+- runtime response shape alignment
+- GPTs / MCP / Codex integration
+- current scene context injection
+- AI instructions from Dev Tool
+- ambiguous natural-language-only operation を避ける
+
+## out of scope
+
+- provider-specific prompt tuning の最適化
+- auth / billing / production governance
+- natural language parser の実装
+
+## near-term implementation tasks
+
+- docs と runtime response shape の差分洗い出し
+- scene snapshot / before-after policy の固定
+- current scene context injection point の整理
+- Dev Tool から AI instruction を送る前提条件の明文化
+
+## later tasks
+
+- provider-neutral AI wrapper stabilization
+- inspector からの AI instruction flow
+- Loom graph / code context injection
+- safer retry / conflict assistance
+
+## dependencies
+
+- Scene Sync Dev Tool / IDE
+- Scene Sync runtime response
+- Enterprise / Security track の permission model
+
+## risks
+
+- action schema と runtime shape がずれると agent 実装が壊れやすい
+- scene context を渡しすぎると payload 膨張と privacy risk が増える
+
+## parallelization notes
+
+- docs / samples と runtime alignment は分けられるが、schema rename は同時に走らせない
+- producer / consumer 両側を変える場合は one PR first の順序を守る
+
+## suggested first PR
+
+- runtime response shape alignment diff doc と minimal reconciliation plan
+
+## agent notes
+
+- action 名を branch ごとに揺らさない
+- scene context は「何を inject するか」を先に固定してから UI を広げる
+

--- a/docs/plans/backlog/asset-pipeline-carrier-glb.md
+++ b/docs/plans/backlog/asset-pipeline-carrier-glb.md
@@ -1,0 +1,66 @@
+# Asset Pipeline / Carrier GLB
+
+## purpose
+
+Scene Sync に入る多様な asset を placement-compatible に扱うため、GLB / carrier GLB を compatibility layer に据えた asset pipeline を整理する track です。
+
+## included ideas
+
+- image upload
+- image to texture plane GLB
+- video poster plane GLB + video blob / URL
+- webpage placeholder GLB + URL metadata
+- text to CanvasTexture text plane GLB
+- GLB placement
+- asset library
+- browser-side vs server-side conversion
+- `prepareSceneSyncFile()` as a central entry point candidate
+- `transfer.putAsset(file)` / `transfer.getAsset(assetId)` future direction
+
+## out of scope
+
+- 全 asset type の production-ready converter 実装
+- asset moderation / DRM
+- advanced renderer 本体
+
+## near-term implementation tasks
+
+- carrier GLB decision を architecture doc に固定する
+- asset class ごとの metadata shape を一覧化する
+- browser-side conversion と server-side conversion の責務を比較する
+- `prepareSceneSyncFile()` の責務候補を整理する
+
+## later tasks
+
+- image-to-plane pipeline
+- video asset pipeline
+- webpage / text carrier pipeline
+- asset library and reusable asset references
+- transfer-core integration
+
+## dependencies
+
+- architecture/asset-carrier-glb-decision
+- Refactoring / Packages track
+- Enterprise / Security track for signed URLs
+
+## risks
+
+- asset type ごとに sync interface を増やすと Scene Sync protocol が崩れやすい
+- conversion を server に寄せすぎると開発速度が落ちる
+- carrier と runtime replacement の境界が曖昧だと debug が難しい
+
+## parallelization notes
+
+- asset type matrix、conversion location、transfer API doc は並列化できる
+- `meshPath` / metadata contract を変える task は single-agent で扱う
+
+## suggested first PR
+
+- asset class matrix と `prepareSceneSyncFile()` responsibility note
+
+## agent notes
+
+- preferred direction は GLB / carrier GLB compatibility layer を崩さないこと
+- special runtime data は metadata または referenced blobs へ逃がす
+

--- a/docs/plans/backlog/enterprise-security.md
+++ b/docs/plans/backlog/enterprise-security.md
@@ -1,0 +1,64 @@
+# Enterprise / Security
+
+## purpose
+
+asset protection、permission control、auditability を後付けで崩さないように、Scene Sync / asset pipeline / AI integration に横断する security backlog を整理する track です。
+
+## included ideas
+
+- authentication / authorization
+- short-lived URLs
+- blob encryption
+- client-side decrypt
+- watermark
+- audit log
+- AssetBundle protection
+- assetId / blobId-based references
+- scene-lock and edit permissions
+
+## out of scope
+
+- production IAM rollout
+- billing / seat management
+- legal policy text
+
+## near-term implementation tasks
+
+- threat surface inventory
+- asset URL lifetime policy draft
+- edit permission / scene-lock permission matrix draft
+- audit log minimum fields definition
+
+## later tasks
+
+- signed asset delivery
+- encrypted blob flow
+- watermark / asset ownership markers
+- per-role edit permissions
+- enterprise audit export
+
+## dependencies
+
+- Asset Pipeline / Carrier GLB
+- AI Integration
+- Refactoring / Packages
+
+## risks
+
+- signed URL / assetId strategyを後回しにすると asset pipeline と API が手戻りしやすい
+- scene-lock permission を曖昧にすると multi-user edit が壊れやすい
+
+## parallelization notes
+
+- threat model、URL policy、audit field list は分離しやすい
+- auth / permission implementation は producer / consumer 両側を同時変更しやすいので慎重に進める
+
+## suggested first PR
+
+- asset URL lifetime policy and minimum audit log fields doc
+
+## agent notes
+
+- direct push to security-sensitive runtime code を複数 agent で同時に進めない
+- permission model は Dev Tool / AI / Scene Sync core と接続点を先に洗い出す
+

--- a/docs/plans/backlog/loom-language-node-graph.md
+++ b/docs/plans/backlog/loom-language-node-graph.md
@@ -1,0 +1,65 @@
+# Loom Language / Node Graph
+
+## purpose
+
+`.loom` コード、node graph、preview、inspector を同期させた Loom authoring 体験を整理し、後続の `loom/` 実装と `afjk.jp` 側 integration を切り分けやすくする track です。
+
+## included ideas
+
+- `.loom` code format
+- code editor and node graph synchronized editing
+- left code editor / right node graph / bottom preview layout
+- IDE autocomplete
+- error display
+- Inspector
+- JS runtime target
+- Unity C# runtime target
+- Scene Sync realtime distribution
+- future collaborative editing
+
+## out of scope
+
+- この repo での Loom runtime 本体完成
+- full collaborative editor の即時実装
+- complete language spec
+
+## near-term implementation tasks
+
+- `.loom` document shape の初期定義
+- code view と graph view の source-of-truth 方針整理
+- error surface と preview ownership の整理
+- Scene Sync distribution interface の接点メモ
+
+## later tasks
+
+- code editor prototype
+- graph editor prototype
+- synchronized editing
+- runtime target adapters
+- collaborative editing
+
+## dependencies
+
+- Loom integration responsibility
+- AI Integration track の schema stability
+- Refactoring / Packages track の protocol extraction
+
+## risks
+
+- code view と graph view の canonical source を曖昧にすると破綻しやすい
+- `afjk.jp` と `loom/` の責務境界がぼやける
+
+## parallelization notes
+
+- language doc、layout doc、runtime target doc は並列化しやすい
+- canonical source の設計が固まる前に editor 実装を並列化しすぎない
+
+## suggested first PR
+
+- `.loom` document shape と code / graph canonical source decision の初期 doc
+
+## agent notes
+
+- `afjk.jp` 側では integration / preview / inspection responsibility に寄せる
+- `loom/` 側 implementation が必要な task は別 repo task として切り出す
+

--- a/docs/plans/backlog/product-positioning.md
+++ b/docs/plans/backlog/product-positioning.md
@@ -1,0 +1,32 @@
+# Product Positioning
+
+## 短い表現
+
+クリエイティブツールのためのリアルタイム空間データブリッジ
+
+## 外向き説明
+
+Web / Unity / Blender / TouchDesigner をつなぐリアルタイム3Dシーン同期ツール
+
+## 内部アーキテクチャ視点
+
+Adapter / Codec / Transport を差し替えられるリアルタイム空間データプラットフォーム
+
+## 2つの顔
+
+- 表の顔: すぐ使える3Dシーン同期ツール
+- 裏の顔: 対応先を増やしやすいリアルタイム空間データプラットフォーム
+
+## Positioning Implications
+
+- product 面では、最初に効くのは Scene Sync viewer / editor / developer tool の使いやすさ
+- architecture 面では、protocol と asset carrier を stable にし、adapter を増やしやすくすることが重要
+- AI integration は product の上に載る補助機能であり、scene context と stable action schema を先に揃える必要がある
+- advanced rendering や enterprise feature は、placement / sync / transfer の基本レイヤを壊さずに積み上げる
+
+## Agent Notes
+
+- user-facing wording と internal architecture wording を混同しない
+- 実装 task を切るときは、「今は product face なのか platform face なのか」を先に書く
+- track の優先順位に迷ったら、まず product feedback を取りやすい track を優先する
+

--- a/docs/plans/backlog/refactoring-packages.md
+++ b/docs/plans/backlog/refactoring-packages.md
@@ -1,0 +1,71 @@
+# Refactoring / Packages
+
+## purpose
+
+`afjk.jp` の app / protocol / transfer / presence 周りを、後続の Scene Sync / Loom / AI / asset development を並列化しやすい構成へ寄せるための track です。
+
+## included ideas
+
+- organize `pipe` internally as `file-transfer`
+- treat `scenesync` as an independent app
+- move toward `apps/` and `packages/`
+- presence-client extraction
+- scene-sync-protocol extraction
+- `scene.js` split
+- transfer-core
+- Scene Sync asset transfer through transfer-core
+- presence-server split
+- URL / API compatibility
+
+## out of scope
+
+- repo split の即時実施
+- user-facing product redesign
+- nonessential dependency migration
+
+## near-term implementation tasks
+
+- priority order を固定する
+- `presence-client` commonization boundary を定義する
+- `scene-sync-protocol` extraction candidate を洗い出す
+- `scene.js` split plan を作る
+
+## later tasks
+
+- `transfer-core`
+- Scene Sync asset transfer through transfer-core
+- presence-server split
+- apps / packages deeper reorg
+- repo / service split if needed
+
+## dependencies
+
+- Scene Sync runtime knowledge
+- FileTransfer area
+- Asset Pipeline / Carrier GLB
+
+## risks
+
+- broad refactor を先にやりすぎると product iteration が止まる
+- URL / API compatibility を壊すと周辺 tool も巻き込む
+
+## parallelization notes
+
+- extraction candidates doc と file inventory は並列化できる
+- `scene.js` split と protocol extraction を同時実装する場合は ownership を細かく分ける
+
+## suggested first PR
+
+- `presence-client` commonization plan and file inventory
+
+## agent notes
+
+- suggested priority:
+- 1. presence-client commonization
+- 2. scene-sync-protocol extraction
+- 3. scene.js split
+- 4. transfer-core
+- 5. Scene Sync asset transfer through transfer-core
+- 6. presence-server split
+- 7. repo / service split only if needed
+

--- a/docs/plans/backlog/scenesync-dev-tool-ide.md
+++ b/docs/plans/backlog/scenesync-dev-tool-ide.md
@@ -1,0 +1,61 @@
+# Scene Sync Dev Tool / IDE
+
+## purpose
+
+Scene Sync 画面の中で scene state を見て、将来的には object / block / AI instruction を扱える developer tool / lightweight IDE に育てるための track です。
+
+## included ideas
+
+- in-scene Inspector panel
+- realtime scene state text / JSON view
+- selected object focus
+- object block editing
+- text editor with autocomplete
+- node graph editor
+- AI instruction input later
+
+## out of scope
+
+- full Loom runtime editor の完成
+- natural language parser の完成
+- multi-user conflict UI の完成
+
+## near-term implementation tasks
+
+- in-scene inspector follow-up
+- state snapshot interface を明示化する
+- selected object focus action を既存 viewer に足す
+- read-only JSON view と copy flow を安定化する
+
+## later tasks
+
+- object block editing
+- autocomplete 付き text editor
+- inspector と node graph の接続
+- AI instruction entry with scene context
+
+## dependencies
+
+- Scene Sync state access interface
+- selected object / focus API
+- AI Integration track の action schema
+
+## risks
+
+- UI を先に広げすぎると state interface が不安定なまま密結合になる
+- node graph editor を早く混ぜると Loom track と責務が曖昧になる
+
+## parallelization notes
+
+- state interface 固定前は UI と state adapter を別 agent に分けすぎない
+- state interface 固定後は panel UI、focus action、copy/export UX を分離しやすい
+
+## suggested first PR
+
+- Scene Inspector follow-up: summary 表示改善、selected object focus、state export helper の小整理
+
+## agent notes
+
+- `/scenesync/` route とその store / state access を複数 agent で同時に触らない
+- standalone payload tester は補助導線として残し、primary direction は in-scene inspector と明記する
+

--- a/docs/plans/backlog/shader-generative-runtime.md
+++ b/docs/plans/backlog/shader-generative-runtime.md
@@ -1,0 +1,71 @@
+# Shader / Generative Runtime
+
+## purpose
+
+GLSL / generative content を Scene Sync で扱うための runtime track を、carrier GLB 互換と GPU safety を保ちながら段階導入するための backlog です。
+
+## included ideas
+
+- GLSL / Shadertoy-compatible shader runtime
+- `iResolution`
+- `iTime`
+- `iTimeDelta`
+- `iFrame`
+- `iMouse`
+- `iChannel0..3`
+- `iTime` synchronized with existing serverClock
+- plane / fullscreen / box / sphere / skybox targets
+- Web Three.js `ShaderMaterial` MVP
+- Godot future support
+- Unity placeholder then staged support
+- Loom `shaderSetUniform` sink node
+- code size limits
+- blob store for large shader code
+- warm-up preview for GPU safety
+
+## out of scope
+
+- native renderer parity across all engines
+- unbounded user shader execution
+- shader editor completion and linting
+
+## near-term implementation tasks
+
+- shader carrier metadata shape を定義する
+- Web MVP target surface を plane first で絞る
+- `iTime` / serverClock alignment rule を整理する
+- code size / blob store threshold の初期方針を決める
+
+## later tasks
+
+- Web `ShaderMaterial` MVP
+- uniform editing / transport
+- Loom sink node
+- Godot support
+- Unity staged support
+
+## dependencies
+
+- Asset Pipeline / Carrier GLB
+- Advanced Rendering track for fallback comparisons
+- AI Integration for code assist later
+
+## risks
+
+- shader source を sync interface に直載せすると互換性と size 管理が崩れる
+- GPU warm-up / safety を後回しにすると preview 体験が不安定になる
+
+## parallelization notes
+
+- metadata / timing / safety guideline docs は分離しやすい
+- shader source transport と runtime execution は同時に変えない
+
+## suggested first PR
+
+- shader carrier metadata と Web MVP constraints doc
+
+## agent notes
+
+- shader は direct sync primitive ではなく runtime-specific augmentation として扱う
+- large code は blob store reference 前提で考える
+

--- a/docs/plans/backlog/webar-snapshot-viewer.md
+++ b/docs/plans/backlog/webar-snapshot-viewer.md
@@ -1,0 +1,65 @@
+# WebAR Snapshot Viewer
+
+## purpose
+
+editing と playback を分離し、room snapshot を各デバイスで再生できる viewer / export flow を整理する track です。
+
+## included ideas
+
+- editing and playback separation
+- iPhone playback via USDZ / AR Quick Look
+- Android via Scene Viewer
+- Quest via WebXR
+- `<model-viewer>` based viewer
+- `/api/room/{roomId}/glb`
+- `/api/room/{roomId}/usdz`
+- QR flow
+- snapshot playback only
+- no realtime sync in first version
+- Three.js `USDZExporter` feasibility
+
+## out of scope
+
+- first version での realtime sync
+- full editor-in-AR
+- multi-user AR session
+
+## near-term implementation tasks
+
+- snapshot export API candidates を整理する
+- USDZ export feasibility を検討する
+- QR flow の UX を定義する
+- playback-only architecture を文書化する
+
+## later tasks
+
+- GLB snapshot viewer
+- USDZ export path
+- Android / Quest playback validation
+- shareable snapshot flow
+
+## dependencies
+
+- Asset Pipeline / Carrier GLB
+- Advanced Rendering for non-GLB fallback
+- Enterprise / Security for signed snapshot URLs
+
+## risks
+
+- realtime editing を混ぜると scope が急激に増える
+- USDZ export feasibility を確認せずに API を決めると手戻りしやすい
+
+## parallelization notes
+
+- API sketch、device playback matrix、QR UX は分離しやすい
+- exporter feasibility が出る前に URL contract を固めすぎない
+
+## suggested first PR
+
+- snapshot playback architecture note and device matrix
+
+## agent notes
+
+- first version は playback only を守る
+- `/api/room/{roomId}/glb` と `/api/room/{roomId}/usdz` は contract 候補として扱い、即実装前提にしない
+


### PR DESCRIPTION
## Summary
- add backlog track docs under `docs/plans/backlog/`
- document product positioning, near-term waves, and parallelization rules for coding agents
- add an architecture decision to keep GLB / carrier GLB as the compatibility and placement layer for special asset types

## Checks
- `git diff --check`
- `git diff -- .github/workflows`
- `git status --short --branch`
- `git pull --ff-only` was attempted first and failed in shell with `Could not resolve host: github.com`
