### PR TITLE
Debug: Add drop detection logging to _dropPositionFromEvent

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -209,6 +209,26 @@ export class DragDropManager {
     const rayInfo = this._createDropRay(event);
     const hit = this._findPlacementHit(rayInfo.raycaster);
 
+    const debugTargetKind = hit
+      ? 'scene-hit'
+      : rayInfo.upness > SKY_DROP_UPNESS_THRESHOLD
+        ? 'sky'
+        : 'scene-fallback';
+
+    this.lastDropDetection = {
+      hit: !!hit,
+      hitObject: hit?.object?.name || null,
+      hitObjectType: hit?.object?.type || null,
+      hitDistance: hit?.distance ?? null,
+      upness: rayInfo.upness,
+      threshold: SKY_DROP_UPNESS_THRESHOLD,
+      targetKind: debugTargetKind,
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+
+    console.debug('[drag-drop] drop detection', this.lastDropDetection);
+
     if (hit) {
       return {
         position: hit.point.clone(),

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3507,6 +3507,11 @@ const dragDropManager = new DragDropManager({
   urlImporter: urlImporterCallback,
 });
 
+window.__sceneSyncDebug = {
+  ...(window.__sceneSyncDebug || {}),
+  dragDropManager,
+};
+
 // ── クリップボード貼り付け ────────────────────────────────────────────
 
 function getDefaultImportPosition() {


### PR DESCRIPTION
- Log hit/upness/targetKind to diagnose skybox D&D detection issues
- Store detection results in lastDropDetection for DevTools console access
- Expose dragDropManager via window.__sceneSyncDebug for debugging
- Helps identify whether failures are due to upness threshold, placement hits, or fallback logic