### PR TITLE
スマホの「ファイルを追加」で GLB / テキストを選べるように修正

### DIFF
--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -973,7 +973,7 @@
   </aside>
   <button id="add-btn" title="GLB/画像を追加">＋</button>
   <button id="paste-btn" title="クリップボードから追加">📋</button>
-  <input type="file" id="file-input" accept=".glb,image/png,image/jpeg,image/webp,.txt,.md,.markdown,text/plain,text/markdown" style="display:none">
+  <input type="file" id="file-input" style="display:none">
   <div id="drop-overlay">GLB / 画像 / テキストをドロップして追加</div>
   <div id="paste-sheet" hidden>
     <div id="paste-sheet-panel">
@@ -992,7 +992,7 @@
         <button id="mobile-action-sheet-close" class="chip" type="button">閉じる</button>
       </div>
       <div class="mobile-sheet-actions">
-        <button id="mobile-add-image-btn" class="chip primary" type="button">画像を追加</button>
+        <button id="mobile-add-image-btn" class="chip primary" type="button">ファイルを追加</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>


### PR DESCRIPTION
### Motivation
- スマホのファイルピッカーが `accept` 属性によって `.glb` や一部テキストファイルを候補から隠しているため、選択可にして Scene Sync 側の `DragDropManager.handleFile()` に判定を任せる必要があった。

### Description
- `html/scenesync/index.html` のモバイル action sheet ボタン文言を `画像を追加` から `ファイルを追加` に変更した。
- 同ファイルの `#file-input` から `accept` 属性を削除してファイル選択を MIME/拡張子で絞り込まないようにした。

### Testing
- 新しいブランチ `codex/mobile-file-picker-glb` を作成し、`html/scenesync/index.html` の差分を `git diff` で確認した後に `git commit` を実行してコミットが成功していることを確認した。
- `git status` とファイルの行表示（`nl`/`sed`）で変更がファイルに反映されていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c016880c8320b0bf5a17ce60e1c9)