### PR TITLE
Add BGM (background music) support to Scene Sync

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -4,6 +4,7 @@ const KNOWN_KINDS = new Set([
   'scene-remove',
   'scene-mesh',
   'scene-env',
+  'scene-bgm',
   'scene-state',
   'scene-request',
   'scene-avatar',
@@ -69,6 +70,19 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-env' && !ENV_IDS.has(payload.envId)) {
     return { ok: false, reason: 'envId is invalid' };
+  }
+
+  if (payload.kind === 'scene-bgm') {
+    if (payload.bgm === null) {
+      // bgm: null is valid (clears BGM)
+      return { ok: true };
+    }
+    if (typeof payload.bgm !== 'object' || !payload.bgm) {
+      return { ok: false, reason: 'bgm must be null or an object' };
+    }
+    if (!isReasonableString(payload.bgm.url)) {
+      return { ok: false, reason: 'bgm.url must be a reasonable string' };
+    }
   }
 
   if (payload.kind === 'scene-batch') {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -157,6 +157,45 @@ describe('Scene Sync guard helpers', () => {
     });
     assert.equal(result.ok, true);
   });
+
+  it('accepts valid scene-bgm with bgm object', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-bgm',
+      bgm: {
+        version: 1,
+        url: 'https://example.com/music.mp3',
+        name: 'music.mp3',
+        loop: true,
+        volume: 1,
+        playback: { mode: 'local-loop' },
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('accepts scene-bgm with bgm null', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-bgm',
+      bgm: null,
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects scene-bgm without url', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-bgm',
+      bgm: { name: 'music' },
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects scene-bgm with invalid url type', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-bgm',
+      bgm: { url: 123 },
+    });
+    assert.equal(result.ok, false);
+  });
 });
 
 describe('Scene Sync server guards', () => {

--- a/apps/presence-server/tests/url-classifier.test.mjs
+++ b/apps/presence-server/tests/url-classifier.test.mjs
@@ -165,6 +165,46 @@ test('classifyUrl', async (t) => {
     assert.equal(r.kind, URL_KIND.TEXT);
     assert.equal(r.ext, 'markdown');
   });
+
+  await t.test('mp3 audio URL', () => {
+    const r = classifyUrl('https://example.com/music.mp3');
+    assert.equal(r.kind, URL_KIND.AUDIO);
+    assert.equal(r.ext, 'mp3');
+  });
+
+  await t.test('wav audio URL', () => {
+    assert.equal(classifyUrl('https://example.com/sound.wav').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('ogg audio URL', () => {
+    assert.equal(classifyUrl('https://example.com/track.ogg').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('m4a audio URL', () => {
+    assert.equal(classifyUrl('https://example.com/song.m4a').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('aac audio URL', () => {
+    assert.equal(classifyUrl('https://example.com/audio.aac').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('normal webpage is not classified as audio', () => {
+    assert.equal(classifyUrl('https://example.com/').kind, URL_KIND.WEBPAGE);
+  });
+
+  await t.test('audio URL with uppercase extension', () => {
+    assert.equal(classifyUrl('https://example.com/music.MP3').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('audio URL with mixed case extension', () => {
+    assert.equal(classifyUrl('https://example.com/song.Mp3').kind, URL_KIND.AUDIO);
+  });
+
+  await t.test('audio URL with query string', () => {
+    const r = classifyUrl('https://example.com/bgm.mp3?token=abc&version=2');
+    assert.equal(r.kind, URL_KIND.AUDIO);
+    assert.equal(r.ext, 'mp3');
+  });
 });
 
 test('parseUriList', async (t) => {

--- a/html/assets/js/scenesync/loaders/url-classifier.js
+++ b/html/assets/js/scenesync/loaders/url-classifier.js
@@ -1,4 +1,5 @@
 export const URL_KIND = {
+  AUDIO: 'audio',
   VIDEO: 'video',
   VIDEO_HLS: 'video-hls',
   IMAGE: 'image',
@@ -9,6 +10,7 @@ export const URL_KIND = {
   INVALID: 'invalid',
 };
 
+const AUDIO_EXTS = ['mp3', 'wav', 'ogg', 'm4a', 'aac'];
 const VIDEO_EXTS = ['mp4', 'webm', 'mov', 'm4v'];
 const HLS_EXTS = ['m3u8'];
 const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'avif', 'bmp'];
@@ -61,6 +63,7 @@ export function classifyUrl(urlString) {
   const ext = (u.pathname.split('.').pop() || '').toLowerCase();
   const host = u.host;
   const url = u.toString();
+  if (AUDIO_EXTS.includes(ext)) return { kind: URL_KIND.AUDIO, url, ext, host };
   if (VIDEO_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO, url, ext, host };
   if (HLS_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO_HLS, url, ext, host };
   if (IMAGE_EXTS.includes(ext)) return { kind: URL_KIND.IMAGE, url, ext, host };

--- a/html/assets/js/scenesync/loaders/url-importers/audio.js
+++ b/html/assets/js/scenesync/loaders/url-importers/audio.js
@@ -1,0 +1,40 @@
+/**
+ * URL から BGM をロードし、scene-bgm を broadcast してローカルに適用。
+ * @param {string} url - 分類済みのオーディオ URL（確定済み）
+ * @param {object} ctx - { applySceneBgm, broadcastSceneBgm, showToast }
+ * @returns {Promise<{ payload }>}
+ */
+export async function importAudioUrl(url, ctx) {
+  try {
+    const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'audio');
+
+    const payload = {
+      kind: 'scene-bgm',
+      bgm: {
+        version: 1,
+        url,
+        name: filename,
+        loop: true,
+        volume: 1,
+        playback: {
+          mode: 'local-loop',
+        },
+      },
+    };
+
+    ctx.broadcastSceneBgm(payload);
+    ctx.applySceneBgm(payload.bgm);
+    ctx.showToast({
+      type: 'success',
+      message: 'BGMを設定しました',
+    });
+
+    return { payload };
+  } catch (err) {
+    ctx.showToast({
+      type: 'error',
+      message: `BGM URL の設定に失敗しました: ${err?.message || 'Unknown error'}`,
+    });
+    throw err;
+  }
+}

--- a/html/assets/js/scenesync/loaders/url-importers/index.js
+++ b/html/assets/js/scenesync/loaders/url-importers/index.js
@@ -1,3 +1,4 @@
+import { importAudioUrl } from './audio.js';
 import { importVideoUrl } from './video.js';
 import { importImageUrl } from './image.js';
 import { importGlbUrl } from './glb.js';
@@ -27,6 +28,10 @@ export async function dispatchUrlImport(url, ctx) {
       message: 'URL が無効です。http(s) で始まる URL を使用してください',
     });
     return;
+  }
+
+  if (classified.kind === URL_KIND.AUDIO) {
+    return await importAudioUrl(classified.url, ctx);
   }
 
   if (classified.kind === URL_KIND.VIDEO || classified.kind === URL_KIND.VIDEO_HLS) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1268,6 +1268,14 @@ const locks = new Map();
 // objectId → wireframe mesh
 const lockOverlays = new Map();
 
+// ── BGM state ────────────────────────────────────────────────
+
+const sceneBgmState = {
+  audio: null,
+  current: null,
+  autoplayBlocked: false,
+};
+
 // ── トランスフォームツイーン（AI/GPT アニメーション） ────────
 
 const activeTransformTweens = new Map();
@@ -4435,6 +4443,12 @@ async function respondToSceneRequest(from) {
   if (ws && ws.readyState === WebSocket.OPEN) {
     const payload = { kind: 'scene-state', envId: environmentManager.getCurrentEnvId(), objects };
 
+    // BGM state を含める
+    const bgmState = serializeSceneBgm();
+    if (bgmState) {
+      payload.bgm = bgmState;
+    }
+
     // Loom graph state を含める
     const loomGraphState = loomIntegration.exportState();
     if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
@@ -4526,6 +4540,15 @@ function handleHandoff(data) {
       const objects = payload.objects || {};
       for (const [objectId, info] of Object.entries(objects)) {
         addOrUpdateObject(objectId, info);
+      }
+
+      // BGM 状態を復元
+      if ('bgm' in payload) {
+        if (payload.bgm === null) {
+          disposeSceneBgm();
+        } else if (payload.bgm) {
+          applySceneBgm(payload.bgm);
+        }
       }
 
       // Loom graph 状態を復元
@@ -4763,6 +4786,15 @@ function handleHandoff(data) {
         }
       }
       notifySceneStateChanged('scene-env-handoff');
+      break;
+    }
+    case 'scene-bgm': {
+      if (payload.bgm === null) {
+        disposeSceneBgm();
+      } else if (payload.bgm) {
+        applySceneBgm(payload.bgm);
+      }
+      notifySceneStateChanged('scene-bgm-handoff');
       break;
     }
     case 'scene-avatar': {
@@ -5029,6 +5061,8 @@ function createAiUrlImportContext(params = {}, context = {}) {
   return {
     addOrUpdateObject,
     broadcastSceneAdd: broadcast,
+    applySceneBgm,
+    broadcastSceneBgm: broadcast,
     showToast,
     generateObjectId: (prefix) => {
       if (!customObjectIdUsed && typeof params.objectId === 'string' && params.objectId.trim()) {
@@ -5986,6 +6020,83 @@ function applyAssetDelta(obj, asset) {
     applyObjectColor(obj, asset.color);
   }
   notifySceneStateChanged('asset-delta-applied');
+}
+
+// ── BGM handling ────────────────────────────────────────
+
+function clamp01(v) {
+  return Math.max(0, Math.min(1, typeof v === 'number' ? v : 1));
+}
+
+function applySceneBgm(bgm, options = {}) {
+  disposeSceneBgm();
+
+  if (!bgm || !bgm.url) {
+    return;
+  }
+
+  const audio = new Audio();
+  audio.src = bgm.url;
+  audio.loop = bgm.loop !== false;
+  audio.volume = clamp01(bgm.volume ?? 1);
+  audio.preload = 'auto';
+
+  sceneBgmState.audio = audio;
+  sceneBgmState.current = {
+    version: bgm.version ?? 1,
+    url: bgm.url,
+    name: bgm.name ?? 'bgm',
+    loop: bgm.loop !== false,
+    volume: clamp01(bgm.volume ?? 1),
+    playback: bgm.playback ?? { mode: 'local-loop' },
+  };
+
+  audio.play().catch((err) => {
+    console.warn('[BGM] autoplay blocked:', err?.message);
+    sceneBgmState.autoplayBlocked = true;
+    showBgmUnlockUI();
+  });
+}
+
+function disposeSceneBgm() {
+  if (sceneBgmState.audio) {
+    sceneBgmState.audio.pause();
+    sceneBgmState.audio.src = '';
+    sceneBgmState.audio.load?.();
+    sceneBgmState.audio = null;
+  }
+  sceneBgmState.current = null;
+  sceneBgmState.autoplayBlocked = false;
+  hideBgmUnlockUI();
+}
+
+function serializeSceneBgm() {
+  if (!sceneBgmState.current) return null;
+  return structuredClone(sceneBgmState.current);
+}
+
+function showBgmUnlockUI() {
+  const btn = dom.bgmUnlockButton;
+  if (!btn) return;
+  btn.style.display = 'block';
+  btn.onclick = () => {
+    if (sceneBgmState.audio) {
+      sceneBgmState.audio.play().then(() => {
+        sceneBgmState.autoplayBlocked = false;
+        hideBgmUnlockUI();
+      }).catch(() => {
+        showToast?.({
+          type: 'error',
+          message: '音声を再生できません',
+        });
+      });
+    }
+  };
+}
+
+function hideBgmUnlockUI() {
+  const btn = dom.bgmUnlockButton;
+  if (btn) btn.style.display = 'none';
 }
 
 // ── Undo/Redo 処理 ──────────────────────────────────────

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -22,5 +22,6 @@ export function getSceneSyncDom() {
     fileInput: document.getElementById('file-input'),
     dropOverlay: document.getElementById('drop-overlay'),
     deleteSkyboxBtn: document.getElementById('delete-skybox-btn'),
+    bgmUnlockButton: document.getElementById('bgm-unlock-button'),
   };
 }


### PR DESCRIPTION
## 概要

Scene Sync に BGM（背景音楽）機能を追加しました。URL から音声ファイルをロードし、シーン全体で共有・同期できるようになります。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### コア機能
- **BGM 状態管理**: `sceneBgmState` を追加し、現在再生中の音声、ループ設定、音量を管理
- **BGM 適用・破棄**: `applySceneBgm()` / `disposeSceneBgm()` で音声の再生制御
- **BGM シリアライズ**: `serializeSceneBgm()` でシーン状態に BGM 情報を含める
- **オートプレイ対応**: ブラウザのオートプレイ制限に対応し、ユーザーが手動で再生できる UI を提供

### メッセージング
- **scene-bgm メッセージ**: 新しいメッセージ種別を追加
  - `kind: 'scene-bgm'`
  - `bgm: { version, url, name, loop, volume, playback }`
  - `bgm: null` で BGM をクリア
- **scene-state に BGM を含める**: ハンドオフ時に BGM 状態を同期
- **scene-bgm ハンドオフ**: 他クライアントからの BGM 変更を受け取り適用

### URL インポート
- **audio.js**: 音声 URL をインポートする新しいローダー
  - MP3, WAV, OGG, M4A, AAC に対応
  - ファイル名から BGM 名を自動抽出
  - `applySceneBgm` / `broadcastSceneBgm` を AI コンテキストに追加

### URL 分類
- **url-classifier.js**: `URL_KIND.AUDIO` を追加
  - 拡張子ベースで音声ファイルを識別
  - クエリ文字列を無視して拡張子を抽出

### バリデーション
- **message-schema.mjs**: `scene-bgm` メッセージのスキーマ検証を追加
  - `bgm.url` が必須（null の場合を除く）
  - URL は reasonable string である必要がある
- **scenesync-guards.test.mjs**: 新しいテストケースを追加
  - 有効な BGM オブジェクト
  - `bgm: null` でのクリア
  - 無効な URL の拒否

### UI
- **dom.js**: `bgmUnlockButton` を DOM 参照に追加
- **showBgmUnlockUI() / hideBgmUnlockUI()**: オートプレイ制限時のボタン表示制御

### テスト
- **url-classifier.test.mjs**: 音声 URL 分類のテストを追加
  - MP3, WAV, OGG, M4A, AAC の拡張子認識
  - 大文字・混合ケースの対応
  - クエリ文字列付き URL の処理

## 変更していないこと

- 既存の scene-add / scene-delta / scene-remove メッセージ
- 環境光（scene-env）機能
- Loom graph 統合
- アバター機能

## staging確認

未確認（staging への deploy 前）

## テスト/チェック

- ✅ `apps/presence-server/tests

https://claude.ai/code/session_01FQzjby4DWHJgC6fNMvPfJ2