### PR TITLE
Document Scene Sync Operator GPT onboarding

### DIFF
--- a/docs/scene-sync-ai-spec.md
+++ b/docs/scene-sync-ai-spec.md
@@ -4,6 +4,8 @@ This document defines the stable tool contract for Scene Sync AI integrations.
 It is the source of truth for GPTs, MCP servers, Codex adapters, and thin API
 clients that call the AI wrapper at `https://afjk.jp/presence/api/ai`.
 
+> For the public Scene Sync Operator GPT, the user-facing profile must explain the pairing flow. Users should not need to know the API contract before using the GPT. See the GPTs section for recommended profile description, conversation starters, and instructions.
+
 ## Scope
 
 - Stable tool names exposed to AI runtimes
@@ -424,6 +426,126 @@ Response:
 - Expose the five stable tool names directly.
 - Keep tool descriptions short and parameter-driven.
 - Prefer prompting the model to fetch a snapshot before destructive changes.
+- The GPT profile must clearly explain that users need to link a Scene Sync room before asking for scene operations.
+- Use the profile description, conversation starters, and instructions to guide first-time users.
+
+#### Recommended GPT profile description
+
+Use a user-facing description like:
+
+```text
+Scene Sync のルームにリンクして、3Dシーン内のオブジェクト追加・移動・色変更・配置確認を会話で操作できます。まず Scene Sync 画面の「AIにリンク」から6桁コードを発行し、このGPTに入力してください。
+```
+
+Short English alternative:
+
+```text
+Control a Scene Sync 3D room by chat. First open Scene Sync, click "AIにリンク", then send the 6-digit pairing code here.
+```
+
+#### Recommended conversation starters
+
+Use starters that teach the user what to do:
+
+```text
+リンク方法を教えて
+```
+
+```text
+Scene Sync の6桁コードを入力します
+```
+
+```text
+今のシーンに何がありますか？
+```
+
+```text
+サンプルキューブを動かして
+```
+
+Avoid starters that assume the GPT is already linked unless they clearly imply a linked state.
+
+#### Recommended GPT instructions
+
+Include this behavior in the GPT instructions:
+
+```text
+When the user starts a new conversation and has not provided a pairing code or sessionId yet, briefly guide them to link Scene Sync first.
+
+Explain the flow:
+1. Open Scene Sync.
+2. Click "AIにリンク".
+3. Copy the 6-digit code.
+4. Send the code in this chat.
+
+If the user sends a 6-digit code, redeem it immediately using scene_sync_redeem.
+After a successful link, say that the room is ready and suggest 2-3 example commands.
+
+Do not say that the scene is controllable until the link is actually redeemed.
+If an API response has peers: 0 or userPresent: false, explain that the AI session exists but the browser may not be connected to the same room.
+```
+
+Japanese version:
+
+```text
+新しい会話で、まだ pairing code または sessionId がない場合は、最初に Scene Sync とのリンク方法を短く案内する。
+
+案内する手順:
+1. Scene Sync を開く
+2. 「AIにリンク」を押す
+3. 表示された6桁コードをコピーする
+4. このチャットにコードを送る
+
+ユーザーが6桁コードを送った場合は、すぐに scene_sync_redeem を実行する。
+リンク成功後は、操作準備ができたことを伝え、使えるコマンド例を2〜3個だけ提示する。
+
+実際にリンクが成功するまでは「操作できます」と断言しない。
+APIレスポンスで peers: 0 または userPresent: false の場合は、「AIセッションは作成されたが、ブラウザが同じルームに接続されていない可能性がある」と説明する。
+```
+
+#### First response template
+
+When the GPT has no active session yet, it should start with a short guide like:
+
+```text
+Scene Sync Operator へようこそ。
+
+まず Scene Sync とリンクしてください。
+
+1. Scene Sync の画面を開く
+2. 左上の「AIにリンク」を押す
+3. 表示された6桁コードをこのチャットに送る
+
+リンク後は、たとえば次のように操作できます。
+
+- 「今のシーンに何がありますか？」
+- 「青い箱を追加して右に置いて」
+- 「サンプルキューブを赤くして少し大きくして」
+- 「選択中のオブジェクトを回転させて」
+
+6桁コードを送ってください。
+```
+
+#### Linked-state response template
+
+After `scene_sync_redeem` succeeds, respond like:
+
+```text
+リンクしました。
+
+Room ID: `{roomId}`
+セッション有効期限: `{expiresAt}`
+
+Scene Sync の操作準備ができています。たとえば次のように頼めます。
+
+- 「今のシーンに何がありますか？」
+- 「青い箱を追加して右に置いて」
+- 「サンプルキューブを赤くして少し大きくして」
+```
+
+Only use this wording after redeem succeeds.
+
+If the later operation response has `peers: 0` or `userPresent: false`, do not say the browser is connected. Explain the possible room/browser mismatch instead.
 
 ### MCP
 

--- a/docs/scene-sync-gpt-openapi.yaml
+++ b/docs/scene-sync-gpt-openapi.yaml
@@ -13,6 +13,7 @@ paths:
     post:
       operationId: redeemGptLink
       summary: Redeem a 6-digit pairing code and create a GPT session
+      description: Redeem a 6-digit pairing code shown by the Scene Sync "AIにリンク" dialog and create an AI session for that room.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary

- Add user-facing GPT profile guidance for Scene Sync Operator.
- Document recommended description, conversation starters, and initial instructions.
- Clarify that users must first link Scene Sync by sending the 6-digit pairing code.
- Add guidance for handling `peers: 0` and `userPresent: false`.

## Why

The current GPT profile does not clearly tell users what to do first. First-time users need an obvious path:

1. Open Scene Sync.
2. Click "AIにリンク".
3. Send the 6-digit code to the GPT.
4. Start operating the scene.

## Testing

- Documentation-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_013v9BCjjFHku8L4BynNaUkh)_