### PR TITLE
Implement editor-only UnityGLTF animation export for Scene Sync Unity

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
+++ b/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
@@ -7,7 +7,6 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using GLTFast.Export;
 using UnityEngine;
 
 namespace Afjk.SceneSync.Editor
@@ -198,49 +197,7 @@ namespace Afjk.SceneSync.Editor
 
         public static async Task<byte[]> ExportGameObjectAsGlb(UnityEngine.GameObject go)
         {
-            try
-            {
-                var exportSettings = new ExportSettings
-                {
-                    Format = GltfFormat.Binary,
-                    FileConflictResolution = FileConflictResolution.Overwrite,
-                };
-                var goSettings = new GameObjectExportSettings
-                {
-                    OnlyActiveInHierarchy = false,
-                };
-                var export = new GameObjectExport(exportSettings, goSettings);
-                // transform を一時的にリセットしてエクスポート
-                // glB にはメッシュ形状のみを含める（配置は wire で制御）
-                var originalPos = go.transform.position;
-                var originalRot = go.transform.rotation;
-                var originalScale = go.transform.localScale;
-
-                go.transform.position = Vector3.zero;
-                go.transform.rotation = Quaternion.identity;
-                go.transform.localScale = Vector3.one;
-
-                export.AddScene(new[] { go }, go.name);
-
-                // 復元
-                go.transform.position = originalPos;
-                go.transform.rotation = originalRot;
-                go.transform.localScale = originalScale;
-
-                using var stream = new MemoryStream();
-                var success = await export.SaveToStreamAndDispose(stream);
-                if (!success)
-                {
-                    Debug.LogWarning("[SceneSync] GLB export returned false for: " + go.name);
-                    return null;
-                }
-                return stream.ToArray();
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarning("[SceneSync] Export failed: " + ex.Message);
-                return null;
-            }
+            return await GlbExporter.ExportGameObjectAsGlb(go);
         }
 
         public static async Task UploadGlb(byte[] glb, string blobBaseUrl, string path)

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -202,6 +202,9 @@ namespace Afjk.SceneSync.Editor
             DrawActionsSection();
             GUILayout.Space(8);
 
+            DrawExportSettingsSection();
+            GUILayout.Space(8);
+
             DrawSetupSection();
             GUILayout.Space(8);
 
@@ -392,6 +395,25 @@ namespace Afjk.SceneSync.Editor
                 ShowSceneSyncGizmos = showSceneSyncGizmos;
                 SceneView.RepaintAll();
             }
+        }
+
+        private void DrawExportSettingsSection()
+        {
+            GUILayout.Label("Export Settings", EditorStyles.boldLabel);
+
+            var currentBackend = GlbExporter.ConfiguredBackend;
+            var newBackend = (SceneSyncGlbExportBackend)EditorGUILayout.EnumPopup("GLB Export Backend", currentBackend);
+            if (newBackend != currentBackend)
+            {
+                GlbExporter.ConfiguredBackend = newBackend;
+            }
+
+            EditorGUILayout.HelpBox(
+                "Auto: Detects animations and uses UnityGLTF if available\n" +
+                "glTFast: Always use glTFast (no animations)\n" +
+                "UnityGltf: Always use UnityGLTF (Editor-only)",
+                MessageType.Info
+            );
         }
 
         private static void MarkManagerDirty(SceneSyncManager manager)

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -118,6 +118,38 @@ https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
    - `Auto Connect`: 起動時に自動接続する場合はチェック
 3. ブラウザで `https://afjk.jp/scenesync/?room=<同じルームコード>` を開く
 
