### PR TITLE
Add GLTFLoader import to scene.js

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 import { createThreeApp } from './core/three-app.js';
 import { createEnvironmentManager } from './core/environment.js';


### PR DESCRIPTION
## 概要

- `GLTFLoader` を scene.js にインポートして、GLTF形式のモデル読み込み機能を利用可能にする

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `html/assets/js/scenesync/scene.js` に `GLTFLoader` のインポートを追加
  - Three.js の `GLTFLoader` アドオンをインポート
  - 既存の `GLTFExporter` インポートの直後に配置

## 変更していないこと

- `GLTFLoader` の実装や使用箇所は含まれていない（インポートのみ）
- その他のモジュールやロジックは変更なし

## staging確認

- 未確認

## テスト/チェック

- インポート構文の妥当性確認済み
- ビルドエラーなし

## リスク

- なし（インポート追加のみで、実装は含まれていない）

## follow-up tasks

- `GLTFLoader` を実際に使用するコードの実装

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_018oa3UsKst9uScj8M7SBuTN