### PR TITLE
Do not rebind unpublished Unity identities

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -618,6 +618,7 @@ namespace Afjk.SceneSync.Editor
                 if (identity.Origin != SceneSyncOrigin.Unity) continue;
                 if (identity.Temporary) continue;
                 if (string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
+                if (string.IsNullOrWhiteSpace(identity.MeshPath)) continue;
 
                 var objectId = identity.ObjectId;
                 _managedObjects[objectId] = go;
@@ -1007,6 +1008,12 @@ namespace Afjk.SceneSync.Editor
             var path = PresenceClient.GenerateRandomPath();
             _meshPaths[objectId] = path;
             await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
+            if (identity.MeshPath != path)
+            {
+                identity.MeshPath = path;
+                EditorUtility.SetDirty(identity);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+            }
 
             var pos = go.transform.position;
             var rot = go.transform.rotation;


### PR DESCRIPTION
Hotfix Unity reconnect rebind criteria so unpublished identities are not treated as published.\n\n- RebindPublishedUnityObjects now requires MeshPath in addition to Unity origin/objectId checks\n- PublishUnityObject now persists identity.MeshPath after upload\n\nThis keeps Add Selected identities local-only until explicit publish.