### PR TITLE
Fix GLB asset type inconsistency in Web-to-Web sync

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2918,9 +2918,36 @@ async function handleAiCommand(from, payload) {
 
 // ── シーン同期ヘルパー ───────────────────────────────────
 
+function normalizeSceneAsset(asset, payload = {}) {
+  const meshPath = payload.meshPath || asset?.meshPath;
+
+  if (meshPath && (asset?.type === 'gltf' || asset?.type === 'glb')) {
+    return {
+      ...asset,
+      type: 'mesh',
+      source: asset.source || 'carrier',
+      meshPath,
+      mime: asset.mime || 'model/gltf-binary',
+    };
+  }
+
+  if (!asset && meshPath) {
+    return {
+      type: 'mesh',
+      source: 'carrier',
+      meshPath,
+      assetId: payload.assetId || null,
+      mime: 'model/gltf-binary',
+    };
+  }
+
+  return asset;
+}
+
 function addOrUpdateObject(objectId, info, options = {}) {
   const existing = managedObjects.get(objectId);
-  const asset = info.asset;
+  let asset = info.asset;
+  asset = normalizeSceneAsset(asset, info);
 
   if (asset) {
     switch (asset.type) {
@@ -3593,16 +3620,17 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       return;
     }
 
-    // Always use fresh meshPath in asset for newly added local objects
+    // Use canonical asset metadata for creator and broadcast
     const asset = {
-      ...(model.userData.asset || {}),
-      type: 'gltf',
+      type: 'mesh',
+      source: 'carrier',
       meshPath: actualMeshPath,
     };
     if (assetId) {
       asset.assetId = assetId;
     }
-    model.userData.asset = asset;
+    model.userData.asset = { ...asset };
+    model.userData.meshPath = actualMeshPath;
 
     const historyEntry = HistoryManager.createAddEntry(
       objectId,
@@ -3625,16 +3653,9 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       position: model.position.toArray(),
       rotation: model.quaternion.toArray(),
       scale: model.scale.toArray(),
-      asset: {
-        type: 'mesh',
-        source: 'carrier',
-        meshPath: actualMeshPath,
-      },
+      asset: { ...asset },
       meshPath: actualMeshPath,
     };
-    if (assetId) {
-      sceneAddPayload.asset.assetId = assetId;
-    }
 
     broadcast(sceneAddPayload);
   } finally {


### PR DESCRIPTION
The creator tab was storing userData.asset.type = 'gltf' while broadcasting
type = 'mesh'. This caused sync failures when the creator's scene state was
later shared, as other tabs couldn't recognize 'gltf' as a valid asset type.

Changes:
1. Add normalizeSceneAsset() compatibility guard to convert legacy 'gltf'/glb'
   types with meshPath to the canonical 'mesh' type
2. Update uploadAndBroadcast() to store the same canonical asset metadata
   (type: 'mesh', source: 'carrier') in both model.userData and the
   broadcast payload, eliminating the inconsistency
3. Call normalizeSceneAsset() in addOrUpdateObject() before asset type checks

This ensures all clients receive and store the same asset metadata,
preventing "unsupported asset type: gltf" errors on reload.

https://claude.ai/code/session_018VqTJNRYdgQQwTceE5LtDU