### PR TITLE
Scene Sync: fix URL image wall placement and z-fighting

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -32,9 +32,13 @@ function normalizePositionContext(input, fallbackPosition) {
       upness: input.upness,
       normal: input.normal || null,
       normalArray: input.normalArray || input.normal?.toArray?.() || null,
+      rawNormalArray: input.rawNormalArray || null,
       hitObjectId: input.hitObjectId || null,
       surfaceKind: input.surfaceKind || null,
       placementRotation: input.placementRotation || null,
+      wallSurfaceOffset: input.wallSurfaceOffset ?? 0,
+      hitPoint: input.hitPoint || null,
+      placementPosition: input.placementPosition || null,
     };
   }
 
@@ -48,9 +52,13 @@ function normalizePositionContext(input, fallbackPosition) {
       upness: undefined,
       normal: null,
       normalArray: null,
+      rawNormalArray: null,
       hitObjectId: null,
       surfaceKind: null,
       placementRotation: null,
+      wallSurfaceOffset: 0,
+      hitPoint: null,
+      placementPosition: null,
     };
   }
 
@@ -62,9 +70,13 @@ function normalizePositionContext(input, fallbackPosition) {
     upness: undefined,
     normal: null,
     normalArray: null,
+    rawNormalArray: null,
     hitObjectId: null,
     surfaceKind: null,
     placementRotation: null,
+    wallSurfaceOffset: 0,
+    hitPoint: null,
+    placementPosition: null,
   };
 }
 
@@ -92,6 +104,7 @@ export class DragDropManager {
       imageImporter,
       textImporter,
       urlImporter,
+      wallSurfaceOffset = 0.01,
       THREE: ThreeModule,
     } = options || {};
 
