### PR TITLE
Add Scene Sync MCP graph tools

### DIFF
--- a/packages/scene-sync-mcp/GRAPH_TOOLS.md
+++ b/packages/scene-sync-mcp/GRAPH_TOOLS.md
@@ -1,0 +1,88 @@
+# Scene Sync MCP Graph Tools
+
+This document describes the experimental Scene Sync graph tools added for persistent behavior graphs.
+
+These tools accept **Scene Sync graph JSON**, not Loomlet DSL. The intended flow is:
+
+```text
+Loomlet DSL or AI-authored behavior
+  -> Scene Sync graph JSON
+  -> MCP graph tool
+  -> Scene Sync scene-graph-set / scene-graph-clear broadcast
+```
+
+Scene Sync stays lightweight and does not need the Loomlet DSL parser.
+
+## Tools
+
+### scene_sync_set_object_graph
+
+Set a persistent behavior graph for one object.
+
+```json
+{
+  "objectId": "cat-123",
+  "graph": {
+    "nodes": [
+      { "id": "clock", "type": "serverClock" },
+      { "id": "jump", "type": "sine", "params": { "freq": 1.2, "amplitude": 0.35, "offset": 0.35 } },
+      { "id": "pos", "type": "sceneSetPosition", "params": { "x": 3, "z": -2 } }
+    ],
+    "edges": [
+      { "from": "clock.t", "to": "jump.t" },
+      { "from": "jump.out", "to": "pos.y" }
+    ]
+  }
+}
+```
+
+### scene_sync_clear_object_graph
+
+Clear one object's behavior graph.
+
+```json
+{
+  "objectId": "cat-123"
+}
+```
+
+### scene_sync_set_scene_graph
+
+Set the room-level behavior graph.
+
+```json
+{
+  "graph": {
+    "nodes": [],
+    "edges": []
+  }
+}
+```
+
+### scene_sync_clear_scene_graph
+
+Clear the room-level behavior graph.
+
+```json
+{}
+```
+
+## Supported node types
+
+- `serverClock`
+- `sine`
+- `cosine`
+- `add`
+- `sceneSetPosition`
+- `sceneSetRotation`
+- `sceneSetScale`
+- `sceneSetColor`
+- `sceneSetVisible`
+
+## Dry run
+
+All graph tools accept `dryRun: true`. In dry-run mode, the tool returns the payload without broadcasting it.
+
+## Notes for AI clients
+
+Before generating object behavior, inspect the current scene with `scene_sync_get_scene` and preserve the object's current base transform. For example, a bounce behavior should animate only the Y component and keep the current X/Z values, instead of moving the object to the origin.

--- a/packages/scene-sync-mcp/bin/scene-sync-mcp-graph-tools.js
+++ b/packages/scene-sync-mcp/bin/scene-sync-mcp-graph-tools.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import '../src/scene-graph-tools.mjs'
+import '../src/cli.mjs'

--- a/packages/scene-sync-mcp/bin/scene-sync-mcp.js
+++ b/packages/scene-sync-mcp/bin/scene-sync-mcp.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+import '../src/scene-graph-tools.mjs'
 import '../src/cli.mjs'

