### PR TITLE
Scene Sync: prioritize IndexedDB GLB cache via assetId

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3268,14 +3268,51 @@ function loadMeshObject(objectId, info, meshPath, existing) {
 
   (async () => {
     try {
+      const incomingAssetId = info.asset?.assetId || info.assetId || null;
+      const cachedByAssetId = incomingAssetId
+        ? await assetCache.getByAssetId(incomingAssetId)
+        : null;
+      const cachedByMeshPath = !cachedByAssetId && meshPath
+        ? await assetCache.getByMeshPath(meshPath)
+        : null;
+      const cachedRecord = cachedByAssetId || cachedByMeshPath || null;
+      if (cachedRecord?.blob) {
+        console.debug('[asset-cache] hit for scene-add mesh', {
+          objectId,
+          assetId: cachedRecord.assetId || incomingAssetId || null,
+          meshPath: cachedRecord.meshPath || meshPath,
+          source: cachedByAssetId ? 'indexeddb-asset-id' : 'indexeddb-mesh-path',
+        });
+        await loadGlbBlobForObject(objectId, cachedRecord.blob, {
+          info,
+          existing,
+          meshPath,
+          assetId: cachedRecord.assetId || incomingAssetId || null,
+        });
+        removeLoadingOverlay(objectId);
+        return;
+      }
+
       const response = await fetch(url);
       if (!response.ok) {
         if (response.status === 404) {
           console.warn('[SceneSync] Mesh blob expired (404):', meshPath);
           removeLoadingOverlay(objectId);
 
-          const assetId = info.asset?.assetId || null;
+          const assetId = incomingAssetId;
           const expectedSize = null;
+          const cachedBeforeRecovery = assetId
+            ? await assetCache.getByAssetId(assetId)
+            : await assetCache.getByMeshPath(meshPath);
+          if (cachedBeforeRecovery?.blob) {
+            await loadGlbBlobForObject(objectId, cachedBeforeRecovery.blob, {
+              info,
+              existing,
+              meshPath,
+              assetId: cachedBeforeRecovery.assetId || assetId || null,
+            });
+            return;
+          }
           await expiredGlbRecovery.handleMissingGlb(
             objectId,
             meshPath,
@@ -3318,7 +3355,7 @@ function loadMeshObject(objectId, info, meshPath, existing) {
           replaceManagedObject(objectId, model, info);
 
           try {
-            let assetId = info.asset?.assetId;
+            let assetId = incomingAssetId;
             if (!assetId) {
               assetId = await computeAssetId(blob);
             }
@@ -3843,11 +3880,25 @@ function generateRandomPath() {
 }
 
 async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
+  const uploadBlob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
   const meshPath = generateRandomPath();
   let actualMeshPath = null;
   let assetId = null;
 
   try {
+    try {
+      assetId = await computeAssetId(arrayBuffer);
+      model.userData.assetId = assetId;
+      await assetCache.putAsset({
+        assetId,
+        meshPath: null,
+        blob: uploadBlob,
+        source: 'local-file',
+      });
+    } catch (cacheErr) {
+      console.warn('[SceneSync] Failed to pre-cache uploaded mesh:', cacheErr);
+    }
+
     try {
       const uploadResponse = await fetch(BLOB_BASE + '/' + meshPath, {
         method: 'POST',
@@ -3863,17 +3914,12 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       model.userData.meshPath = meshPath;
 
       try {
-        assetId = await computeAssetId(arrayBuffer);
-        model.userData.assetId = assetId;
-
-        const blob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
-        await assetCache.putAsset({
-          assetId,
-          meshPath: actualMeshPath,
-          blob,
-          source: 'carrier',
-        });
-        console.log('[SceneSync] Cached uploaded mesh:', { objectId, assetId, meshPath: actualMeshPath });
+        if (!assetId) {
+          assetId = await computeAssetId(arrayBuffer);
+          model.userData.assetId = assetId;
+        }
+        await assetCache.rememberMeshPathAlias(assetId, actualMeshPath);
+        console.log('[SceneSync] Remembered uploaded mesh alias:', { objectId, assetId, meshPath: actualMeshPath });
       } catch (cacheErr) {
         console.warn('[SceneSync] Failed to cache uploaded mesh:', cacheErr);
       }
@@ -3887,11 +3933,12 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
     const asset = {
       type: 'mesh',
       source: 'carrier',
+      assetId: assetId || null,
       meshPath: actualMeshPath,
+      size: uploadBlob.size,
+      mime: 'model/gltf-binary',
+      originalName: name || null,
     };
-    if (assetId) {
-      asset.assetId = assetId;
-    }
     model.userData.asset = { ...asset };
     model.userData.meshPath = actualMeshPath;
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3269,28 +3269,36 @@ function loadMeshObject(objectId, info, meshPath, existing) {
   (async () => {
     try {
       const incomingAssetId = info.asset?.assetId || info.assetId || null;
-      const cachedByAssetId = incomingAssetId
-        ? await assetCache.getByAssetId(incomingAssetId)
-        : null;
-      const cachedByMeshPath = !cachedByAssetId && meshPath
-        ? await assetCache.getByMeshPath(meshPath)
-        : null;
-      const cachedRecord = cachedByAssetId || cachedByMeshPath || null;
-      if (cachedRecord?.blob) {
-        console.debug('[asset-cache] hit for scene-add mesh', {
-          objectId,
-          assetId: cachedRecord.assetId || incomingAssetId || null,
-          meshPath: cachedRecord.meshPath || meshPath,
-          source: cachedByAssetId ? 'indexeddb-asset-id' : 'indexeddb-mesh-path',
-        });
-        await loadGlbBlobForObject(objectId, cachedRecord.blob, {
-          info,
-          existing,
-          meshPath,
-          assetId: cachedRecord.assetId || incomingAssetId || null,
-        });
-        removeLoadingOverlay(objectId);
-        return;
+      let cachedRecord = null;
+
+      try {
+        const cachedByAssetId = incomingAssetId
+          ? await assetCache.getByAssetId(incomingAssetId)
+          : null;
+        const cachedByMeshPath = !cachedByAssetId && meshPath
+          ? await assetCache.getByMeshPath(meshPath)
+          : null;
+
+        cachedRecord = cachedByAssetId || cachedByMeshPath || null;
+
+        if (cachedRecord?.blob) {
+          console.debug('[asset-cache] hit for scene-add mesh', {
+            objectId,
+            assetId: cachedRecord.assetId || incomingAssetId || null,
+            meshPath: cachedRecord.meshPath || meshPath,
+            source: cachedByAssetId ? 'indexeddb-asset-id' : 'indexeddb-mesh-path',
+          });
+          await loadGlbBlobForObject(objectId, cachedRecord.blob, {
+            info,
+            existing,
+            meshPath,
+            assetId: cachedRecord.assetId || incomingAssetId || null,
+          });
+          removeLoadingOverlay(objectId);
+          return;
+        }
+      } catch (cacheErr) {
+        console.warn('[asset-cache] lookup failed, falling back to network fetch:', cacheErr);
       }
 
       const response = await fetch(url);
@@ -3301,9 +3309,16 @@ function loadMeshObject(objectId, info, meshPath, existing) {
 
           const assetId = incomingAssetId;
           const expectedSize = null;
-          const cachedBeforeRecovery = assetId
-            ? await assetCache.getByAssetId(assetId)
-            : await assetCache.getByMeshPath(meshPath);
+          let cachedBeforeRecovery = null;
+
+          try {
+            cachedBeforeRecovery = assetId
+              ? await assetCache.getByAssetId(assetId)
+              : await assetCache.getByMeshPath(meshPath);
+          } catch (cacheErr) {
+            console.warn('[asset-cache] recovery pre-check failed:', cacheErr);
+          }
+
           if (cachedBeforeRecovery?.blob) {
             await loadGlbBlobForObject(objectId, cachedBeforeRecovery.blob, {
               info,


### PR DESCRIPTION
### Motivation

- Improve reload and late-join UX by allowing Scene Sync to restore GLB assets from a browser-local IndexedDB cache keyed by `assetId` instead of always fetching from the blob store.
- Avoid unnecessary re-download / recovery cycles for identical GLB files when they are already cached locally.
- Preserve the existing ephemeral room model and peer-recovery paths, using the IndexedDB cache as a safe local-performance optimization.

### Description

- Precompute `assetId` in `uploadAndBroadcast`, pre-store the local file blob to IndexedDB with `source: 'local-file'`, and call `assetCache.rememberMeshPathAlias(assetId, meshPath)` after upload to alias the uploaded `meshPath` to the `assetId`.
- Enrich the `scene-add` asset metadata to always include `assetId` (nullable) and add `size`, `mime`, and `originalName` while still keeping `meshPath` for backward compatibility.
- Change `loadMeshObject` to first check the asset cache by `assetId` and then by `meshPath`, and on cache hit call the existing `loadGlbBlobForObject` flow with the cached `Blob` (skipping network fetch/recovery); on cache miss it falls back to the existing fetch -> cache -> expired recovery flow.
- Add an extra cache check before invoking peer recovery on 404 responses and ensure fetched blobs are cached with computed `assetId` when available.

### Testing

- Verified repository and changes with `rg`/file inspections and `git diff` to confirm intended edits (succeeded).
- Committed the change using `git commit` (succeeded).
- Created the PR using the repository `make_pr` tooling which generated title and body (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cbdefd50832086a5dab144c5cd4c)