### PR TITLE
Add GLB upload size limit validation in SceneSync

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -12,6 +12,8 @@ namespace Afjk.SceneSync.Editor
     public class SceneSyncWindow : EditorWindow
     {
         private const string ShowSceneSyncGizmosPrefKey = "Afjk.SceneSync.ShowSceneSyncGizmos";
+        private const string MaxGlbUploadMiBPrefKey = "Afjk.SceneSync.MaxGlbUploadMiB";
+        private const float DefaultMaxGlbUploadMiB = 50f;
 
         internal static bool ShowSceneSyncGizmos
         {
@@ -53,6 +55,7 @@ namespace Afjk.SceneSync.Editor
         private string _nickname = "Unity";
         private bool _connected;
         private List<PeerInfo> _peers = new List<PeerInfo>();
+        private float _maxGlbUploadMiB = DefaultMaxGlbUploadMiB;
 
         private Dictionary<string, TransformSnapshot> _lastSnapshots = new Dictionary<string, TransformSnapshot>();
         private double _lastSendTime;
@@ -73,6 +76,12 @@ namespace Afjk.SceneSync.Editor
 
         private void OnEnable()
         {
+            _maxGlbUploadMiB = EditorPrefs.GetFloat(MaxGlbUploadMiBPrefKey, DefaultMaxGlbUploadMiB);
+            if (_maxGlbUploadMiB <= 0f)
+            {
+                _maxGlbUploadMiB = DefaultMaxGlbUploadMiB;
+            }
+
             _client = new PresenceClient();
             _client.OnConnected += () =>
             {
@@ -126,6 +135,25 @@ namespace Afjk.SceneSync.Editor
                 .Replace("ws://", "http://");
             if (url.EndsWith("/")) url = url.TrimEnd('/');
             return url + "/blob";
+        }
+
+        private long MaxGlbUploadBytes
+        {
+            get
+            {
+                var mib = Mathf.Max(1f, _maxGlbUploadMiB);
+                return (long)(mib * 1024f * 1024f);
+            }
+        }
+
+        private static string FormatBytesMiB(long bytes)
+        {
+            return $"{bytes} bytes ({bytes / 1024f / 1024f:F2} MiB)";
+        }
+
+        private bool IsGlbWithinUploadLimit(byte[] glb)
+        {
+            return glb != null && glb.Length <= MaxGlbUploadBytes;
         }
 
         /// <summary>
@@ -442,6 +470,23 @@ namespace Afjk.SceneSync.Editor
                 "Auto: Detects animations and uses UnityGLTF if available\n" +
                 "glTFast: Always use glTFast (no animations)\n" +
                 "UnityGltf: Always use UnityGLTF (Editor-only)",
+                MessageType.Info
+            );
+
+            GUILayout.Space(8);
+
+            EditorGUI.BeginChangeCheck();
+            var newMaxGlbUploadMiB = EditorGUILayout.FloatField("Max GLB Upload Size (MiB)", _maxGlbUploadMiB);
+            if (EditorGUI.EndChangeCheck())
+            {
+                _maxGlbUploadMiB = Mathf.Max(1f, newMaxGlbUploadMiB);
+                EditorPrefs.SetFloat(MaxGlbUploadMiBPrefKey, _maxGlbUploadMiB);
+            }
+
+            EditorGUILayout.HelpBox(
+                "GLB files larger than this value are not uploaded. " +
+                "This is a Unity-side precheck to avoid slow failed uploads. " +
+                "The server may still reject uploads with its own limit.",
                 MessageType.Info
             );
         }
@@ -1271,6 +1316,21 @@ namespace Afjk.SceneSync.Editor
                 $"size={glb.Length} bytes ({glbSizeMiB:F2} MiB)"
             );
 