@@ -113,6 +126,7 @@ export class DragDropManager {
     this.imageImporter = imageImporter;
     this.textImporter = textImporter;
     this.urlImporter = urlImporter;
+    this.wallSurfaceOffset = wallSurfaceOffset;
     this.getPlacementTargets = getPlacementTargets;
     this.THREE = ThreeModule || (globalThis.THREE || {});
     this.coordinateTransformer = new CoordinateTransformer(camera, renderer, scene, {
@@ -244,6 +258,20 @@ export class DragDropManager {
     return new this.THREE.Quaternion().setFromUnitVectors(localForward, n);
   }
 
+  _orientNormalTowardRay(normal, rayDirection = null) {
+    if (!normal) return null;
+
+    const oriented = normal.clone().normalize();
+    if (rayDirection && typeof rayDirection.clone === 'function') {
+      const ray = rayDirection.clone().normalize();
+      if (oriented.dot(ray) > 0) {
+        oriented.multiplyScalar(-1);
+      }
+    }
+
+    return oriented;
+  }
+
   _dropPositionFromEvent(event) {
     if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
       return {
@@ -259,8 +287,19 @@ export class DragDropManager {
     const hit = this._findPlacementHit(rayInfo.raycaster);
     const hitNormal = hit ? this._getWorldNormalFromHit(hit) : null;
     const surfaceKind = this._getSurfaceKind(hitNormal);
+    const orientedNormal = surfaceKind === 'wall'
+      ? this._orientNormalTowardRay(hitNormal, rayInfo.ray.direction)
+      : hitNormal;
     const surfaceQuaternion = surfaceKind === 'wall'
-      ? this._createSurfaceQuaternion(hitNormal, rayInfo.ray.direction)
+      ? this._createSurfaceQuaternion(orientedNormal)
+      : null;
+    const wallSurfaceOffset = surfaceKind === 'wall' && orientedNormal
+      ? this.wallSurfaceOffset
+      : 0;
+    const placementPosition = hit
+      ? (wallSurfaceOffset > 0
+        ? hit.point.clone().addScaledVector(orientedNormal, wallSurfaceOffset)
+        : hit.point.clone())
       : null;
 
     const debugTargetKind = hit
@@ -281,20 +320,28 @@ export class DragDropManager {
       targetKind: debugTargetKind,
       clientX: event.clientX,
       clientY: event.clientY,
-      normal: hitNormal?.toArray?.() || null,
+      normal: orientedNormal?.toArray?.() || null,
+      rawNormal: hitNormal?.toArray?.() || null,
       surfaceKind,
       placementRotation: surfaceQuaternion?.toArray?.() || null,
+      wallSurfaceOffset,
+      hitPoint: hit?.point?.toArray?.() || null,
+      placementPosition: placementPosition?.toArray?.() || null,
     };
 
     console.debug('[drag-drop] drop detection', this.lastDropDetection);
 
     if (hit) {
       return {
-        position: hit.point.clone(),
-        normal: hitNormal,
-        normalArray: hitNormal?.toArray?.() || null,
+        position: placementPosition || hit.point.clone(),
+        normal: orientedNormal,
+        normalArray: orientedNormal?.toArray?.() || null,
+        rawNormalArray: hitNormal?.toArray?.() || null,
         surfaceKind,
         placementRotation: surfaceQuaternion?.toArray?.() || null,
+        wallSurfaceOffset,
+        hitPoint: hit.point.toArray(),
+        placementPosition: (placementPosition || hit.point).toArray(),
         targetKind: 'scene',
         hitObjectId: hit.object?.userData?.objectId || null,
         clientX: event.clientX,

--- a/html/assets/js/scenesync/loaders/url-importers/image.js
+++ b/html/assets/js/scenesync/loaders/url-importers/image.js
@@ -143,16 +143,41 @@ export async function importImageUrl(url, ctx) {
     const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'image');
     const displayName = (ctx.nameOverride || filename).slice(0, 60) || 'image';
     const spawnTransform = ctx.getSpawnTransform();
+    const existingMetadata = (ctx.metadata && typeof ctx.metadata === 'object')
+      ? ctx.metadata
+      : {};
+    const placementRotation = Array.isArray(ctx.placementRotation) && ctx.placementRotation.length >= 4
+      ? ctx.placementRotation
+      : spawnTransform.rotation;
 
     const payload = {
       kind: 'scene-add',
       objectId,
       name: displayName,
       position: spawnTransform.position,
-      rotation: spawnTransform.rotation,
+      rotation: placementRotation,
       scale: spawnTransform.scale,
       asset: { type: 'image', source: 'url', url },
+      metadata: {
+        ...existingMetadata,
+        placement: {
+          surfaceKind: ctx.surfaceKind || null,
+          normal: ctx.normalArray || null,
+          rawNormal: ctx.rawNormalArray || null,
+          wallSurfaceOffset: ctx.wallSurfaceOffset ?? 0,
+        },
+      },
     };
+
+    console.debug('[url-image-import] scene-add transform', {
+      objectId,
+      position: payload.position,
+      rotation: payload.rotation,
+      scale: payload.scale,
+      surfaceKind: ctx.surfaceKind || null,
+      normal: ctx.normalArray || null,
+      wallSurfaceOffset: ctx.wallSurfaceOffset ?? 0,
+    });
 
     ctx.broadcastSceneAdd(payload);
 

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -32,7 +32,7 @@ export async function importTextUrl(url, ctx) {
     throw err;
   }
 
-  await ctx.textImporter(text, filename);
+  await ctx.textImporter(text, filename, ctx);
 
   return { objectId: null, payload: null };
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3565,13 +3565,15 @@ function createAiUrlImportContext(params = {}, context = {}) {
     rawNormalArray: context.rawNormalArray || null,
     wallSurfaceOffset: context.wallSurfaceOffset ?? 0,
     placementPosition: context.placementPosition || null,
-    textImporter: (text, filename) => textImporterCallback(text, position, filename, {
-      ...context,
-      objectId: params.objectId,
-      name: params.name,
-      rotation,
-      scale,
-    }),
+    textImporter: (text, filename, importerContext = {}) =>
+      textImporterCallback(text, position, filename, {
+        ...context,
+        ...importerContext,
+        objectId: params.objectId,
+        name: params.name,
+        rotation,
+        scale,
+      }),
     THREE,
     GLTFLoader,
     targetKind: context?.targetKind || 'scene',
@@ -4964,9 +4966,10 @@ async function urlImporterCallback(url, position, context = {}) {
     rawNormalArray: context.rawNormalArray || null,
     wallSurfaceOffset: context.wallSurfaceOffset ?? 0,
     placementPosition: context.placementPosition || null,
-    textImporter: (text, filename) =>
+    textImporter: (text, filename, importerContext = {}) =>
       textImporterCallback(text, position, filename, {
         ...context,
+        ...importerContext,
       }),
     THREE,
     GLTFLoader,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3558,6 +3558,13 @@ function createAiUrlImportContext(params = {}, context = {}) {
     }),
     nameOverride: (typeof params.name === 'string' && params.name.trim()) ? params.name.trim() : null,
     position,
+    placementRotation: Array.isArray(context.placementRotation) ? context.placementRotation : null,
+    placementQuaternion: context.placementQuaternion || null,
+    surfaceKind: context.surfaceKind || null,
+    normalArray: context.normalArray || null,
+    rawNormalArray: context.rawNormalArray || null,
+    wallSurfaceOffset: context.wallSurfaceOffset ?? 0,
+    placementPosition: context.placementPosition || null,
     textImporter: (text, filename) => textImporterCallback(text, position, filename, {
       ...context,
       objectId: params.objectId,
@@ -4885,7 +4892,12 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
   const positionArray = (position && typeof position.toArray === 'function')
     ? position.toArray()
     : [0, 1, 0];
-  const rotation = readQuaternionArray(context.placementRotation || context.rotation, [0, 0, 0, 1]);
+  const placementQuaternion = Array.isArray(context.placementRotation)
+    ? new THREE.Quaternion().fromArray(context.placementRotation)
+    : context.placementQuaternion || null;
+  const rotation = placementQuaternion
+    ? placementQuaternion.toArray()
+    : readQuaternionArray(context.rotation, [0, 0, 0, 1]);
   const scale = readVector3Array(context.scale, [1, 1, 1]);
 
   const payload = {
@@ -4945,8 +4957,17 @@ async function urlImporterCallback(url, position, context = {}) {
       scale: [1, 1, 1],
     }),
     position: positionArray,
+    placementRotation: context.placementRotation || null,
+    placementQuaternion: context.placementQuaternion || null,
+    surfaceKind: context.surfaceKind || null,
+    normalArray: context.normalArray || null,
+    rawNormalArray: context.rawNormalArray || null,
+    wallSurfaceOffset: context.wallSurfaceOffset ?? 0,
+    placementPosition: context.placementPosition || null,
     textImporter: (text, filename) =>
-      textImporterCallback(text, position, filename, context),
+      textImporterCallback(text, position, filename, {
+        ...context,
+      }),
     THREE,
     GLTFLoader,
     targetKind: context?.targetKind || 'scene',


### PR DESCRIPTION
## Summary

Fixes wall placement for dropped images and text, including URL image imports, and offsets wall-aligned placements slightly along the surface normal to avoid z-fighting.

URL image imports now reuse the same placement rotation that drag/drop computes for wall hits, and wall placements are nudged forward by 0.01m so they do not sit exactly on the wall plane.

## Changes

- Pass placement metadata into URL import contexts
- Apply placementRotation in URL image scene-add payloads
- Keep URL text import context aligned with wall placement metadata
- Offset wall-aligned placements by 0.01m to avoid z-fighting
- Add debug logs for URL image placement and scene-add transforms

## Notes

- GLB and skybox placement remain unchanged
- Floor/ceiling placement remains unchanged
- The offset only applies to wall placements