### PR TITLE
Add collapsible object list with remove buttons to Managed Objects UI

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -68,6 +68,7 @@ namespace Afjk.SceneSync.Editor
         private bool _applyingRemoteTransform;
         private bool _showSetup = false;
         private bool _showQuickGuide = false;
+        private bool _showManagedUnityObjects = true;
         private Vector2 _scrollPosition;
 
         private void OnEnable()
@@ -327,23 +328,47 @@ namespace Afjk.SceneSync.Editor
             GUILayout.Label($"With Identity: {identifiedCount} / {managedCount}");
 
             GUILayout.Space(4);
-            GUILayout.Label("Explicit Managed Objects:", EditorStyles.label);
 
             var list = manager.ManagedObjects;
-            EditorGUI.BeginChangeCheck();
-            for (var i = 0; i < list.Count; i++)
+            _showManagedUnityObjects = EditorGUILayout.Foldout(
+                _showManagedUnityObjects,
+                $"Object List ({list.Count})",
+                true
+            );
+
+            if (_showManagedUnityObjects)
             {
-                list[i] = (GameObject)EditorGUILayout.ObjectField(
-                    $"Object {i + 1}",
-                    list[i],
-                    typeof(GameObject),
-                    true
-                );
-            }
-            if (EditorGUI.EndChangeCheck())
-            {
-                manager.ValidateManagedObjects();
-                MarkManagerDirty(manager);
+                var removeIndex = -1;
+                EditorGUI.BeginChangeCheck();
+                for (var i = 0; i < list.Count; i++)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    list[i] = (GameObject)EditorGUILayout.ObjectField(
+                        $"Object {i + 1}",
+                        list[i],
+                        typeof(GameObject),
+                        true
+                    );
+                    if (GUILayout.Button("×", GUILayout.Width(24)))
+                    {
+                        removeIndex = i;
+                    }
+                    EditorGUILayout.EndHorizontal();
+                }
+                var fieldChanged = EditorGUI.EndChangeCheck();
+
+                if (removeIndex >= 0)
+                {
+                    list.RemoveAt(removeIndex);
+                    manager.ValidateManagedObjects();
+                    MarkManagerDirty(manager);
+                    Repaint();
+                }
+                else if (fieldChanged)
+                {
+                    manager.ValidateManagedObjects();
+                    MarkManagerDirty(manager);
+                }
             }
 
             using (new EditorGUILayout.HorizontalScope())


### PR DESCRIPTION
## 概要

SceneSyncWindow の Managed Objects セクションを改善し、オブジェクトリストを折りたたみ可能にして、各オブジェクトを削除するボタンを追加しました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `_showManagedUnityObjects` フラグを追加して、オブジェクトリストの表示/非表示を制御
- Foldout コントロールでリストを折りたたみ可能に（オブジェクト数をカウント表示）
- 各オブジェクト行に削除ボタン（×）を追加
- 削除時に `ValidateManagedObjects()` を呼び出して整合性を保証
- UI の変更に応じて `Repaint()` を呼び出して即座に反映

## 変更していないこと

- オブジェクト追加機能
- オブジェクト検証ロジック
- その他の SceneSyncWindow 機能

## staging確認

- 未確認（UI 改善のため staging 確認不要）

## テスト/チェック

- Unity Editor で Managed Objects セクションの表示/非表示が正常に動作することを確認
- 削除ボタンのクリックでオブジェクトが正常に削除されることを確認

## リスク

- なし（UI のみの変更で既存機能に影響なし）

## follow-up tasks

- なし

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01PfXvcwmwCyhELtx6oC5Tbf