### PR TITLE
Implement Scene Sync Developer Mode

### DIFF
--- a/apps/presence-server/src/scenesync/config.mjs
+++ b/apps/presence-server/src/scenesync/config.mjs
@@ -22,6 +22,8 @@ export function createSceneSyncConfig(env = process.env) {
     logDir: env.SCENE_SYNC_LOG_DIR || './logs',
     logMaxLineBytes: parseIntEnv(env.SCENE_SYNC_LOG_MAX_LINE_BYTES, 4096, 256),
     actorHashSalt: env.SCENE_SYNC_ACTOR_HASH_SALT || '',
+    developerMode: parseBoolEnv(env.SCENE_SYNC_DEVELOPER_MODE, false),
+    wasabiBackupEnabled: parseBoolEnv(env.SCENE_SYNC_WASABI_BACKUP_ENABLED, true),
     glbBackupEnabled: parseBoolEnv(env.SCENE_SYNC_GLB_BACKUP_ENABLED, true),
     glbBackupDriver: env.SCENE_SYNC_GLB_BACKUP_DRIVER || 'local',
     glbBackupDir: env.SCENE_SYNC_GLB_BACKUP_DIR || './scene-sync-glb-backup',
@@ -42,4 +44,16 @@ export function createSceneSyncConfig(env = process.env) {
   }
 
   return config;
+}
+
+export function isSceneSyncDeveloperMode(config) {
+  return config.developerMode === true;
+}
+
+export function isWasabiBackupEnabled(config) {
+  return config.wasabiBackupEnabled === true;
+}
+
+export function shouldBackupGlb(config) {
+  return isWasabiBackupEnabled(config) && !isSceneSyncDeveloperMode(config);
 }

