### PR TITLE
Scene Sync Unity: handle duplicated assets and bulk deletes

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -679,6 +679,13 @@ namespace Afjk.SceneSync.Editor
             if (fromIdMatch.Success)
                 fromId = fromIdMatch.Groups[1].Value;
 
+            DispatchSceneMessage(raw, fromId);
+        }
+
+        private void DispatchSceneMessage(string raw, string fromId = null)
+        {
+            if (string.IsNullOrEmpty(raw)) return;
+
             if (raw.Contains("\"kind\":\"scene-request\""))
             {
                 if (fromId != null)
@@ -690,6 +697,10 @@ namespace Afjk.SceneSync.Editor
             {
                 HandleSceneState(raw);
             }
+            else if (raw.Contains("\"kind\":\"scene-batch\""))
+            {
+                HandleSceneBatch(raw, fromId);
+            }
             else if (raw.Contains("\"kind\":\"scene-delta\""))
             {
                 HandleSceneDelta(raw);
@@ -698,7 +709,7 @@ namespace Afjk.SceneSync.Editor
             {
                 HandleSceneAdd(raw);
             }
-            else if (raw.Contains("\"kind\":\"scene-remove\""))
+            else if (raw.Contains("\"kind\":\"scene-remove\"") || raw.Contains("\"kind\":\"scene-delete\""))
             {
                 HandleSceneRemove(raw);
             }
@@ -714,6 +725,87 @@ namespace Afjk.SceneSync.Editor
             {
                 HandleSceneUnlock(raw);
             }
+        }
+
+        private void HandleSceneBatch(string raw, string fromId = null)
+        {
+            foreach (var op in ExtractTopLevelObjectsFromArray(raw, "ops"))
+            {
+                DispatchSceneMessage(op, fromId);
+            }
+
+            foreach (var action in ExtractTopLevelObjectsFromArray(raw, "actions"))
+            {
+                DispatchSceneMessage(action, fromId);
+            }
+        }
+
+        private static List<string> ExtractTopLevelObjectsFromArray(string raw, string fieldName)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(raw) || string.IsNullOrEmpty(fieldName)) return result;
+
+            var token = "\"" + fieldName + "\"";
+            var fieldIndex = raw.IndexOf(token, StringComparison.Ordinal);
+            if (fieldIndex < 0) return result;
+
+            var arrayStart = raw.IndexOf('[', fieldIndex);
+            if (arrayStart < 0) return result;
+
+            var depth = 0;
+            var objectStart = -1;
+            var inString = false;
+            var escape = false;
+
+            for (var i = arrayStart + 1; i < raw.Length; i++)
+            {
+                var ch = raw[i];
+
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inString = !inString;
+                    continue;
+                }
+
+                if (inString) continue;
+
+                if (ch == '{')
+                {
+                    if (depth == 0) objectStart = i;
+                    depth++;
+                    continue;
+                }
+
+                if (ch == '}')
+                {
+                    depth--;
+                    if (depth == 0 && objectStart >= 0)
+                    {
+                        result.Add(raw.Substring(objectStart, i - objectStart + 1));
+                        objectStart = -1;
+                    }
+                    continue;
+                }
+
+                if (ch == ']' && depth == 0)
+                {
+                    break;
+                }
+            }
+
+            return result;
         }
 
         private async System.Threading.Tasks.Task RequestSceneFromPeer()
@@ -1167,6 +1259,9 @@ namespace Afjk.SceneSync.Editor
             var meshPathMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"meshPath\":\"([^\"]+)\"");
             var meshPath = meshPathMatch.Success ? meshPathMatch.Groups[1].Value : null;
+            var assetIdMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"assetId\":\"([^\"]+)\"");
+            var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
             // meshPath を保存
             if (!string.IsNullOrEmpty(meshPath))
@@ -1177,14 +1272,14 @@ namespace Afjk.SceneSync.Editor
             // メッシュがある場合は glB をダウンロードしてインポート
             if (!string.IsNullOrEmpty(meshPath))
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId);
             }
             else
             {
                 // メッシュなしの場合はプレースホルダーの Cube を作成
                 var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 go.name = name;
-                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
+                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                 ApplyTransform(go, position, rotation, scale);
                 _managedObjects[objectId] = go;
@@ -1202,13 +1297,9 @@ namespace Afjk.SceneSync.Editor
             var go = FindManagedObject(objectId);
             if (go != null)
             {
-                _instanceToObjectId.Remove(go.GetInstanceID());
                 DestroyImmediate(go);
-                _managedObjects.Remove(objectId);
-                _knownObjectIds.Remove(objectId);
             }
-            _meshPaths.Remove(objectId);
-            _locks.Remove(objectId);
+            ForgetObject(objectId, go);
         }
 
         private void HandleSceneMesh(string raw)
