### PR TITLE
docs(scenesync): note image-to-plane carrier GLB approach

### DIFF
--- a/apps/presence-server/tests/image-to-plane-sizing.test.mjs
+++ b/apps/presence-server/tests/image-to-plane-sizing.test.mjs
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { planeSizeFromImage } from '../../../html/assets/js/scenesync/loaders/image-to-plane.js';
+
+test('horizontal image normalized to maxEdge=2', () => {
+  const { width, height } = planeSizeFromImage(2000, 1000, 2);
+  assert.equal(width, 2);
+  assert.equal(height, 1);
+});
+
+test('vertical image', () => {
+  const { width, height } = planeSizeFromImage(800, 1600, 2);
+  assert.equal(width, 1);
+  assert.equal(height, 2);
+});
+
+test('square image', () => {
+  const result = planeSizeFromImage(512, 512, 2);
+  assert.deepEqual(result, { width: 2, height: 2 });
+});
+
+test('custom maxEdgeMeters', () => {
+  const { width, height } = planeSizeFromImage(1000, 500, 4);
+  assert.equal(width, 4);
+  assert.equal(height, 2);
+});
+
+test('default maxEdgeMeters=2', () => {
+  const { width, height } = planeSizeFromImage(200, 100);
+  assert.equal(width, 2);
+  assert.equal(height, 1);
+});

--- a/docs/plans/backlog/000-index.md
+++ b/docs/plans/backlog/000-index.md
@@ -43,7 +43,7 @@
 ### Wave 3
 
 - Shader runtime Web MVP
-- image-to-plane / image-to-GLB pipeline
+- ✓ image-to-plane / image-to-GLB pipeline (browser-side carrier GLB, Web UI image drop)
 - Loom code editor / graph prototype
 
 ## Parallelization Rules

--- a/docs/plans/backlog/asset-pipeline-carrier-glb.md
+++ b/docs/plans/backlog/asset-pipeline-carrier-glb.md
@@ -32,7 +32,7 @@ Scene Sync に入る多様な asset を placement-compatible に扱うため、G
 
 ## later tasks
 
-- image-to-plane pipeline
+- image-to-plane pipeline (✓ partially done: browser-side carrier GLB via Web UI, Wave 3)
 - video asset pipeline
 - webpage / text carrier pipeline
 - asset library and reusable asset references

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -299,6 +299,8 @@ godot/
 
     { "type": "image", "url": "https://..." }
 
+**Note on Web image support**: The Web client (as of Wave 3) internally converts PNG/JPEG/WebP images dropped via UI to carrier GLB format and delivers them as `{ "type": "mesh", "meshPath": <id> }` via the existing blob store. The `asset.type: "image"` wire format is reserved for future cross-platform standardization but not yet implemented. Images are thus indistinguishable from other meshes at the protocol level.
+
 `video`（IF 定義のみ、未実装）:
 
     { "type": "video", "url": "https://..." }

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -5,6 +5,13 @@ function isGlbFile(file) {
   return !!file && /\.glb$/i.test(file.name || '');
 }
 
