### PR TITLE
Add URL resolver and text file import support

### DIFF
--- a/apps/presence-server/tests/url-classifier.test.mjs
+++ b/apps/presence-server/tests/url-classifier.test.mjs
@@ -135,6 +135,36 @@ test('classifyUrl', async (t) => {
   await t.test('http (non-https) URL is valid', () => {
     assert.equal(classifyUrl('http://example.com/v.mp4').kind, URL_KIND.VIDEO);
   });
+
+  await t.test('X/Twitter image CDN URL with format=jpg', () => {
+    const r = classifyUrl('https://pbs.twimg.com/media/HEEjn1xaEAAHiny?format=jpg&name=large');
+    assert.equal(r.kind, URL_KIND.IMAGE);
+    assert.equal(r.ext, 'jpeg');
+  });
+
+  await t.test('X/Twitter image CDN URL with format=png', () => {
+    const r = classifyUrl('https://pbs.twimg.com/media/ABC123?format=png');
+    assert.equal(r.kind, URL_KIND.IMAGE);
+    assert.equal(r.ext, 'png');
+  });
+
+  await t.test('markdown .md file URL', () => {
+    const r = classifyUrl('https://raw.githubusercontent.com/afjk/afjk.jp/main/README.md');
+    assert.equal(r.kind, URL_KIND.TEXT);
+    assert.equal(r.ext, 'md');
+  });
+
+  await t.test('txt file URL', () => {
+    const r = classifyUrl('https://example.com/note.txt');
+    assert.equal(r.kind, URL_KIND.TEXT);
+    assert.equal(r.ext, 'txt');
+  });
+
+  await t.test('markdown .markdown file URL', () => {
+    const r = classifyUrl('https://example.com/doc.markdown');
+    assert.equal(r.kind, URL_KIND.TEXT);
+    assert.equal(r.ext, 'markdown');
+  });
 });
 
 test('parseUriList', async (t) => {

--- a/apps/presence-server/tests/url-resolver.test.mjs
+++ b/apps/presence-server/tests/url-resolver.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveDroppedUrl } from '../../../html/assets/js/scenesync/loaders/url-resolver.js';
+
+test('resolveDroppedUrl', async (t) => {
+  await t.test('GitHub blob URL is converted to raw URL', () => {
+    const input = 'https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/Avocado/glTF-Binary/Avocado.glb';
+    const r = resolveDroppedUrl(input);
+    assert.equal(
+      r.resolvedUrl,
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Avocado/glTF-Binary/Avocado.glb'
+    );
+    assert.equal(r.source, 'github-blob');
+    assert.equal(r.originalUrl, input);
+  });
+
+  await t.test('GitHub raw URL remains unchanged', () => {
+    const input = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Avocado/glTF-Binary/Avocado.glb';
+    const r = resolveDroppedUrl(input);
+    assert.equal(r.resolvedUrl, input);
+    assert.equal(r.source, 'github-raw');
+  });
+
+  await t.test('direct URL remains unchanged', () => {
+    const input = 'https://example.com/file.glb';
+    const r = resolveDroppedUrl(input);
+    assert.equal(r.resolvedUrl, input);
+    assert.equal(r.source, 'direct');
+  });
+
+  await t.test('GitHub blob URL with nested path structure', () => {
+    const input = 'https://github.com/owner/repo/blob/feature-branch/path/to/deep/file.md';
+    const r = resolveDroppedUrl(input);
+    assert.equal(
+      r.resolvedUrl,
+      'https://raw.githubusercontent.com/owner/repo/feature-branch/path/to/deep/file.md'
+    );
+    assert.equal(r.source, 'github-blob');
+  });
+
+  await t.test('invalid URL returns invalid source', () => {
+    const input = 'not a url';
+    const r = resolveDroppedUrl(input);
+    assert.equal(r.source, 'invalid');
+    assert.equal(r.resolvedUrl, 'not a url');
+  });
+
+  await t.test('empty string returns invalid source', () => {
+    const r = resolveDroppedUrl('');
+    assert.equal(r.source, 'invalid');
+  });
+
+  await t.test('null returns invalid source', () => {
+    const r = resolveDroppedUrl(null);
+    assert.equal(r.source, 'invalid');
+  });
+
+  await t.test('URL with whitespace is trimmed', () => {
+    const input = '  https://github.com/owner/repo/blob/main/file.glb  ';
+    const r = resolveDroppedUrl(input);
+    assert.equal(
+      r.resolvedUrl,
+      'https://raw.githubusercontent.com/owner/repo/main/file.glb'
+    );
+    assert.equal(r.source, 'github-blob');
+  });
+});

--- a/html/assets/js/scenesync/loaders/url-classifier.js
+++ b/html/assets/js/scenesync/loaders/url-classifier.js
@@ -3,6 +3,7 @@ export const URL_KIND = {
   VIDEO_HLS: 'video-hls',
   IMAGE: 'image',
   GLB: 'glb',
+  TEXT: 'text',
   WEBPAGE: 'webpage',
   UNSUPPORTED: 'unsupported',
   INVALID: 'invalid',
@@ -13,6 +14,26 @@ const HLS_EXTS = ['m3u8'];
 const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'avif', 'bmp'];
 const UNSUPPORTED_EXTS = ['svg', 'gltf'];
 const GLB_EXTS = ['glb'];
+const TEXT_EXTS = ['txt', 'md', 'markdown'];
+
+function classifyTwitterImageUrl(u) {
+  if (u.hostname !== 'pbs.twimg.com') return null;
+  if (!u.pathname.startsWith('/media/')) return null;
+
+  const format = (u.searchParams.get('format') || '').toLowerCase();
+  const normalized = format === 'jpg' ? 'jpeg' : format;
+
+  if (['jpeg', 'png', 'webp', 'gif'].includes(normalized)) {
+    return {
+      kind: URL_KIND.IMAGE,
+      url: u.toString(),
+      ext: normalized,
+      host: u.host,
+    };
+  }
+
+  return null;
+}
 
 /**
  * URL 文字列を分類する純関数。
@@ -33,6 +54,10 @@ export function classifyUrl(urlString) {
   } catch {
     return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
   }
+
+  const twitterImage = classifyTwitterImageUrl(u);
+  if (twitterImage) return twitterImage;
+
   const ext = (u.pathname.split('.').pop() || '').toLowerCase();
   const host = u.host;
   const url = u.toString();
@@ -41,6 +66,7 @@ export function classifyUrl(urlString) {
   if (IMAGE_EXTS.includes(ext)) return { kind: URL_KIND.IMAGE, url, ext, host };
   if (UNSUPPORTED_EXTS.includes(ext)) return { kind: URL_KIND.UNSUPPORTED, url, ext, host };
   if (GLB_EXTS.includes(ext)) return { kind: URL_KIND.GLB, url, ext, host };
+  if (TEXT_EXTS.includes(ext)) return { kind: URL_KIND.TEXT, url, ext, host };
   return { kind: URL_KIND.WEBPAGE, url, ext, host };
 }
 

--- a/html/assets/js/scenesync/loaders/url-importers/index.js
+++ b/html/assets/js/scenesync/loaders/url-importers/index.js
@@ -1,6 +1,7 @@
 import { importVideoUrl } from './video.js';
 import { importImageUrl } from './image.js';
 import { importGlbUrl } from './glb.js';
+import { importTextUrl } from './text.js';
 import { classifyUrl, URL_KIND } from '../url-classifier.js';
 
 /**
@@ -38,6 +39,10 @@ export async function dispatchUrlImport(url, ctx) {
 
   if (classified.kind === URL_KIND.GLB) {
     return await importGlbUrl(classified.url, ctx);
+  }
+
+  if (classified.kind === URL_KIND.TEXT) {
+    return await importTextUrl(classified.url, ctx);
   }
 
   if (classified.kind === URL_KIND.WEBPAGE) {

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -1,0 +1,38 @@
+export async function importTextUrl(url, ctx) {
+  let response;
+  try {
+    response = await fetch(url, { mode: 'cors' });
+  } catch (err) {
+    ctx.showToast({
+      type: 'error',
+      message: `テキストURLのフェッチに失敗しました: ${err?.message || 'Failed to fetch'}`,
+    });
+    throw err;
+  }
+
+  if (!response.ok) {
+    const err = new Error(`HTTP ${response.status}`);
+    ctx.showToast({
+      type: 'error',
+      message: `テキストURLの読み込みに失敗しました: ${err.message}`,
+    });
+    throw err;
+  }
+
+  const text = await response.text();
+
+  const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'remote.txt');
+
+  if (typeof ctx.textImporter !== 'function') {
+    const err = new Error('textImporter is not configured');
+    ctx.showToast({
+      type: 'error',
+      message: 'テキストURL importer が設定されていません',
+    });
+    throw err;
+  }
+
+  await ctx.textImporter(text, ctx.position || null, filename);
+
+  return { objectId: null, payload: null };
+}

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -32,7 +32,7 @@ export async function importTextUrl(url, ctx) {
     throw err;
   }
 
-  await ctx.textImporter(text, ctx.position || null, filename);
+  await ctx.textImporter(text, filename);
 
   return { objectId: null, payload: null };
 }

--- a/html/assets/js/scenesync/loaders/url-resolver.js
+++ b/html/assets/js/scenesync/loaders/url-resolver.js
@@ -1,0 +1,60 @@
+export function resolveDroppedUrl(inputUrl) {
+  const originalUrl = typeof inputUrl === 'string' ? inputUrl.trim() : '';
+
+  if (!originalUrl) {
+    return {
+      originalUrl,
+      resolvedUrl: originalUrl,
+      source: 'invalid',
+      warnings: [],
+      notes: [],
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(originalUrl);
+  } catch {
+    return {
+      originalUrl,
+      resolvedUrl: originalUrl,
+      source: 'invalid',
+      warnings: [],
+      notes: [],
+    };
+  }
+
+  if (parsed.hostname === 'github.com') {
+    const parts = parsed.pathname.split('/').filter(Boolean);
+
+    // /owner/repo/blob/branch/path/to/file
+    if (parts.length >= 5 && parts[2] === 'blob') {
+      const [owner, repo, , branch, ...pathParts] = parts;
+      return {
+        originalUrl,
+        resolvedUrl: `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${pathParts.join('/')}`,
+        source: 'github-blob',
+        warnings: [],
+        notes: ['GitHub blob URLをraw URLに変換しました'],
+      };
+    }
+  }
+
+  if (parsed.hostname === 'raw.githubusercontent.com') {
+    return {
+      originalUrl,
+      resolvedUrl: originalUrl,
+      source: 'github-raw',
+      warnings: [],
+      notes: [],
+    };
+  }
+
+  return {
+    originalUrl,
+    resolvedUrl: originalUrl,
+    source: 'direct',
+    warnings: [],
+    notes: [],
+  };
+}

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3325,8 +3325,8 @@ async function urlImporterCallback(url, position) {
       scale: [1, 1, 1],
     }),
     position: positionArray,
-    textImporter: (text, importPosition, filename) =>
-      textImporterCallback(text, importPosition || position, filename),
+    textImporter: (text, filename) =>
+      textImporterCallback(text, position, filename),
     THREE,
     GLTFLoader,
   };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -16,6 +16,7 @@ import { buildPlaneGlbFromImage } from './loaders/image-to-plane.js';
 import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
 import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
+import { resolveDroppedUrl } from './loaders/url-resolver.js';
 import { dispatchUrlImport } from './loaders/url-importers/index.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
@@ -3299,6 +3300,16 @@ function generateObjectId(prefix) {
 }
 
 async function urlImporterCallback(url, position) {
+  const resolved = resolveDroppedUrl(url);
+
+  for (const note of resolved.notes || []) {
+    showToast(note);
+  }
+
+  for (const warning of resolved.warnings || []) {
+    showToast(warning);
+  }
+
   const positionArray = (position && typeof position.toArray === 'function')
     ? position.toArray()
     : [0, 1, 0];
@@ -3313,11 +3324,14 @@ async function urlImporterCallback(url, position) {
       rotation: [0, 0, 0, 1],
       scale: [1, 1, 1],
     }),
+    position: positionArray,
+    textImporter: (text, importPosition, filename) =>
+      textImporterCallback(text, importPosition || position, filename),
     THREE,
     GLTFLoader,
   };
 
-  await dispatchUrlImport(url, ctx);
+  await dispatchUrlImport(resolved.resolvedUrl, ctx);
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/assets/js/scenesync/ui/toast.js
+++ b/html/assets/js/scenesync/ui/toast.js
@@ -1,8 +1,12 @@
 let toastTimer = null;
 
-export function showToast(message, duration = 2500) {
+export function showToast(input, duration = 2500) {
   const el = document.getElementById('toast');
   if (!el) return;
+
+  const message = typeof input === 'string'
+    ? input
+    : input?.message || String(input);
 
   el.textContent = message;
   el.classList.add('show');


### PR DESCRIPTION
## 概要

- GitHub blob URL を raw URL に自動変換する URL resolver を追加
- テキストファイル（.txt, .md, .markdown）のインポート機能を実装
- X/Twitter 画像 CDN URL の分類対応
- URL 分類器にテキストファイル種別を追加

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更

1. **URL Resolver (`url-resolver.js`)**
   - GitHub blob URL (`github.com/.../blob/...`) を raw URL (`raw.githubusercontent.com/...`) に自動変換
   - URL の種別を分類（github-blob, github-raw, direct, invalid）
   - 入力値の trim と null/empty チェック対応
   - 変換時に notes/warnings を返却

2. **テキストファイルインポーター (`text.js`)**
   - URL からテキストファイルを fetch して読み込み
   - ファイル名を URL から抽出
   - エラーハンドリングと toast 通知

3. **URL 分類器の拡張 (`url-classifier.js`)**
   - `TEXT` 種別を追加（.txt, .md, .markdown）
   - X/Twitter 画像 CDN URL (`pbs.twimg.com/media/...`) の分類対応
   - format パラメータから画像形式を判定

4. **Scene.js の統合**
   - URL インポート時に resolver を通す
   - resolver の notes/warnings を toast で表示
   - テキストインポーターコールバックを context に追加

5. **Toast UI の改善 (`toast.js`)**
   - オブジェクト形式の入力に対応（`{ message, type }` など）

### staging で見てほしい点

- GitHub blob URL をドラッグ&ドロップした際に raw URL に変換されること
- テキストファイル（README.md など）をドラッグ&ドロップして読み込めること
- X/Twitter の画像 URL が正しく分類されること

## 変更していないこと

- 既存の video/image/glb インポーター
- URL インポートの全体的なフロー（resolver を通すだけ）

## テスト/チェック

- `url-resolver.test.mjs` で resolver の全パターンをテスト（GitHub blob/raw, direct, invalid, whitespace trim）
- `url-classifier.test.mjs` に Twitter 画像 CDN と テキストファイル拡張子のテストを追加
- 既存テストは全て pass

## リスク

- resolver が URL を変換する際に予期しない URL パターンがあれば direct として扱われる（安全側）
- CORS エラーは既存の fetch エラーハンドリングで対応

## follow-up tasks

- テキストファイルのプレビュー機能
- その他のコード共有サービス（GitLab など）への対応

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01LhgGWWmsuC3GuhZPhfS8Zp