### PR TITLE
Use authored GLB orientation in Scene Sync clients

### DIFF
--- a/docs/scene-sync-glb-orientation.md
+++ b/docs/scene-sync-glb-orientation.md
@@ -1,0 +1,25 @@
+# Scene Sync GLB orientation
+
+Scene Sync treats imported GLB assets as authored assets.
+
+Clients must not apply a fixed, client-specific yaw correction such as `rotateY(Math.PI)` or `rotate_y(PI)` when displaying a `meshPath` GLB.
+
+Object orientation is represented by the Scene Sync wire `rotation` field. The GLB bytes and the authored local orientation inside the GLB should remain unchanged.
+
+## Why
+
+A fixed display-only yaw correction makes different clients disagree about the same object orientation. This is especially risky when Web, Godot, Unity, Blender, and AI-controlled scene updates share one room.
+
+The correct model is:
+
+- GLB local orientation: authored in the asset file
+- Scene object orientation: represented by `rotation`
+- Engine coordinate conversion: handled only at protocol import/export boundaries when required
+
+## Compatibility note
+
+This is a breaking display behavior change for active rooms created by older clients.
+
+Scene Sync rooms are ephemeral and blob assets are temporary, so no persistent migration is provided.
+
+If a GLB appears reversed after mixed-client use, refresh the room after all clients are updated or re-upload the affected GLB. Mixed-client rooms may show different orientations until all clients use the authored-orientation behavior.

--- a/godot/addons/scene_sync/gltf_helper.gd
+++ b/godot/addons/scene_sync/gltf_helper.gd
@@ -53,13 +53,11 @@ static func import_glb(data: PackedByteArray) -> Node3D:
     _print_node_tree(scene, "  ")
 
     # GLB バイト列は改変しない。
-    # Godot の glTF instantiate 結果だけが他クライアントと前後反転するため、
-    # 受信表示用のコンテナ配下で見た目補正を持たせる。
+    # Scene Sync では meshPath GLB の authored orientation をそのまま使う。
+    # クライアント個別の見た目補正は wire rotation と二重化して不整合を生むため行わない。
     var container := Node3D.new()
     container.name = "ImportedGlb"
     container.add_child(scene)
-    if scene is Node3D:
-        (scene as Node3D).rotate_y(PI)
     return container
 
 

--- a/html/assets/js/scenesync/loaders/glb-file-loader.js
+++ b/html/assets/js/scenesync/loaders/glb-file-loader.js
@@ -37,8 +37,9 @@ export class GLBFileLoader {
 
   _buildModel(gltf, position) {
     const wrapper = new THREE.Group();
+    // Scene Sync treats meshPath GLBs as authored assets.
+    // Do not add client-specific yaw fixes here; object rotation comes from wire transforms.
     wrapper.add(gltf.scene);
-    gltf.scene.rotateY(Math.PI);
 
     wrapper.updateMatrixWorld(true);
     const box = new THREE.Box3().setFromObject(wrapper);


### PR DESCRIPTION
## Summary

- Remove the fixed `Math.PI` yaw correction from the Web GLB loader.
- Remove the fixed `PI` yaw correction from the Godot GLB helper.
- Document that Scene Sync treats `meshPath` GLBs as authored assets and represents object orientation only through the wire `rotation` field.

## Why

Scene Sync should not apply client-specific display-only yaw fixes to GLB assets. Doing so makes Web, Godot, Unity, Blender, and AI-driven scene updates disagree about the same object orientation.

The intended model is:

- GLB local orientation comes from the authored asset.
- Scene object orientation comes from the Scene Sync `rotation` field.
- Engine coordinate conversion belongs at protocol import/export boundaries, not as a hidden per-client visual correction.

## Compatibility

This may change display orientation for active rooms created by older clients. Scene Sync rooms are ephemeral and blob assets are temporary, so no persistent migration is provided. Affected GLBs should be re-uploaded after all clients are updated.

## Testing

- Not run locally in this environment.
- Recommended manual check: import the same directional GLB in Web and Godot and confirm both face the authored direction without extra 180-degree yaw compensation.