+### Animated GLB Export
+
+Animation を含む GLB ファイルをエクスポートするには UnityGLTF が必要です。
+
+#### インストール
+
+```json
+{
+  "dependencies": {
+    "com.unity.gltf": "2.4.0-exp.2"
+  }
+}
+```
+
+#### 有効化
+
+以下の Define を Project Settings > Player > Scripting Define Symbols に追加:
+
+```
+SCENESYNC_USE_UNITYGLTF
+```
+
+#### Export Backend 選択
+
+Window > Scene Sync の Export Settings で backend を選択:
+
+- **Auto**（デフォルト）: Animation を検出して自動選択
+  - Animation あり + UnityGLTF 利用可 → UnityGLTF
+  - Animation なし or UnityGLTF 未インストール → glTFast
+- **glTFast**: 常に glTFast を使用（Animation 非対応）
+- **UnityGltf**: 常に UnityGLTF を使用（Editor のみ）
+
 ## 技術仕様
 
 詳細は [docs/scene-sync-spec.md](../../docs/scene-sync-spec.md) を参照。

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -124,13 +124,34 @@ Animation を含む GLB ファイルをエクスポートするには UnityGLTF 
 
 #### インストール
 
+##### manifest.json による方法
+
 ```json
 {
   "dependencies": {
-    "com.unity.gltf": "2.4.0-exp.2"
+    "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git"
   }
 }
 ```
+
+バージョンを固定する場合:
+
+```json
+{
+  "dependencies": {
+    "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git#release/2.14.1"
+  }
+}
+```
+
+##### Package Manager UI による方法
+
+1. **Window > Package Manager** を開く
+2. **+** ボタン > **Add package from git URL** を選択
+3. 以下を入力:
+   ```
+   https://github.com/KhronosGroup/UnityGLTF.git
+   ```
 
 #### 有効化
 

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -120,9 +120,13 @@ https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
 
 ### Animated GLB Export
 
-Animation を含む GLB ファイルをエクスポートするには UnityGLTF が必要です。
+**UnityGLTF はオプショナル依存です。**
 
