### PR TITLE
Add sceneOffsetPosition node type for relative position offsets

### DIFF
--- a/docs/scene-sync-loom-ai-skill.md
+++ b/docs/scene-sync-loom-ai-skill.md
@@ -98,7 +98,8 @@ SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. 
 - `cosine` — cosine wave oscillator
 - `add` — addition
 - `multiply` — multiplication
-- `sceneSetPosition` — set object position
+- `sceneSetPosition` — set object position (absolute coordinates)
+- `sceneOffsetPosition` — apply x/y/z offsets relative to the object position captured when the Behavior Graph starts evaluating. When the graph is cleared or replaced, Scene Sync restores the captured base position.
 - `sceneSetRotation` — set object rotation
 - `sceneSetScale` — set object scale
 - `sceneSetColor` — set object color (RGB)

--- a/docs/scene-sync-loomlet-dsl-ai-authoring.md
+++ b/docs/scene-sync-loomlet-dsl-ai-authoring.md
@@ -89,6 +89,7 @@ The Scene Sync client currently allows these Behavior Graph node types:
 - `add`
 - `multiply`
 - `sceneSetPosition`
+- `sceneOffsetPosition`
 - `sceneSetRotation`
 - `sceneSetScale`
 - `sceneSetColor`
@@ -106,6 +107,7 @@ Use these `.loom` sink calls for Scene Sync Behavior Graphs:
 
 ```loom
 scene.setPosition("sample-cube", x: 0, y: 1, z: 0)
+scene.offsetPosition("sample-cube", x: 0, y: 0.5, z: 0)
 scene.setRotation("sample-cube", x: 0, y: 1.57, z: 0)
 scene.setScale("sample-cube", x: 2, y: 2, z: 2)
 scene.setColor("sample-cube", r: 0, g: 1, b: 1)

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -810,7 +810,7 @@ Phase 1 では予約扱い。現在は受信・中継のみで、サーバー側
   - `cosine`
   - `add`
   - `multiply`
-  - `sceneSetPosition`, `sceneSetRotation`, `sceneSetScale`, `sceneSetColor`, `sceneSetVisible`
+  - `sceneSetPosition`, `sceneOffsetPosition`, `sceneSetRotation`, `sceneSetScale`, `sceneSetColor`, `sceneSetVisible`
 - 以下の node type は禁止（リモート graph では実行不可）：
   - DOM 操作: `setText`, `setStyle`, `setAttr`, `log`
   - Input/Event: `pointerClick`, `pointerPosition`, `keyDown`, `keyUp`
@@ -825,6 +825,12 @@ Phase 1 では予約扱い。現在は受信・中継のみで、サーバー側
 **オブジェクト スコープの自動注入**
 - `scope: { object: "cube1" }` を指定した場合、SceneSync sink node の `params.target` が未指定なら自動注入される
 - これにより、グラフ定義から target 指定を省略可能
+
+**sceneOffsetPosition — 相対位置オフセット**
+- `sceneSetPosition` は絶対座標を指定するのに対し、`sceneOffsetPosition` は Behavior Graph 適用時点のオブジェクト位置を base とし、そこに offset を加える
+- オブジェクトが現在位置から相対的に動く（例：その場で跳ねる、その場で円運動）
+- Graph を clear / replace すると base position に戻る
+- inputs: `x`, `y`, `z` (optional, default 0)
 
 **GLB / Group 対応**
 - `sceneSetColor` は root object が Group の場合も、子 Mesh の material に色を適用する

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -20,6 +20,7 @@ const SCENESYNC_ALLOWED_NODE_TYPES = new Set([
   'multiply',
   'serverClock',
   'sceneSetPosition',
+  'sceneOffsetPosition',
   'sceneSetRotation',
   'sceneSetScale',
   'sceneSetColor',
@@ -48,8 +49,64 @@ export class LoomSceneSync {
     this._sceneGraphDefinition = null;
     this._objectGraphDefinitions = new Map();
 
+    // sceneOffsetPosition の base position 管理
+    this.behaviorBases = new Map();
+
     // ノード型登録（冪等性を保証）
     this._registerNodeTypes();
+  }
+
+  _createScopeKey(scope) {
+    if (scope === 'scene') return 'scene';
+    if (scope && typeof scope === 'object' && scope.object) {
+      return `object:${scope.object}`;
+    }
+    return 'unknown';
+  }
+
+  _createBehaviorBaseKey(scopeKey, target) {
+    return `${scopeKey}:${target}`;
+  }
+
+  _getOrCaptureBehaviorBase(scopeKey, target, obj) {
+    const key = this._createBehaviorBaseKey(scopeKey, target);
+
+    if (!this.behaviorBases.has(key)) {
+      if (obj && obj.position && typeof obj.position.clone === 'function') {
+        this.behaviorBases.set(key, {
+          scopeKey,
+          target,
+          position: obj.position.clone()
+        });
+      }
+    }
+
+    const base = this.behaviorBases.get(key);
+    return base ? base.position : null;
+  }
+
+  _restoreBehaviorBasesForScope(scope) {
+    const scopeKey = this._createScopeKey(scope);
+    const keysToDelete = [];
+
+    for (const [key, base] of this.behaviorBases.entries()) {
+      if (!key.startsWith(`${scopeKey}:`)) continue;
+
+      const obj = this.resolveTarget(base.target);
+      if (obj && obj.position && base.position) {
+        if (typeof obj.position.copy === 'function') {
+          obj.position.copy(base.position);
+        } else if (typeof obj.position.set === 'function') {
+          obj.position.set(base.position.x, base.position.y, base.position.z);
+        }
+      }
+
+      keysToDelete.push(key);
+    }
+
+    for (const key of keysToDelete) {
+      this.behaviorBases.delete(key);
+    }
   }
 
   _registerNodeTypes() {
@@ -92,6 +149,38 @@ export class LoomSceneSync {
         const obj = adapter.resolveTarget(params.target);
         if (obj && obj.position && typeof obj.position.set === "function") {
           obj.position.set(inputs.x, inputs.y, inputs.z);
+        }
+        return {};
+      }
+    });
+
+    // SceneSync sink ノード：offsetPosition
+    LoomClass.registerNodeType("sceneOffsetPosition", {
+      category: "sink",
+      inputs: [
+        { name: "x", type: "number", default: 0, kind: "behavior" },
+        { name: "y", type: "number", default: 0, kind: "behavior" },
+        { name: "z", type: "number", default: 0, kind: "behavior" }
+      ],
+      outputs: [],
+      params: [
+        { name: "target", type: "string", default: "" },
+        { name: "adapterId", type: "string", default: "" },
+        { name: "scopeKey", type: "string", default: "" }
+      ],
+      evaluate: (inputs, params) => {
+        const adapter = adapterRegistry.get(params.adapterId);
+        if (!adapter) return {};
+        const obj = adapter.resolveTarget(params.target);
+        if (!obj || !obj.position) return {};
+
+        const basePosition = adapter._getOrCaptureBehaviorBase(params.scopeKey, params.target, obj);
+        if (basePosition) {
+          obj.position.set(
+            basePosition.x + inputs.x,
+            basePosition.y + inputs.y,
+            basePosition.z + inputs.z
+          );
         }
         return {};
       }
@@ -271,7 +360,9 @@ export class LoomSceneSync {
     const sceneSetNodeTypes = new Set([
       "sceneSetPosition", "sceneSetRotation", "sceneSetScale", "sceneSetColor", "sceneSetVisible"
     ]);
+    const sceneOffsetNodeTypes = new Set(["sceneOffsetPosition"]);
     const objectScopeTarget = typeof scope === "object" && scope !== null ? scope.object : null;
+    const scopeKey = this._createScopeKey(scope);
 
     // グラフをコピー（元を破壊しない）
     const nodes = graph.nodes.map(node => {
@@ -279,8 +370,17 @@ export class LoomSceneSync {
       newNode.params = { ...(node.params || {}) };
 
       // adapterId を注入
-      if (["serverClock", "sceneSetPosition", "sceneSetRotation", "sceneSetScale", "sceneSetColor", "sceneSetVisible"].includes(node.type)) {
+      if (["serverClock", "sceneSetPosition", "sceneSetRotation", "sceneSetScale", "sceneSetColor", "sceneSetVisible", "sceneOffsetPosition"].includes(node.type)) {
         newNode.params.adapterId = this.adapterId;
+      }
+
+      // sceneOffsetPosition に scopeKey を注入
+      if (sceneOffsetNodeTypes.has(node.type)) {
+        newNode.params.scopeKey = scopeKey;
+        // object scope の場合、target を自動注入
+        if (objectScopeTarget && !newNode.params.target) {
+          newNode.params.target = objectScopeTarget;
+        }
       }
 
       // object scope の場合、SceneSync sink node の target を自動注入
@@ -309,6 +409,8 @@ export class LoomSceneSync {
     const injectedGraph = this._injectAdapterId(msg.graph, msg.scope);
 
     if (typeof msg.scope === "string" && msg.scope === "scene") {
+      // シーングラフの置き換え前に offset base を restore
+      this._restoreBehaviorBasesForScope(msg.scope);
       // シーングラフの置き換え
       this._sceneGraph.stop();
       this._sceneGraph = new this.LoomClass(injectedGraph);
@@ -317,6 +419,8 @@ export class LoomSceneSync {
         this._sceneGraph.start();
       }
     } else {
+      // オブジェクト単位グラフの置き換え前に offset base を restore
+      this._restoreBehaviorBasesForScope(msg.scope);
       // オブジェクト単位グラフ
       const targetId = msg.scope.object;
       if (this._objectGraphs.has(targetId)) {
@@ -333,6 +437,9 @@ export class LoomSceneSync {
 
   _handleGraphClear(msg) {
     this._validateScope(msg.scope);
+
+    // offset base を restore
+    this._restoreBehaviorBasesForScope(msg.scope);
 
     if (typeof msg.scope === "string" && msg.scope === "scene") {
       // シーングラフをクリア
@@ -394,6 +501,7 @@ export class LoomSceneSync {
     this._objectGraphs.clear();
     this._objectGraphDefinitions.clear();
     this._sceneGraphDefinition = null;
+    this.behaviorBases.clear();
     adapterRegistry.delete(this.adapterId);
   }
 

--- a/html/assets/js/scenesync/loom/tests/loom-scenesync.test.mjs
+++ b/html/assets/js/scenesync/loom/tests/loom-scenesync.test.mjs
@@ -150,7 +150,7 @@ describe('LoomSceneSync - Graph Validation', () => {
 
     const allowedTypes = [
       'constant', 'sine', 'cosine', 'add', 'multiply',
-      'serverClock', 'sceneSetPosition', 'sceneSetRotation',
+      'serverClock', 'sceneSetPosition', 'sceneOffsetPosition', 'sceneSetRotation',
       'sceneSetScale', 'sceneSetColor', 'sceneSetVisible'
     ];
 
@@ -235,5 +235,339 @@ describe('LoomSceneSync - Object Behavior Graph', () => {
     // Verify the graph is stored
     const state = adapter.exportState();
     assert.ok(state.objects['cube-1'], 'object graph should be stored');
+  });
+});
+
+describe('LoomSceneSync - sceneOffsetPosition', () => {
+  it('should accept sceneOffsetPosition in object scope', () => {
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => ({
+        position: { set: () => {}, clone: () => ({ x: 3, y: 1, z: -2 }) }
+      })
+    });
+
+    const msg = {
+      type: 'scene-graph-set',
+      scope: { object: 'sample-cube' },
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { y: 0.5 } }
+        ],
+        edges: []
+      }
+    };
+
+    assert.doesNotThrow(() => {
+      adapter.handleMessage(msg);
+    }, 'sceneOffsetPosition should be accepted');
+  });
+
+  it('should apply offset to base position on evaluate', () => {
+    const positions = new Map();
+    positions.set('sample-cube', { x: 3, y: 1, z: -2 });
+
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => {
+        const pos = positions.get(targetId);
+        return {
+          position: {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+            set: function(x, y, z) {
+              this.x = x;
+              this.y = y;
+              this.z = z;
+              positions.set(targetId, { x, y, z });
+            },
+            clone: function() {
+              return { x: this.x, y: this.y, z: this.z };
+            }
+          }
+        };
+      }
+    });
+
+    const msg = {
+      type: 'scene-graph-set',
+      scope: { object: 'sample-cube' },
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { y: 0.5 } }
+        ],
+        edges: []
+      }
+    };
+
+    adapter.handleMessage(msg);
+
+    // Let the graph evaluate at time 0
+    adapter._objectGraphs.get('sample-cube').evaluateAt(0);
+
+    const finalPos = positions.get('sample-cube');
+    assert.strictEqual(finalPos.x, 3, 'x should remain unchanged');
+    assert.strictEqual(finalPos.y, 1.5, 'y should be offset from base (1 + 0.5)');
+    assert.strictEqual(finalPos.z, -2, 'z should remain unchanged');
+  });
+
+  it('should restore base position on clear', () => {
+    const positions = new Map();
+    positions.set('sample-cube', { x: 3, y: 1, z: -2 });
+
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => {
+        const pos = positions.get(targetId);
+        return {
+          position: {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+            set: function(x, y, z) {
+              this.x = x;
+              this.y = y;
+              this.z = z;
+              positions.set(targetId, { x, y, z });
+            },
+            clone: function() {
+              return { x: this.x, y: this.y, z: this.z };
+            },
+            copy: function(other) {
+              this.x = other.x;
+              this.y = other.y;
+              this.z = other.z;
+              positions.set(targetId, { x: this.x, y: this.y, z: this.z });
+            }
+          }
+        };
+      }
+    });
+
+    const msg = {
+      type: 'scene-graph-set',
+      scope: { object: 'sample-cube' },
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { y: 0.5 } }
+        ],
+        edges: []
+      }
+    };
+
+    adapter.handleMessage(msg);
+
+    // Evaluate to apply offset
+    adapter._objectGraphs.get('sample-cube').evaluateAt(0);
+    let pos = positions.get('sample-cube');
+    assert.strictEqual(pos.y, 1.5, 'offset should be applied before clear');
+
+    // Clear the graph
+    const clearMsg = {
+      type: 'scene-graph-clear',
+      scope: { object: 'sample-cube' }
+    };
+    adapter.handleMessage(clearMsg);
+
+    // Verify position is restored
+    pos = positions.get('sample-cube');
+    assert.strictEqual(pos.x, 3, 'x should be restored');
+    assert.strictEqual(pos.y, 1, 'y should be restored to base position (1)');
+    assert.strictEqual(pos.z, -2, 'z should be restored');
+  });
+
+  it('should restore base position on graph replace', () => {
+    const positions = new Map();
+    positions.set('sample-cube', { x: 3, y: 1, z: -2 });
+
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => {
+        const pos = positions.get(targetId);
+        return {
+          position: {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+            set: function(x, y, z) {
+              this.x = x;
+              this.y = y;
+              this.z = z;
+              positions.set(targetId, { x, y, z });
+            },
+            clone: function() {
+              return { x: this.x, y: this.y, z: this.z };
+            },
+            copy: function(other) {
+              this.x = other.x;
+              this.y = other.y;
+              this.z = other.z;
+              positions.set(targetId, { x: this.x, y: this.y, z: this.z });
+            }
+          }
+        };
+      }
+    });
+
+    // Apply graph A with y offset 0.5
+    adapter.handleMessage({
+      type: 'scene-graph-set',
+      scope: { object: 'sample-cube' },
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { y: 0.5 } }
+        ],
+        edges: []
+      }
+    });
+    adapter._objectGraphs.get('sample-cube').evaluateAt(0);
+
+    let pos = positions.get('sample-cube');
+    assert.strictEqual(pos.y, 1.5, 'graph A: y offset 0.5 applied');
+
+    // Replace with graph B with y offset 1.0
+    adapter.handleMessage({
+      type: 'scene-graph-set',
+      scope: { object: 'sample-cube' },
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { y: 1.0 } }
+        ],
+        edges: []
+      }
+    });
+    adapter._objectGraphs.get('sample-cube').evaluateAt(0);
+
+    pos = positions.get('sample-cube');
+    assert.strictEqual(pos.y, 2, 'graph B: should use restored base (1) + 1.0 = 2, NOT (1.5 + 1.0 = 2.5)');
+    assert.strictEqual(pos.x, 3, 'x should remain 3');
+    assert.strictEqual(pos.z, -2, 'z should remain -2');
+  });
+
+  it('should work with scene scope and explicit target', () => {
+    const positions = new Map();
+    positions.set('sample-cube', { x: 3, y: 1, z: -2 });
+
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => {
+        const pos = positions.get(targetId);
+        return {
+          position: {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+            set: function(x, y, z) {
+              this.x = x;
+              this.y = y;
+              this.z = z;
+              positions.set(targetId, { x, y, z });
+            },
+            clone: function() {
+              return { x: this.x, y: this.y, z: this.z };
+            }
+          }
+        };
+      }
+    });
+
+    const msg = {
+      type: 'scene-graph-set',
+      scope: 'scene',
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { target: 'sample-cube', x: 1 } }
+        ],
+        edges: []
+      }
+    };
+
+    adapter.handleMessage(msg);
+
+    // Let the graph evaluate
+    adapter._sceneGraph.evaluateAt(0);
+
+    const finalPos = positions.get('sample-cube');
+    assert.strictEqual(finalPos.x, 4, 'x should be offset from base (3 + 1)');
+    assert.strictEqual(finalPos.y, 1, 'y should remain unchanged');
+    assert.strictEqual(finalPos.z, -2, 'z should remain unchanged');
+  });
+
+  it('should restore scene scope offset on clear', () => {
+    const positions = new Map();
+    positions.set('sample-cube', { x: 3, y: 1, z: -2 });
+
+    const adapter = new LoomSceneSync({
+      LoomClass: Loom,
+      send: () => {},
+      getServerTime: () => 0,
+      resolveTarget: (targetId) => {
+        const pos = positions.get(targetId);
+        return {
+          position: {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+            set: function(x, y, z) {
+              this.x = x;
+              this.y = y;
+              this.z = z;
+              positions.set(targetId, { x, y, z });
+            },
+            clone: function() {
+              return { x: this.x, y: this.y, z: this.z };
+            },
+            copy: function(other) {
+              this.x = other.x;
+              this.y = other.y;
+              this.z = other.z;
+              positions.set(targetId, { x: this.x, y: this.y, z: this.z });
+            }
+          }
+        };
+      }
+    });
+
+    const msg = {
+      type: 'scene-graph-set',
+      scope: 'scene',
+      graph: {
+        nodes: [
+          { id: 'offset', type: 'sceneOffsetPosition', params: { target: 'sample-cube', x: 1 } }
+        ],
+        edges: []
+      }
+    };
+
+    adapter.handleMessage(msg);
+
+    // Evaluate to apply offset
+    adapter._sceneGraph.evaluateAt(0);
+    let pos = positions.get('sample-cube');
+    assert.strictEqual(pos.x, 4, 'offset should be applied before clear (3 + 1)');
+
+    // Clear the scene graph
+    const clearMsg = {
+      type: 'scene-graph-clear',
+      scope: 'scene'
+    };
+    adapter.handleMessage(clearMsg);
+
+    // Verify position is restored
+    pos = positions.get('sample-cube');
+    assert.strictEqual(pos.x, 3, 'x should be restored to base position (3)');
+    assert.strictEqual(pos.y, 1, 'y should remain unchanged');
+    assert.strictEqual(pos.z, -2, 'z should remain unchanged');
   });
 });

--- a/packages/scene-sync-mcp/GRAPH_TOOLS.md
+++ b/packages/scene-sync-mcp/GRAPH_TOOLS.md
@@ -84,7 +84,10 @@ Clear the room-level **Scene Behavior Graph**.
 - `sine`
 - `cosine`
 - `add`
+- `multiply`
+- `constant`
 - `sceneSetPosition`
+- `sceneOffsetPosition`
 - `sceneSetRotation`
 - `sceneSetScale`
 - `sceneSetColor`


### PR DESCRIPTION
## 概要

Behavior Graph に新しいノード型 `sceneOffsetPosition` を追加しました。このノード型は、オブジェクトの現在位置を基準として相対的な位置オフセットを適用します。`sceneSetPosition`（絶対座標指定）とは異なり、グラフ適用時点のオブジェクト位置を保存し、そこからのオフセットを計算します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync` / `loom`

