### PR TITLE
Add scroll view to SceneSyncWindow for better UI navigation

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -68,6 +68,7 @@ namespace Afjk.SceneSync.Editor
         private bool _applyingRemoteTransform;
         private bool _showSetup = false;
         private bool _showQuickGuide = false;
+        private Vector2 _scrollPosition;
 
         private void OnEnable()
         {
@@ -190,6 +191,8 @@ namespace Afjk.SceneSync.Editor
 
         private void OnGUI()
         {
+            _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
+
             GUILayout.Label("Scene Sync", EditorStyles.boldLabel);
             GUILayout.Space(4);
 
@@ -209,6 +212,8 @@ namespace Afjk.SceneSync.Editor
             GUILayout.Space(8);
 
             DrawQuickGuide();
+
+            EditorGUILayout.EndScrollView();
         }
 
         private void DrawConnectionSection()


### PR DESCRIPTION
## 概要

SceneSyncWindow の GUI に ScrollView を追加し、ウィンドウサイズが小さい場合でもすべてのコンテンツにアクセスできるようにしました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `_scrollPosition` フィールドを追加してスクロール位置を管理
- `OnGUI()` メソッドで `EditorGUILayout.BeginScrollView()` と `EditorGUILayout.EndScrollView()` でコンテンツをラップ
- ウィンドウが小さい場合でも、スクロールによってすべての UI 要素（接続設定、クイックガイドなど）にアクセス可能に

## 変更していないこと

- UI 要素の配置やロジック
- 接続機能やシーン同期の動作
- その他の Editor ウィンドウ機能

## staging確認

- 未確認（UI 改善のため staging での確認は不要）

## テスト/チェック

- Unity Editor で SceneSyncWindow を開き、ウィンドウをリサイズしてスクロール動作を確認
- 既存の UI 要素がすべて表示されることを確認

## リスク

- なし（UI レイアウトの改善のみで、機能的な変更なし）

## follow-up tasks

- なし

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01ExeZ1nsJevWSHob9ZD7ytZ