### PR TITLE
docs: define Scene Command and Behavior Graph terminology

### DIFF
--- a/docs/scene-sync-command-vs-behavior-graph.md
+++ b/docs/scene-sync-command-vs-behavior-graph.md
@@ -1,0 +1,131 @@
+# Scene Sync: Scene Command vs Behavior Graph
+
+Scene Sync has two different ways to change or drive a scene.
+
+This document defines the terminology used by Scene Sync, Loomlet, MCP tools, GPT actions, and AI authoring docs.
+
+---
+
+## Scene Command
+
+A **Scene Command** is a one-shot operation that immediately changes the current Scene Sync scene state.
+
+Use Scene Commands when the request is an instantaneous edit or operation.
+
+Examples:
+
+- Add an object
+- Remove an object
+- Move an object once
+- Scale an object once
+- Change the environment once
+- Apply a batch of one-shot edits
+
+Typical protocol payloads:
+
+- `scene-add`
+- `scene-remove`
+- `scene-delta`
+- `scene-batch`
+- `scene-env`
+
+In Loomlet integration, the immediate-effect path can convert Loomlet outputs such as `scene.setPosition`, `scene.setRotation`, or `scene.setScale` into Scene Commands such as `scene-delta`.
+
+A Scene Command is not a persistent animation definition. Do not broadcast Scene Commands every frame for continuous animation unless intentionally using result synchronization as a fallback.
+
+---
+
+## Behavior Graph
+
+A **Behavior Graph** is a persistent graph definition that is evaluated continuously by each Scene Sync client.
+
+Use Behavior Graphs when the request describes ongoing behavior.
+
+Examples:
+
+- Bounce the cat
+- Spin the cube continuously
+- Pulse an object's scale
+- Blink visibility
+- Cycle material color
+
+Typical protocol payloads:
+
+- `scene-graph-set`
+- `scene-graph-clear`
+- `scene-graph-patch`
+- `scene-graph-input`
+
+A Behavior Graph shares the definition of behavior, not per-frame transform results. Each client evaluates the graph locally against the same graph and synchronized inputs such as `serverClock`.
+
+---
+
+## Scene Behavior Graph
+
+A **Scene Behavior Graph** is a Behavior Graph scoped to the whole room or scene.
+
+Protocol shape:
+
+```json
+{
+  "type": "scene-graph-set",
+  "scope": "scene",
+  "graph": {
+    "nodes": [],
+    "edges": []
+  }
+}
+```
+
+Use Scene Behavior Graphs for room-level relationships or coordination between objects.
+
+---
+
+## Object Behavior Graph
+
+An **Object Behavior Graph** is a Behavior Graph attached to one Scene Sync object.
+
+Protocol shape:
+
+```json
+{
+  "type": "scene-graph-set",
+  "scope": { "object": "cat-123" },
+  "graph": {
+    "nodes": [],
+    "edges": []
+  }
+}
+```
+
+For object-scoped graphs, Scene Sync clients inject `scope.object` as the target for Scene Sync sink nodes when `params.target` is omitted.
+
+Prefer Object Behavior Graphs for object-specific behavior such as idle motion, bounce, spin, pulse, color cycle, or visibility blinking.
+
+---
+
+## Naming rules
+
+Use these terms in documentation and tool descriptions:
+
+- **Scene Command**: one-shot, immediate operation
+- **Behavior Graph**: persistent, continuously evaluated behavior definition
+- **Scene Behavior Graph**: Behavior Graph with `scope: "scene"`
+- **Object Behavior Graph**: Behavior Graph with `scope: { "object": "<objectId>" }`
+
+Avoid using `scene graph` as a user-facing concept name when referring to Behavior Graphs. `scene graph` is already a common 3D engine term, and Scene Sync also has protocol payloads named `scene-graph-*`.
+
+Keep protocol names unchanged:
+
+- `scene-delta` remains a protocol payload name for Scene Commands.
+- `scene-graph-set` and `scene-graph-clear` remain protocol payload names for Behavior Graphs.
+- Existing MCP tool names such as `scene_sync_set_object_graph` remain unchanged for compatibility.
+
+---
+
+## Quick comparison
+
+| Concept | Lifespan | Transport | Evaluation | Example |
+|---|---|---|---|---|
+| Scene Command | One-shot | `scene-delta`, `scene-add`, `scene-remove`, `scene-batch` | Applied immediately | Move the cat to `[1, 0, 0]` |
+| Behavior Graph | Persistent until replaced or cleared | `scene-graph-set`, `scene-graph-clear` | Evaluated continuously by each client | Make the cat bounce |

--- a/docs/scene-sync-loom-ai-skill.md
+++ b/docs/scene-sync-loom-ai-skill.md
@@ -2,11 +2,13 @@
 
 ## Purpose
 
-This skill explains how an AI agent should control SceneSync objects using Loom graphs.
+This skill explains how an AI agent should control SceneSync objects using **Behavior Graphs**.
+
+For terminology, see `docs/scene-sync-command-vs-behavior-graph.md`.
 
 - Do not add new SceneSync APIs for behaviors
-- Use existing `scene-graph-set` and `scene-graph-clear` payloads
-- The AI should generate valid Loom graph JSON and broadcast it to the SceneSync room
+- Use existing `scene-graph-set` and `scene-graph-clear` payloads for Behavior Graphs
+- The AI should generate valid Scene Sync Behavior Graph JSON and broadcast it to the SceneSync room
 - The goal is to avoid inventing ad-hoc payloads such as `scene-behavior`
 
 **Critical rule:**
@@ -17,9 +19,44 @@ Use only `scene-graph-set` and `scene-graph-clear` for Loom-powered object behav
 
 ---
 
+## Scene Command vs Behavior Graph
+
+Scene Sync has two different integration paths.
+
+### Scene Command
+
+A **Scene Command** is a one-shot operation that immediately changes scene state.
+
+Typical payloads:
+
+- `scene-add`
+- `scene-remove`
+- `scene-delta`
+- `scene-batch`
+- `scene-env`
+
+Use Scene Commands for one-time edits such as adding an object, moving an object once, deleting an object, or changing the environment.
+
+### Behavior Graph
+
+A **Behavior Graph** is a persistent graph definition that is evaluated continuously by each client.
+
+Typical payloads:
+
+- `scene-graph-set`
+- `scene-graph-clear`
+- `scene-graph-patch`
+- `scene-graph-input`
+
+Use Behavior Graphs for ongoing behavior such as bouncing, spinning, pulsing scale, blinking visibility, or cycling color.
+
+Do not broadcast per-frame `scene-delta` results from Loom animation. Send the Behavior Graph definition once and let clients evaluate it locally.
+
+---
+
 ## Allowed Payloads
 
-### Set object graph
+### Set Object Behavior Graph
 
 ```json
 {
@@ -32,7 +69,7 @@ Use only `scene-graph-set` and `scene-graph-clear` for Loom-powered object behav
 }
 ```
 
-### Clear object graph
+### Clear Object Behavior Graph
 
 ```json
 {
@@ -42,15 +79,16 @@ Use only `scene-graph-set` and `scene-graph-clear` for Loom-powered object behav
 ```
 
 **Explanation:**
+
 - `scope.object` is the target SceneSync object id.
-- For object scope graphs, the target object is automatically injected into SceneSync sink nodes.
+- For Object Behavior Graphs, the target object is automatically injected into SceneSync sink nodes.
 - Do not include `params.target` in `sceneSetPosition`, `sceneSetRotation`, `sceneSetScale`, `sceneSetColor`, or `sceneSetVisible` when using object scope.
 
 ---
 
 ## Allowed Node Types
 
-SceneSync graph execution supports a **whitelist** of Loom node types. Remote graph payloads can only use these types.
+SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. Remote graph payloads can only use these types.
 
 ### Allowed node types:
 
@@ -69,12 +107,14 @@ SceneSync graph execution supports a **whitelist** of Loom node types. Remote gr
 ### Forbidden node types:
 
 **DOM nodes (not allowed):**
+
 - `setText` — DOM text manipulation
 - `setStyle` — DOM style manipulation
 - `setAttr` — DOM attribute manipulation
 - `log` — console logging
 
 **Input/Event nodes (not allowed):**
+
 - `pointerClick` — pointer/click events
 - `pointerPosition` — pointer position tracking
 - `keyDown` — keyboard events
@@ -85,22 +125,22 @@ SceneSync graph execution supports a **whitelist** of Loom node types. Remote gr
 
 **Reason for restrictions:**
 
-Remote room messages must be safe. DOM and input nodes could introduce security vulnerabilities or break client isolation. SceneSync graph execution is intentionally restricted to transformation and visibility control only.
+Remote room messages must be safe. DOM and input nodes could introduce security vulnerabilities or break client isolation. SceneSync Behavior Graph execution is intentionally restricted to transformation and visibility control only.
 
 ---
 
-## Object Scope Rules
+## Object Behavior Graph Rules
 
-Always prefer object scope for object-specific behavior.
+Always prefer Object Behavior Graphs for object-specific behavior.
 
 ### Rules:
 
-- Use `scope: { "object": "<objectId>" }` for object-specific graphs
+- Use `scope: { "object": "<objectId>" }` for object-specific Behavior Graphs
 - Do not set `params.target` on SceneSync sink nodes when using object scope
 - The viewer automatically injects the object target from scope
-- Object scope graphs are exported into `loomGraphs.objects[objectId]`
+- Object Behavior Graphs are exported into `loomGraphs.objects[objectId]`
 - Late joiners restore these graphs from `scene-state`
-- When the object is removed via `scene-remove`, the object graph is cleaned up
+- When the object is removed via `scene-remove`, the Object Behavior Graph is cleaned up
 
 ### Good example:
 
@@ -162,41 +202,30 @@ Always prefer object scope for object-specific behavior.
 - Use small amplitudes first, usually `0.5` to `3.0`
 - Always set fixed values for axes that are not animated
 - For position animation:
-  - x and z default base should usually be `0`
-  - y default base should usually be `0.5` (assuming object origin at center)
+  - Inspect the object's current position first
+  - Use the current position as the baseline for fixed axes
+  - Do not blindly use `x: 0`, `y: 0.5`, `z: 0` for objects that should stay near their current location
 - For rotation animation:
   - values are Euler angles in radians
   - `sceneSetRotation` accepts `x`, `y`, and `z` (Euler angles, not quaternion)
   - Do not use quaternion `[x, y, z, w]` for `sceneSetRotation`
 - Do not broadcast per-frame `scene-delta` results from Loom animation
-- Send graph definitions once, not animation results repeatedly
+- Send Behavior Graph definitions once, not animation results repeatedly
+
+---
+
+## Graph Replacement Behavior
+
+SceneSync currently stores **one Object Behavior Graph per object**. When you send a new `scene-graph-set` with the same `scope.object`, it **replaces the previous graph** for that object.
+
+- If you send a movement graph, then a color graph separately, the movement will be replaced and stop.
+- **Solution:** Combine multiple effects into a single Behavior Graph instead of sending multiple separate `scene-graph-set` payloads.
 
 ---
 
 ## Recipes
 
-**Important notes before using recipes:**
-
-### Graph Replacement Behavior
-
-SceneSync currently stores **one Loom graph per object**. When you send a new `scene-graph-set` with the same `scope.object`, it **replaces the previous graph** for that object.
-
-- If you send a movement graph, then a color graph separately, the movement will be replaced and stop.
-- **Solution:** Combine multiple effects into a single graph instead of sending multiple separate `scene-graph-set` payloads.
-- See section "6.8 Combined example: movement + color" for a pattern.
-
-### Coordinate Assumptions
-
-The recipes below assume a test cube located around `[0, 0.5, 0]` (close to world origin). When applying recipes to arbitrary objects:
-
-1. **Inspect the object's current position** first (use `GET /api/room/{roomId}/scene` to check)
-2. **Use the object's current position as the baseline** for fixed axes
-3. **Do not blindly use `x: 0`, `y: 0.5`, `z: 0`** for objects that should stay near their current location
-4. If an object should stay in place while animating, use its current position values as the fixed axes in the sink node
-
----
-
-### 6.1 Move left and right
+### Move left and right
 
 Object `cube1` oscillates along the X axis with a sine wave.
 
@@ -233,44 +262,7 @@ Object `cube1` oscillates along the X axis with a sine wave.
 }
 ```
 
-### 6.2 Float up and down
-
-Object `cube1` oscillates along the Y axis.
-
-```json
-{
-  "type": "scene-graph-set",
-  "scope": { "object": "cube1" },
-  "graph": {
-    "nodes": [
-      { "id": "clock", "type": "serverClock" },
-      {
-        "id": "sine",
-        "type": "sine",
-        "params": {
-          "freq": 0.3,
-          "amplitude": 0.5,
-          "offset": 1.2
-        }
-      },
-      {
-        "id": "pos",
-        "type": "sceneSetPosition",
-        "params": {
-          "x": 0,
-          "z": 0
-        }
-      }
-    ],
-    "edges": [
-      { "from": "clock.t", "to": "sine.t" },
-      { "from": "sine.out", "to": "pos.y" }
-    ]
-  }
-}
-```
-
-### 6.3 Rotate around Y axis
+### Rotate around Y axis
 
 Object `cube1` continuously rotates around the Y axis.
 
@@ -305,106 +297,11 @@ Object `cube1` continuously rotates around the Y axis.
 }
 ```
 
-### 6.4 Pulse scale
-
-Object `cube1` pulses in and out by scaling uniformly.
-
-```json
-{
-  "type": "scene-graph-set",
-  "scope": { "object": "cube1" },
-  "graph": {
-    "nodes": [
-      { "id": "clock", "type": "serverClock" },
-      {
-        "id": "sine",
-        "type": "sine",
-        "params": {
-          "freq": 0.5,
-          "amplitude": 0.25,
-          "offset": 1
-        }
-      },
-      {
-        "id": "scale",
-        "type": "sceneSetScale",
-        "params": {}
-      }
-    ],
-    "edges": [
-      { "from": "clock.t", "to": "sine.t" },
-      { "from": "sine.out", "to": "scale.x" },
-      { "from": "sine.out", "to": "scale.y" },
-      { "from": "sine.out", "to": "scale.z" }
-    ]
-  }
-}
-```
-
-### 6.5 Set static color
-
-Object `cube1` is colored green with a static color sink (no animation).
-
-```json
-{
-  "type": "scene-graph-set",
-  "scope": { "object": "cube1" },
-  "graph": {
-    "nodes": [
-      {
-        "id": "color",
-        "type": "sceneSetColor",
-        "params": {
-          "r": 0,
-          "g": 1,
-          "b": 0
-        }
-      }
-    ],
-    "edges": []
-  }
-}
-```
-
-### 6.6 Hide object
-
-Object `cube1` is made invisible.
-
-```json
-{
-  "type": "scene-graph-set",
-  "scope": { "object": "cube1" },
-  "graph": {
-    "nodes": [
-      {
-        "id": "visible",
-        "type": "sceneSetVisible",
-        "params": {
-          "visible": false
-        }
-      }
-    ],
-    "edges": []
-  }
-}
-```
-
-### 6.7 Clear object behavior
-
-Remove all Loom graph behavior from object `cube1`.
-
-```json
-{
-  "type": "scene-graph-clear",
-  "scope": { "object": "cube1" }
-}
-```
-
-### 6.8 Combined example: movement + color
+### Combined example: movement + color
 
 Object `cube1` moves left-right while pulsing color from blue to cyan.
 
-This demonstrates how to **combine multiple effects in a single graph** to avoid replacement issues.
+This demonstrates how to **combine multiple effects in a single Object Behavior Graph** to avoid replacement issues.
 
 ```json
 {
@@ -457,17 +354,11 @@ This demonstrates how to **combine multiple effects in a single graph** to avoid
 }
 ```
 
-**Key points:**
-- Two independent sine waves in one graph (different frequencies and amplitudes)
-- Position sink receives `sine_pos` for X movement
-- Color sink receives `sine_color` for green channel pulse
-- Sending this single graph once maintains both effects without replacement
-
 ---
 
 ## Broadcast Examples
 
-Use the existing REST broadcast endpoint to send Loom graph payloads.
+Use the existing REST broadcast endpoint to send Behavior Graph payloads.
 
 ### Send left-right movement
 