@@ -1223,6 +1314,10 @@ namespace Afjk.SceneSync.Editor
             if (!meshPathMatch.Success) return;
             var meshPath = meshPathMatch.Groups[1].Value;
 
+            var assetIdMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"assetId\":\"([^\"]+)\"");
+            var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
+
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
 
@@ -1236,16 +1331,17 @@ namespace Afjk.SceneSync.Editor
                 var rot = go.transform.rotation;
                 var scl = go.transform.localScale;
                 DestroyImmediate(go);
-                _managedObjects.Remove(objectId);
+                ForgetObject(objectId, go);
 
                 _ = DownloadAndCreateObject(objectId, name, meshPath,
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
-                    new float[] { scl.x, scl.y, scl.z });
+                    new float[] { scl.x, scl.y, scl.z },
+                    assetId);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId);
             }
         }
 
@@ -1369,7 +1465,7 @@ namespace Afjk.SceneSync.Editor
 
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
-            float[] position, float[] rotation, float[] scale)
+            float[] position, float[] rotation, float[] scale, string assetId = null)
         {
             try
             {
@@ -1385,7 +1481,7 @@ namespace Afjk.SceneSync.Editor
                     // フォールバック: Cube を作成
                     var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     fallback.name = name;
-                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
+                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;
@@ -1413,7 +1509,7 @@ namespace Afjk.SceneSync.Editor
                 if (success)
                 {
                     var go = new GameObject(name);
-                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
+                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -1436,7 +1532,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
                     var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     fallback.name = name;
-                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
+                    ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;
@@ -1464,10 +1560,10 @@ namespace Afjk.SceneSync.Editor
             return identity;
         }
 
-        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath)
+        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath, string assetId = null)
         {
             var identity = EnsureSceneSyncIdentity(go);
-            identity.ConfigureRemoteTemporary(objectId, meshPath);
+            identity.ConfigureRemoteTemporary(objectId, meshPath, assetId);
             SceneSyncPickingUtility.ApplyImportedChildPicking(identity);
         }
 
@@ -1525,18 +1621,38 @@ namespace Afjk.SceneSync.Editor
                 return;
             }
 
-            var objectId = identity.ObjectId;
+            ForgetObject(identity.ObjectId, go);
+        }
+
+        private void ForgetObject(string objectId, GameObject go = null)
+        {
+            if (string.IsNullOrWhiteSpace(objectId)) return;
+
             _managedObjects.Remove(objectId);
-            _knownObjectIds.Remove(objectId);
-            _lastSnapshots.Remove(objectId);
             _meshPaths.Remove(objectId);
             _locks.Remove(objectId);
+            _lastSnapshots.Remove(objectId);
+            _knownObjectIds.Remove(objectId);
 
-            var transforms = go.GetComponentsInChildren<Transform>(true);
-            foreach (var t in transforms)
+            if (go != null)
             {
-                _instanceToObjectId.Remove(t.gameObject.GetInstanceID());
+                _instanceToObjectId.Remove(go.GetInstanceID());
+                foreach (var t in go.GetComponentsInChildren<Transform>(true))
+                {
+                    _instanceToObjectId.Remove(t.gameObject.GetInstanceID());
+                }
+                return;
             }
+
+            var stale = new List<int>();
+            foreach (var kvp in _instanceToObjectId)
+            {
+                if (kvp.Value == objectId)
+                    stale.Add(kvp.Key);
+            }
+
+            foreach (var key in stale)
+                _instanceToObjectId.Remove(key);
         }
 
         private struct TransformSnapshot

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1295,11 +1295,11 @@ namespace Afjk.SceneSync.Editor
             var objectId = objectIdMatch.Groups[1].Value;
 
             var go = FindManagedObject(objectId);
+            ForgetObject(objectId, go);
             if (go != null)
             {
                 DestroyImmediate(go);
             }
-            ForgetObject(objectId, go);
         }
 
         private void HandleSceneMesh(string raw)
@@ -1330,8 +1330,8 @@ namespace Afjk.SceneSync.Editor
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;
                 var scl = go.transform.localScale;
-                DestroyImmediate(go);
                 ForgetObject(objectId, go);
