### PR TITLE
Scene Sync Unity: repair duplicated editor object ids

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1023,6 +1023,87 @@ namespace Afjk.SceneSync.Editor
             return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
+        private static string GenerateUnitySceneSyncObjectId()
+        {
+            return "unity-" + Guid.NewGuid().ToString("N");
+        }
+
+        private static string GetGlobalObjectIdString(GameObject go)
+        {
+            if (go == null) return string.Empty;
+            return GlobalObjectId.GetGlobalObjectIdSlow(go).ToString();
+        }
+
+        private static bool HasDuplicateObjectIdOnDifferentUnityObject(SceneSyncIdentity identity)
+        {
+            if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId))
+            {
+                return false;
+            }
+
+            var currentGlobalId = GetGlobalObjectIdString(identity.gameObject);
+
+#if UNITY_2023_1_OR_NEWER
+            var identities = UnityEngine.Object.FindObjectsByType<SceneSyncIdentity>(
+                FindObjectsInactive.Include,
+                FindObjectsSortMode.None
+            );
+#else
+            var identities = UnityEngine.Object.FindObjectsOfType<SceneSyncIdentity>(true);
+#endif
+
+            foreach (var other in identities)
+            {
+                if (other == null || other == identity) continue;
+                if (other.Temporary) continue;
+                if (other.Origin != SceneSyncOrigin.Unity) continue;
+                if (other.ObjectId != identity.ObjectId) continue;
+
+                var otherGlobalId = GetGlobalObjectIdString(other.gameObject);
+                if (!string.Equals(otherGlobalId, currentGlobalId, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private SceneSyncIdentity EnsureUniqueManagedUnityIdentityForPublish(SceneSyncManager manager, GameObject go)
+        {
+            if (manager == null || go == null) return null;
+
+            var identity = EnsureManagedUnityIdentity(manager, go, out _);
+            if (identity == null) return null;
+
+            var needsNewObjectId =
+                string.IsNullOrWhiteSpace(identity.ObjectId) ||
+                HasDuplicateObjectIdOnDifferentUnityObject(identity);
+
+            if (needsNewObjectId)
+            {
+                var oldObjectId = identity.ObjectId;
+                identity.ObjectId = GenerateUnitySceneSyncObjectId();
+                identity.State = SceneSyncState.Disconnected;
+                identity.Temporary = false;
+                identity.Origin = SceneSyncOrigin.Unity;
+                identity.MeshPath = null;
+                identity.AssetId = null;
+                identity.LockOwner = null;
+
+                EditorUtility.SetDirty(identity);
+                MarkManagerDirty(manager);
+
+                Debug.LogWarning(
+                    "[SceneSync] Assigned a new Scene Sync ObjectId before publish. " +
+                    "This usually happens when a GameObject with SceneSyncIdentity was duplicated. " +
+                    $"GameObject={go.name}, oldObjectId={oldObjectId}, newObjectId={identity.ObjectId}"
+                );
+            }
+
+            return identity;
+        }
+
         private async void PublishSelectedObjects()
         {
             if (!_connected)
@@ -1045,7 +1126,7 @@ namespace Afjk.SceneSync.Editor
                 if (root == null || !seen.Add(root)) continue;
                 if (ShouldSkipPublishObject(root)) continue;
 
-                var identity = EnsureManagedUnityIdentity(manager, root, out _);
+                var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, root);
                 if (identity == null) continue;
 
                 Debug.Log("[SceneSync] Publishing selected object: " + root.name + " (objectId=" + identity.ObjectId + ")");
@@ -1074,7 +1155,7 @@ namespace Afjk.SceneSync.Editor
                 if (go == null || !seen.Add(go)) continue;
                 if (ShouldSkipPublishObject(go)) continue;
 
-                var identity = EnsureManagedUnityIdentity(manager, go, out _);
+                var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, go);
                 if (identity == null) continue;
 
                 Debug.Log("[SceneSync] Publishing managed object: " + go.name + " (objectId=" + identity.ObjectId + ")");

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -690,6 +690,24 @@ namespace Afjk.SceneSync.Editor
                 if (string.IsNullOrWhiteSpace(identity.MeshPath)) continue;
 
                 var objectId = identity.ObjectId;
+
+                // Detect duplicate: another GameObject is already bound with this objectId.
+                // This happens when a published object is duplicated (MeshPath is copied too).
+                if (_managedObjects.TryGetValue(objectId, out var alreadyBound)
+                    && alreadyBound != null
+                    && alreadyBound != go)
+                {
+                    identity.MeshPath = null;
+                    identity.State = SceneSyncState.Disconnected;
+                    EditorUtility.SetDirty(identity);
+                    Debug.LogWarning(
+                        $"[SceneSync] Rebound: duplicate objectId detected on different GameObject. " +
+                        $"Clearing MeshPath on duplicate. " +
+                        $"original={alreadyBound.name}, duplicate={go.name}, objectId={objectId}"
+                    );
+                    continue;
+                }
+
                 _managedObjects[objectId] = go;
                 _instanceToObjectId[go.GetInstanceID()] = objectId;
                 _knownObjectIds.Add(objectId);

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1049,7 +1049,12 @@ namespace Afjk.SceneSync.Editor
         private static string GetGlobalObjectIdString(GameObject go)
         {
             if (go == null) return string.Empty;
-            return GlobalObjectId.GetGlobalObjectIdSlow(go).ToString();
+            var globalId = GlobalObjectId.GetGlobalObjectIdSlow(go).ToString();
+            // GlobalObjectId returns the zero id when the scene is unsaved.
+            // Fall back to InstanceID, which is unique per-object within the current session.
+            if (globalId == "GlobalObjectId_V1-0-00000000000000000000000000000000-0-0")
+                return "instanceId-" + go.GetInstanceID();
+            return globalId;
         }
 
         private static bool HasDuplicateObjectIdOnDifferentUnityObject(SceneSyncIdentity identity)

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1038,10 +1038,12 @@ namespace Afjk.SceneSync.Editor
         {
             if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId))
             {
+                Debug.Log("[SceneSync][DupCheck] Skipped: identity null or ObjectId empty");
                 return false;
             }
 
             var currentGlobalId = GetGlobalObjectIdString(identity.gameObject);
+            Debug.Log($"[SceneSync][DupCheck] Checking objectId={identity.ObjectId}, go={identity.gameObject.name}, globalId={currentGlobalId}");
 
 #if UNITY_2023_1_OR_NEWER
             var identities = UnityEngine.Object.FindObjectsByType<SceneSyncIdentity>(
@@ -1052,20 +1054,41 @@ namespace Afjk.SceneSync.Editor
             var identities = UnityEngine.Object.FindObjectsOfType<SceneSyncIdentity>(true);
 #endif
 
+            Debug.Log($"[SceneSync][DupCheck] Found {identities.Length} SceneSyncIdentity components in scene");
+
             foreach (var other in identities)
             {
                 if (other == null || other == identity) continue;
-                if (other.Temporary) continue;
-                if (other.Origin != SceneSyncOrigin.Unity) continue;
-                if (other.ObjectId != identity.ObjectId) continue;
+
+                Debug.Log($"[SceneSync][DupCheck] Candidate: go={other.gameObject.name}, objectId={other.ObjectId}, origin={other.Origin}, temporary={other.Temporary}");
+
+                if (other.Temporary)
+                {
+                    Debug.Log($"[SceneSync][DupCheck]   → skipped (Temporary)");
+                    continue;
+                }
+                if (other.Origin != SceneSyncOrigin.Unity)
+                {
+                    Debug.Log($"[SceneSync][DupCheck]   → skipped (Origin={other.Origin})");
+                    continue;
+                }
+                if (other.ObjectId != identity.ObjectId)
+                {
+                    Debug.Log($"[SceneSync][DupCheck]   → skipped (different ObjectId: {other.ObjectId})");
+                    continue;
+                }
 
                 var otherGlobalId = GetGlobalObjectIdString(other.gameObject);
+                Debug.Log($"[SceneSync][DupCheck]   → same ObjectId! otherGlobalId={otherGlobalId}, currentGlobalId={currentGlobalId}, match={string.Equals(otherGlobalId, currentGlobalId, StringComparison.Ordinal)}");
+
                 if (!string.Equals(otherGlobalId, currentGlobalId, StringComparison.Ordinal))
                 {
+                    Debug.Log($"[SceneSync][DupCheck]   → DUPLICATE DETECTED on different Unity object");
                     return true;
                 }
             }
 
+            Debug.Log($"[SceneSync][DupCheck] No duplicate found for objectId={identity.ObjectId}");
             return false;
         }
 
@@ -1076,9 +1099,13 @@ namespace Afjk.SceneSync.Editor
             var identity = EnsureManagedUnityIdentity(manager, go, out _);
             if (identity == null) return null;
 
-            var needsNewObjectId =
-                string.IsNullOrWhiteSpace(identity.ObjectId) ||
-                HasDuplicateObjectIdOnDifferentUnityObject(identity);
+            Debug.Log($"[SceneSync][DupCheck] EnsureUnique: go={go.name}, objectId={identity.ObjectId}, origin={identity.Origin}, temporary={identity.Temporary}, state={identity.State}");
+
+            var emptyId = string.IsNullOrWhiteSpace(identity.ObjectId);
+            var hasDuplicate = HasDuplicateObjectIdOnDifferentUnityObject(identity);
+            var needsNewObjectId = emptyId || hasDuplicate;
+
+            Debug.Log($"[SceneSync][DupCheck] needsNewObjectId={needsNewObjectId} (emptyId={emptyId}, hasDuplicate={hasDuplicate})");
 
             if (needsNewObjectId)
             {

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1060,13 +1060,9 @@ namespace Afjk.SceneSync.Editor
         private static bool HasDuplicateObjectIdOnDifferentUnityObject(SceneSyncIdentity identity)
         {
             if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId))
-            {
-                Debug.Log("[SceneSync][DupCheck] Skipped: identity null or ObjectId empty");
                 return false;
-            }
 
             var currentGlobalId = GetGlobalObjectIdString(identity.gameObject);
-            Debug.Log($"[SceneSync][DupCheck] Checking objectId={identity.ObjectId}, go={identity.gameObject.name}, globalId={currentGlobalId}");
 
 #if UNITY_2023_1_OR_NEWER
             var identities = UnityEngine.Object.FindObjectsByType<SceneSyncIdentity>(
@@ -1077,41 +1073,18 @@ namespace Afjk.SceneSync.Editor
             var identities = UnityEngine.Object.FindObjectsOfType<SceneSyncIdentity>(true);
 #endif
 
-            Debug.Log($"[SceneSync][DupCheck] Found {identities.Length} SceneSyncIdentity components in scene");
-
             foreach (var other in identities)
             {
                 if (other == null || other == identity) continue;
-
-                Debug.Log($"[SceneSync][DupCheck] Candidate: go={other.gameObject.name}, objectId={other.ObjectId}, origin={other.Origin}, temporary={other.Temporary}");
-
-                if (other.Temporary)
-                {
-                    Debug.Log($"[SceneSync][DupCheck]   → skipped (Temporary)");
-                    continue;
-                }
-                if (other.Origin != SceneSyncOrigin.Unity)
-                {
-                    Debug.Log($"[SceneSync][DupCheck]   → skipped (Origin={other.Origin})");
-                    continue;
-                }
-                if (other.ObjectId != identity.ObjectId)
-                {
-                    Debug.Log($"[SceneSync][DupCheck]   → skipped (different ObjectId: {other.ObjectId})");
-                    continue;
-                }
+                if (other.Temporary) continue;
+                if (other.Origin != SceneSyncOrigin.Unity) continue;
+                if (other.ObjectId != identity.ObjectId) continue;
 
                 var otherGlobalId = GetGlobalObjectIdString(other.gameObject);
-                Debug.Log($"[SceneSync][DupCheck]   → same ObjectId! otherGlobalId={otherGlobalId}, currentGlobalId={currentGlobalId}, match={string.Equals(otherGlobalId, currentGlobalId, StringComparison.Ordinal)}");
-
                 if (!string.Equals(otherGlobalId, currentGlobalId, StringComparison.Ordinal))
-                {
-                    Debug.Log($"[SceneSync][DupCheck]   → DUPLICATE DETECTED on different Unity object");
                     return true;
-                }
             }
 
-            Debug.Log($"[SceneSync][DupCheck] No duplicate found for objectId={identity.ObjectId}");
             return false;
         }
 
@@ -1122,13 +1095,8 @@ namespace Afjk.SceneSync.Editor
             var identity = EnsureManagedUnityIdentity(manager, go, out _);
             if (identity == null) return null;
 
-            Debug.Log($"[SceneSync][DupCheck] EnsureUnique: go={go.name}, objectId={identity.ObjectId}, origin={identity.Origin}, temporary={identity.Temporary}, state={identity.State}");
-
-            var emptyId = string.IsNullOrWhiteSpace(identity.ObjectId);
-            var hasDuplicate = HasDuplicateObjectIdOnDifferentUnityObject(identity);
-            var needsNewObjectId = emptyId || hasDuplicate;
-
-            Debug.Log($"[SceneSync][DupCheck] needsNewObjectId={needsNewObjectId} (emptyId={emptyId}, hasDuplicate={hasDuplicate})");
+            var needsNewObjectId = string.IsNullOrWhiteSpace(identity.ObjectId)
+                || HasDuplicateObjectIdOnDifferentUnityObject(identity);
 
             if (needsNewObjectId)
             {


### PR DESCRIPTION
## Summary

- Adds `GlobalObjectId`-based duplicate detection to the Unity Editor publish flow in `SceneSyncWindow.cs`
- When a `SceneSyncIdentity.ObjectId` collision is detected (same ObjectId on two different Unity GameObjects), the currently-published object is assigned a fresh `unity-<guid>` ObjectId before publish
- The original object keeps its existing ObjectId; only the duplicate gets a new one
- Both "Publish Selected" and "Publish Managed Objects" paths use the new `EnsureUniqueManagedUnityIdentityForPublish` helper

## New helpers (editor-only, in `SceneSyncWindow.cs`)

- `GenerateUnitySceneSyncObjectId()` — returns `"unity-" + Guid.NewGuid().ToString("N")`
- `GetGlobalObjectIdString(GameObject)` — wraps `GlobalObjectId.GetGlobalObjectIdSlow`
- `HasDuplicateObjectIdOnDifferentUnityObject(SceneSyncIdentity)` — scans the scene for Unity-authored identities sharing the same `ObjectId` but on a different `GlobalObjectId`
- `EnsureUniqueManagedUnityIdentityForPublish(SceneSyncManager, GameObject)` — calls the existing `EnsureManagedUnityIdentity`, then applies collision repair if needed

## Test plan

- [ ] Case 1: normal publish — Cube gets `unity-...` ObjectId, appears on Web
- [ ] Case 2: duplicate after publish — duplicate gets new `unity-...` ObjectId; original unchanged; both appear separately on Web
- [ ] Case 3: publish multiple duplicates together — every duplicate gets unique ObjectId; all appear as separate Web objects
- [ ] Case 4: remote temporary objects — Web-origin GLB objects are not affected (skipped by `other.Temporary` and `other.Origin != Unity` checks)
- [ ] Case 5: remote deletion of Unity object — after Web delete, Unity object can be re-published with the same ObjectId

🤖 Generated with [Claude Code](https://claude.com/claude-code)