### PR TITLE
Scene Sync: align dropped images and text to wall surfaces

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -30,6 +30,9 @@ function normalizePositionContext(input, fallbackPosition) {
       clientX: input.clientX,
       clientY: input.clientY,
       upness: input.upness,
+      normal: input.normal || null,
+      normalArray: input.normalArray || input.normal?.toArray?.() || null,
+      hitObjectId: input.hitObjectId || null,
     };
   }
 
@@ -41,6 +44,9 @@ function normalizePositionContext(input, fallbackPosition) {
       clientX: undefined,
       clientY: undefined,
       upness: undefined,
+      normal: null,
+      normalArray: null,
+      hitObjectId: null,
     };
   }
 
@@ -50,6 +56,9 @@ function normalizePositionContext(input, fallbackPosition) {
     clientX: undefined,
     clientY: undefined,
     upness: undefined,
+    normal: null,
+    normalArray: null,
+    hitObjectId: null,
   };
 }
 
@@ -196,6 +205,33 @@ export class DragDropManager {
     return hits[0] || null;
   }
 
+  _getWorldNormalFromHit(hit) {
+    if (!hit?.face?.normal || !hit.object || !this.THREE?.Matrix3) return null;
+
+    const normalMatrix = new this.THREE.Matrix3().getNormalMatrix(hit.object.matrixWorld);
+    return hit.face.normal.clone().applyMatrix3(normalMatrix).normalize();
+  }
+
+  _getSurfaceKind(normal) {
+    if (!normal) return 'unknown';
+
+    const worldUp = new this.THREE.Vector3(0, 1, 0);
+    const dotUp = normal.clone().normalize().dot(worldUp);
+
+    if (dotUp > 0.75) return 'floor';
+    if (dotUp < -0.75) return 'ceiling';
+    return 'wall';
+  }
+
+  _createSurfaceQuaternion(normal) {
+    if (!normal) return null;
+
+    const n = normal.clone().normalize();
+    const localForward = new this.THREE.Vector3(0, 0, 1);
+
+    return new this.THREE.Quaternion().setFromUnitVectors(localForward, n);
+  }
+
   _dropPositionFromEvent(event) {
     if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
       return {
@@ -220,6 +256,7 @@ export class DragDropManager {
       hit: !!hit,
       hitObject: hit?.object?.name || null,
       hitObjectType: hit?.object?.type || null,
+      hitObjectId: hit?.object?.userData?.objectId || null,
       hitDistance: hit?.distance ?? null,
       upness: rayInfo.upness,
       threshold: SKY_DROP_UPNESS_THRESHOLD,
@@ -231,9 +268,14 @@ export class DragDropManager {
     console.debug('[drag-drop] drop detection', this.lastDropDetection);
 
     if (hit) {
+      const hitNormal = this._getWorldNormalFromHit(hit);
+
       return {
         position: hit.point.clone(),
+        normal: hitNormal,
+        normalArray: hitNormal?.toArray?.() || null,
         targetKind: 'scene',
+        hitObjectId: hit.object?.userData?.objectId || null,
         clientX: event.clientX,
         clientY: event.clientY,
         upness: rayInfo.upness,
@@ -289,6 +331,11 @@ export class DragDropManager {
       positionContext,
       this._defaultDropPosition()
     );
+    const surfaceKind = this._getSurfaceKind(normalized.normal);
+    const surfaceQuaternion = surfaceKind === 'wall'
+      ? this._createSurfaceQuaternion(normalized.normal)
+      : null;
+    const placementRotation = surfaceQuaternion?.toArray?.() || null;
 
     if (isGlbFile(file)) {
       return this._loadFile(file, normalized.position);
@@ -303,6 +350,10 @@ export class DragDropManager {
         source: 'image',
         targetKind: normalized.targetKind,
         temporary: true,
+        normal: normalized.normal,
+        normalArray: normalized.normalArray,
+        surfaceKind,
+        placementRotation,
       };
 
       const toastMessage = normalized.targetKind === 'sky'
@@ -321,6 +372,12 @@ export class DragDropManager {
           clientX: normalized.clientX,
           clientY: normalized.clientY,
           upness: normalized.upness,
+          normal: normalized.normal,
+          normalArray: normalized.normalArray,
+          hitObjectId: normalized.hitObjectId,
+          surfaceKind,
+          placementQuaternion: surfaceQuaternion,
+          placementRotation,
           tempObjectId: objectId,
         });
       } catch (error) {
@@ -342,6 +399,12 @@ export class DragDropManager {
           clientX: normalized.clientX,
           clientY: normalized.clientY,
           upness: normalized.upness,
+          normal: normalized.normal,
+          normalArray: normalized.normalArray,
+          hitObjectId: normalized.hitObjectId,
+          surfaceKind,
+          placementQuaternion: surfaceQuaternion,
+          placementRotation,
         });
       } catch (error) {
         console.warn('[drag-drop] text import failed:', error);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1295,10 +1295,10 @@ function showTemporaryImagePreview(objectId, file, position, options = {}) {
     return;
   }
 
-  createTemporaryPlanePreview(objectId, file, position, entry);
+  createTemporaryPlanePreview(objectId, file, position, entry, options);
 }
 
-async function createTemporaryPlanePreview(objectId, file, position, entry) {
+async function createTemporaryPlanePreview(objectId, file, position, entry, options = {}) {
   const t0 = performance.now();
 
   try {
@@ -1347,6 +1347,11 @@ async function createTemporaryPlanePreview(objectId, file, position, entry) {
       group.position.copy(position);
     } else if (Array.isArray(position)) {
       group.position.fromArray(position);
+    }
+
+    const placementRotation = readQuaternionArray(options.placementRotation, null);
+    if (placementRotation) {
+      group.quaternion.fromArray(placementRotation);
     }
 
     const mesh = new THREE.Mesh(geometry, material);
@@ -4762,13 +4767,14 @@ async function imageImporterCallback(file, position, context = {}) {
     const positionArray = (position && typeof position.toArray === 'function')
       ? position.toArray()
       : [0, 1, 0];
+    const rotation = readQuaternionArray(context.placementRotation, [0, 0, 0, 1]);
 
     const payload = {
       kind: 'scene-add',
       objectId,
       name: displayName,
       position: positionArray,
-      rotation: [0, 0, 0, 1],
+      rotation,
       scale: [1, 1, 1],
       asset: { type: 'mesh', meshPath },
       metadata: {
@@ -4782,6 +4788,10 @@ async function imageImporterCallback(file, position, context = {}) {
           originalBytes: optimizationInfo?.originalBytes,
           maxPixel: optimizationInfo?.maxPixel,
           optimized: !!optimizationInfo?.resized,
+        },
+        placement: {
+          surfaceKind: context.surfaceKind || 'unknown',
+          normal: context.normalArray || null,
         },
       },
     };
@@ -4813,6 +4823,9 @@ async function imageImporterCallback(file, position, context = {}) {
 }
 
 async function textImporterCallback(text, position, filename = 'text.md', context = {}) {
+  const existingMetadata = (context.metadata && typeof context.metadata === 'object')
+    ? context.metadata
+    : {};
   const { arrayBuffer } = await buildTextPlaneGlb(text, {
     THREE,
     GLTFExporter,
@@ -4830,7 +4843,7 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
   const positionArray = (position && typeof position.toArray === 'function')
     ? position.toArray()
     : [0, 1, 0];
-  const rotation = readQuaternionArray(context.rotation, [0, 0, 0, 1]);
+  const rotation = readQuaternionArray(context.placementRotation || context.rotation, [0, 0, 0, 1]);
   const scale = readVector3Array(context.scale, [1, 1, 1]);
 
   const payload = {
@@ -4841,6 +4854,13 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     rotation,
     scale,
     asset: { type: 'mesh', meshPath },
+    metadata: {
+      ...existingMetadata,
+      placement: {
+        surfaceKind: context.surfaceKind || 'unknown',
+        normal: context.normalArray || null,
+      },
+    },
   };
 
   broadcast(payload);
@@ -4915,6 +4935,7 @@ const dragDropManager = new DragDropManager({
     position,
     source,
     targetKind,
+    placementRotation,
   }) => {
     if (!objectId) return;
     const label = source === 'image'
@@ -4926,7 +4947,10 @@ const dragDropManager = new DragDropManager({
     addLoadingOverlay(objectId, label, { position: position?.toArray?.() });
 
     if (source === 'image') {
-      showTemporaryImagePreview(objectId, file, position, { targetKind });
+      showTemporaryImagePreview(objectId, file, position, {
+        targetKind,
+        placementRotation,
+      });
     }
   },
   onLoadEnd: async ({ objectId, source }) => {


### PR DESCRIPTION
## Summary

Aligns dropped images and text with the hit wall surface in Scene Sync.

When dragging an image or text file onto a mesh wall, the client now uses the hit face normal to compute the initial rotation. GLB and skybox placement remain unchanged.

## Changes

- Add world-space hit normal to DragDropManager placement context
- Classify hit surfaces as floor / wall / ceiling
- Apply wall-surface rotation to image and text imports
- Keep GLB placement behavior unchanged
- Preserve rotation in scene-add payloads

## Notes

- This only applies to wall surfaces for now
- Floor and ceiling placement remain unchanged
- GLB yaw/surface alignment is intentionally left for a later PR