### PR TITLE
Connect Loomlet object graphs to Runtime Time Model

### DIFF
--- a/html/assets/js/scenesync/loom/loom-integration.js
+++ b/html/assets/js/scenesync/loom/loom-integration.js
@@ -16,7 +16,6 @@ export function createSceneSyncLoomIntegration({
     getObjectRuntimeTime,
     resolveTarget: (targetId) => {
       if (!targetId) return null;
-      if (isObjectBeingEdited?.(targetId)) return null;
       return getObjectById(targetId);
     },
     isObjectBeingEdited,

--- a/html/assets/js/scenesync/loom/loom-integration.js
+++ b/html/assets/js/scenesync/loom/loom-integration.js
@@ -5,27 +5,21 @@ export function createSceneSyncLoomIntegration({
   getObjectById,
   send,
   getServerTime,
+  getObjectRuntimeTime,
   isObjectBeingEdited,
   showToast,
 }) {
-  // TODO: Integrate Loomlet object graph evaluation with Scene Sync runtime time model.
-  // Currently Loom uses its own requestAnimationFrame loop with wall-clock time.
-  // Should be modified to:
-  // 1. Call getObjectRuntimeTime(objectId) from Scene Sync
-  // 2. Selected object graphs get t=0
-  // 3. Deselected object graphs get advancing t from runtime origin reset on deselect
-  // This will make object graph evaluation deterministic for late joiners and
-  // multi-client synchronization, consistent with GLB animation behavior.
-
   const adapter = new LoomSceneSync({
     LoomClass: Loom,
     send,
     getServerTime,
+    getObjectRuntimeTime,
     resolveTarget: (targetId) => {
       if (!targetId) return null;
       if (isObjectBeingEdited?.(targetId)) return null;
       return getObjectById(targetId);
     },
+    isObjectBeingEdited,
   });
 
   adapter.start();
@@ -63,6 +57,9 @@ export function createSceneSyncLoomIntegration({
     exportState: () => adapter.exportState(),
     importState: (state) => adapter.importState(state),
     clearObjectGraph: (objectId) => adapter.clearObjectGraph(objectId),
+    tickObjectGraphs: (now) => adapter.tickObjectGraphs(now),
+    onObjectSelected: (objectId) => adapter.onObjectSelected(objectId),
+    onObjectDeselected: (objectId) => adapter.onObjectDeselected(objectId),
     dispose,
     adapter,
   };

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -514,7 +514,11 @@ export class LoomSceneSync {
         const t = this.getObjectRuntimeTime
           ? this.getObjectRuntimeTime(targetId, performance.now())
           : 0;
-        engine.evaluateAt(t);
+
+        this.evaluateObjectGraphAt(targetId, t, {
+          reason: 'graph-set-initial',
+          allowEditedTarget: false,
+        });
       }
     }
   }

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -28,11 +28,13 @@ const SCENESYNC_ALLOWED_NODE_TYPES = new Set([
 ]);
 
 export class LoomSceneSync {
-  constructor({ LoomClass, send, getServerTime, resolveTarget }) {
+  constructor({ LoomClass, send, getServerTime, getObjectRuntimeTime, resolveTarget, isObjectBeingEdited }) {
     this.LoomClass = LoomClass;
     this.send = send;
     this.getServerTime = getServerTime;
+    this.getObjectRuntimeTime = getObjectRuntimeTime;
     this.resolveTarget = resolveTarget;
+    this.isObjectBeingEdited = isObjectBeingEdited;
 
     // このアダプタの一意ID
     this.adapterId = `adapter-${nextAdapterId++}`;
@@ -51,6 +53,9 @@ export class LoomSceneSync {
 
     // sceneOffsetPosition の base position 管理
     this.behaviorBases = new Map();
+
+    // Evaluation context for tracking the current evaluation
+    this._evaluationContext = null;
 
     // ノード型登録（冪等性を保証）
     this._registerNodeTypes();
@@ -109,6 +114,74 @@ export class LoomSceneSync {
     }
   }
 
+  _resolveTargetWithEditGuard(targetId) {
+    if (!targetId) return null;
+
+    const allowEditedTarget = this._evaluationContext?.allowEditedTarget === true;
+
+    if (!allowEditedTarget && this.isObjectBeingEdited?.(targetId)) {
+      return null;
+    }
+
+    return this.resolveTarget(targetId);
+  }
+
+  evaluateObjectGraphAt(objectId, time, options = {}) {
+    const engine = this._objectGraphs.get(objectId);
+    if (!engine) return;
+
+    this._evaluationContext = {
+      scope: { object: objectId },
+      allowEditedTarget: Boolean(options.allowEditedTarget),
+      reason: options.reason || 'manual',
+    };
+
+    try {
+      engine.evaluateAt(time);
+    } finally {
+      this._evaluationContext = null;
+    }
+  }
+
+  tickObjectGraphs(now = performance.now()) {
+    if (!this._started) return;
+
+    for (const [objectId, engine] of this._objectGraphs.entries()) {
+      const t = this.getObjectRuntimeTime
+        ? this.getObjectRuntimeTime(objectId, now)
+        : 0;
+
+      this.evaluateObjectGraphAt(objectId, t, {
+        reason: 'runtime-tick',
+        allowEditedTarget: false,
+      });
+    }
+  }
+
+  resetBehaviorBasesForObject(objectId) {
+    const scopeKey = `object:${objectId}`;
+    for (const key of Array.from(this.behaviorBases.keys())) {
+      if (key.startsWith(`${scopeKey}:`)) {
+        this.behaviorBases.delete(key);
+      }
+    }
+  }
+
+  onObjectSelected(objectId) {
+    if (!objectId) return;
+
+    this.evaluateObjectGraphAt(objectId, 0, {
+      reason: 'selected-reset',
+      allowEditedTarget: true,
+    });
+  }
+
+  onObjectDeselected(objectId) {
+    if (!objectId) return;
+
+    this.resetBehaviorBasesForObject(objectId);
+  }
+
   _registerNodeTypes() {
     // 既にこの LoomClass で登録済みならスキップ
     if (registeredLoomClasses.has(this.LoomClass)) {
@@ -146,7 +219,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
         if (obj && obj.position && typeof obj.position.set === "function") {
           obj.position.set(inputs.x, inputs.y, inputs.z);
         }
@@ -171,7 +244,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
         if (!obj || !obj.position) return {};
 
         const basePosition = adapter._getOrCaptureBehaviorBase(params.scopeKey, params.target, obj);
@@ -202,7 +275,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
         if (obj && obj.rotation && typeof obj.rotation.set === "function") {
           obj.rotation.set(inputs.x, inputs.y, inputs.z);
         }
@@ -226,7 +299,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
         if (obj && obj.scale && typeof obj.scale.set === "function") {
           obj.scale.set(inputs.x, inputs.y, inputs.z);
         }
@@ -250,7 +323,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
 
         // Helper function to apply color to material (handles arrays and nested materials)
         const applyColorToMaterial = (material, r, g, b) => {
@@ -296,7 +369,7 @@ export class LoomSceneSync {
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
         if (!adapter) return {};
-        const obj = adapter.resolveTarget(params.target);
+        const obj = adapter._resolveTargetWithEditGuard(params.target);
         if (obj) {
           obj.visible = Boolean(inputs.visible);
         }
@@ -429,8 +502,12 @@ export class LoomSceneSync {
       const engine = new this.LoomClass(injectedGraph);
       this._objectGraphs.set(targetId, engine);
       this._objectGraphDefinitions.set(targetId, graphDefinition);
+
       if (this._started) {
-        engine.start();
+        const t = this.getObjectRuntimeTime
+          ? this.getObjectRuntimeTime(targetId, performance.now())
+          : 0;
+        engine.evaluateAt(t);
       }
     }
   }
@@ -483,14 +560,15 @@ export class LoomSceneSync {
   start() {
     this._started = true;
     this._sceneGraph.start();
-    for (const engine of this._objectGraphs.values()) {
-      engine.start();
-    }
+
+    // Do not call engine.start() for object graphs.
+    // Object graphs are manually ticked by Scene Sync runtime time.
   }
 
   stop() {
     this._started = false;
     this._sceneGraph.stop();
+
     for (const engine of this._objectGraphs.values()) {
       engine.stop();
     }

--- a/html/assets/js/scenesync/loom/loom-scenesync.js
+++ b/html/assets/js/scenesync/loom/loom-scenesync.js
@@ -132,6 +132,7 @@ export class LoomSceneSync {
 
     this._evaluationContext = {
       scope: { object: objectId },
+      time,
       allowEditedTarget: Boolean(options.allowEditedTarget),
       reason: options.reason || 'manual',
     };
@@ -198,8 +199,14 @@ export class LoomSceneSync {
       params: [{ name: "adapterId", type: "string", default: "" }],
       evaluate: (inputs, params) => {
         const adapter = adapterRegistry.get(params.adapterId);
-        const t = adapter ? adapter.getServerTime() : 0;
-        return { t };
+        if (!adapter) return { t: 0 };
+
+        const contextTime = adapter._evaluationContext?.time;
+        if (Number.isFinite(contextTime)) {
+          return { t: contextTime };
+        }
+
+        return { t: adapter.getServerTime() };
       }
     });
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1438,10 +1438,30 @@ let previousSelectedRuntimeObjectIds = new Set();
 function updateRuntimeSelectionTransition() {
   const current = new Set(selectedObjectIds);
 
+  // Compute newly selected and deselected objects
+  const newlySelected = [];
+  const deselected = [];
+
+  for (const objectId of current) {
+    if (!previousSelectedRuntimeObjectIds.has(objectId)) {
+      newlySelected.push(objectId);
+    }
+  }
+
   for (const objectId of previousSelectedRuntimeObjectIds) {
     if (!current.has(objectId)) {
+      deselected.push(objectId);
       resetObjectRuntimeOrigin(objectId);
     }
+  }
+
+  // Notify Loom integration of selection changes
+  for (const objectId of newlySelected) {
+    loomIntegration?.onObjectSelected?.(objectId);
+  }
+
+  for (const objectId of deselected) {
+    loomIntegration?.onObjectDeselected?.(objectId);
   }
 
   previousSelectedRuntimeObjectIds = current;
@@ -3206,6 +3226,7 @@ renderer.setAnimationLoop((time, frame) => {
 
   const now = performance.now();
   updateObjectGlbAnimations(now);
+  loomIntegration?.tickObjectGraphs?.(now);
 
   if (xrState.active) {
     updateXrGrab();
@@ -3414,6 +3435,7 @@ const loomIntegration = createSceneSyncLoomIntegration({
   getObjectById: (objectId) => managedObjects.get(objectId) || null,
   send: (payload) => broadcast(payload),
   getServerTime: () => Date.now() / 1000,
+  getObjectRuntimeTime,
   isObjectBeingEdited: (objectId) => {
     if (!objectId) return false;
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3439,6 +3439,8 @@ const loomIntegration = createSceneSyncLoomIntegration({
   isObjectBeingEdited: (objectId) => {
     if (!objectId) return false;
 
+    if (selectedObjectIds.has(objectId)) return true;
+
     const transformObjectId = transformCtrl.object?.userData?.objectId;
     if (transformObjectId === objectId) return true;
 


### PR DESCRIPTION
Implement runtime time synchronization for Loomlet object graphs to match
GLB animation behavior. Object graphs are now manually evaluated from the
Scene Sync render loop using getObjectRuntimeTime(objectId), ensuring:

- Selected objects get t=0 for editing without graph interference
- Deselected objects resume from t=0 with new runtime origin
- Behavior bases are reset on deselect to respect edited positions
- Evaluation context prevents graph writes during object editing

Key changes:

1. LoomSceneSync now accepts getObjectRuntimeTime in constructor
2. Added tickObjectGraphs(now) for manual evaluation in render loop
3. Added evaluateObjectGraphAt helper with evaluation context
4. Added onObjectSelected/onObjectDeselected hooks for selection transitions
5. Object graphs no longer call engine.start() - only scene graph does
6. All sink nodes now use _resolveTargetWithEditGuard for edit protection
7. Behavior bases reset on object deselection for fresh offset capture
8. Scene Sync render loop calls tickObjectGraphs and selection hooks

The design respects the important constraint that selected objects should
not have their graphs continuously overwriting manual edits.

https://claude.ai/code/session_01D27WsLd8esnTC5Mj1XUZQg