### PR TITLE
Add GLB animation support with metadata tracking

### DIFF
--- a/html/assets/js/scenesync/loaders/url-importers/glb.js
+++ b/html/assets/js/scenesync/loaders/url-importers/glb.js
@@ -66,8 +66,20 @@ export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000
     throw new Error(`GLB ファイルの解析に失敗しました: ${err?.message || '不明なエラー'}`);
   }
 
+  const animations = Array.isArray(gltf.animations) ? gltf.animations : [];
+  const animationState = animations.length > 0
+    ? { enabled: true, clip: 0, mode: 'loop', speed: 1 }
+    : null;
+
+  gltf.scene.userData.scenesync = {
+    ...gltf.scene.userData?.scenesync,
+    animations,
+    animationState,
+  };
+
   return {
     model: gltf.scene,
+    animations,
     sizeBytes: arrayBuffer.byteLength,
     contentType,
   };
@@ -81,12 +93,40 @@ export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000
  */
 export async function importGlbUrl(url, ctx) {
   try {
-    const { model } = await loadGlbFromUrl(url, { THREE: ctx.THREE, GLTFLoader: ctx.GLTFLoader });
+    const { model, animations } = await loadGlbFromUrl(url, {
+      THREE: ctx.THREE,
+      GLTFLoader: ctx.GLTFLoader,
+    });
 
     const objectId = ctx.generateObjectId('glb');
     const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'model.glb');
     const displayName = filename.slice(0, 60) || 'model.glb';
     const spawnTransform = ctx.getSpawnTransform();
+
+    const animationState = animations.length > 0
+      ? { enabled: true, clip: 0, mode: 'loop', speed: 1 }
+      : null;
+
+    model.userData = {
+      ...model.userData,
+      scenesync: {
+        ...model.userData?.scenesync,
+        animations,
+        animationState,
+      },
+    };
+
+    if (animationState) {
+      model.userData.animationState = animationState;
+    }
+
+    if (animations.length > 0) {
+      console.info('[glb-url] animations detected', {
+        url,
+        count: animations.length,
+        names: animations.map((clip) => clip?.name || '(unnamed)'),
+      });
+    }
 
     const payload = {
       kind: 'scene-add',
@@ -97,6 +137,10 @@ export async function importGlbUrl(url, ctx) {
       scale: spawnTransform.scale,
       asset: { type: 'mesh', source: 'url', url },
     };
+
+    if (animations.length > 0) {
+      payload.animation = { enabled: true, clip: 0, mode: 'loop', speed: 1 };
+    }
 
     ctx.broadcastSceneAdd(payload);
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1846,6 +1846,24 @@ function disposeObjectGlbAnimation(objectId) {
   glbAnimationMixers.delete(objectId);
 }
 
+function registerGlbObject(objectId, model, reason = 'unknown') {
+  if (!objectId || !model) return;
+
+  model.userData.objectId = objectId;
+  managedObjects.set(objectId, model);
+  setupObjectGlbAnimation(objectId, model);
+
+  const clips = model.userData?.scenesync?.animations;
+  if (Array.isArray(clips) && clips.length > 0) {
+    console.info('[SceneSync] GLB animations registered', {
+      objectId,
+      reason,
+      count: clips.length,
+      names: clips.map((clip) => clip?.name || '(unnamed)'),
+    });
+  }
+}
+
 function updateObjectGlbAnimations(now = performance.now()) {
   for (const [objectId, entry] of glbAnimationMixers) {
     const obj = managedObjects.get(objectId);
@@ -4245,8 +4263,7 @@ function handleHandoff(data) {
         } else {
           applyTransform(model, payload);
         }
-        managedObjects.set(payload.objectId, model);
-        setupObjectGlbAnimation(payload.objectId, model);
+        registerGlbObject(payload.objectId, model, 'scene-mesh');
         notifySceneStateChanged('scene-mesh-loaded');
       }).catch((err) => {
         removeLoadingOverlay(payload.objectId);
@@ -5586,8 +5603,7 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
       scene.remove(obj);
     }
     scene.add(wrapper);
-    managedObjects.set(objectId, wrapper);
-    setupObjectGlbAnimation(objectId, wrapper);
+    registerGlbObject(objectId, wrapper, 'glb-blob-loaded');
     notifySceneStateChanged('glb-blob-loaded');
   } finally {
     URL.revokeObjectURL(url);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1846,7 +1846,7 @@ function disposeObjectGlbAnimation(objectId) {
   glbAnimationMixers.delete(objectId);
 }
 
-function registerGlbObject(objectId, model, reason = 'unknown') {
+function registerLoadedGlbAnimation(objectId, model, reason = 'unknown') {
   if (!objectId || !model) return;
 
   model.userData.objectId = objectId;
@@ -4263,7 +4263,7 @@ function handleHandoff(data) {
         } else {
           applyTransform(model, payload);
         }
-        registerGlbObject(payload.objectId, model, 'scene-mesh');
+        registerLoadedGlbAnimation(payload.objectId, model, 'scene-mesh');
         notifySceneStateChanged('scene-mesh-loaded');
       }).catch((err) => {
         removeLoadingOverlay(payload.objectId);
@@ -5603,7 +5603,7 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
       scene.remove(obj);
     }
     scene.add(wrapper);
-    registerGlbObject(objectId, wrapper, 'glb-blob-loaded');
+    registerLoadedGlbAnimation(objectId, wrapper, 'glb-blob-loaded');
     notifySceneStateChanged('glb-blob-loaded');
   } finally {
     URL.revokeObjectURL(url);


### PR DESCRIPTION
## 概要

GLB ファイルのアニメーション情報を抽出・保存し、シーン同期時にアニメーション状態を管理できるようにしました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### glb.js
- `loadGlbFromUrl()` で GLTF アニメーションクリップを抽出し、`gltf.scene.userData.scenesync` に保存
- アニメーション検出時に初期状態（enabled: true, clip: 0, mode: 'loop', speed: 1）を設定
- `importGlbUrl()` で animations を返却値に追加
- model.userData に scenesync メタデータとアニメーション状態を設定
- アニメーション検出時にコンソールログで通知（URL、クリップ数、名前）
- scene-add payload にアニメーション情報を含める

### scene.js
- `registerGlbObject()` 新規関数を追加：オブジェクト登録時の共通処理を統一
  - objectId、model、reason（ログ用）を受け取る
  - managedObjects への登録と setupObjectGlbAnimation() の呼び出しを一元化
  - アニメーション検出時にコンソールログで通知
- `handleHandoff()` と `loadGlbBlobForObject()` で registerGlbObject() を使用するよう変更

### staging で見てほしい点
- GLB ファイルのアニメーション情報が正しく抽出・保存されているか
- アニメーション付き GLB をインポート時にコンソールログが出力されるか
- scene-add payload にアニメーション情報が含まれているか

## 変更していないこと

- アニメーション再生ロジック（既存の setupObjectGlbAnimation() に依存）
- アニメーション UI / コントロール
- その他の GLB ローディング機能

## staging確認

未確認

## テスト/チェック

- 既存の GLB ローディング機能が動作することを確認
- アニメーション付き GLB ファイルでメタデータが正しく設定されることを確認

## リスク

- 既存の GLB ファイル（アニメーションなし）の動作に影響なし
- registerGlbObject() への統一により、オブジェクト登録処理の一貫性が向上

## follow-up tasks

- アニメーション再生の UI コントロール実装
- アニメーション状態の同期メッセージ（scene-delta 拡張）

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_016SxWNLAAZYhNZP2JBDMuEd