### PR TITLE
Add skybox (sky sphere) import and deletion functionality

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -116,15 +116,27 @@ export class DragDropManager {
   }
 
   _dropPositionFromEvent(event) {
+    let position;
     if (Number.isFinite(event.clientX) && Number.isFinite(event.clientY)) {
-      return this.coordinateTransformer.screenToWorld(
+      position = this.coordinateTransformer.screenToWorld(
         event.clientX,
         event.clientY,
         this.renderer.domElement
       );
+    } else {
+      position = this._defaultDropPosition();
     }
 
-    return this._defaultDropPosition();
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const isUpperArea = event.clientY < rect.top + rect.height * 0.3;
+    const targetKind = isUpperArea ? 'sky' : 'scene';
+
+    return {
+      position,
+      targetKind,
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
   }
 
   async _loadFile(file, position) {
@@ -152,15 +164,21 @@ export class DragDropManager {
     }
   }
 
-  async handleFile(file, position) {
+  async handleFile(file, positionContext) {
     if (isGlbFile(file)) {
-      return this._loadFile(file, position || this._defaultDropPosition());
+      const pos = positionContext?.position ?? this._defaultDropPosition();
+      return this._loadFile(file, pos);
     }
 
     if (this.imageImporter && isSupportedImageFile(file)) {
-      const dropPos = position || this._defaultDropPosition();
+      const dropPos = positionContext?.position ?? this._defaultDropPosition();
+      const context = {
+        targetKind: positionContext?.targetKind ?? 'scene',
+        clientX: positionContext?.clientX,
+        clientY: positionContext?.clientY,
+      };
       try {
-        await this.imageImporter(file, dropPos);
+        await this.imageImporter(file, dropPos, context);
       } catch (error) {
         console.warn('[drag-drop] image import failed:', error);
         this.showToast?.(error?.message || '画像の読み込みに失敗しました');
@@ -169,10 +187,15 @@ export class DragDropManager {
     }
 
     if (this.textImporter && isSupportedTextFile(file)) {
-      const dropPos = position || this._defaultDropPosition();
+      const dropPos = positionContext?.position ?? this._defaultDropPosition();
+      const context = {
+        targetKind: positionContext?.targetKind ?? 'scene',
+        clientX: positionContext?.clientX,
+        clientY: positionContext?.clientY,
+      };
       try {
         const text = await file.text();
-        await this.textImporter(text, dropPos, file.name);
+        await this.textImporter(text, dropPos, file.name, context);
       } catch (error) {
         console.warn('[drag-drop] text import failed:', error);
         this.showToast?.(error?.message || 'テキストの読み込みに失敗しました');
@@ -238,6 +261,8 @@ export class DragDropManager {
     const dt = event.dataTransfer;
     if (!dt) return;
 
+    const positionContext = this._dropPositionFromEvent(event);
+
     // URL ドロップを先に判定（files が空の場合）
     if (!dt.files || dt.files.length === 0) {
       const uriList = dt.getData('text/uri-list');
@@ -247,8 +272,7 @@ export class DragDropManager {
         candidate = extractUrlFromText(dt.getData('text/plain'));
       }
       if (candidate && this.urlImporter) {
-        const dropPos = this._dropPositionFromEvent(event) || this._defaultDropPosition();
-        this.urlImporter(candidate, dropPos).catch((err) => {
+        this.urlImporter(candidate, positionContext.position, positionContext).catch((err) => {
           console.warn('[drag-drop] url import failed:', err);
           this.showToast?.(err?.message || 'URLの追加に失敗しました');
         });
@@ -262,7 +286,7 @@ export class DragDropManager {
     const file = dt.files?.[0];
     if (!file) return;
 
-    this.handleFile(file, this._dropPositionFromEvent(event)).catch((error) => {
+    this.handleFile(file, positionContext).catch((error) => {
       console.warn('[drag-drop] failed to load dropped file:', error);
       this.showToast?.(error.message || 'GLBの読み込みに失敗しました');
     });

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -21,6 +21,34 @@ function isSupportedTextFile(file) {
   return supportedMimes.includes(file.type) || supportedExts.test(file.name || '');
 }
 
+function normalizePositionContext(input, fallbackPosition) {
+  if (input?.position) {
+    return {
+      position: input.position,
+      targetKind: input.targetKind ?? 'scene',
+      clientX: input.clientX,
+      clientY: input.clientY,
+    };
+  }
+
+  // Backward compatibility: old callers pass THREE.Vector3 directly.
+  if (input && typeof input.toArray === 'function') {
+    return {
+      position: input,
+      targetKind: 'scene',
+      clientX: undefined,
+      clientY: undefined,
+    };
+  }
+
+  return {
+    position: fallbackPosition,
+    targetKind: 'scene',
+    clientX: undefined,
+    clientY: undefined,
+  };
+}
+
 export class DragDropManager {
   constructor(options) {
     const {
@@ -165,20 +193,22 @@ export class DragDropManager {
   }
 
   async handleFile(file, positionContext) {
+    const normalized = normalizePositionContext(
+      positionContext,
+      this._defaultDropPosition()
+    );
+
     if (isGlbFile(file)) {
-      const pos = positionContext?.position ?? this._defaultDropPosition();
-      return this._loadFile(file, pos);
+      return this._loadFile(file, normalized.position);
     }
 
     if (this.imageImporter && isSupportedImageFile(file)) {
-      const dropPos = positionContext?.position ?? this._defaultDropPosition();
-      const context = {
-        targetKind: positionContext?.targetKind ?? 'scene',
-        clientX: positionContext?.clientX,
-        clientY: positionContext?.clientY,
-      };
       try {
-        await this.imageImporter(file, dropPos, context);
+        await this.imageImporter(file, normalized.position, {
+          targetKind: normalized.targetKind,
+          clientX: normalized.clientX,
+          clientY: normalized.clientY,
+        });
       } catch (error) {
         console.warn('[drag-drop] image import failed:', error);
         this.showToast?.(error?.message || '画像の読み込みに失敗しました');
@@ -187,15 +217,13 @@ export class DragDropManager {
     }
 
     if (this.textImporter && isSupportedTextFile(file)) {
-      const dropPos = positionContext?.position ?? this._defaultDropPosition();
-      const context = {
-        targetKind: positionContext?.targetKind ?? 'scene',
-        clientX: positionContext?.clientX,
-        clientY: positionContext?.clientY,
-      };
       try {
         const text = await file.text();
-        await this.textImporter(text, dropPos, file.name, context);
+        await this.textImporter(text, normalized.position, file.name, {
+          targetKind: normalized.targetKind,
+          clientX: normalized.clientX,
+          clientY: normalized.clientY,
+        });
       } catch (error) {
         console.warn('[drag-drop] text import failed:', error);
         this.showToast?.(error?.message || 'テキストの読み込みに失敗しました');
@@ -203,7 +231,7 @@ export class DragDropManager {
       return null;
     }
 
-    this.showToast?.('GLB / 画像 / テキストファイルのみ対応しています');
+    this.showToast?.('未対応のファイル形式です');
     return null;
   }
 

--- a/html/assets/js/scenesync/loaders/image-to-sky-sphere.js
+++ b/html/assets/js/scenesync/loaders/image-to-sky-sphere.js
@@ -1,0 +1,66 @@
+export async function buildImageSkySphereGlb(fileOrBlob, options = {}) {
+  const {
+    THREE,
+    GLTFExporter,
+    radius = 50,
+    widthSegments = 64,
+    heightSegments = 32,
+  } = options;
+
+  if (!THREE) throw new Error('THREE is required');
+  if (!GLTFExporter) throw new Error('GLTFExporter is required');
+
+  const bitmap = await createImageBitmap(fileOrBlob);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Failed to get canvas context');
+  ctx.drawImage(bitmap, 0, 0);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+
+  const geometry = new THREE.SphereGeometry(radius, widthSegments, heightSegments);
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    side: THREE.BackSide,
+  });
+
+  const sphere = new THREE.Mesh(geometry, material);
+  sphere.name = 'sky-sphere';
+
+  const scene = new THREE.Scene();
+  scene.add(sphere);
+
+  const exporter = new GLTFExporter();
+
+  const arrayBuffer = await new Promise((resolve, reject) => {
+    exporter.parse(
+      scene,
+      (result) => {
+        if (result instanceof ArrayBuffer) {
+          resolve(result);
+        } else {
+          reject(new Error('GLTFExporter did not return ArrayBuffer'));
+        }
+      },
+      (error) => reject(error),
+      { binary: true, embedImages: true }
+    );
+  });
+
+  texture.dispose?.();
+  geometry.dispose?.();
+  material.dispose?.();
+  bitmap.close?.();
+
+  return {
+    arrayBuffer,
+    width: canvas.width,
+    height: canvas.height,
+  };
+}

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -13,6 +13,7 @@ import { DragDropManager } from './components/drag-drop-manager.js';
 import { ClipboardImportManager } from './components/clipboard-import-manager.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
 import { buildPlaneGlbFromImage } from './loaders/image-to-plane.js';
+import { buildImageSkySphereGlb } from './loaders/image-to-sky-sphere.js';
 import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
 import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
@@ -62,8 +63,63 @@ const environmentManager = createEnvironmentManager({
   dom,
   showToast,
 });
+
+// Skybox Sphere 管理
+function isSkySphereObject(obj) {
+  return obj?.metadata?.role === 'sky-sphere'
+    || obj?.objectId?.startsWith('sky-')
+    || obj?.name?.startsWith('sky:');
+}
+
+function getSkySphereObjects() {
+  const result = [];
+  for (const [objectId, obj] of managedObjects.entries()) {
+    const info = {
+      objectId,
+      metadata: obj.userData?.metadata,
+      name: obj.userData?.name,
+    };
+    if (isSkySphereObject(info)) {
+      result.push(info);
+    }
+  }
+  return result;
+}
+
+function updateEnvironmentMenuSkyboxControls() {
+  const hasSkybox = getSkySphereObjects().length > 0;
+  if (dom.deleteSkyboxBtn) {
+    dom.deleteSkyboxBtn.hidden = !hasSkybox;
+  }
+}
+
 dom.envSelect?.addEventListener('change', () => {
   notifySceneStateChanged('environment-select-change');
+  updateEnvironmentMenuSkyboxControls();
+});
+
+dom.deleteSkyboxBtn?.addEventListener('click', () => {
+  const skyObjects = getSkySphereObjects();
+
+  if (skyObjects.length === 0) {
+    showToast('削除するSkyboxはありません');
+    updateEnvironmentMenuSkyboxControls();
+    return;
+  }
+
+  const count = skyObjects.length;
+  for (const obj of skyObjects) {
+    deleteObjectById(obj.objectId);
+  }
+
+  showToast(
+    count === 1
+      ? 'Skyboxを削除しました'
+      : `Skyboxを${count}個削除しました`
+  );
+
+  updateEnvironmentMenuSkyboxControls();
+  notifySceneStateChanged('skybox-deleted');
 });
 
 setupXrButtons({
@@ -1287,6 +1343,52 @@ renderer.domElement.addEventListener('touchend', (e) => {
 
 // ── 削除ロジック（共通） ──────────────────────────────────
 
+function deleteObjectById(objectId) {
+  const attached = managedObjects.get(objectId);
+  if (!attached) return;
+
+  if (locks.has(objectId)) {
+    const lockInfo = locks.get(objectId);
+    const lockOwnerId = lockInfo?.id;
+    if (lockOwnerId && lockOwnerId !== presenceState.id) {
+      showToast('他のユーザーが編集中です');
+      return;
+    }
+    // 自分のロックなら unlock をブロードキャストして解除
+    broadcast({ kind: 'scene-unlock', objectId });
+  }
+
+  removeLockOverlay(objectId);
+  locks.delete(objectId);
+
+  // 削除前にオブジェクト情報を保存
+  const name = attached.userData.name || objectId;
+  const position = attached.position.toArray();
+  const rotation = attached.quaternion.toArray();
+  const scale = attached.scale.toArray();
+  const asset = attached.userData.asset || {};
+
+  scene.remove(attached);
+  attached.traverse(child => {
+    if (child.geometry) child.geometry.dispose();
+    if (child.material) {
+      if (Array.isArray(child.material)) {
+        child.material.forEach(m => m.dispose());
+      } else {
+        child.material.dispose();
+      }
+    }
+  });
+  managedObjects.delete(objectId);
+
+  // 履歴に追加
+  presenceState.historyManager.push(
+    HistoryManager.createRemoveEntry(objectId, name, asset, position, rotation, scale)
+  );
+
+  broadcast({ kind: 'scene-remove', objectId });
+}
+
 function deleteSelectedObject() {
   const attached = transformCtrl.object;
   if (!attached) return;
@@ -1303,46 +1405,7 @@ function deleteSelectedObject() {
   hideToolbar();
 
   if (deleteId) {
-    if (locks.has(deleteId)) {
-      const lockInfo = locks.get(deleteId);
-      const lockOwnerId = lockInfo?.id;
-      if (lockOwnerId && lockOwnerId !== presenceState.id) {
-        showToast('他のユーザーが編集中です');
-        return;
-      }
-      // 自分のロックなら unlock をブロードキャストして解除
-      broadcast({ kind: 'scene-unlock', objectId: deleteId });
-    }
-
-    removeLockOverlay(deleteId);
-    locks.delete(deleteId);
-
-    // 削除前にオブジェクト情報を保存
-    const name = attached.userData.name || deleteId;
-    const position = attached.position.toArray();
-    const rotation = attached.quaternion.toArray();
-    const scale = attached.scale.toArray();
-    const asset = attached.userData.asset || {};
-
-    scene.remove(attached);
-    attached.traverse(child => {
-      if (child.geometry) child.geometry.dispose();
-      if (child.material) {
-        if (Array.isArray(child.material)) {
-          child.material.forEach(m => m.dispose());
-        } else {
-          child.material.dispose();
-        }
-      }
-    });
-    managedObjects.delete(deleteId);
-
-    // 履歴に追加
-    presenceState.historyManager.push(
-      HistoryManager.createRemoveEntry(deleteId, name, asset, position, rotation, scale)
-    );
-
-    broadcast({ kind: 'scene-remove', objectId: deleteId });
+    deleteObjectById(deleteId);
     notifySceneStateChanged('selected-object-deleted');
   }
 }
@@ -2947,6 +3010,7 @@ function replaceManagedObject(objectId, nextObject, info) {
   }
 
   nextObject.userData.objectId = objectId;
+  nextObject.userData.metadata = info.metadata;
   applyObjectName(nextObject, info.name);
   applyTransform(nextObject, info);
   applyObjectVisibility(nextObject, info.visible);
@@ -3232,37 +3296,73 @@ async function uploadCarrierGlb(arrayBuffer) {
   throw new Error('blob id collision - unable to generate unique ID');
 }
 
-async function imageImporterCallback(file, position) {
+async function imageImporterCallback(file, position, context = {}) {
   if (file.size > 10 * 1024 * 1024) {
     throw new Error('画像が大きすぎます (最大10MB)');
   }
 
-  const arrayBuffer = await buildPlaneGlbFromImage(file, { THREE, GLTFExporter });
-  const meshPath = await uploadCarrierGlb(arrayBuffer);
+  const { targetKind = 'scene' } = context;
+  const isSkyTarget = targetKind === 'sky';
 
-  const objectId = `img-${meshPath.slice(0, 8)}`;
-  const displayName = `image: ${file.name}`.slice(0, 60);
-  const positionArray = (position && typeof position.toArray === 'function')
-    ? position.toArray()
-    : [0, 1, 0];
+  let arrayBuffer, meshPath, objectId, displayName, positionArray, payload;
 
-  const payload = {
-    kind: 'scene-add',
-    objectId,
-    name: displayName,
-    position: positionArray,
-    rotation: [0, 0, 0, 1],
-    scale: [1, 1, 1],
-    asset: { type: 'mesh', meshPath },
-  };
+  if (isSkyTarget) {
+    const result = await buildImageSkySphereGlb(file, {
+      THREE,
+      GLTFExporter,
+      radius: 50,
+      widthSegments: 64,
+      heightSegments: 32,
+    });
+    arrayBuffer = result.arrayBuffer;
+    meshPath = await uploadCarrierGlb(arrayBuffer);
 
-  broadcast(payload);
+    objectId = `sky-${meshPath.slice(0, 8)}`;
+    displayName = `sky: ${file.name || 'image'}`.slice(0, 60);
+    positionArray = [0, 0, 0];
 
-  // ローカルにも反映（server側が送信元を除外するため、自分のbroadcastはエコーバックされない）
-  addOrUpdateObject(objectId, payload);
+    payload = {
+      kind: 'scene-add',
+      objectId,
+      name: displayName,
+      position: positionArray,
+      rotation: [0, 0, 0, 1],
+      scale: [1, 1, 1],
+      metadata: {
+        role: 'sky-sphere',
+      },
+      asset: { type: 'mesh', meshPath },
+    };
+
+    broadcast(payload);
+    addOrUpdateObject(objectId, payload);
+    showToast('Skyboxを追加しました');
+  } else {
+    arrayBuffer = await buildPlaneGlbFromImage(file, { THREE, GLTFExporter });
+    meshPath = await uploadCarrierGlb(arrayBuffer);
+
+    objectId = `img-${meshPath.slice(0, 8)}`;
+    displayName = `image: ${file.name}`.slice(0, 60);
+    positionArray = (position && typeof position.toArray === 'function')
+      ? position.toArray()
+      : [0, 1, 0];
+
+    payload = {
+      kind: 'scene-add',
+      objectId,
+      name: displayName,
+      position: positionArray,
+      rotation: [0, 0, 0, 1],
+      scale: [1, 1, 1],
+      asset: { type: 'mesh', meshPath },
+    };
+
+    broadcast(payload);
+    addOrUpdateObject(objectId, payload);
+  }
 }
 
-async function textImporterCallback(text, position, filename = 'text.md') {
+async function textImporterCallback(text, position, filename = 'text.md', context = {}) {
   const { arrayBuffer } = await buildTextPlaneGlb(text, {
     THREE,
     GLTFExporter,
@@ -3299,7 +3399,7 @@ function generateObjectId(prefix) {
   return `${prefix}-${id}`;
 }
 
-async function urlImporterCallback(url, position) {
+async function urlImporterCallback(url, position, context = {}) {
   const resolved = resolveDroppedUrl(url);
 
   for (const note of resolved.notes || []) {
@@ -3326,7 +3426,7 @@ async function urlImporterCallback(url, position) {
     }),
     position: positionArray,
     textImporter: (text, filename) =>
-      textImporterCallback(text, position, filename),
+      textImporterCallback(text, position, filename, context),
     THREE,
     GLTFLoader,
   };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -71,6 +71,28 @@ function isSkySphereObject(obj) {
     || obj?.name?.startsWith('sky:');
 }
 
+function isSkySphereThreeObject(obj) {
+  let current = obj;
+
+  while (current) {
+    const objectId = current.userData?.objectId;
+    const metadata = current.userData?.metadata;
+    const name = current.userData?.name;
+
+    if (
+      metadata?.role === 'sky-sphere' ||
+      objectId?.startsWith('sky-') ||
+      name?.startsWith('sky:')
+    ) {
+      return true;
+    }
+
+    current = current.parent;
+  }
+
+  return false;
+}
+
 function getSkySphereObjects() {
   const result = [];
   for (const [objectId, obj] of managedObjects.entries()) {
@@ -302,7 +324,8 @@ function onXrSelectStart(ctrl) {
   xrRaycaster.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
   xrRaycaster.ray.direction.set(0, 0, -1).applyMatrix4(xrTmpMatrix);
 
-  const targets = Array.from(managedObjects.values());
+  const targets = Array.from(managedObjects.values())
+    .filter(obj => !isSkySphereThreeObject(obj));
   const hits = xrRaycaster.intersectObjects(targets, true);
   if (hits.length === 0) return;
 
@@ -1238,7 +1261,8 @@ function selectObjectAt(clientX, clientY) {
   pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
 
-  const targets = Array.from(managedObjects.values());
+  const targets = Array.from(managedObjects.values())
+    .filter(obj => !isSkySphereThreeObject(obj));
   const hits = raycaster.intersectObjects(targets, true);
   if (hits.length > 0) {
     let obj = hits[0].object;
@@ -1326,7 +1350,8 @@ renderer.domElement.addEventListener('touchend', (e) => {
         pointer.x = ((tapX - rect.left) / rect.width) * 2 - 1;
         pointer.y = -((tapY - rect.top) / rect.height) * 2 + 1;
         raycaster.setFromCamera(pointer, camera);
-        const targets = Array.from(managedObjects.values());
+        const targets = Array.from(managedObjects.values())
+          .filter(obj => !isSkySphereThreeObject(obj));
         const hits = raycaster.intersectObjects(targets, true);
         if (hits.length === 0) {
           broadcast({
@@ -1346,6 +1371,11 @@ renderer.domElement.addEventListener('touchend', (e) => {
 function deleteObjectById(objectId) {
   const attached = managedObjects.get(objectId);
   if (!attached) return;
+
+  if (transformCtrl.object === attached) {
+    transformCtrl.detach();
+    hideToolbar();
+  }
 
   if (locks.has(objectId)) {
     const lockInfo = locks.get(objectId);
@@ -1387,6 +1417,7 @@ function deleteObjectById(objectId) {
   );
 
   broadcast({ kind: 'scene-remove', objectId });
+  updateEnvironmentMenuSkyboxControls();
 }
 
 function deleteSelectedObject() {
@@ -2390,6 +2421,7 @@ function handleHandoff(data) {
       // Loom object graph をクリーンアップ
       loomIntegration.clearObjectGraph(objectId);
       notifySceneStateChanged('scene-remove-handoff');
+      updateEnvironmentMenuSkyboxControls();
       break;
     }
     case 'scene-mesh': {
@@ -3017,6 +3049,7 @@ function replaceManagedObject(objectId, nextObject, info) {
   scene.add(nextObject);
   managedObjects.set(objectId, nextObject);
   notifySceneStateChanged('managed-object-replaced');
+  updateEnvironmentMenuSkyboxControls();
 }
 
 function buildDefaultBoxObject(objectId, info, color = 0x4488ff) {
@@ -3180,6 +3213,7 @@ function applyOperationToScene(operation) {
       // Loom object graph をクリーンアップ
       loomIntegration.clearObjectGraph(operation.objectId);
       notifySceneStateChanged('undo-redo-scene-remove');
+      updateEnvironmentMenuSkyboxControls();
       break;
     }
     case 'scene-delta': {

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -19,5 +19,6 @@ export function getSceneSyncDom() {
     peersList: document.getElementById('peers-list'),
     fileInput: document.getElementById('file-input'),
     dropOverlay: document.getElementById('drop-overlay'),
+    deleteSkyboxBtn: document.getElementById('delete-skybox-btn'),
   };
 }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -695,6 +695,12 @@
       </select>
     </div>
     <div class="row">
+      <button id="delete-skybox-btn" class="chip" type="button" title="Skyboxを削除" hidden>
+        <span>🗑️</span>
+        <span>Skyboxを削除</span>
+      </button>
+    </div>
+    <div class="row">
       <button id="link-btn" class="chip" type="button" title="AI とリンク">
         <span id="link-icon">🔗</span>
         <span id="link-label">AIにリンク</span>


### PR DESCRIPTION
## 概要

画像ファイルをドラッグ&ドロップで Skybox（スカイスフィア）として追加できる機能と、追加した Skybox を削除する機能を実装しました。画面上部にドロップした画像は Skybox として、下部にドロップした画像は通常の画像平面として扱い分けます。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更

1. **Skybox 生成機能** (`image-to-sky-sphere.js`)
   - 新しいローダー `buildImageSkySphereGlb` を追加
   - 画像ファイルから球体ジオメトリを生成し、テクスチャをマッピング
   - GLB 形式でエクスポート

2. **ドラッグ&ドロップの領域判定** (`drag-drop-manager.js`)
   - `_dropPositionFromEvent` を拡張し、ドロップ位置の Y 座標で判定
   - 画面上部 30% 以内なら `targetKind: 'sky'`、それ以外は `targetKind: 'scene'`
   - 各インポーター（画像、テキスト、URL）に context 情報を渡す

3. **画像インポーターの拡張** (`scene.js`)
   - `imageImporterCallback` に context パラメータを追加
   - `targetKind === 'sky'` の場合、`buildImageSkySphereGlb` を使用
   - Skybox オブジェクトに `metadata.role: 'sky-sphere'` を付与
   - Skybox 追加時にトーストメッセージを表示

4. **Skybox 管理機能** (`scene.js`)
   - `isSkySphereObject()`: オブジェクトが Skybox かどうかを判定
   - `getSkySphereObjects()`: 現在のシーン内の全 Skybox を取得
   - `updateEnvironmentMenuSkyboxControls()`: 削除ボタンの表示/非表示を制御

5. **Skybox 削除機能** (`scene.js`)
   - 新しい `deleteObjectById()` 関数を追加（共通削除ロジック）
   - `deleteSkyboxBtn` クリックハンドラーで全 Skybox を削除
   - 削除数に応じたトーストメッセージを表示

6. **UI 追加** (`index.html`, `dom.js`)
   - 環境設定パネルに「Skybox を削除」ボタンを追加
   - Skybox が存在しない場合は非表示

7. **オブジェクト置換時のメタデータ保持** (`scene.js`)
   - `replaceManagedObject()` で metadata を保持するよう修正

### staging で見てほしい点

- 画面上部にドラッグ&ドロップした画像が Skybox として追加されること
- 画面下部にドラッグ&ドロップした画像が通常の画像平面として追加されること
- 環境設定パネルの「Skybox を削除」ボタンが Skybox 存在時のみ表示されること
- 複数の Skybox が存在する場合、削除ボタンで全て削除されること
- Skybox の削除が他のユーザーに同期されること

## 変更していないこと

-

https://claude.ai/code/session_01HMiaJrAK82NpSB766g4vrw