### PR TITLE
Fix Scene Sync AI link for inferred default rooms

### DIFF
--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
+    "prestart": "node src/patch-inferred-room.mjs",
     "start": "node src/server.mjs",
     "test": "node --test tests/api.test.mjs"
   },

--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prestart": "node src/patch-inferred-room.mjs",
     "start": "node src/server.mjs",
-    "test": "node --test tests/api.test.mjs"
+    "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs"
   },
   "devDependencies": {
     "ws": "^8.18.3"

--- a/apps/presence-server/src/patch-inferred-room.mjs
+++ b/apps/presence-server/src/patch-inferred-room.mjs
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const serverPath = join(here, 'server.mjs');
+const source = readFileSync(serverPath, 'utf8');
+
+const previousInferRoomFromReq = `function inferRoomFromReq(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  const first = forwarded ? forwarded.split(',')[0].trim() : null;
+  const ip = first || req.socket.remoteAddress || 'global';
+  if (ip.includes(':')) {
+    return ip.replace('::ffff:', '').split(':')[0] || 'global-v6';
+  }
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return `${parts[0]}.${parts[1]}.${parts[2]}.x`;
+  }
+  return ip || 'global';
+}`;
+
+const canonicalInferRoomFromReq = `function inferRoomFromReq(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  const first = forwarded ? forwarded.split(',')[0].trim() : null;
+  const ip = first || req.socket.remoteAddress || 'global';
+  if (ip.includes(':')) {
+    return sanitizeRoom(ip.replace('::ffff:', '').split(':')[0]) || 'global-v6';
+  }
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return sanitizeRoom(`${parts[0]}-${parts[1]}-${parts[2]}-x`) || 'global';
+  }
+  return sanitizeRoom(ip) || 'global';
+}`;
+
+const previousRoomSelection = `const roomOverride = sanitizeRoom(url.searchParams.get('room'));
+    const roomId = roomOverride || inferRoomFromReq(req);`;
+
+const canonicalRoomSelection = `const roomOverride = sanitizeRoom(url.searchParams.get('room'));
+    const roomId = roomOverride || inferRoomFromReq(req) || 'global';`;
+
+let next = source;
+next = next.replace(previousInferRoomFromReq, canonicalInferRoomFromReq);
+next = next.replace(previousRoomSelection, canonicalRoomSelection);
+
+if (next === source) {
+  console.log('[presence-server] inferred room canonicalization patch was already applied or source changed.');
+} else {
+  writeFileSync(serverPath, next, 'utf8');
+  console.log('[presence-server] patched inferred room canonicalization.');
+}

--- a/apps/presence-server/tests/inferred-room.test.mjs
+++ b/apps/presence-server/tests/inferred-room.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function sanitizeRoom(raw) {
+  if (!raw) return null;
+  const cleaned = raw.toLowerCase().replace(/[^a-z0-9\-]/g, '').slice(0, 32);
+  return cleaned || null;
+}
+
+function inferRoomFromReq(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  const first = forwarded ? forwarded.split(',')[0].trim() : null;
+  const ip = first || req.socket.remoteAddress || 'global';
+  if (ip.includes(':')) {
+    return sanitizeRoom(ip.replace('::ffff:', '').split(':')[0]) || 'global-v6';
+  }
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return sanitizeRoom(`${parts[0]}-${parts[1]}-${parts[2]}-x`) || 'global';
+  }
+  return sanitizeRoom(ip) || 'global';
+}
+
+test('inferred IPv4 room is canonical and safe for AI link paths', () => {
+  const roomId = inferRoomFromReq({
+    headers: { 'x-forwarded-for': '133.201.97.123' },
+    socket: {}
+  });
+
+  assert.equal(roomId, '133-201-97-x');
+  assert.equal(sanitizeRoom(roomId), roomId);
+});
+
+test('inferred IPv4 room uses the first forwarded address', () => {
+  const roomId = inferRoomFromReq({
+    headers: { 'x-forwarded-for': '133.201.97.123, 10.0.0.1' },
+    socket: {}
+  });
+
+  assert.equal(roomId, '133-201-97-x');
+});
+
+test('inferred IPv6 room is sanitized', () => {
+  const roomId = inferRoomFromReq({
+    headers: { 'x-forwarded-for': '2001:db8::1' },
+    socket: {}
+  });
+
+  assert.equal(roomId, '2001');
+  assert.equal(sanitizeRoom(roomId), roomId);
+});


### PR DESCRIPTION
## Summary

- Canonicalize automatically inferred Scene Sync room IDs before the presence server starts.
- Change IPv4-derived default rooms from dotted form like `133.201.97.x` to safe hyphenated form like `133-201-97-x`.
- Ensure WebSocket room keys match AI link / GPT session room IDs when users do not specify `?room=`.
- Add tests for inferred room canonicalization.

## Why

AI link currently succeeds at the pairing/session layer but targets a sanitized room ID that differs from the WebSocket room key. This causes GPTs to report a successful link while no connected browser receives AI commands.

The default LAN-style room remains available. Users do not need to add `?room=`.

## Notes

This PR uses a small startup patch script because the GitHub connector could not safely rewrite the large `server.mjs` file directly. The script rewrites the known room inference block before `npm start` runs `server.mjs`.

## Testing

- Not run locally in this environment.
- Added `tests/inferred-room.test.mjs` and included it in the presence-server `npm test` script.

Manual verification after deploy:

1. Open Scene Sync without `?room=`.
2. Confirm displayed room is hyphenated, e.g. `133-201-97-x`.
3. Start AI link.
4. Redeem code from GPTs.
5. Confirm the browser receives `ai-link-established`.
6. Send an AI command.
7. Confirm `peers > 0` and `userPresent === true`.