### PR TITLE
Remove Unity visual basis rotation correction logic

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2706,39 +2706,9 @@ function cloneJsonSafe(value) {
   }
 }
 
-// Unity visual basis copy rotation correction helpers
-const UNITY_VISUAL_BASIS_YAW_CORRECTION = new THREE.Quaternion()
-  .setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
 
-function getSceneSyncVisualBasis(asset, metadata = null) {
-  if (asset && typeof asset.visualBasis === 'string') {
-    return asset.visualBasis;
-  }
-  if (metadata && typeof metadata.visualBasis === 'string') {
-    return metadata.visualBasis;
-  }
-  return null;
-}
-
-function hasUnityVisualBasis(asset, metadata = null) {
-  return getSceneSyncVisualBasis(asset, metadata) === 'unity';
-}
-
-function wasCopyRotationAdjustedForVisualBasis(metadata) {
-  return metadata?.sceneSyncCopyRotationAdjustedForVisualBasis === true;
-}
-
-function getCopyRotationForPayload(source, asset, metadata = null) {
-  const rotation = source.quaternion.clone();
-
-  if (
-    hasUnityVisualBasis(asset, metadata) &&
-    !wasCopyRotationAdjustedForVisualBasis(metadata)
-  ) {
-    rotation.multiply(UNITY_VISUAL_BASIS_YAW_CORRECTION);
-  }
-
-  return rotation.toArray();
+function getCopyRotationForPayload(source) {
+  return source.quaternion.toArray();
 }
 
 function buildCopyMetadata(sourceMetadata, asset, sourceObjectId) {
@@ -2749,11 +2719,6 @@ function buildCopyMetadata(sourceMetadata, asset, sourceObjectId) {
     copiedFrom: sourceObjectId,
     copiedAt: Date.now(),
   };
-
-  if (hasUnityVisualBasis(asset, metadata)) {
-    nextMetadata.visualBasis = 'unity';
-    nextMetadata.sceneSyncCopyRotationAdjustedForVisualBasis = true;
-  }
 
   return nextMetadata;
 }
@@ -3097,7 +3062,7 @@ function duplicateSelectedObject() {
   const scale = source.scale.clone();
   const asset = cloneJsonSafe(source.userData?.asset || null);
   const sourceMetadata = cloneJsonSafe(source.userData?.metadata || null) || {};
-  const rotation = getCopyRotationForPayload(source, asset, sourceMetadata);
+  const rotation = getCopyRotationForPayload(source);
   const newMetadata = buildCopyMetadata(sourceMetadata, asset, sourceObjectId);
   const meshPath = asset?.meshPath || source.userData?.meshPath || null;
   const name = `${source.userData?.name || source.name || 'Object'} Copy`;
@@ -3130,12 +3095,10 @@ function duplicateSelectedObject() {
     )
   );
 
-  console.debug('[scene-copy] visual basis rotation', {
+  console.debug('[scene-copy] root rotation copied as-is', {
     sourceObjectId,
-    visualBasis: getSceneSyncVisualBasis(asset, sourceMetadata),
-    wasAdjusted: wasCopyRotationAdjustedForVisualBasis(sourceMetadata),
-    outputRotation: rotation,
-    metadataAdjusted: newMetadata.sceneSyncCopyRotationAdjustedForVisualBasis === true,
+    visualBasis: asset?.visualBasis,
+    rotation,
   });
 
   broadcast(payload);
@@ -3156,7 +3119,7 @@ function copySelectedObjectToSceneClipboard() {
   const asset = cloneJsonSafe(source.userData?.asset || null);
   const sourceMetadata = cloneJsonSafe(source.userData?.metadata || null) || {};
   const metadata = buildCopyMetadata(sourceMetadata, asset, sourceObjectId);
-  const rotation = getCopyRotationForPayload(source, asset, sourceMetadata);
+  const rotation = getCopyRotationForPayload(source);
 
   sceneObjectClipboard = {
     schemaVersion: 1,
@@ -3176,9 +3139,8 @@ function copySelectedObjectToSceneClipboard() {
   showToast?.('オブジェクトをコピーしました');
   console.debug('[scene-clipboard] copied object', {
     sourceObjectId,
-    visualBasis: getSceneSyncVisualBasis(asset, sourceMetadata),
-    wasAdjusted: wasCopyRotationAdjustedForVisualBasis(sourceMetadata),
-    outputRotation: rotation,
+    visualBasis: asset?.visualBasis,
+    rotation,
     assetId: sceneObjectClipboard.asset?.assetId || null,
     meshPath: sceneObjectClipboard.meshPath || null,
   });


### PR DESCRIPTION
## 概要

Unity の visual basis に対応した回転補正ロジックを削除し、コピー時の回転を常にそのまま使用するように簡略化しました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 削除した機能
- `UNITY_VISUAL_BASIS_YAW_CORRECTION` 定数（Unity visual basis 用の回転補正）
- `getSceneSyncVisualBasis()` 関数
- `hasUnityVisualBasis()` 関数
- `wasCopyRotationAdjustedForVisualBasis()` 関数
- `getCopyRotationForPayload()` の visual basis 補正ロジック
- `buildCopyMetadata()` の visual basis メタデータ設定ロジック

### 簡略化した処理
- `getCopyRotationForPayload()` を単純化：`source.quaternion.toArray()` を直接返すように
- 関数呼び出し時の引数を削減（`asset` と `metadata` パラメータを削除）
- デバッグログを簡潔に（visual basis 関連の情報を削除）

### 影響範囲
- `duplicateSelectedObject()` 関数内のコピー処理
- `copySelectedObjectToSceneClipboard()` 関数内のクリップボード処理

## 変更していないこと

- オブジェクトのコピー・複製の基本的な動作
- その他の回転処理やメタデータ管理
- asset や metadata の構造

## staging確認

未確認

## テスト/チェック

- 変更は既存の回転補正ロジックの削除のため、既存テストで検証可能
- オブジェクトコピー時の回転がそのまま適用されることを確認

## リスク

- Unity からのオブジェクトコピーで回転が異なる可能性がある場合、この変更により補正が失われます
- ただし、visual basis 補正が不要な設計に変更されたと考えられます

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01XrvVSYaigBic4D3JQQCsoW