### PR TITLE
Add visualBasis support for GLB asset orientation

### DIFF
--- a/html/assets/js/scenesync/loaders/glb-file-loader.js
+++ b/html/assets/js/scenesync/loaders/glb-file-loader.js
@@ -35,10 +35,18 @@ export class GLBFileLoader {
     });
   }
 
-  _buildModel(gltf, position) {
+  _buildModel(gltf, position, asset) {
     const wrapper = new THREE.Group();
     // Scene Sync treats meshPath GLBs as authored assets.
     // Do not add client-specific yaw fixes here; object rotation comes from wire transforms.
+
+    // Apply visual-only correction for Unity-authored GLBs.
+    // The correction is applied to the visual hierarchy, not the synced root transform.
+    const isUnityBasis = asset?.visualBasis === "unity";
+    if (isUnityBasis) {
+      gltf.scene.rotation.y = Math.PI;
+    }
+
     wrapper.add(gltf.scene);
 
     wrapper.updateMatrixWorld(true);
@@ -106,13 +114,13 @@ export class GLBFileLoader {
     return { wrapper, metadata };
   }
 
-  async loadFromUrl(url, position, scene, onLoaded) {
+  async loadFromUrl(url, position, scene, onLoaded, asset) {
     if (!url || !scene) {
       throw new Error('必要なパラメータが不足しています');
     }
 
     const gltf = await this._load(url);
-    const { wrapper, metadata } = this._buildModel(gltf, position);
+    const { wrapper, metadata } = this._buildModel(gltf, position, asset);
     scene.add(wrapper);
 
     if (onLoaded) {
@@ -122,7 +130,7 @@ export class GLBFileLoader {
     return wrapper;
   }
 
-  async loadFromFile(file, position, scene, onLoaded) {
+  async loadFromFile(file, position, scene, onLoaded, asset) {
     if (!file || !scene) {
       throw new Error('必要なパラメータが不足しています');
     }
@@ -130,7 +138,7 @@ export class GLBFileLoader {
     const objectURL = URL.createObjectURL(file);
 
     try {
-      const model = await this.loadFromUrl(objectURL, position, scene);
+      const model = await this.loadFromUrl(objectURL, position, scene, null, asset);
       const metadata = model.userData?.scenesync?.glbMetadata;
       if (metadata) {
         metadata.fileName = file.name;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4668,8 +4668,9 @@ function handleHandoff(data) {
         model.userData.objectId = payload.objectId;
         model.userData.name = obj?.userData?.name || payload.name || payload.meshPath;
         model.userData.meshPath = payload.meshPath;
-        if (payload.asset) model.userData.asset = structuredClone(payload.asset);
-      }, payload.asset);
+        if (payload.asset) {
+          model.userData.asset = structuredClone(payload.asset);
+        }
 
         if (obj) {
           // 位置・回転・スケールを引き継ぐ
@@ -4683,7 +4684,7 @@ function handleHandoff(data) {
         }
         registerLoadedGlbAnimation(payload.objectId, model, 'scene-mesh');
         notifySceneStateChanged('scene-mesh-loaded');
-      }).catch((err) => {
+      }, payload.asset).catch((err) => {
         removeLoadingOverlay(payload.objectId);
         // glB ロード失敗時のフォールバック
         console.warn('Failed to load mesh:', err);
@@ -5493,8 +5494,9 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
           model.userData.objectId = objectId;
           model.userData.name = info.name;
           model.userData.meshPath = meshPath;
-          if (info.asset) model.userData.asset = structuredClone(info.asset);
-      }, info.asset);
+          if (info.asset) {
+            model.userData.asset = structuredClone(info.asset);
+          }
 
           if (info.runtime) {
             model.userData.runtime = {
@@ -5551,7 +5553,7 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
           loadCompleted = true;
           URL.revokeObjectURL(objectUrl);
         }
-      }).catch((err) => {
+      }, info.asset).catch((err) => {
         removeLoadingOverlay(objectId);
         console.warn('Failed to load mesh for', objectId, ':', err);
         if (!existing && !skipFallbackOnFailure) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4668,6 +4668,8 @@ function handleHandoff(data) {
         model.userData.objectId = payload.objectId;
         model.userData.name = obj?.userData?.name || payload.name || payload.meshPath;
         model.userData.meshPath = payload.meshPath;
+        if (payload.asset) model.userData.asset = structuredClone(payload.asset);
+      }, payload.asset);
 
         if (obj) {
           // 位置・回転・スケールを引き継ぐ
@@ -5492,6 +5494,7 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
           model.userData.name = info.name;
           model.userData.meshPath = meshPath;
           if (info.asset) model.userData.asset = structuredClone(info.asset);
+      }, info.asset);
 
           if (info.runtime) {
             model.userData.runtime = {

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1279,7 +1279,8 @@ namespace Afjk.SceneSync.Editor
                 ",\"position\":[" + FormatFloat(pos.x) + "," + FormatFloat(pos.y) + "," + FormatFloat(-pos.z) + "]" +
                 ",\"rotation\":[" + FormatFloat(rot.x) + "," + FormatFloat(rot.y) + "," + FormatFloat(-rot.z) + "," + FormatFloat(-rot.w) + "]" +
                 ",\"scale\":[" + FormatFloat(scl.x) + "," + FormatFloat(scl.y) + "," + FormatFloat(scl.z) + "]" +
-                ",\"meshPath\":\"" + JsonEscape(path) + "\"}";
+                ",\"meshPath\":\"" + JsonEscape(path) + "\"" +
+                ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}}";
             await _client.Broadcast(payload);
 
             _managedObjects[objectId] = go;
@@ -1726,7 +1727,10 @@ namespace Afjk.SceneSync.Editor
                     // Keep the synchronized object transform on the parent and apply the
                     // same Unity GLB visual correction as Runtime/SceneSyncManager.
                     importedGlbRoot.transform.localPosition = Vector3.zero;
-                    importedGlbRoot.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                    var shouldApplyUnityImportYawCorrection = true;
+                    importedGlbRoot.transform.localRotation = shouldApplyUnityImportYawCorrection
+                        ? Quaternion.Euler(0f, 180f, 0f)
+                        : Quaternion.identity;
                     importedGlbRoot.transform.localScale = Vector3.one;
 
                     await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1424,6 +1424,11 @@ namespace Afjk.SceneSync.Editor
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            // Extract visualBasis from asset JSON
+            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"visualBasis\":\"([^\"]+)\"");
+            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+
             // meshPath を保存
             if (!string.IsNullOrEmpty(meshPath))
             {
@@ -1433,7 +1438,7 @@ namespace Afjk.SceneSync.Editor
             // メッシュがある場合は glB をダウンロードしてインポート
             if (!string.IsNullOrEmpty(meshPath))
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis);
             }
             else
             {
@@ -1505,6 +1510,11 @@ namespace Afjk.SceneSync.Editor
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            // Extract visualBasis from asset JSON
+            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"visualBasis\":\"([^\"]+)\"");
+            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
 
@@ -1542,11 +1552,11 @@ namespace Afjk.SceneSync.Editor
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId);
+                    assetId, visualBasis);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis);
             }
         }
 