+                DestroyImmediate(go);
 
                 _ = DownloadAndCreateObject(objectId, name, meshPath,
                     new float[] { pos.x, pos.y, -pos.z },
@@ -1469,6 +1469,11 @@ namespace Afjk.SceneSync.Editor
         {
             try
             {
+                if (!string.IsNullOrEmpty(meshPath))
+                {
+                    _meshPaths[objectId] = meshPath;
+                }
+
                 var url = GetBlobUrl() + "/" + meshPath;
                 Debug.Log("[SceneSync] Downloading mesh: " + url);
 

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncIdentity.cs
@@ -24,6 +24,7 @@ namespace Afjk.SceneSync
     {
         [SerializeField] private string objectId;
         [SerializeField] private string meshPath;
+        [SerializeField] private string assetId;
         [SerializeField] private SceneSyncOrigin origin = SceneSyncOrigin.Unknown;
         [SerializeField] private bool temporary;
         [SerializeField] private SceneSyncState state = SceneSyncState.Synced;
@@ -39,6 +40,12 @@ namespace Afjk.SceneSync
         {
             get => meshPath;
             set => meshPath = value;
+        }
+
+        public string AssetId
+        {
+            get => assetId;
+            set => assetId = value;
         }
 
         public SceneSyncOrigin Origin
@@ -65,10 +72,11 @@ namespace Afjk.SceneSync
             set => lockOwner = value;
         }
 
-        public void ConfigureRemoteTemporary(string newObjectId, string newMeshPath)
+        public void ConfigureRemoteTemporary(string newObjectId, string newMeshPath, string newAssetId = null)
         {
             objectId = newObjectId;
             meshPath = newMeshPath;
+            assetId = newAssetId;
             origin = SceneSyncOrigin.Remote;
             temporary = true;
             state = SceneSyncState.Synced;
@@ -78,6 +86,7 @@ namespace Afjk.SceneSync
         public void ConfigureUnityManaged(string newObjectId)
         {
             objectId = newObjectId;
+            assetId = null;
             origin = SceneSyncOrigin.Unity;
             temporary = false;
             state = SceneSyncState.Synced;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1224,11 +1224,11 @@ namespace Afjk.SceneSync
             var objectId = objectIdMatch.Groups[1].Value;
 
             var go = FindManagedObject(objectId);
+            ForgetObject(objectId, go);
             if (go != null)
             {
                 Destroy(go);
             }
-            ForgetObject(objectId, go);
             OnObjectRemoved?.Invoke(objectId);
         }
 
@@ -1260,8 +1260,8 @@ namespace Afjk.SceneSync
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;
                 var scl = go.transform.localScale;
-                Destroy(go);
                 ForgetObject(objectId, go);
+                Destroy(go);
 
                 _ = DownloadAndCreateObject(objectId, name, meshPath,
                     new float[] { pos.x, pos.y, -pos.z },
@@ -1574,6 +1574,11 @@ namespace Afjk.SceneSync
             float[] position, float[] rotation, float[] scale, string assetId = null)
         {
             _knownObjectIds.Add(objectId);
+
+            if (!string.IsNullOrEmpty(meshPath))
+            {
+                _meshPaths[objectId] = meshPath;
+            }
 
             byte[] glbBytes = null;
 
@@ -2150,8 +2155,8 @@ namespace Afjk.SceneSync
 
                 if (success)
                 {
-                    Destroy(go);
                     ForgetObject(objectId, go);
+                    Destroy(go);
 
                     var newGo = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(newGo, objectId, meshPath, assetId);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -715,6 +715,13 @@ namespace Afjk.SceneSync
             if (fromIdMatch.Success)
                 fromId = fromIdMatch.Groups[1].Value;
 
+            DispatchSceneMessage(raw, fromId);
+        }
+
+        private void DispatchSceneMessage(string raw, string fromId = null)
+        {
+            if (string.IsNullOrEmpty(raw)) return;
+
             if (raw.Contains("\"kind\":\"scene-request\""))
             {
                 if (fromId != null)
@@ -730,6 +737,10 @@ namespace Afjk.SceneSync
             {
                 HandleSceneState(raw);
             }
+            else if (raw.Contains("\"kind\":\"scene-batch\""))
+            {
+                HandleSceneBatch(raw, fromId);
+            }
             else if (raw.Contains("\"kind\":\"scene-delta\""))
             {
                 HandleSceneDelta(raw);
@@ -738,7 +749,7 @@ namespace Afjk.SceneSync
             {
                 HandleSceneAdd(raw);
             }
-            else if (raw.Contains("\"kind\":\"scene-remove\""))
+            else if (raw.Contains("\"kind\":\"scene-remove\"") || raw.Contains("\"kind\":\"scene-delete\""))
             {
                 HandleSceneRemove(raw);
             }
@@ -758,6 +769,87 @@ namespace Afjk.SceneSync
             {
                 _ = HandleFileHandoff(fromId, raw);
             }
+        }
+
+        private void HandleSceneBatch(string raw, string fromId = null)
+        {
+            foreach (var op in ExtractTopLevelObjectsFromArray(raw, "ops"))
+            {
+                DispatchSceneMessage(op, fromId);
+            }
+
+            foreach (var action in ExtractTopLevelObjectsFromArray(raw, "actions"))
+            {
+                DispatchSceneMessage(action, fromId);
+            }
+        }
+
+        private static List<string> ExtractTopLevelObjectsFromArray(string raw, string fieldName)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(raw) || string.IsNullOrEmpty(fieldName)) return result;
+
+            var token = "\"" + fieldName + "\"";
+            var fieldIndex = raw.IndexOf(token, StringComparison.Ordinal);
+            if (fieldIndex < 0) return result;
+
+            var arrayStart = raw.IndexOf('[', fieldIndex);
+            if (arrayStart < 0) return result;
+
+            var depth = 0;
+            var objectStart = -1;
+            var inString = false;
+            var escape = false;
+
+            for (var i = arrayStart + 1; i < raw.Length; i++)
+            {
+                var ch = raw[i];
+
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inString = !inString;
+                    continue;
+                }
+
+                if (inString) continue;
+
+                if (ch == '{')
+                {
+                    if (depth == 0) objectStart = i;
+                    depth++;
+                    continue;
+                }
+
+                if (ch == '}')
+                {
+                    depth--;
+                    if (depth == 0 && objectStart >= 0)
+                    {
+                        result.Add(raw.Substring(objectStart, i - objectStart + 1));
+                        objectStart = -1;
+                    }
+                    continue;
+                }
+
+                if (ch == ']' && depth == 0)
+                {
+                    break;
+                }
+            }
+
+            return result;
         }
 
         private async System.Threading.Tasks.Task HandleAssetRequest(string raw, string requesterPeerId)
@@ -1111,7 +1203,7 @@ namespace Afjk.SceneSync
                 // メッシュなしの場合は Cube を作成
                 var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 go.name = name;
-                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
+                ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                 _managedObjects[objectId] = go;
@@ -1134,13 +1226,9 @@ namespace Afjk.SceneSync
             var go = FindManagedObject(objectId);
             if (go != null)
             {
-                _instanceToObjectId.Remove(go.GetInstanceID());
                 Destroy(go);
-                _managedObjects.Remove(objectId);
-                _knownObjectIds.Remove(objectId);
             }
-            _meshPaths.Remove(objectId);
-            _locks.Remove(objectId);
+            ForgetObject(objectId, go);
             OnObjectRemoved?.Invoke(objectId);
         }
 
@@ -1173,7 +1261,7 @@ namespace Afjk.SceneSync
                 var rot = go.transform.rotation;
                 var scl = go.transform.localScale;
                 Destroy(go);
-                _managedObjects.Remove(objectId);
+                ForgetObject(objectId, go);
 
                 _ = DownloadAndCreateObject(objectId, name, meshPath,
                     new float[] { pos.x, pos.y, -pos.z },
@@ -1455,14 +1543,15 @@ namespace Afjk.SceneSync
             string meshPath,
             float[] position,
             float[] rotation,
-            float[] scale)
+            float[] scale,
+            string assetId = null)
         {
             var placeholder = _managedObjects[objectId];
             var placeholderInstanceId = placeholder.GetInstanceID();
 
             var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
             fallback.name = name;
-            ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath);
+            ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
             fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
             var fallbackMaterial = GetFallbackImportMaterial();
@@ -1538,7 +1627,7 @@ namespace Afjk.SceneSync
                         _ = HandleMissingGlb(objectId, meshPath, null, assetId);
                     }
 
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -1597,7 +1686,7 @@ namespace Afjk.SceneSync
                     var placeholderInstanceId = placeholder.GetInstanceID();
 
                     var go = new GameObject(name);
-                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath);
+                    ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -1644,7 +1733,7 @@ namespace Afjk.SceneSync
                         + ", loadingError=" + gltf.LoadingError
                         + ", sceneCount=" + gltf.SceneCount
                         + ", defaultScene=" + (gltf.DefaultSceneIndex.HasValue ? gltf.DefaultSceneIndex.Value.ToString() : "null"));
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
                     OnObjectAdded?.Invoke(objectId, fallback);
                 }
 
