### PR TITLE
Add managed Unity object list

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -273,6 +273,7 @@ namespace Afjk.SceneSync.Editor
             }
             if (EditorGUI.EndChangeCheck())
             {
+                manager.ValidateManagedObjects();
                 MarkManagerDirty(manager);
             }
 
@@ -291,6 +292,7 @@ namespace Afjk.SceneSync.Editor
 
                     if (changed)
                     {
+                        manager.ValidateManagedObjects();
                         MarkManagerDirty(manager);
                     }
                 }

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -180,6 +180,9 @@ namespace Afjk.SceneSync.Editor
             DrawSetupSection();
             GUILayout.Space(8);
 
+            DrawManagedUnityObjectsSection();
+            GUILayout.Space(8);
+
             _presenceUrl = EditorGUILayout.TextField("Presence URL", _presenceUrl);
             _blobUrl = EditorGUILayout.TextField("Blob URL", _blobUrl);
             _room = EditorGUILayout.TextField("Room", _room);
@@ -224,6 +227,115 @@ namespace Afjk.SceneSync.Editor
                     _client.Disconnect();
                 }
             }
+        }
+
+        private void DrawManagedUnityObjectsSection()
+        {
+            GUILayout.Label("Managed Unity Objects", EditorStyles.boldLabel);
+
+            var manager = FindSceneSyncManager();
+            if (manager == null)
+            {
+                EditorGUILayout.HelpBox(
+                    "Create a SceneSyncManager from Setup to manage Unity objects.",
+                    MessageType.Info
+                );
+                return;
+            }
+
+            EditorGUI.BeginChangeCheck();
+            var includeManagerChildren = EditorGUILayout.Toggle(
+                "Include Manager Children",
+                manager.IncludeManagerChildren
+            );
+            if (EditorGUI.EndChangeCheck())
+            {
+                manager.IncludeManagerChildren = includeManagerChildren;
+                MarkManagerDirty(manager);
+            }
+
+            var managedCount = manager.GetManagedUnityObjects().Count;
+            GUILayout.Label("Managed Unity Objects: " + managedCount);
+
+            GUILayout.Space(4);
+            GUILayout.Label("Explicit Managed Objects:", EditorStyles.label);
+
+            var list = manager.ManagedObjects;
+            EditorGUI.BeginChangeCheck();
+            for (var i = 0; i < list.Count; i++)
+            {
+                list[i] = (GameObject)EditorGUILayout.ObjectField(
+                    $"Object {i + 1}",
+                    list[i],
+                    typeof(GameObject),
+                    true
+                );
+            }
+            if (EditorGUI.EndChangeCheck())
+            {
+                MarkManagerDirty(manager);
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Add Selected"))
+                {
+                    var changed = false;
+                    foreach (var selected in Selection.gameObjects)
+                    {
+                        if (manager.AddManagedObject(selected))
+                        {
+                            changed = true;
+                        }
+                    }
+
+                    if (changed)
+                    {
+                        MarkManagerDirty(manager);
+                    }
+                }
+
+                if (GUILayout.Button("Remove Selected"))
+                {
+                    var changed = false;
+                    foreach (var selected in Selection.gameObjects)
+                    {
+                        if (manager.RemoveManagedObject(selected))
+                        {
+                            changed = true;
+                        }
+                    }
+
+                    if (changed)
+                    {
+                        MarkManagerDirty(manager);
+                    }
+                }
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Remove Missing"))
+                {
+                    var before = manager.ManagedObjects.Count;
+                    manager.RemoveNullManagedObjects();
+                    if (manager.ManagedObjects.Count != before)
+                    {
+                        MarkManagerDirty(manager);
+                    }
+                }
+
+                if (GUILayout.Button("Select SceneSyncManager"))
+                {
+                    Selection.activeGameObject = manager.gameObject;
+                }
+            }
+        }
+
+        private static void MarkManagerDirty(SceneSyncManager manager)
+        {
+            EditorUtility.SetDirty(manager);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
         }
 
         private void DrawSetupSection()

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -199,6 +199,32 @@ namespace Afjk.SceneSync
             managedObjects.RemoveAll(item => item == null);
         }
 
