### PR TITLE
Add Loomlet to works

### DIFF
--- a/html/assets/js/worksData.js
+++ b/html/assets/js/worksData.js
@@ -123,6 +123,22 @@ export const WORKS = [
     ]
   },
   {
+    id: 'loomlet',
+    type: 'tool',
+    typeLabel: 'Tool',
+    title: { ja: 'Loomlet', en: 'Loomlet' },
+    desc: {
+      ja: '同期可能なふるまいを記述するための軽量データフロー DSL / ランタイム。ノードエディタや VS Code 拡張から、2D / 3D の動きや Scene Sync 向けのグラフを作成できます。',
+      en: 'A lightweight dataflow DSL and runtime for describing syncable behaviors. Create 2D / 3D motion and Scene Sync graphs from the node editor or VS Code extension.'
+    },
+    stat: '',
+    links: [
+      { label: 'Node Editor', url: 'https://afjk.github.io/loomlet/node-editor/' },
+      { label: 'GitHub', url: 'https://github.com/afjk/loomlet' },
+      { label: 'npm', url: 'https://www.npmjs.com/package/@afjk/loomlet' },
+    ]
+  },
+  {
     id: 'scenesync',
     type: 'tool',
     typeLabel: 'Tool',


### PR DESCRIPTION
## 概要

`afjk.jp` の Works 一覧に Loomlet を追加しました。

## 変更内容

- `html/assets/js/worksData.js` に `loomlet` のカード定義を追加
- 日本語 / 英語の説明文を追加
- リンクを追加
  - Node Editor
  - GitHub
  - npm

## 表示上の扱い

- type: `tool`
- typeLabel: `Tool`
- 配置: `afjk File Transfer` と `Scene Sync` の間

## テスト

- データ追加のみのため、ロジック変更なし
- `WorksSection` は `WORKS` 配列をそのままカード化する構成のため、追加データがカードとして表示される想定です。

## merge方針

- squash merge
- merge 後に remote branch を削除