@@ -1683,7 +1772,7 @@ namespace Afjk.SceneSync
 
                 if (_managedObjects.ContainsKey(objectId))
                 {
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -1704,10 +1793,10 @@ namespace Afjk.SceneSync
             return identity;
         }
 
-        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath)
+        private static void ConfigureRemoteTemporaryIdentity(GameObject go, string objectId, string meshPath, string assetId = null)
         {
             var identity = EnsureSceneSyncIdentity(go);
-            identity.ConfigureRemoteTemporary(objectId, meshPath);
+            identity.ConfigureRemoteTemporary(objectId, meshPath, assetId);
         }
 
         private void EnsureManagedObjectsList()
@@ -2013,7 +2102,7 @@ namespace Afjk.SceneSync
                     _meshPathCache[recovery.meshPath] = data;
 
                 Debug.Log("[ExpiredGlbRecovery] Loading recovered GLB into object: " + recovery.objectId);
-                await LoadGlbFromBytes(recovery.objectId, data);
+                await LoadGlbFromBytes(recovery.objectId, data, computedAssetId ?? recovery.assetId);
                 Debug.Log("[ExpiredGlbRecovery] Recovered GLB loaded successfully");
             }
             catch (Exception err)
@@ -2022,7 +2111,7 @@ namespace Afjk.SceneSync
             }
         }
 
