### PR TITLE
Add animation clip switching for AI commands

### DIFF
--- a/docs/scene-sync-ai-instructions-short.md
+++ b/docs/scene-sync-ai-instructions-short.md
@@ -202,3 +202,17 @@ Implemented actions:
 - `addTextFromUrl`
 - `setSkyboxFromImageUrl`
 - `getSelection`
+- `setAnimationClip`
+
+## Animation clips
+
+For animated GLB objects, use `setAnimationClip` to switch clips by name or index.
+
+Preferred flow:
+
+1. Use `getSelection` when the user says "selected object".
+2. Inspect `animationClips` in the selected object payload.
+3. Call `setAnimationClip` with `objectId` and `clipName`.
+
+If the requested name is ambiguous, ask the user to choose from candidates.
+Do not guess between `attack_1`, `attack_2`, etc.

--- a/docs/scene-sync-ai-openapi.yaml
+++ b/docs/scene-sync-ai-openapi.yaml
@@ -185,7 +185,7 @@ paths:
         Stable AI tool mapping: `scene_sync_ai_command`.
         Use this for browser-only actions such as current selection queries, camera queries,
         focus, undo/redo, screenshots, URL-based GLB import, URL-based image/video/text import,
-        and skybox updates. Use action `getSelection` to retrieve the objects currently
+        skybox updates, and GLB animation clip switching. Use action `getSelection` to retrieve the objects currently
         selected by the linked browser user. Selection is browser-local/session-local and
         is not part of the shared scene snapshot. For `focusObject`, always send
         `params.objectId`. Do not call `focusObject` without an object id.
@@ -224,6 +224,7 @@ paths:
                     - addVideoFromUrl
                     - addTextFromUrl
                     - setSkyboxFromImageUrl
+                    - setAnimationClip
                 params:
                   description: |
                     Parameters depend on `action`. For `getSelection`, send `{}`.
@@ -241,6 +242,7 @@ paths:
                     - $ref: '#/components/schemas/UploadGlbFromUrlParams'
                     - $ref: '#/components/schemas/UrlImportParams'
                     - $ref: '#/components/schemas/SetSkyboxFromImageUrlParams'
+                    - $ref: '#/components/schemas/SetAnimationClipParams'
                 targetPeerId:
                   type: string
             examples:
@@ -288,6 +290,15 @@ paths:
                   action: setSkyboxFromImageUrl
                   params:
                     url: https://example.com/panorama.jpg
+              setAnimationClip:
+                summary: Set an animated GLB object to the laugh clip
+                value:
+                  sessionId: v1.example
+                  action: setAnimationClip
+                  params:
+                    objectId: minotauros-001
+                    clipName: laugh
+                    mode: loop
       responses:
         '200':
           description: AI command result
@@ -563,6 +574,42 @@ components:
           format: uri
       example:
         url: https://example.com/panorama.jpg
+    SetAnimationClipParams:
+      type: object
+      additionalProperties: false
+      properties:
+        objectId:
+          type: string
+          description: Existing animated GLB object id. Prefer passing this explicitly.
+        clip:
+          type: integer
+          minimum: 0
+          description: Animation clip index. Takes priority over clipName.
+        clipName:
+          type: string
+          description: Animation clip name, such as idle, laugh, talk, or attack_1.
+        name:
+          type: string
+          description: Alias for clipName.
+        mode:
+          type: string
+          enum: [loop, once]
+          default: loop
+        speed:
+          type: number
+          minimum: 0
+          default: 1
+        enabled:
+          type: boolean
+          default: true
+      anyOf:
+        - required: [clip]
+        - required: [clipName]
+        - required: [name]
+      example:
+        objectId: minotauros-001
+        clipName: laugh
+        mode: loop
     SceneState:
       type: object
       properties:

--- a/docs/scene-sync-gpt-instructions-short.md
+++ b/docs/scene-sync-gpt-instructions-short.md
@@ -199,6 +199,20 @@ Implemented actions:
 - `addVideoFromUrl`
 - `addTextFromUrl`
 - `setSkyboxFromImageUrl`
+- `setAnimationClip`
+
+## Animation clips
+
+For animated GLB objects, use `setAnimationClip` to switch clips by name or index.
+
+Preferred flow:
+
+1. Use `getSelection` when the user says "selected object".
+2. Inspect `animationClips` in the selected object payload.
+3. Call `setAnimationClip` with `objectId` and `clipName`.
+
+If the requested name is ambiguous, ask the user to choose from candidates.
+Do not guess between `attack_1`, `attack_2`, etc.
 
 ## IDs and coordinates
 