+            if (!IsGlbWithinUploadLimit(glb))
+            {
+                identity.State = SceneSyncState.Error;
+                EditorUtility.SetDirty(identity);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+
+                Debug.LogError(
+                    $"[SceneSync] Publish aborted before upload because GLB is too large: " +
+                    $"{go.name}, objectId={identity.ObjectId}, " +
+                    $"size={FormatBytesMiB(glb.Length)}, " +
+                    $"limit={FormatBytesMiB(MaxGlbUploadBytes)}"
+                );
+                return;
+            }
+
             var objectId = identity.ObjectId;
             var path = PresenceClient.GenerateRandomPath();
 
@@ -1675,6 +1735,18 @@ namespace Afjk.SceneSync.Editor
                     var glb = await PresenceClient.ExportGameObjectAsGlb(go);
                     if (glb != null)
                     {
+                        if (!IsGlbWithinUploadLimit(glb))
+                        {
+                            Debug.LogWarning(
+                                $"[SceneSync] scene-state skipped before upload because GLB is too large: " +
+                                $"objectId={objectId}, name={go.name}, " +
+                                $"size={FormatBytesMiB(glb.Length)}, " +
+                                $"limit={FormatBytesMiB(MaxGlbUploadBytes)}"
+                            );
+                            // サイズ超過オブジェクトは objectData に追加しない
+                            continue;
+                        }
+
                         path = PresenceClient.GenerateRandomPath();
                         pendingUploads.Add((objectId, glb, path));
                     }


### PR DESCRIPTION
## 概要

Unity SceneSync エディタウィンドウに GLB ファイルのアップロードサイズ制限機能を追加しました。デフォルト 50 MiB の制限値を設定でき、制限を超えるオブジェクトはアップロード前に検証して除外します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **設定値の追加**
   - `MaxGlbUploadMiBPrefKey`: EditorPrefs キーの定義
   - `DefaultMaxGlbUploadMiB`: デフォルト値 50 MiB
   - `_maxGlbUploadMiB`: インスタンス変数で現在の設定値を保持

2. **UI コンポーネント**
   - Export Settings セクションに「Max GLB Upload Size (MiB)」フローティング入力フィールドを追加
   - ユーザーが値を変更すると EditorPrefs に自動保存
   - 最小値 1 MiB の制約を適用

3. **検証ロジック**
   - `MaxGlbUploadBytes`: MiB を バイト単位に変換するプロパティ
   - `IsGlbWithinUploadLimit()`: GLB サイズが制限以下かチェック
   - `FormatBytesMiB()`: ログ出力用のバイト数フォーマッタ

4. **アップロード前チェック**
   - `PublishUnityObject()`: オブジェクト公開時に制限チェック、超過時はエラー状態に設定
   - `HandleSceneRequest()`: シーン状態リクエスト応答時に制限チェック、超過オブジェクトをスキップ

### staging で見てほしい点

- 大容量 GLB ファイルを持つオブジェクトが正しく検証されるか
- エラーログが適切に出力されるか
- EditorPrefs の値が正しく保存・復元されるか
- UI での値変更が即座に反映されるか

## 変更していないこと

- サーバー側の制限値チェック（サーバーは独立した制限を持つ）
- GLB エクスポート処理自体
- ネットワーク通信ロジック

## staging確認

未確認（staging 環境での確認が必要）

## テスト/チェック

- コード レビュー: 変更内容の妥当性確認
- ビルド: Unity エディタでのコンパイル確認
- 手動テスト: エディタ UI での設定値変更と検証ロジックの動作確認が必要

## リスク

- 既存のシーン同期機能への影響は最小限（新規チェック処理のみ追加）
- デフォルト値 50 MiB は一般的な GLB ファイルサイズ内に設定

## follow-up tasks

- サーバー側のアップロード制限値との整合性確認
- ユーザードキュメントへの制限値説明追加

## merge方針

- squash merge を推奨
- merge 後に remote branch を削除

https://claude.ai/code/session_01LSUJcavS5mxk6vq8qg7fzE