## 変更内容

### 主要な変更

1. **新ノード型 `sceneOffsetPosition` の実装**
   - `loom-scenesync.js` に新しい sink ノード型を登録
   - 入力: `x`, `y`, `z` (number, デフォルト 0)
   - パラメータ: `target`, `adapterId`, `scopeKey`
   - グラフ評価時に base position + offset を計算して適用

2. **Base Position 管理機構**
   - `behaviorBases` Map でスコープ・ターゲット単位に base position を保存
   - `_getOrCaptureBehaviorBase()`: グラフ適用時に現在位置をキャプチャ
   - `_restoreBehaviorBasesForScope()`: グラフクリア・置き換え時に base position を復元
   - グラフ置き換え時に前のグラフの offset を適用した位置から、新しいグラフは元の base position からのオフセットを計算

3. **スコープキー管理**
   - `_createScopeKey()`: scene / object スコープを統一的に管理
   - `_createBehaviorBaseKey()`: scopeKey + target で一意なキーを生成

4. **グラフ注入時の自動パラメータ設定**
   - `sceneOffsetPosition` に `scopeKey` を自動注入
   - object scope の場合、`target` を自動注入（`sceneSetPosition` と同様）

5. **ドキュメント更新**
   - `scene-sync-spec.md`: 許可ノード型リストに `sceneOffsetPosition` を追加、動作説明を記載
   - `scene-sync-loom-ai-skill.md`: AI skill ドキュメントを更新
   - `scene-sync-loomlet-dsl-ai-authoring.md`: Loomlet DSL ドキュメントを更新
   - `GRAPH_TOOLS.md`: MCP ツール定義を更新

### テスト

- `loom-scenesync.test.mjs` に 6 つの新しいテストケースを追加：
  1. object scope での `sceneOffsetPosition` 受け入れテスト
  2. offset 適用の動作確認（base position + offset）
  3. グラフクリア時の base position 復元
  4. グラフ置き換え時の base position 復元（重要：新グラフは元の base から計算）
  5. scene scope での明示的 target 指定での動作
  6. scene scope でのクリア時の復元

## 変更していないこと

- 既存の `sceneSetPosition` など他のノード型の動作
- グラフ検証ロジック（許可リストへの追加のみ）
- Loom コア機能

## staging確認

未確認（テストのみで動作確認）

## テスト/チェック

- 新規テス

https://claude.ai/code/session_017X1k8Top5aUBhSLz1BkpYj