--- a/docs/scene-sync-gpt-openapi.yaml
+++ b/docs/scene-sync-gpt-openapi.yaml
@@ -137,7 +137,7 @@ paths:
       description: |
         Use this for browser-only actions such as current selection queries, camera queries,
         focus, undo/redo, screenshots, URL-based GLB import, URL-based image/video/text import,
-        and skybox updates. Use action `getSelection` to retrieve the objects currently
+        skybox updates, and GLB animation clip switching. Use action `getSelection` to retrieve the objects currently
         selected by the linked browser user. Selection is browser-local/session-local and
         is not part of the shared scene snapshot. For `focusObject`, always send
         `params.objectId`. Do not call `focusObject` without an object id.
@@ -174,6 +174,7 @@ paths:
                     - addVideoFromUrl
                     - addTextFromUrl
                     - setSkyboxFromImageUrl
+                    - setAnimationClip
                 params:
                   description: |
                     Parameters depend on `action`. For `getSelection`, send `{}`.
@@ -191,6 +192,7 @@ paths:
                     - $ref: '#/components/schemas/UploadGlbFromUrlParams'
                     - $ref: '#/components/schemas/UrlImportParams'
                     - $ref: '#/components/schemas/SetSkyboxFromImageUrlParams'
+                    - $ref: '#/components/schemas/SetAnimationClipParams'
                 targetPeerId:
                   type: string
             examples:
@@ -238,6 +240,15 @@ paths:
                   action: setSkyboxFromImageUrl
                   params:
                     url: https://example.com/panorama.jpg
+              setAnimationClip:
+                summary: Set an animated GLB object to the laugh clip
+                value:
+                  sessionId: v1.example
+                  action: setAnimationClip
+                  params:
+                    objectId: minotauros-001
+                    clipName: laugh
+                    mode: loop
       responses:
         '200':
           description: AI command result
@@ -404,6 +415,42 @@ components:
           format: uri
       example:
         url: https://example.com/panorama.jpg
+    SetAnimationClipParams:
+      type: object
+      additionalProperties: false
+      properties:
+        objectId:
+          type: string
+          description: Existing animated GLB object id. Prefer passing this explicitly.
+        clip:
+          type: integer
+          minimum: 0
+          description: Animation clip index. Takes priority over clipName.
+        clipName:
+          type: string
+          description: Animation clip name, such as idle, laugh, talk, or attack_1.
+        name:
+          type: string
+          description: Alias for clipName.
+        mode:
+          type: string
+          enum: [loop, once]
+          default: loop
+        speed:
+          type: number
+          minimum: 0
+          default: 1
+        enabled:
+          type: boolean
+          default: true
+      anyOf:
+        - required: [clip]
+        - required: [clipName]
+        - required: [name]
+      example:
+        objectId: minotauros-001
+        clipName: laugh
+        mode: loop
     SceneState:
       type: object
       properties:

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1876,6 +1876,117 @@ function getObjectAnimationClipSummaries(obj) {
   }));
 }
 
+function normalizeAnimationClipName(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[-]+/g, '_');
+}
+
+function getObjectAnimationClips(obj) {
+  const clips = obj?.userData?.scenesync?.animations;
+  return Array.isArray(clips) ? clips : [];
+}
+
+function serializeObjectAnimationClipSummariesForExternalUse(obj) {
+  return getObjectAnimationClips(obj).map((clip, index) => ({
+    index,
+    name: clip?.name || `Animation ${index}`,
+    duration: Number.isFinite(clip?.duration) ? clip.duration : null,
+  }));
+}
+
+function resolveAnimationClipIndex(obj, params = {}) {
+  const clips = getObjectAnimationClips(obj);
+
+  if (clips.length === 0) {
+    return {
+      ok: false,
+      error: 'target object has no animation clips',
+      clips: [],
+    };
+  }
+
+  if (params.clip !== undefined) {
+    const clipIndex = clampAnimationClipIndex(params.clip, clips.length);
+    return {
+      ok: true,
+      clipIndex,
+      clipName: clips[clipIndex]?.name || `Animation ${clipIndex}`,
+      matchedBy: 'clip',
+      clips,
+    };
+  }
+
+  const requestedName = params.clipName ?? params.name;
+  if (typeof requestedName !== 'string' || !requestedName.trim()) {
+    return {
+      ok: false,
+      error: 'clip or clipName is required',
+      clips,
+    };
+  }
+
+  const normalizedRequested = normalizeAnimationClipName(requestedName);
+
+  // 1. exact normalized match
+  let clipIndex = clips.findIndex((clip, index) => {
+    const displayName = clip?.name || `Animation ${index}`;
+    return normalizeAnimationClipName(displayName) === normalizedRequested;
+  });
+
+  // 2. case-insensitive raw exact match
+  if (clipIndex < 0) {
+    const lowerRequested = requestedName.trim().toLowerCase();
+    clipIndex = clips.findIndex((clip, index) => {
+      const displayName = clip?.name || `Animation ${index}`;
+      return String(displayName).trim().toLowerCase() === lowerRequested;
+    });
+  }
+
+  // 3. safe partial match only if exactly one candidate matches
+  if (clipIndex < 0) {
+    const candidates = clips
+      .map((clip, index) => ({
+        index,
+        name: clip?.name || `Animation ${index}`,
+        normalized: normalizeAnimationClipName(clip?.name || `Animation ${index}`),
+      }))
+      .filter((candidate) => candidate.normalized.includes(normalizedRequested));
+
+    if (candidates.length === 1) {
+      clipIndex = candidates[0].index;
+    } else if (candidates.length > 1) {
+      return {
+        ok: false,
+        error: `ambiguous animation clip name: ${requestedName}`,
+        candidates: candidates.map((candidate) => ({
+          index: candidate.index,
+          name: candidate.name,
+        })),
+        clips,
+      };
+    }
+  }
+
+  if (clipIndex < 0) {
+    return {
+      ok: false,
+      error: `animation clip not found: ${requestedName}`,
+      clips: serializeObjectAnimationClipSummariesForExternalUse(obj),
+    };
+  }
+
+  return {
+    ok: true,
+    clipIndex,
+    clipName: clips[clipIndex]?.name || `Animation ${clipIndex}`,
+    matchedBy: 'clipName',
+    clips,
+  };
+}
+
 function clampAnimationClipIndex(value, clipCount) {
   const index = Number.parseInt(value, 10);
   if (!Number.isFinite(index)) return 0;
@@ -4970,6 +5081,11 @@ function serializeSceneObjectForExternalUse(objectId, obj) {
     result.animation = animation;
   }
 
+  const animationClips = serializeObjectAnimationClipSummariesForExternalUse(obj);
+  if (animationClips.length > 0) {
+    result.animationClips = animationClips;
+  }
+
   return result;
 }
 
@@ -5003,6 +5119,98 @@ function getCurrentSelectionPayload() {
     selectedCount: selectedObjects.length,
     missingObjectIds,
     skippedObjectIds,
+  };
+}
+
+function resolveAiCommandObjectId(params = {}) {
+  const explicit = typeof params.objectId === 'string' ? params.objectId.trim() : '';
+  if (explicit) return explicit;
+
+  const selected = selectedObjectIds instanceof Set ? Array.from(selectedObjectIds)[0] : '';
+  return selected || '';
+}
+
+function setObjectAnimationClipByAiCommand(params = {}) {
+  const objectId = resolveAiCommandObjectId(params);
+
+  if (!objectId) {
+    return {
+      ok: false,
+      error: 'objectId is required when there is no selected object',
+    };
+  }
+
+  const obj = managedObjects.get(objectId);
+  if (!obj) {
+    return {
+      ok: false,
+      error: `object not found: ${objectId}`,
+    };
+  }
+
+  const resolution = resolveAnimationClipIndex(obj, params);
+  if (!resolution.ok) {
+    return {
+      ok: false,
+      error: resolution.error,
+      candidates: resolution.candidates,
+      clips: Array.isArray(resolution.clips)
+        ? resolution.clips.map((clip, index) => {
+            if (clip && typeof clip.index === 'number') return clip;
+            return {
+              index,
+              name: clip?.name || `Animation ${index}`,
+              duration: Number.isFinite(clip?.duration) ? clip.duration : null,
+            };
+          })
+        : undefined,
+    };
+  }
+
+  const current =
+    obj.userData?.animationState ||
+    obj.userData?.scenesync?.animationState ||
+    {};
+
+  const delta = {
+    enabled: typeof params.enabled === 'boolean' ? params.enabled : true,
+    clip: resolution.clipIndex,
+    clipName: resolution.clipName,
+    mode: params.mode === 'once' ? 'once' : 'loop',
+  };
+
+  if (params.speed !== undefined) {
+    const speed = Number(params.speed);
+    if (Number.isFinite(speed) && speed >= 0) {
+      delta.speed = speed;
+    }
+  } else if (Number.isFinite(current.speed)) {
+    delta.speed = current.speed;
+  } else {
+    delta.speed = 1;
+  }
+
+  const operation = {
+    kind: 'scene-delta',
+    objectId,
+    animation: delta,
+  };
+
+  applyOperationToScene(operation);
+  broadcast(operation);
+  notifySceneStateChanged('ai-animation-clip-updated');
+  notifySelectionChanged('ai-animation-clip-updated');
+
+  return {
+    ok: true,
+    objectId,
+    animation: {
+      ...delta,
+      clip: resolution.clipIndex,
+      clipName: resolution.clipName,
+    },
+    matchedBy: resolution.matchedBy,
+    availableClips: serializeObjectAnimationClipSummariesForExternalUse(obj),
   };
 }
 
@@ -5076,6 +5284,9 @@ async function handleAiCommand(from, payload) {
           action: 'getSelection',
           ...getCurrentSelectionPayload(),
         };
+        break;
+      case 'setAnimationClip':
+        result = setObjectAnimationClipByAiCommand(payload.params || {});
         break;
       default:
         result = { ok: false, error: `unsupported ai-command action: ${payload.action}` };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5126,8 +5126,12 @@ function resolveAiCommandObjectId(params = {}) {
   const explicit = typeof params.objectId === 'string' ? params.objectId.trim() : '';
   if (explicit) return explicit;
 
-  const selected = selectedObjectIds instanceof Set ? Array.from(selectedObjectIds)[0] : '';
-  return selected || '';
+  if (!(selectedObjectIds instanceof Set) || selectedObjectIds.size !== 1) {
+    return '';
+  }
+
+  const [selected] = Array.from(selectedObjectIds);
+  return typeof selected === 'string' ? selected : '';
 }
 
 function setObjectAnimationClipByAiCommand(params = {}) {
@@ -5136,7 +5140,7 @@ function setObjectAnimationClipByAiCommand(params = {}) {
   if (!objectId) {
     return {
       ok: false,
-      error: 'objectId is required when there is no selected object',
+      error: 'objectId is required unless exactly one object is selected',
     };
   }
 

--- a/packages/scene-sync-mcp/README.md
+++ b/packages/scene-sync-mcp/README.md
@@ -10,6 +10,7 @@ Scene Sync is a real-time 3D scene synchronization system. This MCP server lets 
 - Focus the camera on objects
 - Update the scene skybox from an image URL
 - Take screenshots
+- Switch animation clips on animated GLB objects
 - Manage the link session
 
 ## Installation
@@ -340,6 +341,53 @@ Input:
 
 Returns the last N history entries from the browser.
 
+### scene_sync_set_animation_clip
+
+Switch an animated GLB object to a specific animation clip by name or index.
+
+First inspect selected object clips:
+
+````json
+{
+  "tool": "scene_sync_get_selection",
+  "arguments": {}
+}
+````
+
+Then switch clip:
+
+````json
+{
+  "tool": "scene_sync_set_animation_clip",
+  "arguments": {
+    "objectId": "minotauros-001",
+    "clipName": "laugh",
+    "mode": "loop"
+  }
+}
+````
+
+If a clip name is ambiguous, for example `attack`, the browser returns candidates such as `attack_1`, `attack_2`, etc. Choose a specific one.
+
+Input:
+```json
+{
+  "objectId": "minotauros-001",
+  "clipName": "laugh",
+  "mode": "loop"
+}
+```
+
+Or by index:
+```json
+{
+  "objectId": "minotauros-001",
+  "clip": 7
+}
+```
+
+Fields: `objectId` (required), `clipName` or `name` or `clip` (one required), `mode` (loop/once, default loop), `speed` (default 1), `enabled` (default true).
+
 ### scene_sync_get_selection
 
 Returns the objects currently selected in the linked Scene Sync browser.
@@ -443,6 +491,7 @@ Browser AI commands in `html/assets/js/scenesync/scene.js` should stay in sync w
 | `undo` | `scene_sync_undo` | supported |
 | `redo` | `scene_sync_redo` | supported |
 | `getSelection` | `scene_sync_get_selection` | supported |
+| `setAnimationClip` | `scene_sync_set_animation_clip` | supported |
 
 When adding a new browser AI command:
 

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -387,6 +387,70 @@ server.registerTool(
   }
 )
 
+// scene_sync_set_animation_clip
+const animationClipInputSchema = z.object({
+  objectId: z.string().describe('Target animated GLB object ID'),
+  clipName: z.string().optional().describe('Animation clip name, such as idle, laugh, talk, or attack_1'),
+  name: z.string().optional().describe('Alias for clipName'),
+  clip: z.number().int().min(0).optional().describe('Animation clip index. Takes priority over clipName.'),
+  mode: z.enum(['loop', 'once']).optional().describe('Playback mode. Defaults to loop.'),
+  speed: z.number().min(0).optional().describe('Playback speed. Omit to keep current speed.'),
+  enabled: z.boolean().optional().describe('Whether animation playback is enabled. Defaults to true.')
+}).refine((value) => (
+  value.clip !== undefined ||
+  typeof value.clipName === 'string' ||
+  typeof value.name === 'string'
+), {
+  message: 'clip, clipName, or name is required'
+})
+
+server.registerTool(
+  'scene_sync_set_animation_clip',
+  {
+    title: 'Set GLB animation clip',
+    description: 'Switch an animated GLB object to a specific animation clip by name or index. Use scene_sync_get_selection or scene_sync_get_scene first to inspect available animationClips.',
+    inputSchema: animationClipInputSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async ({ objectId, clipName, name, clip, mode, speed, enabled }) => {
+    try {
+      assertObjectId(objectId)
+
+      const params = { objectId }
+
+      if (clip !== undefined) params.clip = clip
+      if (clipName !== undefined) params.clipName = clipName
+      if (name !== undefined) params.name = name
+      if (mode !== undefined) params.mode = mode
+      if (speed !== undefined) params.speed = speed
+      if (enabled !== undefined) params.enabled = enabled
+
+      const response = await runAiCommand(
+        'setAnimationClip',
+        params,
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ...response,
+        ok: response?.ok !== false,
+        action: 'setAnimationClip',
+        objectId
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
 // scene_sync_add_primitive
 server.registerTool(
   'scene_sync_add_primitive',


### PR DESCRIPTION
## 概要

AI コマンドを通じてアニメーション GLB オブジェクトのアニメーションクリップを切り替える機能を追加しました。ユーザーはクリップ名またはインデックスで指定でき、再生モード・速度・有効状態も制御できます。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### ブラウザ側 (`html/assets/js/scenesync/scene.js`)

1. **アニメーションクリップ名の正規化**
   - `normalizeAnimationClipName()`: スペース・ハイフンをアンダースコアに統一し、小文字化
   - クリップ名の曖昧性を減らすための前処理

2. **クリップ解決ロジック**
   - `resolveAnimationClipIndex()`: クリップ名またはインデックスから実際のクリップを特定
   - 3段階のマッチング: 正規化済み完全一致 → 小文字完全一致 → 部分一致（候補が1つの場合のみ）
   - 曖昧な場合は候補を返す

3. **AI コマンドハンドラ**
   - `setObjectAnimationClipByAiCommand()`: AI コマンドからのアニメーション切り替え処理
   - `resolveAiCommandObjectId()`: 明示的な objectId または選択中のオブジェクトを解決
   - scene-delta 操作として animation 状態を更新・ブロードキャスト

4. **シーン出力の拡張**
   - `serializeObjectAnimationClipSummariesForExternalUse()`: オブジェクトのアニメーションクリップ一覧を外部向けに出力
   - `serializeSceneObjectForExternalUse()` に animationClips フィールドを追加

### MCP サーバー側 (`packages/scene-sync-mcp/src/server.mjs`)

- `scene_sync_set_animation_clip` ツールを登録
- Zod スキーマで入力検証（clip / clipName / name のいずれか必須）
- ブラウザの AI コマンドハンドラを呼び出し

### ドキュメント更新

- OpenAPI スキーマ (`docs/scene-sync-ai-openapi.yaml`, `docs/scene-sync-gpt-openapi.yaml`)
  - `SetAnimationClipParams` スキーマ定義
  - `setAnimationClip` アクション追加
  - 使用例を追加

- AI 指示ドキュメント (`docs/scene-sync-ai-instructions-short.md`, `docs/scene-sync-gpt-instructions-short.md`)
  - アニメーションクリップ切り替えの推奨フロー
  - 曖昧性への対応方法を記載

- MCP README (`packages/scene-sync-mcp/README.md`)
  - `scene_sync_set_animation_clip` の使用例と説明を追加
  - ツール対応表に追加

## 変更していないこと

- 既存のアニメーション再生ロジック（animation state の管理）
- クリップの読み込みやメタデータ抽出
- その他の AI コマンド（getSelection, setSkyboxFromImageUrl など）

## staging確認

未確認（ローカル開発環境での動作確認のみ）

## テスト/チェック

https://claude.ai/code/session_01As83mS2Qnn1RQAQXgQxL12