### PR TITLE
Preserve Unity-authored objects when remotely removed

### DIFF
--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -45,6 +45,7 @@ namespace Afjk.SceneSync
         private Dictionary<string, ExpiredGlbRecovery> _pendingRecoveries = new Dictionary<string, ExpiredGlbRecovery>();
         private Dictionary<string, double> _responderCooldowns = new Dictionary<string, double>(); // cacheKey-peerId → timestamp
         private string _activeOutgoingTransferId = null;
+        private readonly HashSet<string> _remoteRemovedUnityObjectIds = new HashSet<string>();
 
         private const double RECOVERY_TIMEOUT_MS = 30000;
         private const double PEER_RETRY_INTERVAL_MS = 4000;
@@ -596,6 +597,11 @@ namespace Afjk.SceneSync
                 var id = instanceId.ToString();
                 currentIds.Add(id);
 
+                if (_remoteRemovedUnityObjectIds.Contains(id))
+                {
+                    continue;
+                }
+
                 if (!_knownObjectIds.Contains(id))
                 {
                     // 新規オブジェクト
@@ -654,6 +660,8 @@ namespace Afjk.SceneSync
 
         private async System.Threading.Tasks.Task SendSceneAdd(GameObject go)
         {
+            _remoteRemovedUnityObjectIds.Remove(go.GetInstanceID().ToString());
+
             var pos = go.transform.position;
             var rot = go.transform.rotation;
             var scl = go.transform.localScale;
@@ -1224,12 +1232,56 @@ namespace Afjk.SceneSync
             var objectId = objectIdMatch.Groups[1].Value;
 
             var go = FindManagedObject(objectId);
-            ForgetObject(objectId, go);
-            if (go != null)
+
+            if (go != null && IsUnityAuthoredObject(go, objectId))
             {
-                Destroy(go);
+                RestoreUnityAuthoredObjectAfterRemoteRemove(objectId, go);
             }
+            else
+            {
+                ForgetObject(objectId, go);
+                if (go != null)
+                {
+                    Debug.Log("[SceneSync] Remote removed temporary object; destroying local object: " + objectId);
+                    Destroy(go);
+                }
+            }
+
             OnObjectRemoved?.Invoke(objectId);
+        }
+
+        private bool IsUnityAuthoredObject(GameObject go, string objectId)
+        {
+            if (go == null) return false;
+
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity != null)
+            {
+                if (identity.Origin == SceneSyncOrigin.Unity && !identity.Temporary)
+                    return true;
+            }
+
+            // Fallback: Unity-authored objects use Unity InstanceID as objectId.
+            return int.TryParse(objectId, out var instanceId)
+                && go.GetInstanceID() == instanceId
+                && !IsTemporaryObject(go);
+        }
+
+        private void RestoreUnityAuthoredObjectAfterRemoteRemove(string objectId, GameObject go)
+        {
+            ForgetObject(objectId, go);
+
+            var identity = go.GetComponent<SceneSyncIdentity>();
+            if (identity != null)
+            {
+                identity.State = SceneSyncState.Disconnected;
+                identity.Temporary = false;
+                identity.Origin = SceneSyncOrigin.Unity;
+            }
+
+            _remoteRemovedUnityObjectIds.Add(objectId);
+
+            Debug.Log("[SceneSync] Remote removed Unity-authored object; restored to unpublished state: " + objectId);
         }
 
         private void HandleSceneMesh(string raw)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -333,6 +333,7 @@ namespace Afjk.SceneSync
                 if (glb == null) continue;
 
                 var objectId = go.GetInstanceID().ToString();
+                _remoteRemovedUnityObjectIds.Remove(objectId);
 
                 // blob store に POST（全クライアント共有）
                 var path = PresenceClientRuntime.GenerateRandomPath();
@@ -1277,8 +1278,14 @@ namespace Afjk.SceneSync
                 identity.State = SceneSyncState.Disconnected;
                 identity.Temporary = false;
                 identity.Origin = SceneSyncOrigin.Unity;
+                identity.MeshPath = null;
+                identity.AssetId = null;
+                identity.LockOwner = null;
             }
 
+            _lastSnapshots.Remove(objectId);
+            _meshPaths.Remove(objectId);
+            _locks.Remove(objectId);
             _remoteRemovedUnityObjectIds.Add(objectId);
 
             Debug.Log("[SceneSync] Remote removed Unity-authored object; restored to unpublished state: " + objectId);


### PR DESCRIPTION
## 概要

Unity エディタで作成されたオブジェクトがリモートから削除された場合、ローカルで復元する機能を追加しました。これにより、Unity 側で作成したオブジェクトが誤ってリモート削除されても、未発行状態で保持されるようになります。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **リモート削除トラッキング**: `_remoteRemovedUnityObjectIds` HashSet を追加し、リモートから削除された Unity オブジェクトを追跡
2. **オブジェクト判定ロジック**: `IsUnityAuthoredObject()` メソッドを追加し、オブジェクトが Unity で作成されたものかを判定
   - `SceneSyncIdentity` コンポーネントの `Origin` と `Temporary` フラグで判定
   - フォールバック: Unity InstanceID が objectId として使用されているかで判定
3. **復元処理**: `RestoreUnityAuthoredObjectAfterRemoteRemove()` メソッドを追加
   - オブジェクトを `Disconnected` 状態に設定
   - `Temporary` フラグを解除
   - リモート削除トラッキングセットに追加
4. **削除ハンドリング**: `HandleSceneRemove()` を修正
   - Unity オブジェクトの場合は復元処理を実行
   - その他のオブジェクト（リモート作成）は従来通り削除
5. **再発行時のクリーンアップ**: `SendSceneAdd()` で再発行時にトラッキングセットから削除
6. **階層変更検出**: `DetectHierarchyChanges()` でリモート削除済みオブジェクトをスキップ

### staging で見てほしい点

- Unity エディタで作成したオブジェクトをシーンに発行
- ブラウザ側から scene-remove で削除
- Unity 側でオブジェクトが復元され、未発行状態になることを確認
- 復元後に再度発行できることを確認

## 変更していないこと

- リモート作成オブジェクトの削除動作（従来通り）
- オブジェクト同期の基本ロジック
- その他の SceneSync 機能

## staging確認

未確認

## テスト/チェック

- コード レビュー対象
- 既存の削除ロジックとの互換性確認が必要

## リスク

- Unity オブジェクトの判定ロジックが不完全な場合、意図しない復元が発生する可能性
- リモート削除トラッキングセットのメモリ管理（削除済みオブジェクトの参照が残る可能性）

## follow-up tasks

- リモート削除トラッキングセットの定期的なクリーンアップ機構の検討
- Unity オブジェクト判定ロジックの統一化（現在は複数箇所で判定）
- テストケースの追加（Unity オブジェクト削除・復元シナリオ）

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01MSB2qW5Tej8TguHLCV2Qjc