### PR TITLE
Align Unity Editor GLB orientation with runtime

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -779,7 +779,16 @@ namespace Afjk.SceneSync.Editor
                 if (success)
                 {
                     var go = new GameObject(name);
-                    await gltf.InstantiateMainSceneAsync(go.transform);
+                    var importedGlbRoot = new GameObject("ImportedGlbRoot");
+                    importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
+
+                    // Keep the synchronized object transform on the parent and apply the
+                    // same Unity GLB visual correction as Runtime/SceneSyncManager.
+                    importedGlbRoot.transform.localPosition = Vector3.zero;
+                    importedGlbRoot.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                    importedGlbRoot.transform.localScale = Vector3.one;
+
+                    await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);
                     ApplyTransform(go, position, rotation, scale);
                     _managedObjects[objectId] = go;
                     _knownObjectIds.Add(objectId);


### PR DESCRIPTION
## Summary
- Instantiate EditorWindow GLB visuals under an `ImportedGlbRoot` child.
- Apply the same `Quaternion.Euler(0f, 180f, 0f)` visual correction used by Runtime while keeping the Scene Sync transform on the parent object.

## Verification
- `git diff --check`
- `uloop get-project-info` could not run Unity verification from this workspace root because no Unity project was found.

Manual EditorWindow verification still needed in a Unity project:
1. Open Scene Sync from Unity EditorWindow.
2. Request scene from Web.
3. Confirm hierarchy `Duck > ImportedGlbRoot > Node-0`.
4. Confirm GLBs face the same direction in Unity Editor and Web.
5. Confirm Scene Sync transform remains on the synchronized root and visual correction only on `ImportedGlbRoot`.