### PR TITLE
Scene Sync: fix image wall rotation follow-up

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -33,6 +33,8 @@ function normalizePositionContext(input, fallbackPosition) {
       normal: input.normal || null,
       normalArray: input.normalArray || input.normal?.toArray?.() || null,
       hitObjectId: input.hitObjectId || null,
+      surfaceKind: input.surfaceKind || null,
+      placementRotation: input.placementRotation || null,
     };
   }
 
@@ -47,6 +49,8 @@ function normalizePositionContext(input, fallbackPosition) {
       normal: null,
       normalArray: null,
       hitObjectId: null,
+      surfaceKind: null,
+      placementRotation: null,
     };
   }
 
@@ -59,6 +63,8 @@ function normalizePositionContext(input, fallbackPosition) {
     normal: null,
     normalArray: null,
     hitObjectId: null,
+    surfaceKind: null,
+    placementRotation: null,
   };
 }
 
@@ -346,10 +352,12 @@ export class DragDropManager {
       positionContext,
       this._defaultDropPosition()
     );
-    const surfaceKind = this._getSurfaceKind(normalized.normal);
-    const surfaceQuaternion = surfaceKind === 'wall'
-      ? this._createSurfaceQuaternion(normalized.normal)
-      : null;
+    const surfaceKind = normalized.surfaceKind || this._getSurfaceKind(normalized.normal);
+    const surfaceQuaternion = normalized.placementRotation
+      ? new this.THREE.Quaternion().fromArray(normalized.placementRotation)
+      : (surfaceKind === 'wall'
+        ? this._createSurfaceQuaternion(normalized.normal)
+        : null);
     const placementRotation = surfaceQuaternion?.toArray?.() || null;
 
     if (isGlbFile(file)) {

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -223,10 +223,16 @@ export class DragDropManager {
     return 'wall';
   }
 
-  _createSurfaceQuaternion(normal) {
+  _createSurfaceQuaternion(normal, rayDirection = null) {
     if (!normal) return null;
 
     const n = normal.clone().normalize();
+    if (rayDirection && typeof rayDirection.clone === 'function') {
+      const ray = rayDirection.clone().normalize();
+      if (n.dot(ray) > 0) {
+        n.multiplyScalar(-1);
+      }
+    }
     const localForward = new this.THREE.Vector3(0, 0, 1);
 
     return new this.THREE.Quaternion().setFromUnitVectors(localForward, n);
@@ -245,6 +251,11 @@ export class DragDropManager {
 
     const rayInfo = this._createDropRay(event);
     const hit = this._findPlacementHit(rayInfo.raycaster);
+    const hitNormal = hit ? this._getWorldNormalFromHit(hit) : null;
+    const surfaceKind = this._getSurfaceKind(hitNormal);
+    const surfaceQuaternion = surfaceKind === 'wall'
+      ? this._createSurfaceQuaternion(hitNormal, rayInfo.ray.direction)
+      : null;
 
     const debugTargetKind = hit
       ? 'scene-hit'
@@ -253,6 +264,7 @@ export class DragDropManager {
         : 'scene-fallback';
 
     this.lastDropDetection = {
+      ...this.lastDropDetection,
       hit: !!hit,
       hitObject: hit?.object?.name || null,
       hitObjectType: hit?.object?.type || null,
@@ -263,17 +275,20 @@ export class DragDropManager {
       targetKind: debugTargetKind,
       clientX: event.clientX,
       clientY: event.clientY,
+      normal: hitNormal?.toArray?.() || null,
+      surfaceKind,
+      placementRotation: surfaceQuaternion?.toArray?.() || null,
     };
 
     console.debug('[drag-drop] drop detection', this.lastDropDetection);
 
     if (hit) {
-      const hitNormal = this._getWorldNormalFromHit(hit);
-
       return {
         position: hit.point.clone(),
         normal: hitNormal,
         normalArray: hitNormal?.toArray?.() || null,
+        surfaceKind,
+        placementRotation: surfaceQuaternion?.toArray?.() || null,
         targetKind: 'scene',
         hitObjectId: hit.object?.userData?.objectId || null,
         clientX: event.clientX,
@@ -354,12 +369,19 @@ export class DragDropManager {
         normalArray: normalized.normalArray,
         surfaceKind,
         placementRotation,
+        placementQuaternion: surfaceQuaternion,
       };
 
       const toastMessage = normalized.targetKind === 'sky'
         ? 'Skybox画像を準備中…'
         : '画像を準備中…';
       this.showToast?.(toastMessage);
+      console.debug('[drag-drop] image placement', {
+        targetKind: normalized.targetKind,
+        normal: normalized.normalArray,
+        surfaceKind,
+        placementRotation,
+      });
       if (this.onLoadStart) {
         Promise.resolve(this.onLoadStart(loadInfo)).catch((error) => {
           console.warn('[drag-drop] image onLoadStart failed:', error);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1349,9 +1349,11 @@ async function createTemporaryPlanePreview(objectId, file, position, entry, opti
       group.position.fromArray(position);
     }
 
-    const placementRotation = readQuaternionArray(options.placementRotation, null);
-    if (placementRotation) {
-      group.quaternion.fromArray(placementRotation);
+    const placementQuaternion = Array.isArray(options.placementRotation)
+      ? new THREE.Quaternion().fromArray(options.placementRotation)
+      : options.placementQuaternion || null;
+    if (placementQuaternion) {
+      group.quaternion.copy(placementQuaternion);
     }
 
     const mesh = new THREE.Mesh(geometry, material);
@@ -4767,7 +4769,12 @@ async function imageImporterCallback(file, position, context = {}) {
     const positionArray = (position && typeof position.toArray === 'function')
       ? position.toArray()
       : [0, 1, 0];
-    const rotation = readQuaternionArray(context.placementRotation, [0, 0, 0, 1]);
+    const placementQuaternion = Array.isArray(context.placementRotation)
+      ? new THREE.Quaternion().fromArray(context.placementRotation)
+      : context.placementQuaternion || null;
+    const rotation = placementQuaternion
+      ? placementQuaternion.toArray()
+      : [0, 0, 0, 1];
 
     const payload = {
       kind: 'scene-add',
@@ -4935,6 +4942,7 @@ const dragDropManager = new DragDropManager({
     position,
     source,
     targetKind,
+    placementQuaternion,
     placementRotation,
   }) => {
     if (!objectId) return;
@@ -4949,6 +4957,7 @@ const dragDropManager = new DragDropManager({
     if (source === 'image') {
       showTemporaryImagePreview(objectId, file, position, {
         targetKind,
+        placementQuaternion,
         placementRotation,
       });
     }


### PR DESCRIPTION
## Summary

Fixes the follow-up bug where image drag/drop onto a wall did not preserve the wall-aligned rotation.

The drop context now keeps the hit normal, surface kind, and placement quaternion all the way through the image import flow. Temporary image preview and the final scene-add payload now use the same rotation, and the wall-facing quaternion is flipped toward the dropper when needed.

## Changes

- Add richer wall-drop debug data to DragDropManager
- Preserve hit normal and placement rotation in image drop context
- Convert placement rotation to a quaternion in the image importer
- Apply the same quaternion to temporary preview and final image object
- Preserve wall rotation in scene-add payloads for remote clients and snapshot restore

## Notes

- GLB and skybox placement remain unchanged
- Floor and ceiling image placement remain unchanged