### PR TITLE
Fix skybox sphere visibility from inside

### DIFF
--- a/html/assets/js/scenesync/loaders/image-to-sky-sphere.js
+++ b/html/assets/js/scenesync/loaders/image-to-sky-sphere.js
@@ -25,9 +25,13 @@ export async function buildImageSkySphereGlb(fileOrBlob, options = {}) {
   texture.needsUpdate = true;
 
   const geometry = new THREE.SphereGeometry(radius, widthSegments, heightSegments);
+  // GLB化後も内側から見えるように、面の向きをジオメトリ側で反転する
+  geometry.scale(-1, 1, 1);
+  geometry.computeVertexNormals();
+
   const material = new THREE.MeshBasicMaterial({
     map: texture,
-    side: THREE.BackSide,
+    side: THREE.FrontSide,
   });
 
   const sphere = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
Modify SphereGeometry to face inward by scaling geometry and computing vertex normals,
ensuring the skybox is visible from inside even after GLB export/import. Change material
side from BackSide to FrontSide as geometry now handles the orientation.

https://claude.ai/code/session_01LRWGBS7ZZqcReJ2c7jRqTY