### PR TITLE
Toggle mobile participants panel via status indicator

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5724,9 +5724,27 @@ btnCancelPairing?.addEventListener('click', cancelPairing);
 btnRevokeLink?.addEventListener('click', revokeLink);
 btnCopyPairingCode?.addEventListener('click', copyPairingCode);
 pairingCode?.addEventListener('click', copyPairingCode);
+function setMobilePeersOpen(open) {
+  peersPanelEl?.classList.toggle('mobile-open', open);
+  statusEl?.setAttribute('aria-expanded', open ? 'true' : 'false');
+}
+
 statusEl?.addEventListener('click', () => {
   if (!isMobileUi()) return;
-  peersPanelEl?.classList.toggle('mobile-open');
+  const next = !peersPanelEl?.classList.contains('mobile-open');
+  setMobilePeersOpen(Boolean(next));
+});
+
+document.addEventListener('click', (event) => {
+  if (!isMobileUi()) return;
+  if (!peersPanelEl?.classList.contains('mobile-open')) return;
+
+  const target = event.target;
+  if (!(target instanceof Node)) return;
+  if (peersPanelEl.contains(target)) return;
+  if (statusEl?.contains(target)) return;
+
+  setMobilePeersOpen(false);
 });
 sceneInspectorToggleBtn?.addEventListener('click', () => {
   setSceneInspectorOpen(!sceneInspectorState.isOpen);

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -911,7 +911,7 @@
     </div>
   </div>
 
-  <div id="status"><span class="dot off"></span>接続中…</div>
+  <div id="status" role="button" aria-controls="peers-panel" aria-expanded="false"><span class="dot off"></span>接続中…</div>
   <div id="peers-panel">
     <div id="peers-list"></div>
   </div>


### PR DESCRIPTION
### Motivation
- After a mobile UI change the participants list was hidden by CSS but had no JS to toggle it, so tapping the status chip did nothing on phones.
- The goal is to keep the panel hidden by default on mobile while allowing users to open/close it by tapping the connection/status indicator and to close it by tapping outside.

### Description
- Add `setMobilePeersOpen(open)` helper to sync the `mobile-open` class on `#peers-panel` and the `aria-expanded` state on `#status` in `html/assets/js/scenesync/scene.js`.
- Wire `#status` click to toggle the peers panel only on mobile by using `isMobileUi()` and the new helper in `html/assets/js/scenesync/scene.js`.
- Close the mobile peers panel when tapping outside of `#status` and `#peers-panel` by handling `document.click` in `html/assets/js/scenesync/scene.js`.
- Add accessibility attributes `role="button"`, `aria-controls="peers-panel"`, and `aria-expanded="false"` to the `#status` element in `html/scenesync/index.html`.

### Testing
- Ran `node --check html/assets/js/scenesync/scene.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c797df248320b06e7f48ed6f9201)