-#### インストール
+- Scene Sync は UnityGLTF を自動インストールしません
+- Editor で animation を含む GLB エクスポートが必要な場合のみインストールしてください
+- Runtime / Player builds は常に glTFast を使用します（UnityGLTF 不要）
+
+#### インストール（オプション）
 
 ##### manifest.json による方法
 

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -21,18 +21,65 @@ namespace Afjk.SceneSync
         public static async Task<byte[]> ExportGameObjectAsGlb(GameObject go)
         {
             var backend = ResolveExportBackend(go);
-            return await ExportGameObjectAsGlbWithBackend(go, backend);
+            return await ExportGameObjectAsGlb(go, backend);
+        }
+
+        public static async Task<byte[]> ExportGameObjectAsGlb(GameObject go, SceneSyncGlbExportBackend backend)
+        {
+            var originalPos = go.transform.position;
+            var originalRot = go.transform.rotation;
+            var originalScale = go.transform.localScale;
+
+            try
+            {
+                go.transform.position = Vector3.zero;
+                go.transform.rotation = Quaternion.identity;
+                go.transform.localScale = Vector3.one;
+
+                if (backend == SceneSyncGlbExportBackend.GltfFast)
+                {
+                    return await ExportWithGltfFast(go);
+                }
+#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
+                else if (backend == SceneSyncGlbExportBackend.UnityGltf)
+                {
+                    return await ExportWithUnityGltf(go);
+                }
+#endif
+
+                Debug.LogWarning("[SceneSync] Invalid export backend: " + backend);
+                return null;
+            }
+            finally
+            {
+                go.transform.position = originalPos;
+                go.transform.rotation = originalRot;
+                go.transform.localScale = originalScale;
+            }
         }
 
         private static SceneSyncGlbExportBackend ResolveExportBackend(GameObject root)
         {
+            if (ConfiguredBackend == SceneSyncGlbExportBackend.UnityGltf)
+            {
+#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
+                return SceneSyncGlbExportBackend.UnityGltf;
+#else
+                Debug.LogWarning(
+                    "[SceneSync] UnityGLTF exporter is not enabled. " +
+                    "Falling back to glTFast; animations will not be exported."
+                );
+                return SceneSyncGlbExportBackend.GltfFast;
+#endif
+            }
+
             if (ConfiguredBackend != SceneSyncGlbExportBackend.Auto)
             {
 #if !UNITY_EDITOR
                 if (ConfiguredBackend == SceneSyncGlbExportBackend.UnityGltf)
                 {
                     Debug.LogWarning(
-                        "[SceneSync] UnityGLTF export is Editor-only for now. " +
+                        "[SceneSync] UnityGLTF export is Editor-only. " +
                         "Falling back to glTFast in runtime/player builds."
                     );
                     return SceneSyncGlbExportBackend.GltfFast;
@@ -91,44 +138,6 @@ namespace Afjk.SceneSync
             return false;
         }
 
-        private static async Task<byte[]> ExportGameObjectAsGlbWithBackend(GameObject go, SceneSyncGlbExportBackend backend)
-        {
-            try
-            {
-                var originalPos = go.transform.position;
-                var originalRot = go.transform.rotation;
-                var originalScale = go.transform.localScale;
-
-                go.transform.position = Vector3.zero;
-                go.transform.rotation = Quaternion.identity;
-                go.transform.localScale = Vector3.one;
-
-                byte[] result = null;
-
-                if (backend == SceneSyncGlbExportBackend.GltfFast)
-                {
-                    result = await ExportWithGltfFast(go);
-                }
-#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
-                else if (backend == SceneSyncGlbExportBackend.UnityGltf)
-                {
-                    result = await ExportWithUnityGltf(go);
-                }
-#endif
-
-                go.transform.position = originalPos;
-                go.transform.rotation = originalRot;
-                go.transform.localScale = originalScale;
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarning("[SceneSync] Export failed: " + ex.Message);
-                return null;
-            }
-        }
-
         private static async Task<byte[]> ExportWithGltfFast(GameObject go)
         {
             try
@@ -163,23 +172,28 @@ namespace Afjk.SceneSync
         }
 
 #if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
-        private static async Task<byte[]> ExportWithUnityGltf(GameObject go)
+        private static Task<byte[]> ExportWithUnityGltf(GameObject go)
         {
             try
             {
-                using var stream = new MemoryStream();
-                var exporter = new UnityGLTF.Exporter(new[] { go });
-                await exporter.SaveGLB(stream, go.name);
+                var context = new UnityGLTF.ExportContext();
+                var exporter = new UnityGLTF.GLTFSceneExporter(
+                    new[] { go.transform },
+                    context
+                );
+
+                var bytes = exporter.SaveGLBToByteArray(go.name);
 
                 Debug.Log("[SceneSync] Export backend: UnityGLTF with animations.");
-                return stream.ToArray();
+                return Task.FromResult(bytes);
             }
             catch (Exception ex)
             {
                 Debug.LogWarning("[SceneSync] UnityGLTF export failed: " + ex.Message);
-                return null;
+                return Task.FromResult<byte[]>(null);
             }
         }
 #endif
     }
 }