--- a/apps/presence-server/src/scenesync/glb-backup.mjs
+++ b/apps/presence-server/src/scenesync/glb-backup.mjs
@@ -2,6 +2,7 @@ import { randomUUID, createHash } from 'node:crypto';
 import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, statfsSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { isSceneSyncDeveloperMode, isWasabiBackupEnabled, shouldBackupGlb } from './config.mjs';
 
 function todayDateString(now = new Date()) {
   return now.toISOString().slice(0, 10);
@@ -132,8 +133,20 @@ export function createGlbBackupManager(config, logger, internals = {}) {
 
   return {
     async saveAcceptedGlb({ buffer, roomId, actorId, filename = '', mimeType = '', source = 'upload', blobId = null }) {
+      // Check if backup should be skipped due to developer mode
+      if (isSceneSyncDeveloperMode(config)) {
+        logger?.log('glb_backup_skipped', { roomId, actorId, reason: 'developer_mode', size: buffer.length });
+        return { saved: false, reason: 'developer_mode' };
+      }
+
+      // Check if backup is disabled via config
+      if (!isWasabiBackupEnabled(config)) {
+        logger?.log('glb_backup_skipped', { roomId, actorId, reason: 'backup_disabled', size: buffer.length });
+        return { saved: false, reason: 'backup_disabled' };
+      }
+
       if (!config.glbBackupEnabled) {
-        logger?.log('glb_backup_skipped', { roomId, actorId, reason: 'disabled' });
+        logger?.log('glb_backup_skipped', { roomId, actorId, reason: 'disabled', size: buffer.length });
         return { saved: false, reason: 'disabled' };
       }
 

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -4,7 +4,7 @@ import { URL, pathToFileURL } from 'node:url';
 import { readFileSync, writeFileSync, mkdirSync, unlinkSync, createReadStream } from 'node:fs';
 import { verifyLinkToken, initiatePairingCode, redeemPairingCode, revokeLinkToken, getActiveLink } from './link-token.mjs';
 import { encodeSession, decodeSession } from './gpt-session.mjs';
-import { createSceneSyncConfig } from './scenesync/config.mjs';
+import { createSceneSyncConfig, isSceneSyncDeveloperMode } from './scenesync/config.mjs';
 import { getActorIdFromRequest } from './scenesync/actor-id.mjs';
 import { createPerActorRateLimiter } from './scenesync/rate-limit.mjs';
 import { validateUpload, isGlbLike } from './scenesync/upload-guards.mjs';
@@ -77,6 +77,9 @@ function writeStatsFile(data) {
 }
 
 function saveStats(data) {
+  if (isSceneSyncDeveloperMode(sceneSyncConfig)) {
+    return; // Skip stats persistence in developer mode
+  }
   try {
     writeStatsFile(data);
     if (stats.logs.length >= STATS_ARCHIVE_AFTER) {
@@ -88,6 +91,9 @@ function saveStats(data) {
 }
 
 function archiveStats() {
+  if (isSceneSyncDeveloperMode(sceneSyncConfig)) {
+    return; // Skip stats archiving in developer mode
+  }
   try {
     mkdirSync(STATS_ARCHIVE_DIR, { recursive: true });
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -1175,6 +1181,16 @@ function createPresenceServer() {
       } catch {}
       res.writeHead(204, CORS).end();
     });
+    return;
+  }
+
+  // GET /api/config — Server configuration for frontend
+  if (req.method === 'GET' && path === '/api/config') {
+    const configResp = {
+      developerMode: sceneSyncConfig.developerMode,
+      wasabiBackupEnabled: sceneSyncConfig.wasabiBackupEnabled,
+    };
+    res.writeHead(200, { 'content-type': 'application/json', ...CORS }).end(JSON.stringify(configResp));
     return;
   }
 

--- a/apps/presence-server/tests/developer-mode.test.mjs
+++ b/apps/presence-server/tests/developer-mode.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { createSceneSyncConfig, isSceneSyncDeveloperMode, isWasabiBackupEnabled, shouldBackupGlb } from '../src/scenesync/config.mjs';
+
+test('Developer Mode Configuration', async (t) => {
+  await t.test('should recognize developer mode enabled', () => {
+    const config = createSceneSyncConfig({
+      SCENE_SYNC_DEVELOPER_MODE: 'true',
+      SCENE_SYNC_WASABI_BACKUP_ENABLED: 'true',
+    });
+
+    assert.equal(isSceneSyncDeveloperMode(config), true);
+    assert.equal(isWasabiBackupEnabled(config), true);
+  });
+
+  await t.test('should recognize wasabi backup disabled', () => {
+    const config = createSceneSyncConfig({
+      SCENE_SYNC_DEVELOPER_MODE: 'false',
+      SCENE_SYNC_WASABI_BACKUP_ENABLED: 'false',
+    });
+
+    assert.equal(isSceneSyncDeveloperMode(config), false);
+    assert.equal(isWasabiBackupEnabled(config), false);
+  });
+
+  await t.test('should not backup when developer mode is enabled', () => {
+    const config = createSceneSyncConfig({
+      SCENE_SYNC_DEVELOPER_MODE: 'true',
+      SCENE_SYNC_WASABI_BACKUP_ENABLED: 'true',
+    });
+
+    assert.equal(shouldBackupGlb(config), false);
+  });
+
+  await t.test('should backup when both developer mode and backup are properly configured', () => {
+    const config = createSceneSyncConfig({
+      SCENE_SYNC_DEVELOPER_MODE: 'false',
+      SCENE_SYNC_WASABI_BACKUP_ENABLED: 'true',
+    });
+
+    assert.equal(shouldBackupGlb(config), true);
+  });
+
+  await t.test('should not backup when backup is disabled regardless of developer mode', () => {
+    const config = createSceneSyncConfig({
+      SCENE_SYNC_DEVELOPER_MODE: 'false',
+      SCENE_SYNC_WASABI_BACKUP_ENABLED: 'false',
+    });
+
+    assert.equal(shouldBackupGlb(config), false);
+  });
+
+  await t.test('should use default values when env vars are not set', () => {
+    const config = createSceneSyncConfig({});
+
+    assert.equal(isSceneSyncDeveloperMode(config), false); // default false
+    assert.equal(isWasabiBackupEnabled(config), true); // default true
+    assert.equal(shouldBackupGlb(config), true); // should backup by default
+  });
+
+  await t.test('should handle various truthy values for developer mode', () => {
+    for (const value of ['1', 'true', 'yes', 'on', 'TRUE', 'YES', 'ON']) {
+      const config = createSceneSyncConfig({
+        SCENE_SYNC_DEVELOPER_MODE: value,
+      });
+      assert.equal(isSceneSyncDeveloperMode(config), true, `Failed for value: ${value}`);
+    }
+  });
+
+  await t.test('should handle various falsy values for developer mode', () => {
+    for (const value of ['0', 'false', 'no', 'off', 'FALSE', 'NO', 'OFF', '', null, undefined]) {
+      const config = createSceneSyncConfig({
+        SCENE_SYNC_DEVELOPER_MODE: value,
+      });
+      assert.equal(isSceneSyncDeveloperMode(config), false, `Failed for value: ${value}`);
+    }
+  });
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -3855,6 +3855,28 @@ function getApiBaseUrl() {
 
 const linkManager = createLinkManager(getApiBaseUrl());
 
+async function fetchAndShowDeveloperMode() {
+  try {
+    const isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+    const isStaging = location.hostname === 'staging.afjk.jp';
+
+    const response = await fetch(`${getApiBaseUrl()}/config`);
+    if (!response.ok) return;
+
+    const config = await response.json();
+    const devModeIndicator = document.getElementById('developer-mode-indicator');
+
+    // Show developer mode if:
+    // 1. It's enabled on the server, AND
+    // 2. (it's localhost/staging OR server is exposing it)
+    if (config.developerMode && (isLocal || isStaging)) {
+      devModeIndicator.removeAttribute('hidden');
+    }
+  } catch (error) {
+    // Silently ignore config fetch errors
+  }
+}
+
 const presenceState = {
   ws: null,
   id: null,
@@ -8681,6 +8703,7 @@ updateNicknameLabel();
 renderRoomSection();
 syncSceneUiState();
 connectPresence();
+fetchAndShowDeveloperMode();
 
 // Safari / iOS: バックグラウンドから復帰時に即再接続（3秒タイマーを待たない）
 document.addEventListener('visibilitychange', () => {

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -82,6 +82,17 @@
     #status .dot.on  { background: #4f4; }
     #status .dot.off { background: #f44; }
 
+    #developer-mode-indicator {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      z-index: 10;
+      background: rgba(255, 140, 0, 0.6) !important;
+    }
+    #developer-mode-indicator:hover {
+      background: rgba(255, 140, 0, 0.8) !important;
+    }
+
     /* ── 左上 設定パネル ── */
     #settings-panel {
       position: fixed;
@@ -961,6 +972,7 @@
   </div>
 
   <div id="status" role="button" aria-controls="peers-panel" aria-expanded="false"><span class="dot off"></span>接続中…</div>
+  <div id="developer-mode-indicator" hidden class="chip"><span>📟</span><span>Developer Mode · Backup OFF</span></div>
   <div id="peers-panel">
     <div id="peers-list"></div>
   </div>


### PR DESCRIPTION
Add Developer Mode support to skip GLB Wasabi backup and stats persistence for staging/local testing.

Server Changes:
- Add SCENE_SYNC_DEVELOPER_MODE and SCENE_SYNC_WASABI_BACKUP_ENABLED environment variables
- Create helper functions in config.mjs: isSceneSyncDeveloperMode(), isWasabiBackupEnabled(), shouldBackupGlb()
- Update glb-backup.mjs to skip backup when developer mode is enabled, log with reason 'developer_mode' or 'backup_disabled'
- Skip stats persistence and archiving in developer mode
- Add GET /api/config endpoint to expose developerMode and wasabiBackupEnabled to frontend

Frontend Changes:
- Add fetchAndShowDeveloperMode() function to fetch config and display indicator on localhost/staging
- Show orange Developer Mode indicator chip at bottom right: "📟 Developer Mode · Backup OFF"
- Indicator only displays on localhost, 127.0.0.1, or staging.afjk.jp when enabled

Logging:
- Log glb_backup_skipped events with reason field (developer_mode or backup_disabled) and size

Tests:
- Add comprehensive developer-mode.test.mjs covering all configurations

https://claude.ai/code/session_01KAoKFQ4Mo9VPmiiCoaVRYr