+function isSupportedImageFile(file) {
+  if (!file) return false;
+  const supportedMimes = ['image/png', 'image/jpeg', 'image/webp'];
+  const supportedExts = /\.(png|jpe?g|webp)$/i;
+  return supportedMimes.includes(file.type) || supportedExts.test(file.name || '');
+}
+
 export class DragDropManager {
   constructor(options) {
     const {
@@ -23,6 +30,7 @@ export class DragDropManager {
       dracoPath,
       maxDimension,
       glbLoader,
+      imageImporter,
     } = options || {};
 
     if (!camera || !renderer || !scene) {
@@ -40,6 +48,7 @@ export class DragDropManager {
     this.onLoaded = onLoaded;
     this.onLoadStart = onLoadStart;
     this.onLoadEnd = onLoadEnd;
+    this.imageImporter = imageImporter;
     this.coordinateTransformer = new CoordinateTransformer(camera, renderer, scene, {
       getRaycastTargets,
     });
@@ -122,12 +131,23 @@ export class DragDropManager {
   }
 
   async handleFile(file, position) {
-    if (!isGlbFile(file)) {
-      this.showToast?.('GLBファイルのみ対応しています');
+    if (isGlbFile(file)) {
+      return this._loadFile(file, position || this._defaultDropPosition());
+    }
+
+    if (this.imageImporter && isSupportedImageFile(file)) {
+      const dropPos = position || this._defaultDropPosition();
+      try {
+        await this.imageImporter(file, dropPos);
+      } catch (error) {
+        console.warn('[drag-drop] image import failed:', error);
+        this.showToast?.(error?.message || '画像の読み込みに失敗しました');
+      }
       return null;
     }
 
-    return this._loadFile(file, position || this._defaultDropPosition());
+    this.showToast?.('GLB / 画像ファイルのみ対応しています');
+    return null;
   }
 
   _onAddClick() {

--- a/html/assets/js/scenesync/loaders/image-to-plane.js
+++ b/html/assets/js/scenesync/loaders/image-to-plane.js
@@ -1,0 +1,79 @@
+// Plane size calculation from image dimensions
+export function planeSizeFromImage(width, height, maxEdgeMeters = 2) {
+  const maxPx = Math.max(width, height);
+  const scale = maxEdgeMeters / maxPx;
+  return {
+    width: width * scale,
+    height: height * scale,
+  };
+}
+
+// Convert image File to carrier GLB (ArrayBuffer)
+export async function buildPlaneGlbFromImage(file, { THREE, GLTFExporter, maxPixel = 4096, maxEdgeMeters = 2 } = {}) {
+  if (!THREE || !GLTFExporter) {
+    throw new Error('THREE and GLTFExporter are required');
+  }
+
+  // Read image as bitmap
+  const bitmap = await createImageBitmap(file);
+  let { width, height } = bitmap;
+
+  // Downsample if exceeds maxPixel
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Failed to get canvas context');
+
+  if (width > maxPixel || height > maxPixel) {
+    const maxDim = Math.max(width, height);
+    const scale = maxPixel / maxDim;
+    width = Math.floor(width * scale);
+    height = Math.floor(height * scale);
+    canvas.width = width;
+    canvas.height = height;
+    ctx.drawImage(bitmap, 0, 0, width, height);
+  } else {
+    canvas.width = width;
+    canvas.height = height;
+    ctx.drawImage(bitmap, 0, 0);
+  }
+
+  // Create texture from canvas
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+
+  // Calculate plane size
+  const { width: planeWidth, height: planeHeight } = planeSizeFromImage(width, height, maxEdgeMeters);
+
+  // Create plane geometry and material
+  const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
+  const material = new THREE.MeshStandardMaterial({
+    map: texture,
+    transparent: true,
+    side: THREE.DoubleSide,
+  });
+
+  // Create mesh and wrap in Group
+  const mesh = new THREE.Mesh(geometry, material);
+  const group = new THREE.Group();
+  group.add(mesh);
+
+  // Export to GLB
+  const exporter = new GLTFExporter();
+  const arrayBuffer = await new Promise((resolve, reject) => {
+    exporter.parse(
+      group,
+      (result) => {
+        if (result instanceof ArrayBuffer) {
+          resolve(result);
+        } else {
+          reject(new Error('GLTFExporter did not return ArrayBuffer'));
+        }
+      },
+      (error) => reject(error),
+      { binary: true, embedImages: true }
+    );
+  });
+
+  return arrayBuffer;
+}

--- a/html/assets/js/scenesync/loaders/image-to-plane.js
+++ b/html/assets/js/scenesync/loaders/image-to-plane.js
@@ -47,14 +47,18 @@ export async function buildPlaneGlbFromImage(file, { THREE, GLTFExporter, maxPix
 
   // Create plane geometry and material
   const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
-  const material = new THREE.MeshStandardMaterial({
+  const material = new THREE.MeshBasicMaterial({
     map: texture,
     transparent: true,
     side: THREE.DoubleSide,
+    toneMapped: false,
   });
 
   // Create mesh and wrap in Group
   const mesh = new THREE.Mesh(geometry, material);
+  // Lift mesh so the bottom edge sits on the group's origin (y=0).
+  // This matches the existing GLB import which grounds objects via groundOffset.
+  mesh.position.y = planeHeight / 2;
   const group = new THREE.Group();
   group.add(mesh);
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -10,6 +10,7 @@ import { createThreeApp } from './core/three-app.js';
 import { createEnvironmentManager } from './core/environment.js';
 import { DragDropManager } from './components/drag-drop-manager.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
+import { buildPlaneGlbFromImage } from './loaders/image-to-plane.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { extractYaw } from './utils/math.js';
@@ -2999,6 +3000,49 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
   }
 }
 
+function generateBlobId() {
+  const raw = globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`;
+  return raw.replace(/[^a-z0-9]/gi, '').toLowerCase().slice(0, 24);
+}
+
+async function uploadCarrierGlb(arrayBuffer) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const id = generateBlobId();
+    const res = await fetch(`${BLOB_BASE}/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'model/gltf-binary' },
+      body: arrayBuffer,
+    });
+    if (res.status === 201 || res.status === 200) return id;
+    if (res.status !== 409) throw new Error(`blob upload failed: ${res.status}`);
+  }
+  throw new Error('blob id collision - unable to generate unique ID');
+}
+
+async function imageImporterCallback(file, position) {
+  if (file.size > 10 * 1024 * 1024) {
+    throw new Error('画像が大きすぎます (最大10MB)');
+  }
+
+  const arrayBuffer = await buildPlaneGlbFromImage(file, { THREE, GLTFExporter });
+  const meshPath = await uploadCarrierGlb(arrayBuffer);
+
+  const objectId = `img-${meshPath.slice(0, 8)}`;
+  const displayName = `image: ${file.name}`.slice(0, 60);
+
+  const payload = {
+    kind: 'scene-add',
+    objectId,
+    name: displayName,
+    position: position.toArray(),
+    rotation: [0, 0, 0, 1],
+    scale: [1, 1, 1],
+    asset: { type: 'mesh', meshPath },
+  };
+
+  broadcast(payload);
+}
+
 const dragDropManager = new DragDropManager({
   container: document,
   camera,
@@ -3030,6 +3074,7 @@ const dragDropManager = new DragDropManager({
       arrayBuffer
     );
   },
+  imageImporter: imageImporterCallback,
 });
 
 // ── AI ペアリング UI ───────────────────────────────────────────────────

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3029,18 +3029,24 @@ async function imageImporterCallback(file, position) {
 
   const objectId = `img-${meshPath.slice(0, 8)}`;
   const displayName = `image: ${file.name}`.slice(0, 60);
+  const positionArray = (position && typeof position.toArray === 'function')
+    ? position.toArray()
+    : [0, 1, 0];
 
   const payload = {
     kind: 'scene-add',
     objectId,
     name: displayName,
-    position: position.toArray(),
+    position: positionArray,
     rotation: [0, 0, 0, 1],
     scale: [1, 1, 1],
     asset: { type: 'mesh', meshPath },
   };
 
   broadcast(payload);
+
+  // ローカルにも反映（server側が送信元を除外するため、自分のbroadcastはエコーバックされない）
+  addOrUpdateObject(objectId, payload);
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -701,9 +701,9 @@
 }</pre>
     </section>
   </aside>
-  <button id="add-btn" title="GLB を追加">＋</button>
-  <input type="file" id="file-input" accept=".glb" style="display:none">
-  <div id="drop-overlay">GLB をドロップして追加</div>
+  <button id="add-btn" title="GLB/画像を追加">＋</button>
+  <input type="file" id="file-input" accept=".glb,image/png,image/jpeg,image/webp" style="display:none">
+  <div id="drop-overlay">GLB または画像をドロップして追加</div>
   <div id="mode">W: 移動 &nbsp; E: 回転 &nbsp; R: スケール</div>
   <div id="toast"></div>
   <div id="history-toolbar">


### PR DESCRIPTION
Document the Web client's image-to-plane pipeline: images are
internally converted to carrier GLB and delivered via the existing
mesh/meshPath mechanism. asset.type: "image" wire format is reserved
for future cross-platform standardization.

Update Wave 3 status to reflect browser-side image drop completion.

https://claude.ai/code/session_01VhzbwS4g8HHH4YAHzJP8th