### PR TITLE
Hide desktop toolbar on mobile devices via media query

### DIFF
--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -191,7 +191,7 @@
       bottom: 24px;
       left: 50%;
       transform: translateX(-50%);
-      display: flex;
+      display: none;
       gap: 8px;
       z-index: 50;
     }
@@ -594,7 +594,7 @@
       font-size: 20px;
       cursor: pointer;
       z-index: 11;
-      display: flex;
+      display: none;
       align-items: center;
       justify-content: center;
       backdrop-filter: blur(6px);
@@ -602,6 +602,14 @@
     }
     #paste-btn:hover {
       background: rgba(68, 136, 255, 0.8);
+    }
+    @media (hover: none) and (pointer: coarse) and (max-width: 1024px) {
+      #mobile-toolbar {
+        display: flex;
+      }
+      #paste-btn {
+        display: flex;
+      }
     }
     #paste-sheet {
       position: fixed;


### PR DESCRIPTION
## 概要

- モバイルデバイスでのUI表示を改善するため、デスクトップ向けツールバーをメディアクエリで制御

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `#mobile-toolbar` と `#paste-btn` の初期状態を `display: none` に変更
- モバイルデバイス向けメディアクエリ `@media (hover: none) and (pointer: coarse) and (max-width: 1024px)` を追加
- メディアクエリ内で両要素を `display: flex` に設定し、モバイル環境でのみ表示

**staging で見てほしい点:**
- モバイルデバイス（タッチ操作、1024px以下）でツールバーとペーストボタンが正常に表示されること
- デスクトップ環境では従来通り非表示のままであること

## 変更していないこと

- その他のツールバー機能やスタイル
- ペーストボタンの機能実装

## staging確認

- 未確認（staging環境の確認待ち）

## テスト/チェック

- 変更内容がシンプルなCSS修正のため、ブラウザの開発者ツールでメディアクエリの動作確認が可能
- 各デバイスサイズでの表示/非表示の切り替わりを確認

## リスク

- 既知の制約なし

## follow-up tasks

- 必要に応じて他のモバイル向けUI要素の表示制御も検討

## merge方針

- squash merge
- merge後にremote branchを削除

https://claude.ai/code/session_019KhbAuEREcjbHK7UW47kbf