+

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GLTFast.Export;
+using UnityEngine;
+
+namespace Afjk.SceneSync
+{
+    public enum SceneSyncGlbExportBackend
+    {
+        Auto,
+        GltfFast,
+        UnityGltf
+    }
+
+    public static class GlbExporter
+    {
+        public static SceneSyncGlbExportBackend ConfiguredBackend { get; set; } = SceneSyncGlbExportBackend.Auto;
+
+        public static async Task<byte[]> ExportGameObjectAsGlb(GameObject go)
+        {
+            var backend = ResolveExportBackend(go);
+            return await ExportGameObjectAsGlbWithBackend(go, backend);
+        }
+
+        private static SceneSyncGlbExportBackend ResolveExportBackend(GameObject root)
+        {
+            if (ConfiguredBackend != SceneSyncGlbExportBackend.Auto)
+            {
+#if !UNITY_EDITOR
+                if (ConfiguredBackend == SceneSyncGlbExportBackend.UnityGltf)
+                {
+                    Debug.LogWarning(
+                        "[SceneSync] UnityGLTF export is Editor-only for now. " +
+                        "Falling back to glTFast in runtime/player builds."
+                    );
+                    return SceneSyncGlbExportBackend.GltfFast;
+                }
+#endif
+                return ConfiguredBackend;
+            }
+
+#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
+            if (HasExportableAnimation(root))
+            {
+                Debug.Log("[SceneSync] Animation detected. Using UnityGLTF exporter.");
+                return SceneSyncGlbExportBackend.UnityGltf;
+            }
+#else
+            if (HasExportableAnimation(root))
+            {
+                Debug.LogWarning(
+                    "[SceneSync] Animation detected, but animated GLB export is Editor-only " +
+                    "and requires UnityGLTF. Falling back to glTFast; animations will not be exported."
+                );
+            }
+#endif
+
+            return SceneSyncGlbExportBackend.GltfFast;
+        }
+
+        private static bool HasExportableAnimation(GameObject root)
+        {
+            if (!root) return false;
+
+            foreach (var animator in root.GetComponentsInChildren<Animator>(true))
+            {
+                var controller = animator.runtimeAnimatorController;
+                if (controller?.animationClips != null && controller.animationClips.Length > 0)
+                    return true;
+            }
+
+            foreach (var animation in root.GetComponentsInChildren<Animation>(true))
+            {
+                foreach (AnimationState state in animation)
+                {
+                    if (state?.clip != null)
+                        return true;
+                }
+            }
+
+#if UNITY_EDITOR
+            foreach (var director in root.GetComponentsInChildren<UnityEngine.Playables.PlayableDirector>(true))
+            {
+                if (director.playableAsset != null)
+                    return true;
+            }
+#endif
+
+            return false;
+        }
+
+        private static async Task<byte[]> ExportGameObjectAsGlbWithBackend(GameObject go, SceneSyncGlbExportBackend backend)
+        {
+            try
+            {
+                var originalPos = go.transform.position;
+                var originalRot = go.transform.rotation;
+                var originalScale = go.transform.localScale;
+
+                go.transform.position = Vector3.zero;
+                go.transform.rotation = Quaternion.identity;
+                go.transform.localScale = Vector3.one;
+
+                byte[] result = null;
+
+                if (backend == SceneSyncGlbExportBackend.GltfFast)
+                {
+                    result = await ExportWithGltfFast(go);
+                }
+#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
+                else if (backend == SceneSyncGlbExportBackend.UnityGltf)
+                {
+                    result = await ExportWithUnityGltf(go);
+                }
+#endif
+
+                go.transform.position = originalPos;
+                go.transform.rotation = originalRot;
+                go.transform.localScale = originalScale;
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[SceneSync] Export failed: " + ex.Message);
+                return null;
+            }
+        }
+
+        private static async Task<byte[]> ExportWithGltfFast(GameObject go)
+        {
+            try
+            {
+                var exportSettings = new ExportSettings
+                {
+                    Format = GltfFormat.Binary,
+                    FileConflictResolution = FileConflictResolution.Overwrite,
+                };
+                var goSettings = new GameObjectExportSettings
+                {
+                    OnlyActiveInHierarchy = false,
+                };
+                var export = new GameObjectExport(exportSettings, goSettings);
+                export.AddScene(new[] { go }, go.name);
+
+                using var stream = new MemoryStream();
+                var success = await export.SaveToStreamAndDispose(stream);
+                if (!success)
+                {
+                    Debug.LogWarning("[SceneSync] glTFast export returned false for: " + go.name);
+                    return null;
+                }
+                Debug.Log("[SceneSync] Export backend: glTFast.");
+                return stream.ToArray();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[SceneSync] glTFast export failed: " + ex.Message);
+                return null;
+            }
+        }
+
+#if UNITY_EDITOR && SCENESYNC_USE_UNITYGLTF
+        private static async Task<byte[]> ExportWithUnityGltf(GameObject go)
+        {
+            try
+            {
+                using var stream = new MemoryStream();
+                var exporter = new UnityGLTF.Exporter(new[] { go });
+                await exporter.SaveGLB(stream, go.name);
+
+                Debug.Log("[SceneSync] Export backend: UnityGLTF with animations.");
+                return stream.ToArray();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[SceneSync] UnityGLTF export failed: " + ex.Message);
+                return null;
+            }
+        }
+#endif
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f7a8c6d5e4b9f2a1c3d7e6f8a9b0c2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
+++ b/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
@@ -215,8 +215,7 @@ namespace Afjk.SceneSync
 
         public static async Task<byte[]> ExportGameObjectAsGlb(UnityEngine.GameObject go)
         {
-            GlbExporter.ConfiguredBackend = SceneSyncGlbExportBackend.GltfFast;
-            return await GlbExporter.ExportGameObjectAsGlb(go);
+            return await GlbExporter.ExportGameObjectAsGlb(go, SceneSyncGlbExportBackend.GltfFast);
         }
 
         public static async Task UploadGlb(byte[] glb, string blobBaseUrl, string path)

--- a/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
+++ b/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
@@ -215,53 +215,8 @@ namespace Afjk.SceneSync
 
         public static async Task<byte[]> ExportGameObjectAsGlb(UnityEngine.GameObject go)
         {
-            try
-            {
-                Debug.Log("[SceneSync] Export start: " + DescribeGameObject(go));
-
-                var exportSettings = new ExportSettings
-                {
-                    Format = GltfFormat.Binary,
-                    FileConflictResolution = FileConflictResolution.Overwrite,
-                };
-                var goSettings = new GameObjectExportSettings
-                {
-                    OnlyActiveInHierarchy = false,
-                };
-                var export = new GameObjectExport(exportSettings, goSettings);
-                // transform を一時的にリセットしてエクスポート
-                // glB にはメッシュ形状のみを含める（配置は wire で制御）
-                var originalPos = go.transform.position;
-                var originalRot = go.transform.rotation;
-                var originalScale = go.transform.localScale;
-
-                go.transform.position = Vector3.zero;
-                go.transform.rotation = Quaternion.identity;
-                go.transform.localScale = Vector3.one;
-
-                export.AddScene(new[] { go }, go.name);
-
-                // 復元
-                go.transform.position = originalPos;
-                go.transform.rotation = originalRot;
-                go.transform.localScale = originalScale;
-
-                using var stream = new MemoryStream();
-                var success = await export.SaveToStreamAndDispose(stream);
-                if (!success)
-                {
-                    Debug.LogWarning("[SceneSync] GLB export returned false: " + DescribeGameObject(go));
-                    return null;
-                }
-
-                Debug.Log("[SceneSync] Export success: name=" + go.name + ", bytes=" + stream.Length);
-                return stream.ToArray();
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarning("[SceneSync] Export failed: " + DescribeGameObject(go) + "\n" + ex);
-                return null;
-            }
+            GlbExporter.ConfiguredBackend = SceneSyncGlbExportBackend.GltfFast;
+            return await GlbExporter.ExportGameObjectAsGlb(go);
         }
 
         public static async Task UploadGlb(byte[] glb, string blobBaseUrl, string path)


### PR DESCRIPTION
Add backend enum and resolution logic that:
- Always uses glTFast in runtime/player builds
- Uses Auto mode in Editor that auto-detects animations
- Falls back to glTFast if UnityGLTF is unavailable
- Guards UnityGLTF code with SCENESYNC_USE_UNITYGLTF compile flag

Create GlbExporter class that:
- Implements animation detection for Animator, Animation, and PlayableDirector
- Handles backend resolution with proper Editor/runtime separation
- Supports both glTFast and UnityGLTF export paths

Update Editor UI to allow backend selection in Scene Sync window.
Simplify PresenceClient and PresenceClientRuntime to delegate to GlbExporter.

https://claude.ai/code/session_01642VcGmwD7pJzNoonQsJRT