### PR TITLE
Assign identities to managed Unity objects

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -254,8 +254,20 @@ namespace Afjk.SceneSync.Editor
                 MarkManagerDirty(manager);
             }
 
-            var managedCount = manager.GetManagedUnityObjects().Count;
+            var managedUnityObjects = manager.GetManagedUnityObjects();
+            var managedCount = managedUnityObjects.Count;
             GUILayout.Label("Managed Unity Objects: " + managedCount);
+
+            var identifiedCount = 0;
+            foreach (var go in managedUnityObjects)
+            {
+                var identity = go != null ? go.GetComponent<SceneSyncIdentity>() : null;
+                if (identity != null && identity.Origin == SceneSyncOrigin.Unity && !identity.Temporary)
+                {
+                    identifiedCount++;
+                }
+            }
+            GUILayout.Label($"Identified Unity Objects: {identifiedCount} / {managedCount}");
 
             GUILayout.Space(4);
             GUILayout.Label("Explicit Managed Objects:", EditorStyles.label);
@@ -330,6 +342,24 @@ namespace Afjk.SceneSync.Editor
                 if (GUILayout.Button("Select SceneSyncManager"))
                 {
                     Selection.activeGameObject = manager.gameObject;
+                }
+            }
+
+            if (GUILayout.Button("Ensure Identities"))
+            {
+                var count = manager.EnsureManagedUnityObjectIdentities();
+                if (count > 0)
+                {
+                    EditorUtility.SetDirty(manager);
+                    foreach (var go in manager.GetManagedUnityObjects())
+                    {
+                        var identity = go != null ? go.GetComponent<SceneSyncIdentity>() : null;
+                        if (identity != null)
+                        {
+                            EditorUtility.SetDirty(identity);
+                        }
+                    }
+                    EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
                 }
             }
         }

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -199,6 +199,49 @@ namespace Afjk.SceneSync
             managedObjects.RemoveAll(item => item == null);
         }
 
+        public int EnsureManagedUnityObjectIdentities()
+        {
+            var count = 0;
+
+            foreach (var go in GetManagedUnityObjects())
+            {
+                if (EnsureUnityManagedIdentity(go) != null)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        public SceneSyncIdentity EnsureUnityManagedIdentity(GameObject go)
+        {
+            if (go == null) return null;
+            if (go == gameObject) return null;
+            if (IsTemporaryObject(go)) return null;
+
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity == null)
+            {
+                identity = go.AddComponent<SceneSyncIdentity>();
+            }
+
+            if (string.IsNullOrWhiteSpace(identity.ObjectId))
+            {
+                identity.ObjectId = GenerateUnityObjectId(go);
+            }
+
+            identity.Origin = SceneSyncOrigin.Unity;
+            identity.Temporary = false;
+
+            if (identity.State == SceneSyncState.Disconnected || identity.State == SceneSyncState.Error)
+            {
+                identity.State = SceneSyncState.Synced;
+            }
+
+            return identity;
+        }
+
         public bool ValidateManagedObjects()
         {
             EnsureManagedObjectsList();
@@ -1303,6 +1346,43 @@ namespace Afjk.SceneSync
             {
                 managedObjects = new List<GameObject>();
             }
+        }
+
+        private static string GenerateUnityObjectId(GameObject go)
+        {
+            var namePart = SanitizeObjectIdPart(go != null ? go.name : "unity-object");
+            var randomPart = Guid.NewGuid().ToString("N").Substring(0, 8);
+            return string.IsNullOrEmpty(namePart)
+                ? "unity-" + randomPart
+                : namePart + "-" + randomPart;
+        }
+
+        private static string SanitizeObjectIdPart(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return "unity-object";
+
+            var builder = new System.Text.StringBuilder(value.Length);
+
+            foreach (var c in value.ToLowerInvariant())
+            {
+                if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+                {
+                    builder.Append(c);
+                }
+                else if (c == '-' || c == '_' || c == ' ')
+                {
+                    builder.Append('-');
+                }
+            }
+
+            var result = builder.ToString().Trim('-');
+
+            while (result.Contains("--"))
+            {
+                result = result.Replace("--", "-");
+            }
+
+            return string.IsNullOrEmpty(result) ? "unity-object" : result;
         }
 
         private bool IsTemporaryObject(GameObject go)


### PR DESCRIPTION
## Summary
- add managed Unity identity assignment APIs to SceneSyncManager
- ensure managed Unity objects get SceneSyncIdentity with stable objectId generation when missing
- keep temporary/remote objects excluded from Unity identity assignment
- add Ensure Identities button in Scene Sync EditorWindow
- show identified managed Unity object count in the window

## Scope
- no publish or mesh upload changes
- no scene-add or scene-delta behavior changes
- no connect or disconnect behavior changes

## Files
- unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
- unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs