### PR TITLE
Stop locking unpublished Unity objects

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -139,10 +139,19 @@ namespace Afjk.SceneSync.Editor
             if (selectionRoot != null)
             {
                 if (_instanceToObjectId.TryGetValue(selectionRoot.GetInstanceID(), out var origId))
+                {
                     selectionId = origId;
-                else if (IsSyncTarget(selectionRoot))
-                    selectionId = selectionRoot.GetInstanceID().ToString();
-                // メッシュなしの Unity オブジェクト（Camera 等）は selectionId = null のまま
+                }
+                else
+                {
+                    var identity = selectionRoot.GetComponent<SceneSyncIdentity>();
+                    if (identity != null
+                        && !string.IsNullOrWhiteSpace(identity.ObjectId)
+                        && _managedObjects.ContainsKey(identity.ObjectId))
+                    {
+                        selectionId = identity.ObjectId;
+                    }
+                }
             }
 
             // ロック状態の更新


### PR DESCRIPTION
## Summary
- remove legacy selection lock fallback that used GameObject instance IDs for unpublished objects
- resolve selection lock IDs only from tracked Scene Sync object mappings or tracked SceneSyncIdentity object IDs
- keep lock/unlock flow unchanged for already-known published Unity objects and remote temporary objects

## Scope
- no publish behavior changes
- no transform delta behavior changes
- no reconnect rebind changes
- no hierarchy auto-publish changes

## File
- unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs