### PR TITLE
Fix video plane material transparency and depth rendering

### DIFF
--- a/html/assets/js/scenesync/loaders/video-url-importer.js
+++ b/html/assets/js/scenesync/loaders/video-url-importer.js
@@ -56,8 +56,10 @@ export function createVideoPlaneGroup(textureBundle, THREE) {
   const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
   const material = new THREE.MeshBasicMaterial({
     map: texture,
+    transparent: true,
+    alphaTest: 0.01,
+    depthWrite: true,
     side: THREE.DoubleSide,
-    transparent: false,
     toneMapped: false,
   });
   const mesh = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
## 概要

- ビデオプレーン用の Three.js マテリアル設定を修正し、透明度とデプス書き込みの処理を改善

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

`video-url-importer.js` の `createVideoPlaneGroup` 関数内で、ビデオプレーンのマテリアル設定を以下のように修正しました：

- `transparent: true` に変更（従来は `false`）
- `alphaTest: 0.01` を追加（アルファ値が 0.01 未満のピクセルを破棄）
- `depthWrite: true` を明示的に設定（デプスバッファへの書き込みを有効化）

これにより、ビデオテクスチャの透明度が正しく処理され、3D シーン内での奥行き関係が適切に反映されるようになります。

## 変更していないこと

- ジオメトリ、テクスチャ、その他のマテリアルプロパティ
- ビデオローダーの基本的なロジック

## staging確認

- 未確認

## テスト/チェック

- 既存の lint/build check に依存

## リスク

- 既存のビデオプレーン表示に視覚的な変化が生じる可能性があります
- 透明度処理が有効になることで、パフォーマンスに軽微な影響がある可能性があります

## follow-up tasks

- staging 環境でビデオプレーンの透明度とデプス処理が期待通りに動作することを確認

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01UumjRVMYHPUcGD2bWtYCZW