### PR TITLE
Fix scene-state serialization to exclude internal hierarchy objects

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1581,6 +1581,18 @@ namespace Afjk.SceneSync.Editor
             _locks.Remove(objectId);
         }
 
+        private static bool IsUnderSceneSyncInternalHierarchy(GameObject go)
+        {
+            var t = go.transform;
+            while (t != null)
+            {
+                if (t.name == "SceneSync Temporary") return true;
+                if (t.name == "SceneSyncManager") return true;
+                t = t.parent;
+            }
+            return false;
+        }
+
         private bool ShouldIncludeInUnitySceneState(SceneSyncIdentity identity)
         {
             if (identity == null) return false;
@@ -1611,12 +1623,22 @@ namespace Afjk.SceneSync.Editor
 
                 var objectId = go.GetInstanceID().ToString();
 
+                if (IsUnderSceneSyncInternalHierarchy(go))
+                {
+                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: objectId={objectId} name={go.name}");
+                    continue;
+                }
+
                 var identity = go.GetComponent<SceneSyncIdentity>();
                 if (identity != null && !ShouldIncludeInUnitySceneState(identity))
                 {
                     Debug.Log($"[SceneSync] scene-state skip: objectId={objectId} origin={identity.Origin} temporary={identity.Temporary}");
                     continue;
                 }
+
+                var originStr = identity != null ? identity.Origin.ToString() : "None";
+                var temporaryStr = identity != null ? identity.Temporary.ToString() : "None";
+                Debug.Log($"[SceneSync] scene-state include: source=rootObjects objectId={objectId} name={go.name} origin={originStr} temporary={temporaryStr}");
 
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;
@@ -1667,6 +1689,10 @@ namespace Afjk.SceneSync.Editor
                     Debug.Log($"[SceneSync] scene-state skip: objectId={kvp.Key} origin={originStr} temporary={temporaryStr}");
                     continue;
                 }
+
+                var originStr2 = identity != null ? identity.Origin.ToString() : "None";
+                var temporaryStr2 = identity != null ? identity.Temporary.ToString() : "None";
+                Debug.Log($"[SceneSync] scene-state include: source=managedObjects objectId={kvp.Key} name={go.name} origin={originStr2} temporary={temporaryStr2}");
 
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1240,6 +1240,7 @@ namespace Afjk.SceneSync
                 // プレースホルダーを先行登録（同期フェーズで登録を確実にする）
                 var placeholder = new GameObject(objectId);
                 placeholder.hideFlags = HideFlags.NotEditable;
+                ConfigureRemoteTemporaryIdentity(placeholder, objectId, meshPath, assetId);
                 placeholder.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                 _managedObjects[objectId] = placeholder;
@@ -1436,6 +1437,18 @@ namespace Afjk.SceneSync
             _locks.Remove(objectId);
         }
 
+        private static bool IsUnderSceneSyncInternalHierarchy(GameObject go)
+        {
+            var t = go.transform;
+            while (t != null)
+            {
+                if (t.name == "SceneSync Temporary") return true;
+                if (t.name == "SceneSyncManager") return true;
+                t = t.parent;
+            }
+            return false;
+        }
+
         private bool ShouldIncludeInUnitySceneState(SceneSyncIdentity identity)
         {
             if (identity == null) return false;
@@ -1465,12 +1478,22 @@ namespace Afjk.SceneSync
 
                 var objectId = go.GetInstanceID().ToString();
 
+                if (IsUnderSceneSyncInternalHierarchy(go))
+                {
+                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: objectId={objectId} name={go.name}");
+                    continue;
+                }
+
                 var identity = go.GetComponent<SceneSyncIdentity>();
                 if (identity != null && !ShouldIncludeInUnitySceneState(identity))
                 {
                     Debug.Log($"[SceneSync] scene-state skip: objectId={objectId} origin={identity.Origin} temporary={identity.Temporary}");
                     continue;
                 }
+
+                var originStr = identity != null ? identity.Origin.ToString() : "None";
+                var temporaryStr = identity != null ? identity.Temporary.ToString() : "None";
+                Debug.Log($"[SceneSync] scene-state include: source=rootObjects objectId={objectId} name={go.name} origin={originStr} temporary={temporaryStr}");
 
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;
@@ -1531,6 +1554,10 @@ namespace Afjk.SceneSync
                     Debug.Log($"[SceneSync] scene-state skip: objectId={kvp.Key} origin={originStr} temporary={temporaryStr}");
                     continue;
                 }
+
+                var originStr2 = identity != null ? identity.Origin.ToString() : "None";
+                var temporaryStr2 = identity != null ? identity.Temporary.ToString() : "None";
+                Debug.Log($"[SceneSync] scene-state include: source=managedObjects objectId={kvp.Key} name={go.name} origin={originStr2} temporary={temporaryStr2}");
 
                 var pos = go.transform.position;
                 var rot = go.transform.rotation;


### PR DESCRIPTION
## 概要

- SceneSync の scene-state 応答から内部管理用オブジェクト（SceneSync Temporary、SceneSyncManager 配下）を除外
- リモートオブジェクト作成時に ConfigureRemoteTemporaryIdentity を呼び出して適切な identity を設定
- scene-state 処理のデバッグログを追加して、どのオブジェクトが含まれるか可視化

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### SceneSyncManager.cs
1. **プレースホルダー初期化の改善**
   - `HandleSceneAdd` で placeholder 作成時に `ConfigureRemoteTemporaryIdentity` を呼び出し
   - リモートオブジェクトの identity を早期に設定

2. **内部階層フィルタリング**
   - `IsUnderSceneSyncInternalHierarchy` メソッドを追加
   - "SceneSync Temporary" または "SceneSyncManager" 配下のオブジェクトを検出

3. **scene-state 処理の改善**
   - `HandleSceneRequest` で内部階層チェックを追加
   - rootObjects と managedObjects の両方で内部オブジェクトをスキップ
   - デバッグログで origin/temporary フラグを出力

### SceneSyncWindow.cs
- SceneSyncManager.cs と同じ変更を Editor 側にも適用
- 一貫性を保つため同じロジックを実装

## 変更していないこと

- scene-add/scene-delta/scene-remove の基本的な処理フロー
- SceneSyncIdentity の定義や ShouldIncludeInUnitySceneState の判定ロジック
- ネットワーク通信部分

## staging確認

- 未確認（staging への deploy 前）

## テスト/チェック

- 既存の scene-state 処理が正常に動作することを確認
- デバッグログで内部オブジェクトがスキップされることを確認可能

## リスク

- 内部階層の判定が "SceneSync Temporary" と "SceneSyncManager" の名前に依存
- 今後これらの名前が変更される場合は同期が必要

## follow-up tasks

- デバッグログの本番環境での出力レベル調整（必要に応じて Debug.Log → conditional compile）
- 内部階層判定ロジックの定数化（マジックストリングの削除）

## merge方針

- squash merge を推奨
- merge 後に remote branch を削除

https://claude.ai/code/session_01M4TBuyKoLtBd6AYa1eYH1w