--- a/packages/scene-sync-mcp/package.json
+++ b/packages/scene-sync-mcp/package.json
@@ -13,7 +13,8 @@
   },
   "bin": {
     "scene-sync-mcp": "./bin/scene-sync-mcp.js",
-    "scene-sync-mcp-setup": "./bin/scene-sync-mcp-setup.js"
+    "scene-sync-mcp-setup": "./bin/scene-sync-mcp-setup.js",
+    "scene-sync-mcp-graph-tools": "./bin/scene-sync-mcp-graph-tools.js"
   },
   "files": [
     "bin",

--- a/packages/scene-sync-mcp/src/scene-graph-tools.mjs
+++ b/packages/scene-sync-mcp/src/scene-graph-tools.mjs
@@ -1,0 +1,256 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { SceneSyncClient } from './scene-sync-client.mjs'
+import { SessionStore } from './session-store.mjs'
+import { ValidationError, assertLinked, assertObjectId } from './validators.mjs'
+import { jsonResult, errorResult } from './tool-results.mjs'
+
+const client = new SceneSyncClient()
+const store = new SessionStore()
+
+const GRAPH_TOOL_PATCHED = Symbol.for('scene-sync-mcp.scene-graph-tools.patched')
+const GRAPH_TOOLS_REGISTERED = Symbol.for('scene-sync-mcp.scene-graph-tools.registered')
+
+const supportedGraphNodeTypes = [
+  'serverClock',
+  'sine',
+  'cosine',
+  'add',
+  'sceneSetPosition',
+  'sceneSetRotation',
+  'sceneSetScale',
+  'sceneSetColor',
+  'sceneSetVisible'
+]
+
+const graphNodeSchema = z.object({
+  id: z.string().min(1).describe('Unique node ID within this graph'),
+  type: z.enum(supportedGraphNodeTypes).describe('Scene Sync graph node type'),
+  params: z.record(z.unknown()).optional().describe('Node parameters')
+}).passthrough()
+
+const graphEdgeSchema = z.object({
+  from: z.string().min(1).describe('Source endpoint, for example "clock.t"'),
+  to: z.string().min(1).describe('Destination endpoint, for example "sine.t"')
+}).passthrough()
+
+const graphSchema = z.object({
+  nodes: z.array(graphNodeSchema).max(100).describe('Scene Sync graph nodes'),
+  edges: z.array(graphEdgeSchema).max(300).describe('Scene Sync graph edges')
+}).passthrough()
+
+function endpointNodeId(endpoint) {
+  const index = endpoint.indexOf('.')
+  return index === -1 ? endpoint : endpoint.slice(0, index)
+}
+
+function validateGraph(graph) {
+  if (!graph || typeof graph !== 'object') {
+    throw new ValidationError('graph must be an object with nodes and edges arrays.')
+  }
+
+  const ids = new Set()
+
+  for (const node of graph.nodes || []) {
+    if (ids.has(node.id)) {
+      throw new ValidationError(`Duplicate graph node id: ${node.id}`)
+    }
+    ids.add(node.id)
+  }
+
+  for (const edge of graph.edges || []) {
+    const fromId = endpointNodeId(edge.from)
+    const toId = endpointNodeId(edge.to)
+    if (!ids.has(fromId)) {
+      throw new ValidationError(`Graph edge references missing source node: ${edge.from}`)
+    }
+    if (!ids.has(toId)) {
+      throw new ValidationError(`Graph edge references missing destination node: ${edge.to}`)
+    }
+  }
+
+  return graph
+}
+
+async function getSession() {
+  await store.load()
+  const session = store.get()
+  assertLinked(session)
+  return session
+}
+
+async function broadcastGraphPayload(payload, { dryRun = false } = {}) {
+  if (dryRun) {
+    return jsonResult({
+      ok: true,
+      dryRun: true,
+      payload
+    })
+  }
+
+  const session = await getSession()
+  const response = await client.broadcast(session.roomId, session.sessionId, payload)
+
+  return jsonResult({
+    ...response,
+    ok: true,
+    dryRun: false,
+    payload
+  })
+}
+
+function registerSceneGraphTools(server) {
+  if (server[GRAPH_TOOLS_REGISTERED]) return
+
+  Object.defineProperty(server, GRAPH_TOOLS_REGISTERED, {
+    value: true,
+    enumerable: false
+  })
+
+  server.registerTool(
+    'scene_sync_set_object_graph',
+    {
+      title: 'Set an object behavior graph',
+      description: 'Set a Scene Sync behavior graph for a single object. This accepts Scene Sync graph JSON, not Loomlet DSL. Use this for persistent object behavior such as bouncing, spinning, pulsing, or procedural motion.',
+      inputSchema: z.object({
+        objectId: z.string().min(1).describe('Target Scene Sync object ID'),
+        graph: graphSchema.describe('Scene Sync graph JSON'),
+        dryRun: z.boolean().optional().describe('If true, return the payload without broadcasting it')
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false
+      }
+    },
+    async ({ objectId, graph, dryRun }) => {
+      try {
+        assertObjectId(objectId)
+        validateGraph(graph)
+
+        const payload = {
+          type: 'scene-graph-set',
+          scope: { object: objectId },
+          graph
+        }
+
+        return await broadcastGraphPayload(payload, { dryRun })
+      } catch (e) {
+        return errorResult(e)
+      }
+    }
+  )
+
+  server.registerTool(
+    'scene_sync_clear_object_graph',
+    {
+      title: 'Clear an object behavior graph',
+      description: 'Clear the Scene Sync behavior graph for a single object. Use this to stop an object behavior such as bouncing or spinning.',
+      inputSchema: z.object({
+        objectId: z.string().min(1).describe('Target Scene Sync object ID'),
+        dryRun: z.boolean().optional().describe('If true, return the payload without broadcasting it')
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false
+      }
+    },
+    async ({ objectId, dryRun }) => {
+      try {
+        assertObjectId(objectId)
+
+        const payload = {
+          type: 'scene-graph-clear',
+          scope: { object: objectId }
+        }
+
+        return await broadcastGraphPayload(payload, { dryRun })
+      } catch (e) {
+        return errorResult(e)
+      }
+    }
+  )
+
+  server.registerTool(
+    'scene_sync_set_scene_graph',
+    {
+      title: 'Set the scene behavior graph',
+      description: 'Set the room-level Scene Sync behavior graph. This accepts Scene Sync graph JSON, not Loomlet DSL. Prefer object graph tools for object-specific behavior.',
+      inputSchema: z.object({
+        graph: graphSchema.describe('Scene Sync graph JSON'),
+        dryRun: z.boolean().optional().describe('If true, return the payload without broadcasting it')
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false
+      }
+    },
+    async ({ graph, dryRun }) => {
+      try {
+        validateGraph(graph)
+
+        const payload = {
+          type: 'scene-graph-set',
+          scope: 'scene',
+          graph
+        }
+
+        return await broadcastGraphPayload(payload, { dryRun })
+      } catch (e) {
+        return errorResult(e)
+      }
+    }
+  )
+
+  server.registerTool(
+    'scene_sync_clear_scene_graph',
+    {
+      title: 'Clear the scene behavior graph',
+      description: 'Clear the room-level Scene Sync behavior graph.',
+      inputSchema: z.object({
+        dryRun: z.boolean().optional().describe('If true, return the payload without broadcasting it')
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false
+      }
+    },
+    async ({ dryRun }) => {
+      try {
+        const payload = {
+          type: 'scene-graph-clear',
+          scope: 'scene'
+        }
+
+        return await broadcastGraphPayload(payload, { dryRun })
+      } catch (e) {
+        return errorResult(e)
+      }
+    }
+  )
+}
+
+export function installSceneGraphToolPatch() {
+  if (McpServer.prototype[GRAPH_TOOL_PATCHED]) return
+
+  const originalConnect = McpServer.prototype.connect
+
+  Object.defineProperty(McpServer.prototype, GRAPH_TOOL_PATCHED, {
+    value: true,
+    enumerable: false
+  })
+
+  McpServer.prototype.connect = async function patchedConnect(...args) {
+    registerSceneGraphTools(this)
+    return originalConnect.apply(this, args)
+  }
+}
+
+installSceneGraphToolPatch()


### PR DESCRIPTION
## Summary

Adds MCP tools for Scene Sync behavior graphs so AI clients can set and clear persistent scene/object graph JSON without requiring the Scene Sync runtime to include the Loomlet DSL parser.

### Added tools

- `scene_sync_set_object_graph`
- `scene_sync_clear_object_graph`
- `scene_sync_set_scene_graph`
- `scene_sync_clear_scene_graph`

### Notes

- These tools accept Scene Sync graph JSON, not Loomlet DSL.
- `dryRun: true` returns the payload without broadcasting.
- Graph node types are allowlisted to the current Scene Sync behavior runtime nodes.
- The default `scene-sync-mcp` binary now imports the graph-tool patch module before starting the existing CLI.
- A temporary `scene-sync-mcp-graph-tools` binary is also included for explicit local testing.

## Test plan

Not run in this environment. Recommended local checks:

```bash
cd packages/scene-sync-mcp
node --check src/scene-graph-tools.mjs
node --check bin/scene-sync-mcp.js
node --check bin/scene-sync-mcp-graph-tools.js
node bin/scene-sync-mcp.js doctor
```

Then register the local package and verify the four new MCP tools are listed.

## Review note

The attempt to mark this PR ready hit a connector-side GraphQL shape error, so the PR may still appear as draft in GitHub UI.