-        private async System.Threading.Tasks.Task LoadGlbFromBytes(string objectId, byte[] glbBytes)
+        private async System.Threading.Tasks.Task LoadGlbFromBytes(string objectId, byte[] glbBytes, string assetId = null)
         {
             var go = FindManagedObject(objectId);
             if (go == null)
@@ -2062,10 +2151,10 @@ namespace Afjk.SceneSync
                 if (success)
                 {
                     Destroy(go);
-                    _managedObjects.Remove(objectId);
+                    ForgetObject(objectId, go);
 
                     var newGo = new GameObject(name);
-                    ConfigureRemoteTemporaryIdentity(newGo, objectId, meshPath);
+                    ConfigureRemoteTemporaryIdentity(newGo, objectId, meshPath, assetId);
                     newGo.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
@@ -2105,17 +2194,39 @@ namespace Afjk.SceneSync
                 return;
             }
 
-            var objectId = identity.ObjectId;
+            ForgetObject(identity.ObjectId, go);
+        }
+
+        private void ForgetObject(string objectId, GameObject go = null)
+        {
+            if (string.IsNullOrWhiteSpace(objectId)) return;
+
             _managedObjects.Remove(objectId);
             _knownObjectIds.Remove(objectId);
             _lastSnapshots.Remove(objectId);
             _meshPaths.Remove(objectId);
             _locks.Remove(objectId);
 
-            var transforms = go.GetComponentsInChildren<Transform>(true);
-            foreach (var t in transforms)
+            if (go != null)
             {
-                _instanceToObjectId.Remove(t.gameObject.GetInstanceID());
+                _instanceToObjectId.Remove(go.GetInstanceID());
+                foreach (var t in go.GetComponentsInChildren<Transform>(true))
+                {
+                    _instanceToObjectId.Remove(t.gameObject.GetInstanceID());
+                }
+                return;
+            }
+
+            var stale = new List<int>();
+            foreach (var kvp in _instanceToObjectId)
+            {
+                if (kvp.Value == objectId)
+                    stale.Add(kvp.Key);
+            }
+
+            foreach (var key in stale)
+            {
+                _instanceToObjectId.Remove(key);
             }
         }
 


### PR DESCRIPTION
## Summary

Updates the Unity Scene Sync plugin to follow recent Web editing improvements.

The Web client can now duplicate/paste objects by creating new scene objects that reuse the same assetId/meshPath. This PR makes Unity handle those duplicated asset references correctly and improves cleanup for bulk remove messages.

## Changes

- Treat scene-add with a new objectId as a new Unity GameObject even when assetId/meshPath is reused
- Reuse cached GLB bytes without reusing existing GameObject instances
- Clean up managed state consistently on scene-remove and scene-mesh replacement
- Accept scene-delete as a compatibility alias
- Add basic scene-batch handling for future multi-op messages
- Preserve existing Unity publish and transform sync behavior
- Track assetId on SceneSyncIdentity for remote objects

## Notes

- This does not add Unity-side copy/paste UI
- This does not add Unity-side multi-object transform
- This does not add persistent disk cache
- Validation still needs Unity Editor / Runtime runtime checks for duplicate restore and bulk delete flows