### PR TITLE
Add Scene Sync identity metadata

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -651,6 +651,7 @@ namespace Afjk.SceneSync.Editor
                 // メッシュなしの場合はプレースホルダーの Cube を作成
                 var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 go.name = name;
+                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
                 ApplyTransform(go, position, rotation, scale);
                 _managedObjects[objectId] = go;
                 _knownObjectIds.Add(objectId);
@@ -877,6 +878,7 @@ namespace Afjk.SceneSync.Editor
                     // フォールバック: Cube を作成
                     var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     fallback.name = name;
+                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;
                     _knownObjectIds.Add(objectId);
@@ -903,6 +905,7 @@ namespace Afjk.SceneSync.Editor
                 if (success)
                 {
                     var go = new GameObject(name);
+                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
 
@@ -924,6 +927,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
                     var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     fallback.name = name;
+                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;
                     _knownObjectIds.Add(objectId);
@@ -937,6 +941,23 @@ namespace Afjk.SceneSync.Editor
             {
                 Debug.LogWarning("[SceneSync] DownloadAndCreate failed: " + ex.Message);
             }
+        }
+
+        private static SceneSyncIdentity EnsureSceneSyncIdentity(GameObject go)
+        {
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity == null)
+            {
+                identity = go.AddComponent<SceneSyncIdentity>();
+            }
+
+            return identity;
+        }
+
+        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath)
+        {
+            var identity = EnsureSceneSyncIdentity(go);
+            identity.ConfigureRemoteTemporary(objectId, meshPath);
         }
 
         private struct TransformSnapshot

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+
+namespace Afjk.SceneSync
+{
+    public enum SceneSyncOrigin
+    {
+        Unknown,
+        Unity,
+        Remote
+    }
+
+    public enum SceneSyncState
+    {
+        Synced,
+        Dirty,
+        Pending,
+        Locked,
+        Error,
+        Disconnected
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncIdentity : MonoBehaviour
+    {
+        [SerializeField] private string objectId;
+        [SerializeField] private string meshPath;
+        [SerializeField] private SceneSyncOrigin origin = SceneSyncOrigin.Unknown;
+        [SerializeField] private bool temporary;
+        [SerializeField] private SceneSyncState state = SceneSyncState.Synced;
+        [SerializeField] private string lockOwner;
+
+        public string ObjectId
+        {
+            get => objectId;
+            set => objectId = value;
+        }
+
+        public string MeshPath
+        {
+            get => meshPath;
+            set => meshPath = value;
+        }
+
+        public SceneSyncOrigin Origin
+        {
+            get => origin;
+            set => origin = value;
+        }
+
+        public bool Temporary
+        {
+            get => temporary;
+            set => temporary = value;
+        }
+
+        public SceneSyncState State
+        {
+            get => state;
+            set => state = value;
+        }
+
+        public string LockOwner
+        {
+            get => lockOwner;
+            set => lockOwner = value;
+        }
+
+        public void ConfigureRemoteTemporary(string newObjectId, string newMeshPath)
+        {
+            objectId = newObjectId;
+            meshPath = newMeshPath;
+            origin = SceneSyncOrigin.Remote;
+            temporary = true;
+            state = SceneSyncState.Synced;
+            lockOwner = null;
+        }
+
+        public void ConfigureUnityManaged(string newObjectId)
+        {
+            objectId = newObjectId;
+            origin = SceneSyncOrigin.Unity;
+            temporary = false;
+            state = SceneSyncState.Synced;
+            lockOwner = null;
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9d54b54c15f459495b99ff89afdb7e6

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -606,6 +606,7 @@ namespace Afjk.SceneSync
                 // メッシュなしの場合は Cube を作成
                 var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 go.name = name;
+                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
 
                 _managedObjects[objectId] = go;
                 _knownObjectIds.Add(objectId);
@@ -926,6 +927,7 @@ namespace Afjk.SceneSync
         private GameObject ReplaceWithFallbackPrimitive(
             string objectId,
             string name,
+            string meshPath,
             float[] position,
             float[] rotation,
             float[] scale)
@@ -935,6 +937,7 @@ namespace Afjk.SceneSync
 
             var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
             fallback.name = name;
+            ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
 
             var fallbackMaterial = GetFallbackImportMaterial();
             var fallbackRenderer = fallback.GetComponent<Renderer>();
@@ -989,7 +992,7 @@ namespace Afjk.SceneSync
                         + ", objectId=" + objectId
                         + ", name=" + name
                         + ", meshPath=" + meshPath);
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -1038,6 +1041,7 @@ namespace Afjk.SceneSync
                     var placeholderInstanceId = placeholder.GetInstanceID();
 
                     var go = new GameObject(name);
+                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
 
@@ -1087,7 +1091,7 @@ namespace Afjk.SceneSync
                         + ", loadingError=" + gltf.LoadingError
                         + ", sceneCount=" + gltf.SceneCount
                         + ", defaultScene=" + (gltf.DefaultSceneIndex.HasValue ? gltf.DefaultSceneIndex.Value.ToString() : "null"));
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
                     OnObjectAdded?.Invoke(objectId, fallback);
                 }
 
@@ -1127,7 +1131,7 @@ namespace Afjk.SceneSync
 
                 if (_managedObjects.ContainsKey(objectId))
                 {
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -1135,6 +1139,23 @@ namespace Afjk.SceneSync
                 if (!_managedObjects.ContainsKey(objectId))
                     _knownObjectIds.Remove(objectId);
             }
+        }
+
+        private static SceneSyncIdentity EnsureSceneSyncIdentity(GameObject go)
+        {
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity == null)
+            {
+                identity = go.AddComponent<SceneSyncIdentity>();
+            }
+
+            return identity;
+        }
+
+        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath)
+        {
+            var identity = EnsureSceneSyncIdentity(go);
+            identity.ConfigureRemoteTemporary(objectId, meshPath);
         }
 
         private struct TransformSnapshot


### PR DESCRIPTION
## Summary
- add Runtime SceneSyncIdentity component with serialized metadata fields and accessors
- attach SceneSyncIdentity to remote/incoming object roots in Runtime SceneSyncManager paths
- attach SceneSyncIdentity to remote/incoming object roots in Editor SceneSyncWindow paths

## Notes
- identity is attached only to Scene Sync root objects (not ImportedGlbRoot or child mesh nodes)
- no protocol, lock, connection, mesh upload, or transform sync behavior changes