### PR TITLE
Restore published-only reconnect rebind

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -633,6 +633,9 @@ namespace Afjk.SceneSync.Editor
                 if (identity.Origin != SceneSyncOrigin.Unity) continue;
                 if (identity.Temporary) continue;
                 if (string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
+                // ObjectId only means the object has a stable Scene Sync identity.
+                // MeshPath is the marker that the Unity object was actually published before.
+                if (string.IsNullOrWhiteSpace(identity.MeshPath)) continue;
 
                 var objectId = identity.ObjectId;
                 _managedObjects[objectId] = go;
@@ -1022,6 +1025,9 @@ namespace Afjk.SceneSync.Editor
             var path = PresenceClient.GenerateRandomPath();
             _meshPaths[objectId] = path;
             await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
+            identity.MeshPath = path;
+            EditorUtility.SetDirty(identity);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
 
             var pos = go.transform.position;
             var rot = go.transform.rotation;


### PR DESCRIPTION
Restore reconnect rebind guard so only previously published Unity identities are rebound.\n\n- RebindPublishedUnityObjects now requires identity.MeshPath in addition to Unity/objectId checks\n- added inline comment clarifying ObjectId vs MeshPath semantics\n- PublishUnityObject now persists identity.MeshPath after upload and marks identity/scene dirty