@@ -1613,11 +1623,12 @@ namespace Afjk.SceneSync.Editor
                 if (!first) objectsJson.Append(",");
                 first = false;
                 var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
+                var assetJson = path != null ? ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}" : "";
                 objectsJson.Append("\"" + objectId + "\":{\"name\":\"" + go.name + "\"" +
                     ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
                     ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
                     ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                    meshPathJson + "}");
+                    meshPathJson + assetJson + "}");
             }
 
             // Web 由来のオブジェクトも含める
@@ -1670,7 +1681,7 @@ namespace Afjk.SceneSync.Editor
 
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
-            float[] position, float[] rotation, float[] scale, string assetId = null)
+            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null)
         {
             try
             {
@@ -1727,11 +1738,17 @@ namespace Afjk.SceneSync.Editor
                     // Keep the synchronized object transform on the parent and apply the
                     // same Unity GLB visual correction as Runtime/SceneSyncManager.
                     importedGlbRoot.transform.localPosition = Vector3.zero;
-                    var shouldApplyUnityImportYawCorrection = true;
+                    var shouldApplyUnityImportYawCorrection = visualBasis != "unity";
                     importedGlbRoot.transform.localRotation = shouldApplyUnityImportYawCorrection
                         ? Quaternion.Euler(0f, 180f, 0f)
                         : Quaternion.identity;
                     importedGlbRoot.transform.localScale = Vector3.one;
+
+                    Debug.Log(
+                        "[SceneSync] GLB visual basis: objectId=" + objectId
+                        + ", visualBasis=" + (visualBasis ?? "web")
+                        + ", applyUnityImportYawCorrection=" + shouldApplyUnityImportYawCorrection
+                        + ", importedGlbRoot.localEulerAngles=" + importedGlbRoot.transform.localEulerAngles);
 
                     await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);
                     ApplyTransform(go, position, rotation, scale);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1205,6 +1205,11 @@ namespace Afjk.SceneSync
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            // Extract visualBasis from asset JSON
+            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"visualBasis\":\"([^\"]+)\"");
+            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+
             // meshPath を保存
             if (!string.IsNullOrEmpty(meshPath))
             {
@@ -1242,7 +1247,7 @@ namespace Afjk.SceneSync
                 _instanceToObjectId[placeholder.GetInstanceID()] = objectId;
 
                 // 非同期でダウンロード・インポート開始
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis);
             }
             else
             {
@@ -1350,6 +1355,11 @@ namespace Afjk.SceneSync
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            // Extract visualBasis from asset JSON
+            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
+                raw, "\"visualBasis\":\"([^\"]+)\"");
+            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
 
@@ -1397,11 +1407,11 @@ namespace Afjk.SceneSync
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId);
+                    assetId, visualBasis);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis);
             }
         }
 
@@ -1701,7 +1711,7 @@ namespace Afjk.SceneSync
 
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
-            float[] position, float[] rotation, float[] scale, string assetId = null)
+            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null)
         {
             _knownObjectIds.Add(objectId);
 
@@ -1831,8 +1841,17 @@ namespace Afjk.SceneSync
                     // Keep the synchronized object transform on the parent and apply this asset-local
                     // correction only to the imported visual root.
                     importedGlbRoot.transform.localPosition = Vector3.zero;
-                    importedGlbRoot.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                    var shouldApplyUnityImportYawCorrection = visualBasis != "unity";
+                    importedGlbRoot.transform.localRotation = shouldApplyUnityImportYawCorrection
+                        ? Quaternion.Euler(0f, 180f, 0f)
+                        : Quaternion.identity;
                     importedGlbRoot.transform.localScale = Vector3.one;
+
+                    Debug.Log(
+                        "[SceneSync] GLB visual basis: objectId=" + objectId
+                        + ", visualBasis=" + (visualBasis ?? "web")
+                        + ", applyUnityImportYawCorrection=" + shouldApplyUnityImportYawCorrection
+                        + ", importedGlbRoot.localEulerAngles=" + importedGlbRoot.transform.localEulerAngles);
 
                     // プレースホルダーのマッピングを新オブジェクトに移動
                     _instanceToObjectId.Remove(placeholderInstanceId);


### PR DESCRIPTION
## 概要

GLB アセットの視覚的な向きを制御するための `visualBasis` フィールドを追加しました。Unity で作成された GLB は Y 軸 180° の回転補正を適用し、Web ベースの GLB は補正を適用しないようにします。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### Unity Runtime (SceneSyncManager.cs)
- `HandleSceneAdd` と `HandleSceneMesh` で JSON から `visualBasis` フィールドを抽出
- `DownloadAndCreateObject` メソッドに `visualBasis` パラメータを追加
- GLB インポート時に `visualBasis != "unity"` の場合のみ Y 軸 180° 回転を適用
- デバッグログを追加して、適用された補正を記録

### Unity Editor (SceneSyncWindow.cs)
- Unity オブジェクト公開時に `asset` オブジェクトに `visualBasis: "unity"` を含める
- Editor での GLB インポート処理も同様に補正を適用

### Web (glb-file-loader.js)
- `loadFromUrl` と `loadFromFile` に `asset` パラメータを追加
- Unity 作成の GLB（`visualBasis === "unity"`）に対して、Web 側で Y 軸 π ラジアン回転を適用

### Web (scene.js)
- `handleHandoff` と `loadMeshObject` で `asset` メタデータを保持
- GLB ローダーに `asset` 情報を渡すように修正

## 変更していないこと

- プリミティブアセットの処理
- シーン同期の基本的なロジック
- 既存の座標変換ロジック（position/rotation/scale）

## staging確認

未確認

## テスト/チェック

- コード変更は既存の GLB ロード処理に条件分岐を追加するもので、デフォルト動作（`visualBasis` が指定されない場合）は従来通り
- Unity と Web の両側で同じ補正ロジックを実装し、一貫性を確保

## リスク

- `visualBasis` フィールドが存在しない既存アセットは `null` として扱われ、従来の補正が適用される（後方互換性あり）
- Web 側での回転補正は視覚的な階層にのみ適用され、同期ルートトランスフォームには影響しない

## follow-up tasks

- 他のエンジン（Godot など）での `visualBasis` サポート実装
- `visualBasis` の値を拡張する場合のドキュメント更新

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_017XQSutVWRDvKBu1Grwqxqp