### PR TITLE
feat(scenesync): add URL drop detection in DragDropManager

### DIFF
--- a/apps/presence-server/tests/url-classifier.test.mjs
+++ b/apps/presence-server/tests/url-classifier.test.mjs
@@ -1,0 +1,227 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  URL_KIND, classifyUrl, parseUriList, extractUrlFromText,
+} from '../../../html/assets/js/scenesync/loaders/url-classifier.js';
+
+test('classifyUrl', async (t) => {
+  await t.test('mp4 video URL', () => {
+    const r = classifyUrl('https://example.com/clip.mp4');
+    assert.equal(r.kind, URL_KIND.VIDEO);
+    assert.equal(r.ext, 'mp4');
+  });
+
+  await t.test('webm video URL', () => {
+    assert.equal(classifyUrl('https://example.com/v.webm').kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('mov video URL', () => {
+    assert.equal(classifyUrl('https://example.com/v.mov').kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('m4v video URL', () => {
+    assert.equal(classifyUrl('https://example.com/v.m4v').kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('m3u8 HLS', () => {
+    assert.equal(classifyUrl('https://example.com/master.m3u8').kind, URL_KIND.VIDEO_HLS);
+  });
+
+  await t.test('png image URL', () => {
+    assert.equal(classifyUrl('https://example.com/cat.png').kind, URL_KIND.IMAGE);
+  });
+
+  await t.test('jpg image URL', () => {
+    assert.equal(classifyUrl('https://example.com/photo.jpg').kind, URL_KIND.IMAGE);
+  });
+
+  await t.test('jpeg image URL', () => {
+    assert.equal(classifyUrl('https://example.com/photo.jpeg').kind, URL_KIND.IMAGE);
+  });
+
+  await t.test('webp image URL', () => {
+    assert.equal(classifyUrl('https://example.com/image.webp').kind, URL_KIND.IMAGE);
+  });
+
+  await t.test('gif image URL', () => {
+    assert.equal(classifyUrl('https://example.com/animation.gif').kind, URL_KIND.IMAGE);
+  });
+
+  await t.test('glb model URL', () => {
+    assert.equal(classifyUrl('https://example.com/model.glb').kind, URL_KIND.GLB);
+  });
+
+  await t.test('gltf model URL', () => {
+    assert.equal(classifyUrl('https://example.com/model.gltf').kind, URL_KIND.GLB);
+  });
+
+  await t.test('webpage URL', () => {
+    assert.equal(classifyUrl('https://example.com/').kind, URL_KIND.WEBPAGE);
+  });
+
+  await t.test('webpage with path', () => {
+    assert.equal(classifyUrl('https://example.com/path/to/page').kind, URL_KIND.WEBPAGE);
+  });
+
+  await t.test('uppercase extension is normalized', () => {
+    assert.equal(classifyUrl('https://example.com/A.MP4').kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('mixed case extension', () => {
+    assert.equal(classifyUrl('https://example.com/video.Mp4').kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('ftp protocol is invalid', () => {
+    assert.equal(classifyUrl('ftp://example.com/clip.mp4').kind, URL_KIND.INVALID);
+  });
+
+  await t.test('javascript protocol is invalid', () => {
+    assert.equal(classifyUrl('javascript:alert(1)').kind, URL_KIND.INVALID);
+  });
+
+  await t.test('no protocol is invalid', () => {
+    assert.equal(classifyUrl('example.com/clip.mp4').kind, URL_KIND.INVALID);
+  });
+
+  await t.test('empty string is invalid', () => {
+    assert.equal(classifyUrl('').kind, URL_KIND.INVALID);
+  });
+
+  await t.test('null is invalid', () => {
+    assert.equal(classifyUrl(null).kind, URL_KIND.INVALID);
+  });
+
+  await t.test('undefined is invalid', () => {
+    assert.equal(classifyUrl(undefined).kind, URL_KIND.INVALID);
+  });
+
+  await t.test('number is invalid', () => {
+    assert.equal(classifyUrl(123).kind, URL_KIND.INVALID);
+  });
+
+  await t.test('URL with query string', () => {
+    const r = classifyUrl('https://example.com/v.mp4?token=abc&start=0');
+    assert.equal(r.kind, URL_KIND.VIDEO);
+    assert.equal(r.ext, 'mp4');
+  });
+
+  await t.test('URL with fragment', () => {
+    const r = classifyUrl('https://example.com/v.mp4#start=10');
+    assert.equal(r.kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('URL with port', () => {
+    const r = classifyUrl('https://example.com:8443/v.mp4');
+    assert.equal(r.kind, URL_KIND.VIDEO);
+  });
+
+  await t.test('returns host correctly', () => {
+    const r = classifyUrl('https://cdn.example.com/v.mp4');
+    assert.equal(r.host, 'cdn.example.com');
+  });
+
+  await t.test('http (non-https) URL is valid', () => {
+    assert.equal(classifyUrl('http://example.com/v.mp4').kind, URL_KIND.VIDEO);
+  });
+});
+
+test('parseUriList', async (t) => {
+  await t.test('single URI', () => {
+    const r = parseUriList('https://example.com/');
+    assert.deepEqual(r, ['https://example.com/']);
+  });
+
+  await t.test('multiple URIs', () => {
+    const r = parseUriList('https://a/\nhttps://b/');
+    assert.deepEqual(r, ['https://a/', 'https://b/']);
+  });
+
+  await t.test('URIs with trailing whitespace', () => {
+    const r = parseUriList('  https://a/  \n  https://b/  ');
+    assert.deepEqual(r, ['https://a/', 'https://b/']);
+  });
+
+  await t.test('comments are skipped', () => {
+    const r = parseUriList('# comment\nhttps://a/\n# another\nhttps://b/');
+    assert.deepEqual(r, ['https://a/', 'https://b/']);
+  });
+
+  await t.test('CRLF line endings', () => {
+    const r = parseUriList('https://a/\r\nhttps://b/\r\n');
+    assert.deepEqual(r, ['https://a/', 'https://b/']);
+  });
+
+  await t.test('mixed line endings', () => {
+    const r = parseUriList('https://a/\nhttps://b/\r\nhttps://c/');
+    assert.deepEqual(r, ['https://a/', 'https://b/', 'https://c/']);
+  });
+
+  await t.test('empty input returns empty array', () => {
+    assert.deepEqual(parseUriList(''), []);
+  });
+
+  await t.test('null input returns empty array', () => {
+    assert.deepEqual(parseUriList(null), []);
+  });
+
+  await t.test('whitespace only input', () => {
+    assert.deepEqual(parseUriList('   \n  \n  '), []);
+  });
+
+  await t.test('comments only input', () => {
+    assert.deepEqual(parseUriList('# comment 1\n# comment 2'), []);
+  });
+});
+
+test('extractUrlFromText', async (t) => {
+  await t.test('extracts http URL', () => {
+    const result = extractUrlFromText('see https://example.com/v.mp4 here');
+    assert.equal(result, 'https://example.com/v.mp4');
+  });
+
+  await t.test('extracts http (non-https) URL', () => {
+    const result = extractUrlFromText('check http://example.com/v.mp4 out');
+    assert.equal(result, 'http://example.com/v.mp4');
+  });
+
+  await t.test('returns first URL only', () => {
+    const result = extractUrlFromText('https://first.com https://second.com');
+    assert.equal(result, 'https://first.com');
+  });
+
+  await t.test('returns null when no URL', () => {
+    assert.equal(extractUrlFromText('hello world'), null);
+  });
+
+  await t.test('returns null for empty string', () => {
+    assert.equal(extractUrlFromText(''), null);
+  });
+
+  await t.test('returns null for null input', () => {
+    assert.equal(extractUrlFromText(null), null);
+  });
+
+  await t.test('returns null for undefined', () => {
+    assert.equal(extractUrlFromText(undefined), null);
+  });
+
+  await t.test('extracts URL with query string', () => {
+    const result = extractUrlFromText('try https://example.com/v.mp4?token=abc');
+    assert.equal(result, 'https://example.com/v.mp4?token=abc');
+  });
+
+  await t.test('extracts URL at start of text', () => {
+    const result = extractUrlFromText('https://example.com/v.mp4 is great');
+    assert.equal(result, 'https://example.com/v.mp4');
+  });
+
+  await t.test('extracts URL at end of text', () => {
+    const result = extractUrlFromText('check out https://example.com/v.mp4');
+    assert.equal(result, 'https://example.com/v.mp4');
+  });
+
+  await t.test('does not extract non-http URLs', () => {
+    const result = extractUrlFromText('ftp://example.com is not extracted');
+    assert.equal(result, null);
+  });
+});

--- a/docs/plans/backlog/asset-pipeline-carrier-glb.md
+++ b/docs/plans/backlog/asset-pipeline-carrier-glb.md
@@ -34,7 +34,7 @@ Scene Sync に入る多様な asset を placement-compatible に扱うため、G
 
 - image-to-plane pipeline (✓ done: browser-side carrier GLB via Web UI, Wave 3)
 - text-to-plane pipeline (✓ done: browser-side carrier GLB via Web UI, Wave 4)
-- video asset pipeline
+- video asset pipeline (✓ Phase 1 done: Web URL drop + VideoTexture plane, mp4/webm/mov/m4v only; Phase 2 needed: playback sync; Phase 3-4: Unity/Godot; HLS/DASH deferred)
 - webpage carrier pipeline
 - asset library and reusable asset references
 - transfer-core integration

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -303,9 +303,11 @@ godot/
 
 **Note on Web text support**: The Web client (as of Wave 4) converts plain text and Markdown files dropped via UI to carrier GLB format (canvas-textured plane) and delivers them as `{ "type": "mesh", "meshPath": <id> }` via the existing blob store. Supported formats: `.txt` (plain text) and `.md` / `.markdown` (Markdown with Phase 1 subset: headings (`#`/`##`/`###`), bullet points (`-`/`*`), horizontal rules (`---`). Inline `**bold**` markers are stripped but rendering remains regular weight. Headings are rendered bold automatically). Files are rasterized to 2048px canvas, normalized to max 5000 chars, clamped to 256-8192px height. Text is thus indistinguishable from other meshes at the protocol level.
 
-`video`（IF 定義のみ、未実装）:
+`video`（Phase 1: Web のみ実装、Unity/Godot 未実装）:
 
     { "type": "video", "url": "https://..." }
+
+**Web video URL drop support** (Phase 1): The Web client accepts video URL drops via drag-and-drop interface. Supported video formats: `mp4`, `webm`, `mov`, `m4v`. The video is rendered on a textured plane with automatic playback (muted, looped). CORS headers are required on the video hosting server. Dropped video URLs are broadcast as `{ "type": "video", "url": "..." }` to all clients. HLS/DASH streams (`.m3u8`, `.mpd`) are not yet supported (Phase 2). Video playback synchronization (play/pause/seek) is not implemented (Phase 2).
 
 `audio`（IF 定義のみ、未実装）:
 

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -1,5 +1,6 @@
 import { CoordinateTransformer } from '../utils/coordinate-utils.js';
 import { GLBFileLoader } from '../loaders/glb-file-loader.js';
+import { parseUriList, extractUrlFromText } from '../loaders/url-classifier.js';
 
 function isGlbFile(file) {
   return !!file && /\.glb$/i.test(file.name || '');
@@ -40,6 +41,7 @@ export class DragDropManager {
       glbLoader,
       imageImporter,
       textImporter,
+      urlImporter,
     } = options || {};
 
     if (!camera || !renderer || !scene) {
@@ -59,6 +61,7 @@ export class DragDropManager {
     this.onLoadEnd = onLoadEnd;
     this.imageImporter = imageImporter;
     this.textImporter = textImporter;
+    this.urlImporter = urlImporter;
     this.coordinateTransformer = new CoordinateTransformer(camera, renderer, scene, {
       getRaycastTargets,
     });
@@ -87,6 +90,15 @@ export class DragDropManager {
 
   _isFileDrag(event) {
     return Array.from(event.dataTransfer?.types || []).includes('Files');
+  }
+
+  _isUrlDrag(event) {
+    const types = Array.from(event.dataTransfer?.types || []);
+    return types.includes('text/uri-list') || types.includes('text/plain');
+  }
+
+  _isDraggableContent(event) {
+    return this._isFileDrag(event) || this._isUrlDrag(event);
   }
 
   _setOverlay(active) {
@@ -191,7 +203,7 @@ export class DragDropManager {
   }
 
   _onDragEnter(event) {
-    if (!this._isFileDrag(event)) return;
+    if (!this._isDraggableContent(event)) return;
 
     event.preventDefault();
     this.dragCounter += 1;
@@ -199,7 +211,7 @@ export class DragDropManager {
   }
 
   _onDragLeave(event) {
-    if (!this._isFileDrag(event)) return;
+    if (!this._isDraggableContent(event)) return;
 
     event.preventDefault();
     this.dragCounter -= 1;
@@ -210,7 +222,7 @@ export class DragDropManager {
   }
 
   _onDragOver(event) {
-    if (!this._isFileDrag(event)) return;
+    if (!this._isDraggableContent(event)) return;
 
     event.preventDefault();
     if (event.dataTransfer) {
@@ -219,13 +231,35 @@ export class DragDropManager {
   }
 
   _onDrop(event) {
-    if (!this._isFileDrag(event)) return;
-
     event.preventDefault();
     this.dragCounter = 0;
     this._setOverlay(false);
 
-    const file = event.dataTransfer?.files?.[0];
+    const dt = event.dataTransfer;
+    if (!dt) return;
+
+    // URL ドロップを先に判定（files が空の場合）
+    if (!dt.files || dt.files.length === 0) {
+      const uriList = dt.getData('text/uri-list');
+      const urls = parseUriList(uriList);
+      let candidate = urls[0];
+      if (!candidate) {
+        candidate = extractUrlFromText(dt.getData('text/plain'));
+      }
+      if (candidate && this.urlImporter) {
+        const dropPos = this._dropPositionFromEvent(event) || this._defaultDropPosition();
+        this.urlImporter(candidate, dropPos).catch((err) => {
+          console.warn('[drag-drop] url import failed:', err);
+          this.showToast?.(err?.message || 'URLの追加に失敗しました');
+        });
+      }
+      return;
+    }
+
+    // ファイルドロップ
+    if (!this._isFileDrag(event)) return;
+
+    const file = dt.files?.[0];
     if (!file) return;
 
     this.handleFile(file, this._dropPositionFromEvent(event)).catch((error) => {

--- a/html/assets/js/scenesync/loaders/url-classifier.js
+++ b/html/assets/js/scenesync/loaders/url-classifier.js
@@ -1,0 +1,62 @@
+export const URL_KIND = {
+  VIDEO: 'video',
+  VIDEO_HLS: 'video-hls',
+  IMAGE: 'image',
+  GLB: 'glb',
+  WEBPAGE: 'webpage',
+  UNSUPPORTED: 'unsupported',
+  INVALID: 'invalid',
+};
+
+const VIDEO_EXTS = ['mp4', 'webm', 'mov', 'm4v'];
+const HLS_EXTS = ['m3u8'];
+const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'webp', 'gif'];
+const GLB_EXTS = ['glb', 'gltf'];
+
+/**
+ * URL 文字列を分類する純関数。
+ * @param {string} urlString
+ * @returns {{ kind: string, url: string|null, ext: string, host: string }}
+ */
+export function classifyUrl(urlString) {
+  if (!urlString || typeof urlString !== 'string') {
+    return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
+  }
+  const trimmed = urlString.trim();
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
+  }
+  let u;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
+  }
+  const ext = (u.pathname.split('.').pop() || '').toLowerCase();
+  const host = u.host;
+  const url = u.toString();
+  if (VIDEO_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO, url, ext, host };
+  if (HLS_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO_HLS, url, ext, host };
+  if (IMAGE_EXTS.includes(ext)) return { kind: URL_KIND.IMAGE, url, ext, host };
+  if (GLB_EXTS.includes(ext)) return { kind: URL_KIND.GLB, url, ext, host };
+  return { kind: URL_KIND.WEBPAGE, url, ext, host };
+}
+
+/**
+ * text/uri-list 形式から URL 配列を抽出。# で始まる行はコメント。
+ */
+export function parseUriList(uriList) {
+  if (!uriList) return [];
+  return uriList.split(/\r?\n/)
+    .map(s => s.trim())
+    .filter(s => s.length > 0 && !s.startsWith('#'));
+}
+
+/**
+ * プレーンテキストから http(s) URL を 1 件抽出（最初に見つかったもの）。
+ */
+export function extractUrlFromText(text) {
+  if (!text) return null;
+  const m = text.match(/https?:\/\/\S+/);
+  return m ? m[0] : null;
+}

--- a/html/assets/js/scenesync/loaders/video-url-importer.js
+++ b/html/assets/js/scenesync/loaders/video-url-importer.js
@@ -1,0 +1,89 @@
+/**
+ * URL から動画を読み込み <video> + VideoTexture を返す。CORS 必須。
+ * @param {string} url
+ * @param {object} opts { THREE, maxEdgeMeters = 2, timeoutMs = 15000 }
+ * @returns {Promise<{video, texture, planeWidth, planeHeight, aspect}>}
+ */
+export async function loadVideoTextureFromUrl(url, opts) {
+  const { THREE, maxEdgeMeters = 2, timeoutMs = 15000 } = opts;
+  const video = document.createElement('video');
+  video.crossOrigin = 'anonymous';
+  video.src = url;
+  video.muted = true;
+  video.autoplay = true;
+  video.loop = true;
+  video.playsInline = true;
+  video.preload = 'auto';
+
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    const onLoaded = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    const onError = () => {
+      if (!settled) {
+        settled = true;
+        reject(new Error('動画の読み込みに失敗しました（CORS 設定が必要、または URL が無効です）'));
+      }
+    };
+    video.addEventListener('loadedmetadata', onLoaded, { once: true });
+    video.addEventListener('error', onError, { once: true });
+    const timerId = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        reject(new Error('動画の読み込みがタイムアウトしました'));
+      }
+    }, timeoutMs);
+
+    // cleanup on resolve/reject
+    const cleanup = () => clearTimeout(timerId);
+    const originalResolve = resolve;
+    const originalReject = reject;
+    resolve = (...args) => {
+      cleanup();
+      originalResolve(...args);
+    };
+    reject = (...args) => {
+      cleanup();
+      originalReject(...args);
+    };
+  });
+
+  const aspect = video.videoWidth / video.videoHeight || 16 / 9;
+  const planeWidth = aspect >= 1 ? maxEdgeMeters : maxEdgeMeters * aspect;
+  const planeHeight = aspect >= 1 ? maxEdgeMeters / aspect : maxEdgeMeters;
+
+  const texture = new THREE.VideoTexture(video);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+
+  // 再生開始
+  video.play().catch(() => {
+    /* autoplay 拒否時は muted なのでほぼ通る */
+  });
+
+  return { video, texture, planeWidth, planeHeight, aspect };
+}
+
+/**
+ * 既に作成された video texture から PlaneMesh + Group を作る。
+ */
+export function createVideoPlaneGroup(textureBundle, THREE) {
+  const { texture, planeWidth, planeHeight } = textureBundle;
+  const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    side: THREE.DoubleSide,
+    transparent: false,
+    toneMapped: false,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.y = planeHeight / 2;
+  const group = new THREE.Group();
+  group.add(mesh);
+  return { group, mesh, material, texture };
+}

--- a/html/assets/js/scenesync/loaders/video-url-importer.js
+++ b/html/assets/js/scenesync/loaders/video-url-importer.js
@@ -17,39 +17,18 @@ export async function loadVideoTextureFromUrl(url, opts) {
 
   await new Promise((resolve, reject) => {
     let settled = false;
-    const onLoaded = () => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
+    let timerId = null;
+    const finish = (fn, arg) => {
+      if (settled) return;
+      settled = true;
+      if (timerId !== null) clearTimeout(timerId);
+      fn(arg);
     };
-    const onError = () => {
-      if (!settled) {
-        settled = true;
-        reject(new Error('動画の読み込みに失敗しました（CORS 設定が必要、または URL が無効です）'));
-      }
-    };
+    const onLoaded = () => finish(resolve);
+    const onError = () => finish(reject, new Error('動画の読み込みに失敗しました（CORS 設定が必要、または URL が無効です）'));
     video.addEventListener('loadedmetadata', onLoaded, { once: true });
     video.addEventListener('error', onError, { once: true });
-    const timerId = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        reject(new Error('動画の読み込みがタイムアウトしました'));
-      }
-    }, timeoutMs);
-
-    // cleanup on resolve/reject
-    const cleanup = () => clearTimeout(timerId);
-    const originalResolve = resolve;
-    const originalReject = reject;
-    resolve = (...args) => {
-      cleanup();
-      originalResolve(...args);
-    };
-    reject = (...args) => {
-      cleanup();
-      originalReject(...args);
-    };
+    timerId = setTimeout(() => finish(reject, new Error('動画の読み込みがタイムアウトしました')), timeoutMs);
   });
 
   const aspect = video.videoWidth / video.videoHeight || 16 / 9;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -12,6 +12,8 @@ import { DragDropManager } from './components/drag-drop-manager.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
 import { buildPlaneGlbFromImage } from './loaders/image-to-plane.js';
 import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
+import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
+import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { extractYaw } from './utils/math.js';
@@ -2305,6 +2307,12 @@ function handleHandoff(data) {
       locks.delete(objectId);
       if (obj) {
         if (transformCtrl.object === obj) { transformCtrl.detach(); hideToolbar(); }
+        // Clean up video objects
+        if (obj.userData?.video) {
+          obj.userData.video.pause();
+          obj.userData.video.src = '';
+          obj.userData.video.load();
+        }
         scene.remove(obj);
         managedObjects.delete(objectId);
       }
@@ -2676,6 +2684,12 @@ function addOrUpdateObject(objectId, info) {
           return;
         }
         break;
+      case 'video':
+        if (asset.url) {
+          loadVideoObject(objectId, info, asset.url, existing);
+          return;
+        }
+        break;
       default:
         console.warn(`unsupported asset type: ${asset.type}`);
         replaceManagedObject(objectId, buildUnsupportedAssetObject(objectId, info), info);
@@ -2730,6 +2744,41 @@ function loadMeshObject(objectId, info, meshPath, existing) {
       return;
     }
     notifySceneStateChanged('mesh-load-failed');
+  });
+}
+
+function loadVideoObject(objectId, info, videoUrl, existing) {
+  addLoadingOverlay(objectId, info.name || objectId, info);
+  const initialPosition = info.position
+    ? new THREE.Vector3().fromArray(info.position)
+    : undefined;
+
+  loadVideoTextureFromUrl(videoUrl, { THREE }).then((bundle) => {
+    removeLoadingOverlay(objectId);
+    const { group } = createVideoPlaneGroup(bundle, THREE);
+    group.userData.objectId = objectId;
+    group.userData.name = info.name;
+    group.userData.video = bundle.video;
+    group.userData.assetType = 'video';
+    if (info.asset) group.userData.asset = structuredClone(info.asset);
+
+    if (existing) {
+      group.position.copy(existing.position);
+      group.quaternion.copy(existing.quaternion);
+      group.scale.copy(existing.scale);
+      if (transformCtrl.object === existing) transformCtrl.detach();
+      scene.remove(existing);
+    }
+
+    replaceManagedObject(objectId, group, info);
+  }).catch((err) => {
+    removeLoadingOverlay(objectId);
+    console.warn('Failed to load video for', objectId, ':', err);
+    if (!existing) {
+      replaceManagedObject(objectId, buildDefaultBoxObject(objectId, info, 0xff4444), info);
+      return;
+    }
+    notifySceneStateChanged('video-load-failed');
   });
 }
 
@@ -2897,6 +2946,12 @@ function applyOperationToScene(operation) {
         if (transformCtrl.object === obj) {
           transformCtrl.detach();
           hideToolbar();
+        }
+        // Clean up video objects
+        if (obj.userData?.video) {
+          obj.userData.video.pause();
+          obj.userData.video.src = '';
+          obj.userData.video.load();
         }
         scene.remove(obj);
         managedObjects.delete(operation.objectId);
@@ -3082,6 +3137,38 @@ async function textImporterCallback(text, position, filename = 'text.md') {
   addOrUpdateObject(objectId, payload);
 }
 
+async function videoUrlImporterCallback(url, position) {
+  const classified = classifyUrl(url);
+  if (classified.kind !== URL_KIND.VIDEO) {
+    throw new Error('未対応の URL です（Phase 1 は mp4/webm/mov/m4v のみ）');
+  }
+
+  const bundle = await loadVideoTextureFromUrl(classified.url, { THREE });
+
+  const blobId = generateBlobId();
+  const objectId = `vid-${blobId.slice(0, 8)}`;
+  const filename = decodeURIComponent(new URL(classified.url).pathname.split('/').pop() || 'video');
+  const displayName = `video: ${filename}`.slice(0, 60);
+  const positionArray = (position && typeof position.toArray === 'function')
+    ? position.toArray()
+    : [0, 1, 0];
+
+  const payload = {
+    kind: 'scene-add',
+    objectId,
+    name: displayName,
+    position: positionArray,
+    rotation: [0, 0, 0, 1],
+    scale: [1, 1, 1],
+    asset: { type: 'video', url: classified.url },
+  };
+
+  broadcast(payload);
+
+  // ローカルにも反映
+  addOrUpdateObject(objectId, payload);
+}
+
 const dragDropManager = new DragDropManager({
   container: document,
   camera,
@@ -3115,6 +3202,7 @@ const dragDropManager = new DragDropManager({
   },
   imageImporter: imageImporterCallback,
   textImporter: textImporterCallback,
+  urlImporter: videoUrlImporterCallback,
 });
 
 // ── AI ペアリング UI ───────────────────────────────────────────────────

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2669,7 +2669,7 @@ async function handleAiCommand(from, payload) {
 
 // ── シーン同期ヘルパー ───────────────────────────────────
 
-function addOrUpdateObject(objectId, info) {
+function addOrUpdateObject(objectId, info, options = {}) {
   const existing = managedObjects.get(objectId);
   const asset = info.asset;
 
@@ -2686,7 +2686,7 @@ function addOrUpdateObject(objectId, info) {
         break;
       case 'video':
         if (asset.url) {
-          loadVideoObject(objectId, info, asset.url, existing);
+          loadVideoObject(objectId, info, asset.url, existing, options.prebuiltVideoBundle);
           return;
         }
         break;
@@ -2747,13 +2747,13 @@ function loadMeshObject(objectId, info, meshPath, existing) {
   });
 }
 
-function loadVideoObject(objectId, info, videoUrl, existing) {
+function loadVideoObject(objectId, info, videoUrl, existing, prebuilt = null) {
   addLoadingOverlay(objectId, info.name || objectId, info);
-  const initialPosition = info.position
-    ? new THREE.Vector3().fromArray(info.position)
-    : undefined;
+  const promise = prebuilt
+    ? Promise.resolve(prebuilt)
+    : loadVideoTextureFromUrl(videoUrl, { THREE });
 
-  loadVideoTextureFromUrl(videoUrl, { THREE }).then((bundle) => {
+  promise.then((bundle) => {
     removeLoadingOverlay(objectId);
     const { group } = createVideoPlaneGroup(bundle, THREE);
     group.userData.objectId = objectId;
@@ -2775,7 +2775,8 @@ function loadVideoObject(objectId, info, videoUrl, existing) {
     removeLoadingOverlay(objectId);
     console.warn('Failed to load video for', objectId, ':', err);
     if (!existing) {
-      replaceManagedObject(objectId, buildDefaultBoxObject(objectId, info, 0xff4444), info);
+      const failedInfo = { ...info, name: `${info.name || objectId} (動画読み込み失敗)` };
+      replaceManagedObject(objectId, buildDefaultBoxObject(objectId, failedInfo, 0xff4444), failedInfo);
       return;
     }
     notifySceneStateChanged('video-load-failed');
@@ -3165,8 +3166,8 @@ async function videoUrlImporterCallback(url, position) {
 
   broadcast(payload);
 
-  // ローカルにも反映
-  addOrUpdateObject(objectId, payload);
+  // ローカルにも反映: prebuilt bundle を渡してロードを省略
+  addOrUpdateObject(objectId, payload, { prebuiltVideoBundle: bundle });
 }
 
 const dragDropManager = new DragDropManager({


### PR DESCRIPTION
- Add parseUriList and extractUrlFromText imports
- Add urlImporter callback option to DragDropManager constructor
- Implement _isUrlDrag and _isDraggableContent helper methods
- Update _onDragEnter, _onDragLeave, _onDragOver to show overlay for URL drags
- Update _onDrop to detect and handle URL drops (text/uri-list priority over text/plain)
- Create url-classifier.js with pure URL classification functions
- Support VIDEO, VIDEO_HLS, IMAGE, GLB, WEBPAGE, UNSUPPORTED, INVALID URL kinds

https://claude.ai/code/session_01Mkqg2x3sPXMUhyZ3xeDdeC