### PR TITLE
Experiment/fix unity glb visual orientation

### DIFF
--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -175,6 +175,34 @@ glB ファイルをサーバー側に一時保存する HTTP エンドポイン�
     }
 
 `meshPath` がある場合、`<BLOB_BASE>/<meshPath>` から glB を取得する。
+blob store は一時保存なので、TTL 切れ等で取得できない場合がある。その場合、受信側は同室の他クライアントへ `scene-mesh-request` を送り、対象オブジェクトを再 export / re-upload してもらう。
+
+### `scene-mesh-request`（blob 再送要求）
+
+`meshPath` の glB が blob store に存在しない、または取得に失敗した場合に送る。
+
+    {
+      "kind": "scene-mesh-request",
+      "objectId": "obj-001",
+      "meshPath": "expired123",
+      "reason": "blob-missing"
+    }
+
+受信したクライアントは対象 `objectId` を持っていれば GLB を再 export し、新しい blob に upload してリクエスト元へ `scene-mesh` を返す。
+
+### `scene-mesh`（メッシュ差し替え）
+
+対象オブジェクトの GLB を新しい blob path で通知する。既存オブジェクトがある場合、受信側は現在の transform を維持して mesh だけ差し替える。
+
+    {
+      "kind": "scene-mesh",
+      "objectId": "obj-001",
+      "name": "Robot",
+      "meshPath": "fresh456",
+      "position": [0, 0, 0],
+      "rotation": [0, 0, 0, 1],
+      "scale": [1, 1, 1]
+    }
 
 ### `scene-delta`（プロパティ差分）
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1859,6 +1859,7 @@ let activeRoomCode = sanitizeRoomCode(new URLSearchParams(location.search).get('
 let sceneReceived = false;
 let sceneRequestTimer = null;
 let sceneRequestAttempt = 0;
+const pendingMeshRequests = new Set();
 let reconnectTimer = null;
 const sceneInspectorState = {
   isOpen: false,
@@ -2309,6 +2310,65 @@ async function respondToSceneRequest(from) {
   }
 }
 
+function requestMeshFromPeers(objectId, meshPath, reason = 'blob-missing') {
+  if (!objectId || pendingMeshRequests.has(objectId)) return;
+
+  const peers = presenceState.peers.filter(p => p.id !== presenceState.id);
+  if (peers.length === 0) return;
+
+  const ws = presenceState.ws;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+  pendingMeshRequests.add(objectId);
+  console.warn('[SceneSync] Requesting mesh reupload from peers:', objectId, meshPath || '');
+
+  for (const peer of peers) {
+    ws.send(JSON.stringify({
+      type: 'handoff',
+      targetId: peer.id,
+      payload: {
+        kind: 'scene-mesh-request',
+        objectId,
+        meshPath,
+        reason,
+      },
+    }));
+  }
+
+  setTimeout(() => pendingMeshRequests.delete(objectId), 10000);
+}
+
+async function respondToSceneMeshRequest(from, payload) {
+  const objectId = payload?.objectId;
+  const obj = objectId ? managedObjects.get(objectId) : null;
+  if (!from?.id || !objectId || !obj) return;
+
+  try {
+    const arrayBuffer = await exportObjectAsGlb(obj);
+    const meshPath = await uploadCarrierGlb(arrayBuffer);
+    obj.userData.meshPath = meshPath;
+
+    const ws = presenceState.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    ws.send(JSON.stringify({
+      type: 'handoff',
+      targetId: from.id,
+      payload: {
+        kind: 'scene-mesh',
+        objectId,
+        name: obj.userData.name || obj.name || objectId,
+        position: obj.position.toArray(),
+        rotation: obj.quaternion.toArray(),
+        scale: obj.scale.toArray(),
+        meshPath,
+      },
+    }));
+  } catch (error) {
+    console.warn('[SceneSync] Failed to respond to scene-mesh-request:', objectId, error);
+  }
+}
+
 // ── Handoff 受信（Scene Sync 用） ────────────────────────
 
 function handleHandoff(data) {
@@ -2358,6 +2418,10 @@ function handleHandoff(data) {
     }
     case 'scene-request': {
       respondToSceneRequest(data.from);
+      break;
+    }
+    case 'scene-mesh-request': {
+      respondToSceneMeshRequest(data.from, payload);
       break;
     }
     case 'scene-delta': {
@@ -2465,6 +2529,7 @@ function handleHandoff(data) {
 
       glbLoader.loadFromUrl(url, initialPosition, scene, (model) => {
         removeLoadingOverlay(payload.objectId);
+        pendingMeshRequests.delete(payload.objectId);
         model.userData.objectId = payload.objectId;
         model.userData.name = obj?.userData?.name || payload.name || payload.meshPath;
         model.userData.meshPath = payload.meshPath;
@@ -2485,6 +2550,7 @@ function handleHandoff(data) {
         removeLoadingOverlay(payload.objectId);
         // glB ロード失敗時のフォールバック
         console.warn('Failed to load mesh:', err);
+        requestMeshFromPeers(payload.objectId, payload.meshPath, 'scene-mesh-load-failed');
         // 既存オブジェクトがあれば使用し続ける、なければ Box を生成
         if (!obj) {
           const geo = new THREE.BoxGeometry(1, 1, 1);
@@ -2952,6 +3018,7 @@ function loadMeshObject(objectId, info, meshPath, existing) {
 
   glbLoader.loadFromUrl(url, initialPosition, scene, (model) => {
     removeLoadingOverlay(objectId);
+    pendingMeshRequests.delete(objectId);
     model.userData.objectId = objectId;
     model.userData.name = info.name;
     model.userData.meshPath = meshPath;
@@ -2969,6 +3036,7 @@ function loadMeshObject(objectId, info, meshPath, existing) {
   }).catch((err) => {
     removeLoadingOverlay(objectId);
     console.warn('Failed to load mesh for', objectId, ':', err);
+    requestMeshFromPeers(objectId, meshPath, 'scene-state-mesh-load-failed');
     if (!existing) {
       replaceManagedObject(objectId, buildDefaultBoxObject(objectId, info, 0xff4444), info);
       return;

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -31,6 +31,9 @@ namespace Afjk.SceneSync.Editor
         private Dictionary<string, string> _locks = new Dictionary<string, string>(); // objectId → lockOwnerId
         private string _currentlyLockedObjectId;
         private Dictionary<string, string> _meshPaths = new Dictionary<string, string>(); // objectId → meshPath
+        private Dictionary<string, string> _hierarchySignatures = new Dictionary<string, string>(); // objectId → child mesh structure
+        private HashSet<string> _pendingMeshResyncObjectIds = new HashSet<string>();
+        private HashSet<string> _pendingMeshRequestObjectIds = new HashSet<string>();
         private bool _sceneReceived = false;
         private bool _firstPeersReceived = false;
         private Dictionary<int, string> _instanceToObjectId = new Dictionary<int, string>(); // Unity InstanceID → 元の objectId
@@ -246,11 +249,24 @@ namespace Afjk.SceneSync.Editor
 
                 var id = instanceId.ToString();
                 currentIds.Add(id);
+                var hierarchySignature = BuildHierarchySignature(go);
 
                 if (!_knownObjectIds.Contains(id))
                 {
                     // 新規オブジェクト
+                    _hierarchySignatures[id] = hierarchySignature;
                     _ = SendSceneAdd(go);
+                }
+                else if (_hierarchySignatures.TryGetValue(id, out var lastHierarchySignature))
+                {
+                    if (lastHierarchySignature != hierarchySignature && !_pendingMeshResyncObjectIds.Contains(id))
+                    {
+                        _ = SendSceneMesh(go, id, hierarchySignature);
+                    }
+                }
+                else
+                {
+                    _hierarchySignatures[id] = hierarchySignature;
                 }
             }
 
@@ -261,6 +277,7 @@ namespace Afjk.SceneSync.Editor
                 {
                     _ = SendSceneRemove(id);
                     _meshPaths.Remove(id);
+                    _hierarchySignatures.Remove(id);
                     _locks.Remove(id);
                 }
             }
@@ -276,6 +293,31 @@ namespace Afjk.SceneSync.Editor
                 _instanceToObjectId.Remove(key);
 
             _knownObjectIds = currentIds;
+        }
+
+        private static string BuildHierarchySignature(GameObject go)
+        {
+            var builder = new System.Text.StringBuilder();
+            AppendHierarchySignature(go.transform, builder);
+            return builder.ToString();
+        }
+
+        private static void AppendHierarchySignature(Transform transform, System.Text.StringBuilder builder)
+        {
+            var go = transform.gameObject;
+            builder.Append(go.GetInstanceID())
+                .Append(':')
+                .Append(go.name)
+                .Append(':')
+                .Append(go.GetComponents<MeshFilter>().Length)
+                .Append(':')
+                .Append(go.GetComponents<SkinnedMeshRenderer>().Length)
+                .Append(':')
+                .Append(transform.childCount)
+                .Append(';');
+
+            foreach (Transform child in transform)
+                AppendHierarchySignature(child, builder);
         }
 
         private void OnHandoff(string raw)
@@ -315,6 +357,11 @@ namespace Afjk.SceneSync.Editor
             else if (raw.Contains("\"kind\":\"scene-mesh\""))
             {
                 HandleSceneMesh(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-mesh-request\""))
+            {
+                if (fromId != null)
+                    _ = HandleSceneMeshRequest(fromId, raw);
             }
             else if (raw.Contains("\"kind\":\"scene-lock\""))
             {
@@ -489,6 +536,101 @@ namespace Afjk.SceneSync.Editor
             await _client.Broadcast(payload);
         }
 
+        private async System.Threading.Tasks.Task SendSceneMesh(
+            GameObject go,
+            string objectId,
+            string hierarchySignature = null)
+        {
+            if (go == null || string.IsNullOrEmpty(objectId)) return;
+            if (_pendingMeshResyncObjectIds.Contains(objectId)) return;
+
+            _pendingMeshResyncObjectIds.Add(objectId);
+            try
+            {
+                var glb = await PresenceClient.ExportGameObjectAsGlb(go);
+                if (glb == null) return;
+
+                var path = PresenceClient.GenerateRandomPath();
+                _meshPaths[objectId] = path;
+                await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
+
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + path + "\"}";
+                await _client.Broadcast(payload);
+
+                if (hierarchySignature != null)
+                    _hierarchySignatures[objectId] = hierarchySignature;
+            }
+            finally
+            {
+                _pendingMeshResyncObjectIds.Remove(objectId);
+            }
+        }
+
+        private async System.Threading.Tasks.Task SendSceneMeshToPeer(
+            string targetPeerId,
+            GameObject go,
+            string objectId)
+        {
+            if (string.IsNullOrEmpty(targetPeerId) || go == null || string.IsNullOrEmpty(objectId)) return;
+
+            var glb = await PresenceClient.ExportGameObjectAsGlb(go);
+            if (glb == null) return;
+
+            var path = PresenceClient.GenerateRandomPath();
+            _meshPaths[objectId] = path;
+            await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
+
+            var pos = go.transform.position;
+            var rot = go.transform.rotation;
+            var scl = go.transform.localScale;
+            var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"name\":\"" + go.name + "\"" +
+                ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
+                ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
+                ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
+                ",\"meshPath\":\"" + path + "\"}";
+            await _client.SendHandoff(targetPeerId, payload);
+        }
+
+        private async System.Threading.Tasks.Task HandleSceneMeshRequest(string fromId, string raw)
+        {
+            var objectIdMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"objectId\":\"([^\"]+)\"");
+            if (!objectIdMatch.Success) return;
+
+            var objectId = objectIdMatch.Groups[1].Value;
+            var go = FindManagedObject(objectId);
+            if (go == null) return;
+
+            await SendSceneMeshToPeer(fromId, go, objectId);
+        }
+
+        private void RequestSceneMeshFromPeers(string objectId, string meshPath)
+        {
+            if (string.IsNullOrEmpty(objectId)) return;
+            if (_pendingMeshRequestObjectIds.Contains(objectId)) return;
+
+            var sent = false;
+            foreach (var peer in _peers)
+            {
+                if (peer.id == _client.Id) continue;
+                sent = true;
+                _ = _client.SendHandoff(peer.id,
+                    "{\"kind\":\"scene-mesh-request\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + meshPath + "\"}");
+            }
+
+            if (sent)
+            {
+                _pendingMeshRequestObjectIds.Add(objectId);
+                _ = ClearPendingMeshRequestLater(objectId);
+            }
+        }
+
+        private async System.Threading.Tasks.Task ClearPendingMeshRequestLater(string objectId)
+        {
+            await System.Threading.Tasks.Task.Delay(10000);
+            _pendingMeshRequestObjectIds.Remove(objectId);
+        }
+
         private void HandleSceneAdd(string raw)
         {
             var objectIdMatch = System.Text.RegularExpressions.Regex.Match(
@@ -566,6 +708,7 @@ namespace Afjk.SceneSync.Editor
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
+            _pendingMeshRequestObjectIds.Remove(objectId);
 
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
@@ -750,6 +893,7 @@ namespace Afjk.SceneSync.Editor
                 if (!response.IsSuccessStatusCode)
                 {
                     Debug.LogWarning("[SceneSync] Download failed: " + response.StatusCode);
+                    RequestSceneMeshFromPeers(objectId, meshPath);
                     // フォールバック: Cube を作成
                     var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     fallback.name = name;
@@ -803,6 +947,7 @@ namespace Afjk.SceneSync.Editor
             catch (Exception ex)
             {
                 Debug.LogWarning("[SceneSync] DownloadAndCreate failed: " + ex.Message);
+                RequestSceneMeshFromPeers(objectId, meshPath);
             }
         }
 

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1038,6 +1038,16 @@ namespace Afjk.SceneSync
                     var placeholderInstanceId = placeholder.GetInstanceID();
 
                     var go = new GameObject(name);
+                    var importedGlbRoot = new GameObject("ImportedGlbRoot");
+                    importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
+
+                    // Scene Sync stores object rotation in wire space.
+                    // GLB assets are authored in glTF/Web space, but Unity imports them into Unity space.
+                    // Keep the synchronized object transform on the parent and apply this asset-local
+                    // correction only to the imported visual root.
+                    importedGlbRoot.transform.localPosition = Vector3.zero;
+                    importedGlbRoot.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                    importedGlbRoot.transform.localScale = Vector3.one;
 
                     // プレースホルダーのマッピングを新オブジェクトに移動
                     _instanceToObjectId.Remove(placeholderInstanceId);
@@ -1045,9 +1055,9 @@ namespace Afjk.SceneSync
                     _managedObjects[objectId] = go;
 
                     Debug.Log(
-                        "[SceneSync] Instantiating glTF main scene: parent=" + DescribeGameObject(go)
+                        "[SceneSync] Instantiating glTF main scene: parent=" + DescribeGameObject(importedGlbRoot)
                         + ", placeholder=" + DescribeGameObject(placeholder));
-                    await gltf.InstantiateMainSceneAsync(go.transform);
+                    await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);
                     ApplyFallbackMaterialToRenderers(go, replaceAll: false, reason: "post-import broken materials");
 
                     // 位置・回転・スケールを設定（SetParent の前）

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -29,6 +29,9 @@ namespace Afjk.SceneSync
         private Dictionary<string, string> _locks = new Dictionary<string, string>(); // objectId → lockOwnerId
         private string _currentlyLockedObjectId;
         private Dictionary<string, string> _meshPaths = new Dictionary<string, string>(); // objectId → meshPath
+        private Dictionary<string, string> _hierarchySignatures = new Dictionary<string, string>(); // objectId → child mesh structure
+        private HashSet<string> _pendingMeshResyncObjectIds = new HashSet<string>();
+        private HashSet<string> _pendingMeshRequestObjectIds = new HashSet<string>();
         private bool _sceneReceived = false;
         private bool _firstPeersReceived = false;
         private Dictionary<int, string> _instanceToObjectId = new Dictionary<int, string>(); // Unity InstanceID → 元の objectId
@@ -304,11 +307,24 @@ namespace Afjk.SceneSync
 
                 var id = instanceId.ToString();
                 currentIds.Add(id);
+                var hierarchySignature = BuildHierarchySignature(go);
 
                 if (!_knownObjectIds.Contains(id))
                 {
                     // 新規オブジェクト
+                    _hierarchySignatures[id] = hierarchySignature;
                     _ = SendSceneAdd(go);
+                }
+                else if (_hierarchySignatures.TryGetValue(id, out var lastHierarchySignature))
+                {
+                    if (lastHierarchySignature != hierarchySignature && !_pendingMeshResyncObjectIds.Contains(id))
+                    {
+                        _ = SendSceneMesh(go, id, hierarchySignature);
+                    }
+                }
+                else
+                {
+                    _hierarchySignatures[id] = hierarchySignature;
                 }
             }
 
@@ -319,6 +335,7 @@ namespace Afjk.SceneSync
                 {
                     _ = SendSceneRemove(id);
                     _meshPaths.Remove(id);
+                    _hierarchySignatures.Remove(id);
                     _locks.Remove(id);
                 }
             }
@@ -334,6 +351,31 @@ namespace Afjk.SceneSync
                 _instanceToObjectId.Remove(key);
 
             _knownObjectIds = currentIds;
+        }
+
+        private static string BuildHierarchySignature(GameObject go)
+        {
+            var builder = new System.Text.StringBuilder();
+            AppendHierarchySignature(go.transform, builder);
+            return builder.ToString();
+        }
+
+        private static void AppendHierarchySignature(Transform transform, System.Text.StringBuilder builder)
+        {
+            var go = transform.gameObject;
+            builder.Append(go.GetInstanceID())
+                .Append(':')
+                .Append(go.name)
+                .Append(':')
+                .Append(go.GetComponents<MeshFilter>().Length)
+                .Append(':')
+                .Append(go.GetComponents<SkinnedMeshRenderer>().Length)
+                .Append(':')
+                .Append(transform.childCount)
+                .Append(';');
+
+            foreach (Transform child in transform)
+                AppendHierarchySignature(child, builder);
         }
 
         private static bool IsSyncTarget(GameObject go)
@@ -385,6 +427,101 @@ namespace Afjk.SceneSync
             OnObjectRemoved?.Invoke(objectId);
         }
 
+        private async System.Threading.Tasks.Task SendSceneMesh(
+            GameObject go,
+            string objectId,
+            string hierarchySignature = null)
+        {
+            if (go == null || string.IsNullOrEmpty(objectId)) return;
+            if (_pendingMeshResyncObjectIds.Contains(objectId)) return;
+
+            _pendingMeshResyncObjectIds.Add(objectId);
+            try
+            {
+                var glb = await PresenceClientRuntime.ExportGameObjectAsGlb(go);
+                if (glb == null) return;
+
+                var path = PresenceClientRuntime.GenerateRandomPath();
+                _meshPaths[objectId] = path;
+                await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + path + "\"}";
+                await _client.Broadcast(payload);
+
+                if (hierarchySignature != null)
+                    _hierarchySignatures[objectId] = hierarchySignature;
+            }
+            finally
+            {
+                _pendingMeshResyncObjectIds.Remove(objectId);
+            }
+        }
+
+        private async System.Threading.Tasks.Task SendSceneMeshToPeer(
+            string targetPeerId,
+            GameObject go,
+            string objectId)
+        {
+            if (string.IsNullOrEmpty(targetPeerId) || go == null || string.IsNullOrEmpty(objectId)) return;
+
+            var glb = await PresenceClientRuntime.ExportGameObjectAsGlb(go);
+            if (glb == null) return;
+
+            var path = PresenceClientRuntime.GenerateRandomPath();
+            _meshPaths[objectId] = path;
+            await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+
+            var pos = go.transform.position;
+            var rot = go.transform.rotation;
+            var scl = go.transform.localScale;
+            var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"name\":\"" + go.name + "\"" +
+                ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
+                ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
+                ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
+                ",\"meshPath\":\"" + path + "\"}";
+            await _client.SendHandoff(targetPeerId, payload);
+        }
+
+        private async System.Threading.Tasks.Task HandleSceneMeshRequest(string fromId, string raw)
+        {
+            var objectIdMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"objectId\":\"([^\"]+)\"");
+            if (!objectIdMatch.Success) return;
+
+            var objectId = objectIdMatch.Groups[1].Value;
+            var go = FindManagedObject(objectId);
+            if (go == null) return;
+
+            await SendSceneMeshToPeer(fromId, go, objectId);
+        }
+
+        private void RequestSceneMeshFromPeers(string objectId, string meshPath)
+        {
+            if (string.IsNullOrEmpty(objectId)) return;
+            if (_pendingMeshRequestObjectIds.Contains(objectId)) return;
+
+            var sent = false;
+            foreach (var peer in _peers)
+            {
+                if (peer.id == _client.Id) continue;
+                sent = true;
+                _ = _client.SendHandoff(peer.id,
+                    "{\"kind\":\"scene-mesh-request\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + meshPath + "\"}");
+            }
+
+            if (sent)
+            {
+                _pendingMeshRequestObjectIds.Add(objectId);
+                _ = ClearPendingMeshRequestLater(objectId);
+            }
+        }
+
+        private async System.Threading.Tasks.Task ClearPendingMeshRequestLater(string objectId)
+        {
+            await System.Threading.Tasks.Task.Delay(10000);
+            _pendingMeshRequestObjectIds.Remove(objectId);
+        }
+
         private void OnHandoff(string raw)
         {
             if (!raw.Contains("\"kind\"")) return;
@@ -422,6 +559,11 @@ namespace Afjk.SceneSync
             else if (raw.Contains("\"kind\":\"scene-mesh\""))
             {
                 HandleSceneMesh(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-mesh-request\""))
+            {
+                if (fromId != null)
+                    _ = HandleSceneMeshRequest(fromId, raw);
             }
             else if (raw.Contains("\"kind\":\"scene-lock\""))
             {
@@ -655,6 +797,7 @@ namespace Afjk.SceneSync
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
+            _pendingMeshRequestObjectIds.Remove(objectId);
 
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
@@ -989,6 +1132,7 @@ namespace Afjk.SceneSync
                         + ", objectId=" + objectId
                         + ", name=" + name
                         + ", meshPath=" + meshPath);
+                    RequestSceneMeshFromPeers(objectId, meshPath);
                     var fallback = ReplaceWithFallbackPrimitive(objectId, name, position, rotation, scale);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
@@ -1106,6 +1250,7 @@ namespace Afjk.SceneSync
                     + ", meshPath=" + meshPath
                     + ", managedState=" + DescribeManagedObjectState(objectId)
                     + "\n" + ex);
+                RequestSceneMeshFromPeers(objectId, meshPath);
 
                 if (_managedObjects.TryGetValue(objectId, out var currentObject) && currentObject != null)
                 {


### PR DESCRIPTION
## Summary

- Add `scene-mesh-request` fallback for expired/missing Scene Sync blob GLBs
- Re-export and re-upload meshes from other room participants when blob download fails
- Detect child hierarchy changes under synced Unity objects and broadcast refreshed `scene-mesh`
- Document the mesh re-request flow in `scene-sync-spec.md`

## Verification

- `node --check html/assets/js/scenesync/scene.js`
- `git diff --check`

## Notes

- `apps/presence-server` tests could not run because `ws` is not installed in the local `node_modules`.
- `uloop compile` could not run because this repo contains the Unity package, not a Unity project with `ProjectSettings`.
