### PR TITLE
Switch Skybox detection from fixed UI coordinate to camera ray direction

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -28,6 +28,7 @@ function normalizePositionContext(input, fallbackPosition) {
       targetKind: input.targetKind ?? 'scene',
       clientX: input.clientX,
       clientY: input.clientY,
+      upness: input.upness,
     };
   }
 
@@ -38,6 +39,7 @@ function normalizePositionContext(input, fallbackPosition) {
       targetKind: 'scene',
       clientX: undefined,
       clientY: undefined,
+      upness: undefined,
     };
   }
 
@@ -46,8 +48,11 @@ function normalizePositionContext(input, fallbackPosition) {
     targetKind: 'scene',
     clientX: undefined,
     clientY: undefined,
+    upness: undefined,
   };
 }
+
+const SKY_DROP_UPNESS_THRESHOLD = 0.35;
 
 export class DragDropManager {
   constructor(options) {
@@ -64,12 +69,14 @@ export class DragDropManager {
       onLoadStart,
       onLoadEnd,
       getRaycastTargets,
+      getPlacementTargets,
       dracoPath,
       maxDimension,
       glbLoader,
       imageImporter,
       textImporter,
       urlImporter,
+      THREE: ThreeModule,
     } = options || {};
 
     if (!camera || !renderer || !scene) {
@@ -90,6 +97,8 @@ export class DragDropManager {
     this.imageImporter = imageImporter;
     this.textImporter = textImporter;
     this.urlImporter = urlImporter;
+    this.getPlacementTargets = getPlacementTargets;
+    this.THREE = ThreeModule || (globalThis.THREE || {});
     this.coordinateTransformer = new CoordinateTransformer(camera, renderer, scene, {
       getRaycastTargets,
     });
@@ -143,27 +152,67 @@ export class DragDropManager {
     );
   }
 
-  _dropPositionFromEvent(event) {
-    let position;
-    if (Number.isFinite(event.clientX) && Number.isFinite(event.clientY)) {
-      position = this.coordinateTransformer.screenToWorld(
-        event.clientX,
-        event.clientY,
-        this.renderer.domElement
-      );
-    } else {
-      position = this._defaultDropPosition();
-    }
-
+  _createDropRay(event) {
     const rect = this.renderer.domElement.getBoundingClientRect();
-    const isUpperArea = event.clientY < rect.top + rect.height * 0.3;
-    const targetKind = isUpperArea ? 'sky' : 'scene';
+
+    const ndc = new this.THREE.Vector2(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1
+    );
+
+    const raycaster = new this.THREE.Raycaster();
+    raycaster.setFromCamera(ndc, this.camera);
+
+    const worldUp = new this.THREE.Vector3(0, 1, 0);
+    const upness = raycaster.ray.direction.dot(worldUp);
 
     return {
-      position,
-      targetKind,
+      raycaster,
+      ray: raycaster.ray,
+      ndc,
+      upness,
+    };
+  }
+
+  _findPlacementHit(raycaster) {
+    const targets = this.getPlacementTargets?.() || [];
+
+    if (!targets.length) return null;
+
+    const hits = raycaster.intersectObjects(targets, true);
+    return hits[0] || null;
+  }
+
+  _dropPositionFromEvent(event) {
+    const rayInfo = this._createDropRay(event);
+    const hit = this._findPlacementHit(rayInfo.raycaster);
+
+    if (hit) {
+      return {
+        position: hit.point.clone(),
+        targetKind: 'scene',
+        clientX: event.clientX,
+        clientY: event.clientY,
+        upness: rayInfo.upness,
+      };
+    }
+
+    if (rayInfo.upness > SKY_DROP_UPNESS_THRESHOLD) {
+      return {
+        position: this._defaultDropPosition(),
+        targetKind: 'sky',
+        clientX: event.clientX,
+        clientY: event.clientY,
+        upness: rayInfo.upness,
+      };
+    }
+
+    return {
+      position: this._defaultDropPosition(),
+      targetKind: 'scene',
       clientX: event.clientX,
       clientY: event.clientY,
+      upness: rayInfo.upness,
     };
   }
 
@@ -208,6 +257,7 @@ export class DragDropManager {
           targetKind: normalized.targetKind,
           clientX: normalized.clientX,
           clientY: normalized.clientY,
+          upness: normalized.upness,
         });
       } catch (error) {
         console.warn('[drag-drop] image import failed:', error);
@@ -223,6 +273,7 @@ export class DragDropManager {
           targetKind: normalized.targetKind,
           clientX: normalized.clientX,
           clientY: normalized.clientY,
+          upness: normalized.upness,
         });
       } catch (error) {
         console.warn('[drag-drop] text import failed:', error);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3478,8 +3478,11 @@ const dragDropManager = new DragDropManager({
   dropOverlay: dom.dropOverlay,
   showToast,
   glbLoader,
+  THREE,
   getRaycastTargets: () => Array.from(managedObjects.values())
     .filter(obj => obj.userData?.dropRaycastTarget && obj.visible !== false),
+  getPlacementTargets: () => Array.from(managedObjects.values())
+    .filter(obj => !isSkySphereThreeObject(obj) && obj.visible !== false),
   onLoadStart: async ({ objectId, file, position }) => {
     addLoadingOverlay(objectId, file.name, { position: position?.toArray?.() });
   },


### PR DESCRIPTION
## Changes

1. **Ray-based sky detection in DragDropManager**
   - Replace screen-top 30% fixed UI coordinate check with camera+ray based detection
   - Add _createDropRay() to compute ray from drop position
   - Add _findPlacementHit() to check raycast against placement targets
   - Modify _dropPositionFromEvent() to:
     1. Raycast against placement targets first
     2. Check upness (ray.direction.dot(worldUp)) if no hit 3. Compare against SKY_DROP_UPNESS_THRESHOLD (0.35)

2. **Constants and configuration**
   - Add SKY_DROP_UPNESS_THRESHOLD = 0.35
   - Support THREE module via constructor option
   - Add getPlacementTargets callback to exclude sky-sphere from placement raycast

3. **Scene.js integration**
   - Pass THREE to DragDropManager constructor
   - Add getPlacementTargets filter excluding sky-sphere objects
   - Ensure Skybox Sphere never blocks placement target selection

4. **Skybox judgment logic**
   - Scene hit → targetKind='scene'
   - No hit + upness > 0.35 → targetKind='sky'
   - No hit + upness ≤ 0.35 → fallback with targetKind='scene'

https://claude.ai/code/session_01HMiaJrAK82NpSB766g4vrw

## 概要

- この PR で何を変えるか

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync` / `loom` / `file-transfer` / `platform` のいずれか、または複数

## 変更内容

- 主要な変更点
- staging で見てほしい点

## 変更していないこと

- 明示的に触っていない範囲
- `out of scope`

## staging確認

- 確認 URL
- どの branch が staging に出ているか
- 未確認ならその理由

## テスト/チェック

- 実行したテスト
- 実行した lint / YAML / build check
- 未実施の確認があればその理由

## リスク

- staging が最新 deploy branch で上書きされる影響
- 既知の制約

## follow-up tasks

- 必要なら `follow-up task` を列挙
- 今回入れなかった小さな改善

## merge方針

- 期待する merge 方法: squash merge / merge しない
- merge 後に remote branch を削除するか
