### PR TITLE
Restore mobile object-selection toolbar visibility in Scene Sync

### DIFF
--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -840,7 +840,8 @@
       }
 
       #mobile-toolbar {
-        display: none !important;
+        bottom: calc(84px + var(--mobile-safe-bottom));
+        z-index: 65;
       }
     }
   </style>


### PR DESCRIPTION
### Motivation
- Restore contextual mobile toolbar visibility which was unintentionally force-hidden by CSS so that JS-driven selection controls (Move/Rotate/Scale/Delete) can appear on object selection while preserving mobile safe-area spacing.

### Description
- Remove the mobile-only `display: none !important;` for `#mobile-toolbar` in `html/scenesync/index.html` and instead set `bottom: calc(84px + var(--mobile-safe-bottom));` and `z-index: 65` so visibility is driven by existing JS selection logic.

### Testing
- Ran `rg`/`sed` to locate affected selectors, used `git diff`/`nl` to verify the CSS update in `html/scenesync/index.html`, and committed the change with message `Fix mobile contextual toolbar visibility on object selection`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c40a8b50832099a90b9996aa9230)