@@ -480,23 +371,8 @@ curl -X POST "http://localhost:8787/api/room/loom-test/broadcast?name=AI" \
     "graph": {
       "nodes": [
         { "id": "clock", "type": "serverClock" },
-        {
-          "id": "sine",
-          "type": "sine",
-          "params": {
-            "freq": 0.2,
-            "amplitude": 2,
-            "offset": 0
-          }
-        },
-        {
-          "id": "pos",
-          "type": "sceneSetPosition",
-          "params": {
-            "y": 0.5,
-            "z": 0
-          }
-        }
+        { "id": "sine", "type": "sine", "params": { "freq": 0.2, "amplitude": 2, "offset": 0 } },
+        { "id": "pos", "type": "sceneSetPosition", "params": { "y": 0.5, "z": 0 } }
       ],
       "edges": [
         { "from": "clock.t", "to": "sine.t" },
@@ -521,7 +397,7 @@ curl -X POST "http://localhost:8787/api/room/loom-test/broadcast?name=AI" \
 
 ## Checklist Before Sending
 
-Before sending a Loom graph payload to the REST broadcast endpoint, verify:
+Before sending a Behavior Graph payload to the REST broadcast endpoint, verify:
 
 - The payload uses `type: "scene-graph-set"` or `type: "scene-graph-clear"`
 - Do not use `kind: "scene-behavior"` or any custom behavior payload
@@ -534,9 +410,9 @@ Before sending a Loom graph payload to the REST broadcast endpoint, verify:
 - Object scope sink nodes do not include `params.target`
 - Non-animated axes have fixed values in sink node `params`
 - Animation uses `serverClock` unless local-only timing is explicitly desired
-- Amplitude values are reasonable (not too large, typically 0.5 to 3.0)
-- Frequency values are appropriate for the effect (0.1 to 1.0 Hz for smooth effects)
-- Loom animation results are NOT sent as `scene-delta` (the graph is executed client-side)
+- Amplitude values are reasonable
+- Frequency values are appropriate for the effect
+- Loom animation results are NOT sent as `scene-delta`
 
 ---
 
@@ -576,8 +452,6 @@ Before sending a Loom graph payload to the REST broadcast endpoint, verify:
 
 **Lesson:** Always use `scene-graph-set` / `scene-graph-clear`, never invent new payload kinds.
 
----
-
 ### Mistake 2: Setting target manually in object scope
 
 **Bad:**
@@ -611,71 +485,20 @@ Before sending a Loom graph payload to the REST broadcast endpoint, verify:
 
 ---
 
-### Mistake 3: Using disallowed DOM or input nodes
-
-**Bad:**
-
-```json
-{
-  "id": "click",
-  "type": "pointerClick"
-}
-```
-
-**Good:**
-
-Use only the SceneSync allowed node whitelist (see section "Allowed Node Types").
-
-**Lesson:** Remote graph payloads are restricted to safe transformation and visibility nodes. DOM and input nodes are forbidden.
-
----
-
-### Mistake 4: Missing fixed axes in sink nodes
-
-**Bad:**
-
-```json
-{
-  "id": "pos",
-  "type": "sceneSetPosition",
-  "params": {
-    "x": 1
-  }
-}
-```
-
-**Good:**
-
-```json
-{
-  "id": "pos",
-  "type": "sceneSetPosition",
-  "params": {
-    "x": 1,
-    "y": 0.5,
-    "z": 0
-  }
-}
-```
-
-**Lesson:** Always explicitly set values for non-animated axes to prevent unexpected behavior from the previous state.
-
----
-
 ## Notes for MCP / GPT Actions
 
-- An MCP server or GPT Action does not need a dedicated behavior tool or API endpoint
-- It can use the existing SceneSync room broadcast tool (REST POST `/api/room/{roomId}/broadcast`)
+- An MCP server or GPT Action does not need a custom behavior payload
+- It can use the existing SceneSync room broadcast tool or a dedicated Behavior Graph tool
 - The tool should send a valid `scene-graph-set` or `scene-graph-clear` payload
 - Include this skill text in the AI system/developer instructions or tool description
 - The AI should not create new payload kinds unless the SceneSync protocol explicitly documents them
-- Always refer to the latest `docs/scene-sync-spec.md` for the authoritative protocol definition
+- Always refer to the latest `docs/scene-sync-spec.md` and `docs/scene-sync-command-vs-behavior-graph.md` for authoritative terminology
 
 ---
 
 ## References
 
+- **Scene Sync terminology:** `docs/scene-sync-command-vs-behavior-graph.md`
 - **SceneSync Core Protocol:** `docs/scene-sync-spec.md`
-- **Loom Graph Protocol:** See "Loom グラフプロトコル" section in `scene-sync-spec.md`
 - **REST API Endpoint:** `POST /api/room/{roomId}/broadcast?name={nickname}`
 - **Allowed node types and restrictions:** This document, section "Allowed Node Types"

--- a/docs/scene-sync-loomlet-dsl-ai-authoring.md
+++ b/docs/scene-sync-loomlet-dsl-ai-authoring.md
@@ -1,16 +1,18 @@
 # Scene Sync × Loomlet DSL AI Authoring Notes
 
-This document explains how AI agents should author Loomlet behavior for Scene Sync.
+This document explains how AI agents should author Loomlet **Behavior Graphs** for Scene Sync.
 
 Scene Sync executes graph payloads, but AI assistants should usually generate **Loomlet DSL (`.loom`) first** and let the Loomlet compiler produce Scene Sync graph JSON.
+
+For terminology, see `docs/scene-sync-command-vs-behavior-graph.md`.
 
 ---
 
 ## Recommended flow
 
-1. User asks for behavior in natural language.
+1. User asks for continuous behavior in natural language.
 2. AI generates a small `.loom` program.
-3. Loomlet compiles the `.loom` source to a Scene Sync graph.
+3. Loomlet compiles the `.loom` source to a Scene Sync **Behavior Graph**.
 4. Scene Sync receives `scene-graph-set` or `scene-graph-clear`.
 5. Scene Sync executes the graph client-side.
 
@@ -20,7 +22,7 @@ Do not invent new behavior payloads such as `scene-behavior`, `animateObject`, o
 
 ## Authoring rule
 
-When an AI is asked to write behavior, prefer this output:
+When an AI is asked to write continuous behavior, prefer this output:
 
 ```loom
 import time
@@ -33,13 +35,13 @@ y = math.sine(t, freq: 0.6, amplitude: 0.4, offset: 1.2)
 scene.setPosition("sample-cube", x: 0, y: y, z: 0)
 ```
 
-The compiler/runtime bridge should convert that source into the graph payload Scene Sync understands.
+The compiler/runtime bridge should convert that source into the Behavior Graph payload Scene Sync understands.
 
 ---
 
-## Scene Sync graph protocol remains authoritative
+## Scene Sync Behavior Graph protocol remains authoritative
 
-Scene Sync still receives graph messages in this form:
+Scene Sync still receives Behavior Graph messages in this form:
 
 ```json
 {
@@ -65,9 +67,20 @@ The DSL is an authoring layer, not a replacement for the Scene Sync protocol.
 
 ---
 
+## Scene Command vs Behavior Graph
+
+Scene Sync has two different integration paths:
+
+- **Scene Command**: a one-shot operation that immediately changes scene state, usually through payloads such as `scene-delta`, `scene-add`, or `scene-remove`.
+- **Behavior Graph**: a persistent graph definition that is evaluated continuously by each client, managed through `scene-graph-set` and `scene-graph-clear`.
+
+Use Behavior Graphs for animation-like requests such as "bounce the cat", "spin the cube", or "pulse the color". Do not repeatedly broadcast per-frame Scene Commands for continuous animation.
+
+---
+
 ## Allowed Scene Sync runtime nodes
 
-The Scene Sync client currently allows these graph node types:
+The Scene Sync client currently allows these Behavior Graph node types:
 
 - `clock`
 - `constant`
@@ -87,7 +100,7 @@ Loomlet DSL authoring should map to those runtime nodes through the compiler/ada
 
 ## DSL scene sink mapping
 
-Use these `.loom` sink calls for Scene Sync behavior:
+Use these `.loom` sink calls for Scene Sync Behavior Graphs:
 
 ```loom
 scene.setPosition("sample-cube", x: 0, y: 1, z: 0)
@@ -97,13 +110,15 @@ scene.setColor("sample-cube", r: 0, g: 1, b: 1)
 scene.setVisible("sample-cube", visible: true)
 ```
 
-Important: `scene.setRotation` uses **Euler radians** in Scene Sync. Do not author quaternion `w` values for Scene Sync rotation.
+Important: `scene.setRotation` uses **Euler radians** in Scene Sync Behavior Graphs. Do not author quaternion `w` values for Scene Sync rotation.
 
 ---
 
-## Object scope behavior
+## Object Behavior Graph
 
-Scene Sync stores one Loom graph per object. Sending a new graph to the same object replaces the old one.
+An **Object Behavior Graph** is a Behavior Graph attached to a single Scene Sync object using `scope: { "object": "<objectId>" }`.
+
+Scene Sync stores one Object Behavior Graph per object. Sending a new graph to the same object replaces the old one.
 
 Therefore, combine related effects into one `.loom` program:
 
@@ -120,13 +135,13 @@ scene.setPosition("sample-cube", x: x, y: 0.5, z: 0)
 scene.setColor("sample-cube", r: 0, g: g, b: 1)
 ```
 
-Do not send movement and color as two separate object graphs unless replacing the previous behavior is intended.
+Do not send movement and color as two separate Object Behavior Graphs unless replacing the previous behavior is intended.
 
 ---
 
 ## Safety restrictions
 
-Remote Scene Sync graph execution is intentionally restricted.
+Remote Scene Sync Behavior Graph execution is intentionally restricted.
 
 Do not allow remote graphs to use:
 
@@ -142,6 +157,7 @@ For public AI-facing tools, keep the graph node whitelist narrow and reject unkn
 
 ## References
 
+- Scene Sync terminology: `docs/scene-sync-command-vs-behavior-graph.md`
 - Loomlet AI authoring guide: `afjk/loomlet/docs/AI_AUTHORING_GUIDE.md`
 - Existing graph-level skill: `docs/scene-sync-loom-ai-skill.md`
 - Scene Sync protocol spec: `docs/scene-sync-spec.md`

--- a/packages/scene-sync-mcp/GRAPH_TOOLS.md
+++ b/packages/scene-sync-mcp/GRAPH_TOOLS.md
@@ -1,23 +1,34 @@
 # Scene Sync MCP Graph Tools
 
-This document describes the experimental Scene Sync graph tools added for persistent behavior graphs.
+This document describes the experimental Scene Sync graph tools added for **Behavior Graphs**.
 
-These tools accept **Scene Sync graph JSON**, not Loomlet DSL. The intended flow is:
+For terminology, see `docs/scene-sync-command-vs-behavior-graph.md`.
+
+These tools accept **Scene Sync Behavior Graph JSON**, not Loomlet DSL. The intended flow is:
 
 ```text
 Loomlet DSL or AI-authored behavior
-  -> Scene Sync graph JSON
+  -> Scene Sync Behavior Graph JSON
   -> MCP graph tool
   -> Scene Sync scene-graph-set / scene-graph-clear broadcast
 ```
 
 Scene Sync stays lightweight and does not need the Loomlet DSL parser.
 
+## Scene Command vs Behavior Graph
+
+Scene Sync has two different integration paths:
+
+- **Scene Command**: a one-shot operation that immediately changes scene state, usually through payloads such as `scene-delta`, `scene-add`, or `scene-remove`.
+- **Behavior Graph**: a persistent graph definition that is evaluated continuously by each client, managed through `scene-graph-set` and `scene-graph-clear`.
+
+MCP graph tools are for Behavior Graphs. Do not use these tools to send one-shot Scene Commands.
+
 ## Tools
 
 ### scene_sync_set_object_graph
 
-Set a persistent behavior graph for one object.
+Set an **Object Behavior Graph** for one object.
 
 ```json
 {
@@ -38,7 +49,7 @@ Set a persistent behavior graph for one object.
 
 ### scene_sync_clear_object_graph
 
-Clear one object's behavior graph.
+Clear one object's **Object Behavior Graph**.
 
 ```json
 {
@@ -48,7 +59,7 @@ Clear one object's behavior graph.
 
 ### scene_sync_set_scene_graph
 
-Set the room-level behavior graph.
+Set the room-level **Scene Behavior Graph**.
 
 ```json
 {
@@ -61,7 +72,7 @@ Set the room-level behavior graph.
 
 ### scene_sync_clear_scene_graph
 
-Clear the room-level behavior graph.
+Clear the room-level **Scene Behavior Graph**.
 
 ```json
 {}
@@ -85,4 +96,4 @@ All graph tools accept `dryRun: true`. In dry-run mode, the tool returns the pay
 
 ## Notes for AI clients
 
-Before generating object behavior, inspect the current scene with `scene_sync_get_scene` and preserve the object's current base transform. For example, a bounce behavior should animate only the Y component and keep the current X/Z values, instead of moving the object to the origin.
+Before generating an Object Behavior Graph, inspect the current scene with `scene_sync_get_scene` and preserve the object's current base transform. For example, a bounce behavior should animate only the Y component and keep the current X/Z values, instead of moving the object to the origin.


### PR DESCRIPTION
## Summary

- Add a terminology doc that distinguishes Scene Command from Behavior Graph.
- Align Scene Sync × Loomlet AI authoring docs with the new terms.
- Update MCP graph tool docs to use Object Behavior Graph / Scene Behavior Graph consistently.
- Clarify that protocol/tool names remain unchanged for compatibility.

## Notes

This is documentation-only. No runtime behavior or API names are changed.