+        public bool ValidateManagedObjects()
+        {
+            EnsureManagedObjectsList();
+
+            var changed = false;
+            var seen = new HashSet<GameObject>();
+
+            for (var i = managedObjects.Count - 1; i >= 0; i--)
+            {
+                var go = managedObjects[i];
+
+                if (go == null)
+                {
+                    continue;
+                }
+
+                if (go == gameObject || IsTemporaryObject(go) || !seen.Add(go))
+                {
+                    managedObjects.RemoveAt(i);
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+
         public async System.Threading.Tasks.Task SyncAllMeshes()
         {
             if (!_connected) return;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -14,6 +14,8 @@ namespace Afjk.SceneSync
         [SerializeField] private string _nickname = "Unity";
         [SerializeField] private bool _autoConnect = true;
         [SerializeField] private Transform _syncRoot;
+        [SerializeField] private bool includeManagerChildren = true;
+        [SerializeField] private List<GameObject> managedObjects = new List<GameObject>();
         [SerializeField] private Transform temporaryRoot;
         [SerializeField] private Material _fallbackImportMaterial;
 
@@ -40,6 +42,17 @@ namespace Afjk.SceneSync
         public string Room => _client?.Room;
         public List<PeerInfo> Peers => _peers;
         public GameObject SelectedObject => _selectedObject;
+        public bool IncludeManagerChildren
+        {
+            get => includeManagerChildren;
+            set => includeManagerChildren = value;
+        }
+        public List<GameObject> ManagedObjects => managedObjects;
+        public Transform TemporaryRoot
+        {
+            get => temporaryRoot;
+            set => temporaryRoot = value;
+        }
 
         public event Action OnConnected;
         public event Action OnDisconnected;
@@ -116,6 +129,74 @@ namespace Afjk.SceneSync
         public void DeselectObject()
         {
             _selectedObject = null;
+        }
+
+        public List<GameObject> GetManagedUnityObjects()
+        {
+            EnsureManagedObjectsList();
+
+            var result = new List<GameObject>();
+            var seen = new HashSet<GameObject>();
+
+            void AddIfValid(GameObject go)
+            {
+                if (go == null) return;
+                if (go == gameObject) return;
+                if (IsTemporaryObject(go)) return;
+                if (!seen.Add(go)) return;
+                result.Add(go);
+            }
+
+            if (includeManagerChildren)
+            {
+                foreach (Transform child in transform)
+                {
+                    AddIfValid(child.gameObject);
+                }
+            }
+
+            foreach (var go in managedObjects)
+            {
+                AddIfValid(go);
+            }
+
+            return result;
+        }
+
+        public bool AddManagedObject(GameObject go)
+        {
+            EnsureManagedObjectsList();
+            if (go == null) return false;
+            if (go == gameObject) return false;
+            if (IsTemporaryObject(go)) return false;
+            if (managedObjects.Contains(go)) return false;
+
+            managedObjects.Add(go);
+            return true;
+        }
+
+        public bool RemoveManagedObject(GameObject go)
+        {
+            EnsureManagedObjectsList();
+            if (go == null) return false;
+
+            var removed = false;
+            for (var i = managedObjects.Count - 1; i >= 0; i--)
+            {
+                if (managedObjects[i] == go)
+                {
+                    managedObjects.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            return removed;
+        }
+
+        public void RemoveNullManagedObjects()
+        {
+            EnsureManagedObjectsList();
+            managedObjects.RemoveAll(item => item == null);
         }
 
         public async System.Threading.Tasks.Task SyncAllMeshes()
@@ -1188,6 +1269,27 @@ namespace Afjk.SceneSync
         {
             var identity = EnsureSceneSyncIdentity(go);
             identity.ConfigureRemoteTemporary(objectId, meshPath);
+        }
+
+        private void EnsureManagedObjectsList()
+        {
+            if (managedObjects == null)
+            {
+                managedObjects = new List<GameObject>();
+            }
+        }
+
+        private bool IsTemporaryObject(GameObject go)
+        {
+            if (go == null) return false;
+
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity != null && identity.Temporary) return true;
+
+            var root = temporaryRoot != null ? temporaryRoot : GameObject.Find("SceneSync Temporary")?.transform;
+            if (root == null) return false;
+
+            return go == root.gameObject || go.transform.IsChildOf(root);
         }
 
         private Transform GetOrCreateTemporaryRoot()


### PR DESCRIPTION
## Summary\n- add managed Unity object settings to SceneSyncManager\n- expose manager children toggle and explicit managed object list\n- add EditorWindow UI for managing and inspecting managed Unity objects\n- keep existing publish/connect/disconnect behavior unchanged\n\n## Files\n- unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs\n- unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs