### PR TITLE
Scene Sync: preserve Unity GameObjects on Web-side deletion

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1278,12 +1278,21 @@ namespace Afjk.SceneSync.Editor
 
             if (IsBoundUnityOriginObject(objectId))
             {
-                Debug.Log("[SceneSync] Skipping remote import for bound Unity object: " + objectId);
+                Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → bound Unity object, skipping remote creation");
                 return;
             }
 
             // 既に存在する場合はスキップ
-            if (_managedObjects.ContainsKey(objectId)) return;
+            if (_managedObjects.ContainsKey(objectId))
+            {
+                var existing = _managedObjects[objectId];
+                Debug.Log("[SceneSync] scene-add received: objectId=" + objectId
+                    + " → already managed (name=" + (existing != null ? existing.name : "null")
+                    + ", unityOrigin=" + IsBoundUnityOriginObject(objectId) + "), skipping");
+                return;
+            }
+
+            Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
             var nameMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"name\":\"([^\"]+)\"");
@@ -1347,10 +1356,33 @@ namespace Afjk.SceneSync.Editor
             var objectId = objectIdMatch.Groups[1].Value;
 
             var go = FindManagedObject(objectId);
-            ForgetObject(objectId, go);
-            if (go != null)
+
+            Debug.Log(
+                "[SceneSync] scene-remove received: objectId=" + objectId
+                + ", found=" + (go != null)
+                + ", unityOrigin=" + IsBoundUnityOriginObject(objectId));
+
+            if (IsBoundUnityOriginObject(objectId))
             {
-                DestroyImmediate(go);
+                var identity = go.GetComponent<SceneSyncIdentity>();
+                if (identity != null)
+                {
+                    identity.State = SceneSyncState.Disconnected;
+                    identity.MeshPath = null;
+                    identity.AssetId = null;
+                    EditorUtility.SetDirty(identity);
+                }
+                ForgetObject(objectId, go);
+                Debug.Log("[SceneSync] Remote removed Unity-authored object; restored to unpublished state: " + objectId);
+            }
+            else
+            {
+                ForgetObject(objectId, go);
+                if (go != null)
+                {
+                    Debug.Log("[SceneSync] Remote removed temporary object; destroying local object: " + objectId);
+                    DestroyImmediate(go);
+                }
             }
         }
 
@@ -1376,7 +1408,25 @@ namespace Afjk.SceneSync.Editor
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
 
-            // 既存オブジェクトがあれば削除して再作成
+            Debug.Log(
+                "[SceneSync] scene-mesh received: objectId=" + objectId
+                + ", found=" + (go != null)
+                + ", unityOrigin=" + IsBoundUnityOriginObject(objectId));
+
+            if (go != null && IsBoundUnityOriginObject(objectId))
+            {
+                var identity = go.GetComponent<SceneSyncIdentity>();
+                if (identity != null)
+                {
+                    identity.MeshPath = meshPath;
+                    if (assetId != null) identity.AssetId = assetId;
+                    EditorUtility.SetDirty(identity);
+                }
+                Debug.Log("[SceneSync] Received scene-mesh for Unity-authored object; keeping local GameObject: " + objectId);
+                return;
+            }
+
+            // 既存の remote temporary object は従来通り置き換えてよい
             if (go != null)
             {
                 var pos = go.transform.position;

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1368,8 +1368,11 @@ namespace Afjk.SceneSync.Editor
                 if (identity != null)
                 {
                     identity.State = SceneSyncState.Disconnected;
+                    identity.Temporary = false;
+                    identity.Origin = SceneSyncOrigin.Unity;
                     identity.MeshPath = null;
                     identity.AssetId = null;
+                    identity.LockOwner = null;
                     EditorUtility.SetDirty(identity);
                 }
                 ForgetObject(objectId, go);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -329,6 +329,8 @@ namespace Afjk.SceneSync
                     && go.GetComponentInChildren<SkinnedMeshRenderer>() == null)
                     continue;
 
+                EnsureUnityManagedIdentity(go);
+
                 var glb = await PresenceClientRuntime.ExportGameObjectAsGlb(go);
                 if (glb == null) continue;
 
@@ -662,6 +664,7 @@ namespace Afjk.SceneSync
         private async System.Threading.Tasks.Task SendSceneAdd(GameObject go)
         {
             _remoteRemovedUnityObjectIds.Remove(go.GetInstanceID().ToString());
+            EnsureUnityManagedIdentity(go);
 
             var pos = go.transform.position;
             var rot = go.transform.rotation;
@@ -1234,6 +1237,12 @@ namespace Afjk.SceneSync
 
             var go = FindManagedObject(objectId);
 
+            Debug.Log(
+                "[SceneSync] scene-remove received: objectId=" + objectId
+                + ", found=" + (go != null)
+                + ", unityAuthored=" + (go != null && IsUnityAuthoredObject(go, objectId))
+                + ", temporary=" + (go != null && IsTemporaryObject(go)));
+
             if (go != null && IsUnityAuthoredObject(go, objectId))
             {
                 RestoreUnityAuthoredObjectAfterRemoteRemove(objectId, go);
@@ -1313,7 +1322,35 @@ namespace Afjk.SceneSync
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
 
-            // 既存オブジェクトがあれば削除して再作成
+            Debug.Log(
+                "[SceneSync] scene-mesh received: objectId=" + objectId
+                + ", found=" + (go != null)
+                + ", unityAuthored=" + (go != null && IsUnityAuthoredObject(go, objectId))
+                + ", temporary=" + (go != null && IsTemporaryObject(go)));
+
+            if (go != null && IsUnityAuthoredObject(go, objectId))
+            {
+                _meshPaths[objectId] = meshPath;
+
+                var identity = go.GetComponent<SceneSyncIdentity>();
+                if (identity != null)
+                {
+                    identity.Origin = SceneSyncOrigin.Unity;
+                    identity.Temporary = false;
+                    identity.State = SceneSyncState.Synced;
+                    identity.MeshPath = meshPath;
+                    identity.AssetId = assetId;
+                }
+
+                _managedObjects[objectId] = go;
+                _knownObjectIds.Add(objectId);
+                _remoteRemovedUnityObjectIds.Remove(objectId);
+
+                Debug.Log("[SceneSync] Received scene-mesh for Unity-authored object; keeping local GameObject: " + objectId);
+                return;
+            }
+
+            // 既存の remote temporary object は従来通り置き換えてよい
             if (go != null)
             {
                 var pos = go.transform.position;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -608,6 +608,7 @@ namespace Afjk.SceneSync
                 if (!_knownObjectIds.Contains(id))
                 {
                     // 新規オブジェクト
+                    Debug.Log("[SceneSync] DetectHierarchyChanges: new object detected, publishing: objectId=" + id + ", name=" + go.name);
                     _ = SendSceneAdd(go);
                 }
             }
@@ -634,6 +635,7 @@ namespace Afjk.SceneSync
             {
                 if (!currentIds.Contains(id))
                 {
+                    Debug.Log("[SceneSync] DetectHierarchyChanges: object gone from hierarchy, sending scene-remove: objectId=" + id);
                     _ = SendSceneRemove(id);
                     _meshPaths.Remove(id);
                     _locks.Remove(id);
@@ -663,7 +665,11 @@ namespace Afjk.SceneSync
 
         private async System.Threading.Tasks.Task SendSceneAdd(GameObject go)
         {
-            _remoteRemovedUnityObjectIds.Remove(go.GetInstanceID().ToString());
+            var sendObjectId = go.GetInstanceID().ToString();
+            Debug.Log("[SceneSync] SendSceneAdd: objectId=" + sendObjectId + ", name=" + go.name
+                + ", remoteRemoved=" + _remoteRemovedUnityObjectIds.Contains(sendObjectId)
+                + ", known=" + _knownObjectIds.Contains(sendObjectId));
+            _remoteRemovedUnityObjectIds.Remove(sendObjectId);
             EnsureUnityManagedIdentity(go);
 
             var pos = go.transform.position;
@@ -1156,7 +1162,17 @@ namespace Afjk.SceneSync
             var objectId = objectIdMatch.Groups[1].Value;
 
             // 既に存在する場合はスキップ
-            if (_managedObjects.ContainsKey(objectId)) return;
+            if (_managedObjects.ContainsKey(objectId))
+            {
+                var existing = _managedObjects[objectId];
+                Debug.Log("[SceneSync] scene-add received: objectId=" + objectId
+                    + " → already managed (name=" + (existing != null ? existing.name : "null")
+                    + ", unityAuthored=" + (existing != null && IsUnityAuthoredObject(existing, objectId))
+                    + ", temporary=" + (existing != null && IsTemporaryObject(existing)) + "), skipping");
+                return;
+            }
+
+            Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
             var nameMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"name\":\"([^\"]+)\"");
@@ -1215,6 +1231,7 @@ namespace Afjk.SceneSync
             // メッシュがある場合は glB をダウンロードしてインポート
             if (!string.IsNullOrEmpty(meshPath))
             {
+                Debug.Log("[SceneSync] scene-add: creating remote temporary for objectId=" + objectId + ", meshPath=" + meshPath);
                 // プレースホルダーを先行登録（同期フェーズで登録を確実にする）
                 var placeholder = new GameObject(objectId);
                 placeholder.hideFlags = HideFlags.NotEditable;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1195,6 +1195,23 @@ namespace Afjk.SceneSync
                 _meshPaths[objectId] = meshPath;
             }
 
+            // Unity 由来の objectId は整数（InstanceID）。
+            // ローカルにその instanceId を持つ GO があれば自分自身のブロードキャストなので
+            // リモート temporary を作らずそのまま登録して返す。
+            if (int.TryParse(objectId, out var parsedInstanceId))
+            {
+                foreach (var candidate in GetAllSyncTargets())
+                {
+                    if (candidate.GetInstanceID() == parsedInstanceId && !IsTemporaryObject(candidate))
+                    {
+                        _managedObjects[objectId] = candidate;
+                        _knownObjectIds.Add(objectId);
+                        Debug.Log("[SceneSync] scene-add received for own Unity-authored object; skipping remote creation: " + objectId);
+                        return;
+                    }
+                }
+            }
+
             // メッシュがある場合は glB をダウンロードしてインポート
             if (!string.IsNullOrEmpty(meshPath))
             {


### PR DESCRIPTION
## Summary

- `SceneSyncWindow.HandleSceneRemove`: Unity 由来オブジェクトを `DestroyImmediate` せず unpublished 状態に復元するよう修正
- `SceneSyncWindow.HandleSceneMesh`: Unity 由来オブジェクトを再ダウンロード・再生成せず identity メタデータのみ更新するよう修正
- `SceneSyncManager.HandleSceneMesh`: 同様の修正（Runtime 側）
- `SceneSyncManager.HandleSceneAdd`: 自身の `scene-add` ブロードキャストエコーを受信した際にリモート temporary を作らないよう修正
- `SyncAllMeshes` / `SendSceneAdd` で publish 前に `EnsureUnityManagedIdentity` を呼ぶよう修正
- 調査用ログを `HandleSceneAdd` / `HandleSceneRemove` / `HandleSceneMesh` / `DetectHierarchyChanges` / `SendSceneAdd` に追加

## Root cause

PR #232 の修正は `SceneSyncManager`（Runtime）の `HandleSceneRemove` にのみ入っていたが、Editor ウィンドウは独自の `DispatchSceneMessage` / `HandleSceneRemove` を持ち、`IsBoundUnityOriginObject` チェックがなかった。Web 削除 → `scene-remove` 受信 → `FindManagedObject` が Unity GO を返す → `DestroyImmediate(go)` で消えていた。

## Test plan

- [ ] Unity GameObject を Publish
- [ ] Web 側に表示されることを確認
- [ ] Web 側で削除
- [ ] Unity Console に `Remote removed Unity-authored object; restored to unpublished state` が出ることを確認
- [ ] Unity Hierarchy の元 GameObject が残っていることを確認
- [ ] 再 Publish で Web に再表示されることを確認
- [ ] Web 由来オブジェクト（GLB import）は Web 削除で Unity 側でも削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)