### PR TITLE
Add BGM clear button

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -190,13 +190,11 @@ dom.clearBgmButton?.addEventListener('click', () => {
     return;
   }
 
-  const previousBgm = serializeSceneBgm();
   applySceneBgm(null);
 
   const operation = {
     kind: 'scene-bgm',
     bgm: null,
-    previousBgm,
   };
   broadcast(operation);
 
@@ -6252,7 +6250,7 @@ function applyOperationToScene(operation) {
     }
     case 'scene-bgm': {
       applySceneBgm(operation.bgm ?? null);
-      notifySceneStateChanged('undo-redo-scene-bgm');
+      notifySceneStateChanged('scene-bgm-applied');
       break;
     }
   }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -183,6 +183,27 @@ dom.deleteSkyboxBtn?.addEventListener('click', () => {
   notifySceneStateChanged('skybox-deleted');
 });
 
+dom.clearBgmButton?.addEventListener('click', () => {
+  if (!serializeSceneBgm()) {
+    showToast('削除するBGMはありません');
+    updateBgmControls();
+    return;
+  }
+
+  const previousBgm = serializeSceneBgm();
+  applySceneBgm(null);
+
+  const operation = {
+    kind: 'scene-bgm',
+    bgm: null,
+    previousBgm,
+  };
+  broadcast(operation);
+
+  showToast('BGMを削除しました');
+  notifySceneStateChanged('bgm-cleared');
+});
+
 setupXrButtons({
   renderer,
   dom,
@@ -6076,6 +6097,7 @@ function applySceneBgm(bgm, options = {}) {
   disposeSceneBgm();
 
   if (!bgm || !bgm.url) {
+    updateBgmControls();
     return;
   }
 
@@ -6100,6 +6122,8 @@ function applySceneBgm(bgm, options = {}) {
     sceneBgmState.autoplayBlocked = true;
     showBgmUnlockUI();
   });
+
+  updateBgmControls();
 }
 
 function disposeSceneBgm() {
@@ -6112,6 +6136,7 @@ function disposeSceneBgm() {
   sceneBgmState.current = null;
   sceneBgmState.autoplayBlocked = false;
   hideBgmUnlockUI();
+  updateBgmControls();
 }
 
 function serializeSceneBgm() {
@@ -6141,6 +6166,12 @@ function showBgmUnlockUI() {
 function hideBgmUnlockUI() {
   const btn = dom.bgmUnlockButton;
   if (btn) btn.style.display = 'none';
+}
+
+function updateBgmControls() {
+  const clearButton = dom.clearBgmButton;
+  if (!clearButton) return;
+  clearButton.style.display = sceneBgmState.current ? 'block' : 'none';
 }
 
 // ── Undo/Redo 処理 ──────────────────────────────────────
@@ -6217,6 +6248,11 @@ function applyOperationToScene(operation) {
         applyOperationToScene(action);
       }
       notifySceneStateChanged('undo-redo-scene-batch');
+      break;
+    }
+    case 'scene-bgm': {
+      applySceneBgm(operation.bgm ?? null);
+      notifySceneStateChanged('undo-redo-scene-bgm');
       break;
     }
   }

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -23,5 +23,6 @@ export function getSceneSyncDom() {
     dropOverlay: document.getElementById('drop-overlay'),
     deleteSkyboxBtn: document.getElementById('delete-skybox-btn'),
     bgmUnlockButton: document.getElementById('bgm-unlock-button'),
+    clearBgmButton: document.getElementById('clear-bgm-btn'),
   };
 }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -918,6 +918,10 @@
         <span>🗑️</span>
         <span>Skyboxを削除</span>
       </button>
+      <button id="clear-bgm-btn" class="chip" type="button" title="BGMを削除" hidden>
+        <span>🔇</span>
+        <span>BGMを削除</span>
+      </button>
     </div>
     <div class="row mobile-collapsible-row">
       <button id="link-btn" class="chip" type="button" title="AI とリンク">


### PR DESCRIPTION
## 概要

BGM削除機能を追加し、UIボタンの表示/非表示を動的に制御します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

1. **BGM削除ボタンの追加**
   - `html/scenesync/index.html` に「BGMを削除」ボタン（id: `clear-bgm-btn`）を追加
   - 初期状態は `hidden` で、BGM存在時のみ表示

2. **BGM削除イベントハンドラ**
   - `dom.clearBgmButton` のクリックイベントリスナーを実装
   - BGMが存在しない場合はトースト表示して終了
   - BGM削除時に `scene-bgm` operation を broadcast

3. **BGM制御UI の動的更新**
   - `updateBgmControls()` 関数を新規追加
   - BGM状態に応じてクリアボタンの表示/非表示を制御
   - `applySceneBgm()`, `disposeSceneBgm()` 内で呼び出し

4. **Operation ハンドラ**
   - `applyOperationToScene()` に `scene-bgm` case を追加（将来の Undo/Redo 対応に向けた下準備）

### staging で見てほしい点

- BGM設定時にクリアボタンが表示される
- BGM削除後にボタンが非表示になる
- 複数クライアント間で BGM 削除が同期される

## 変更していないこと

- BGM再生機能そのもの
- その他のシーン操作機能
- Undo/Redo対応（将来の PR に延期）

## staging確認

- 未確認

## テスト/チェック

- 既存の BGM 関連機能との統合確認が必要
- 複数クライアント間の同期確認

## リスク

- なし（既存機能への影響は最小限）

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_0192L3ppNZwvkjNAW1YKp8rJ