### PR TITLE
Disable picking for imported Scene Sync children

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs
@@ -17,12 +17,17 @@ namespace Afjk.SceneSync.Editor
             var sceneVisibilityManager = SceneVisibilityManager.instance;
             if (sceneVisibilityManager == null) return;
 
+            // The Scene Sync root should remain selectable/pickable.
             sceneVisibilityManager.EnablePicking(root, false);
 
-            foreach (Transform child in root.transform)
+            var transforms = root.GetComponentsInChildren<Transform>(true);
+            foreach (var t in transforms)
             {
-                if (child == null) continue;
-                sceneVisibilityManager.DisablePicking(child.gameObject, true);
+                if (t == null) continue;
+                if (t.gameObject == root) continue;
+
+                // Apply to each descendant explicitly.
+                sceneVisibilityManager.DisablePicking(t.gameObject, false);
             }
         }
 
@@ -36,12 +41,17 @@ namespace Afjk.SceneSync.Editor
             var sceneVisibilityManager = SceneVisibilityManager.instance;
             if (sceneVisibilityManager == null) return;
 
-            foreach (Transform child in root.transform)
+            var transforms = root.GetComponentsInChildren<Transform>(true);
+            foreach (var t in transforms)
             {
-                if (child == null) continue;
-                sceneVisibilityManager.EnablePicking(child.gameObject, true);
+                if (t == null) continue;
+                if (t.gameObject == root) continue;
+
+                // Restore each descendant explicitly.
+                sceneVisibilityManager.EnablePicking(t.gameObject, false);
             }
 
+            // The Scene Sync root should remain selectable/pickable.
             sceneVisibilityManager.EnablePicking(root, false);
         }
     }

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs
@@ -1,0 +1,48 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Editor
+{
+    public static class SceneSyncPickingUtility
+    {
+        public static void ApplyImportedChildPicking(SceneSyncIdentity identity)
+        {
+            if (identity == null) return;
+            if (identity.Origin != SceneSyncOrigin.Remote) return;
+            if (!identity.Temporary) return;
+
+            var root = identity.gameObject;
+            if (root == null) return;
+
+            var sceneVisibilityManager = SceneVisibilityManager.instance;
+            if (sceneVisibilityManager == null) return;
+
+            sceneVisibilityManager.EnablePicking(root, false);
+
+            foreach (Transform child in root.transform)
+            {
+                if (child == null) continue;
+                sceneVisibilityManager.DisablePicking(child.gameObject, true);
+            }
+        }
+
+        public static void RestoreImportedChildPicking(SceneSyncIdentity identity)
+        {
+            if (identity == null) return;
+
+            var root = identity.gameObject;
+            if (root == null) return;
+
+            var sceneVisibilityManager = SceneVisibilityManager.instance;
+            if (sceneVisibilityManager == null) return;
+
+            foreach (Transform child in root.transform)
+            {
+                if (child == null) continue;
+                sceneVisibilityManager.EnablePicking(child.gameObject, true);
+            }
+
+            sceneVisibilityManager.EnablePicking(root, false);
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs.meta
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncPickingUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7e92ca65a8f4640a6274f7ec5fbb5e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -386,6 +386,11 @@ namespace Afjk.SceneSync.Editor
                     PublishManagedObjects();
                 }
             }
+
+            if (GUILayout.Button("Apply Picking Rules"))
+            {
+                ApplyPickingRules();
+            }
         }
 
         private static void MarkManagerDirty(SceneSyncManager manager)
@@ -1434,6 +1439,16 @@ namespace Afjk.SceneSync.Editor
         {
             var identity = EnsureSceneSyncIdentity(go);
             identity.ConfigureRemoteTemporary(objectId, meshPath);
+            SceneSyncPickingUtility.ApplyImportedChildPicking(identity);
+        }
+
+        private static void ApplyPickingRules()
+        {
+            var identities = UnityEngine.Object.FindObjectsOfType<SceneSyncIdentity>();
+            foreach (var identity in identities)
+            {
+                SceneSyncPickingUtility.ApplyImportedChildPicking(identity);
+            }
         }
 
         private Transform GetOrCreateTemporaryRoot()


### PR DESCRIPTION
Disable Scene View picking for children under remote temporary Scene Sync roots, keep roots pickable, and add an Apply Picking Rules button in the Scene Sync window.