### PR TITLE
Improve GLB asset recovery reliability: 500MB size limit, requestId tracking, responder queue, fetch retry, recovery states

### DIFF
--- a/docs/scene-sync-assets-and-cache.md
+++ b/docs/scene-sync-assets-and-cache.md
@@ -300,17 +300,71 @@ Responder は `assetId` を優先して cache lookup する。なければ `mesh
 
 Responder:
 
-- active send は同時 1 件まで。
+- active send は同時 1 件まで。複数 request は queue（最大 8）に積み、順番に処理。
 - 同一 asset への応答には cooldown を設ける。
-- 50MB 超過など、client / server limit を超えるものは無視する。
+- 500MB 超過など、client / server limit を超えるものは無視する。
 - requestId 重複は一定時間無視する。
+- 復元対象の object が現在 scene に存在していなくても、asset cache に blob があれば応答する。
 
 Receiver:
 
+- file handoff に含まれた `recoveryRequestId` で pending recovery を特定する。
+- matching しない場合は fallback として `fromPeerId` で探す。
 - pending recovery がない file は無視する。
 - `assetId` が指定されていれば hash 検証する。
 - `expectedSize` があれば size 検証する。
 - MIME が GLB として妥当でない場合は無視する。
+- file fetch は retry を含む（最大 4 回、delay: 0ms, 500ms, 1500ms, 3000ms）。
+
+---
+
+## Recovery states
+
+当データの復元フロー中、以下の visual states が表示される。
+
+### `loading`
+
+通常の GLB fetch 中。中立的な見た目 + animation。
+
+### `recovering`
+
+blob fetch が 404 になり、peer recovery を開始した状態。
+
+- オレンジ色の placeholder cube。
+- pulsing animation（処理中であることを表現）。
+- text label や retry button はない。
+- timeout or peer exhausted で failed になるまで継続。
+
+### `failed`
+
+local cache と peer recovery のどちらにも asset がない最終失敗状態。
+
+- 赤色の placeholder cube。
+- animation なし（停止状態を表現）。
+- text label や retry button はない。
+- metadata（position / rotation / scale など）は保持される。
+
+---
+
+## Recovery sources
+
+Scene Sync では以下の source からのみ GLB 復元を行う。
+
+1. **自分の browser local cache（IndexedDB）**
+   - TTL 切れ後、ローカルに blob があれば復元。
+   - 再度参加時にも自動的に lookup。
+
+2. **active peer の cache**
+   - 同じ room に現在参加中の peer が、その asset を IndexedDB に持っていれば request / receive。
+   - responder が object を scene に持っていなくても、cache に blob があれば応答。
+
+### 復元不可のケース
+
+以下の場合、asset は復元不可。
+
+- local cache にもなく、active peer にも cache がない。
+- Wasabi backup など、long-term backup storage からは復元しない。
+- production debug backup は operational investigation 用であり、user-facing restore path ではない。
 
 ---
 

--- a/html/assets/js/scenesync/assets/asset-cache.js
+++ b/html/assets/js/scenesync/assets/asset-cache.js
@@ -1,6 +1,6 @@
 const DB_NAME = 'scene-sync-assets';
 const STORE_NAME = 'assets';
-const MAX_SINGLE_GLB_SIZE = 50 * 1024 * 1024;
+const DEFAULT_MAX_GLB_SIZE = 500 * 1024 * 1024;
 
 export function createSceneAssetCache(options = {}) {
   let db = null;
@@ -34,7 +34,7 @@ export function createSceneAssetCache(options = {}) {
       throw new Error('putAsset requires assetId and blob');
     }
 
-    if (blob.size > MAX_SINGLE_GLB_SIZE) {
+    if (blob.size > DEFAULT_MAX_GLB_SIZE) {
       console.warn(`[AssetCache] GLB too large (${blob.size} bytes), skipping cache`);
       return;
     }

--- a/html/assets/js/scenesync/assets/expired-glb-recovery.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.js
@@ -12,7 +12,6 @@ const RECOVERY_TIMEOUT_MS = 30000;
 const PEER_RETRY_INTERVAL_MS = 4000;
 const COOLDOWN_MS = 30000;
 const DEFAULT_MAX_GLB_SIZE = 500 * 1024 * 1024;
-const MAX_ACTIVE_OUTGOING = 1;
 const MAX_OUTGOING_QUEUE = 8;
 
 function getOtherPeers(presenceState) {
@@ -29,11 +28,8 @@ export function createExpiredGlbRecovery({
   assetCache,
   fileTransfer,
   presenceState,
-  broadcast,
   sendHandoff,
   loadGlbBlobForObject,
-  getObjectById,
-  showToast,
 }) {
   const pendingRecoveries = new Map();
   const responderCooldowns = new Map();
@@ -64,8 +60,6 @@ export function createExpiredGlbRecovery({
     };
 
     pendingRecoveries.set(requestId, recovery);
-
-    showToast('GLBアセットの期限切れ。近くの参加者に問い合わせています...');
 
     const peers = getOtherPeers(presenceState);
     if (peers.length === 0) {
@@ -346,8 +340,6 @@ export function createExpiredGlbRecovery({
           console.warn('[ExpiredGlbRecovery] Error in recovery success callback:', err);
         }
       });
-
-      showToast('GLBアセットが別の参加者から復元されました。');
     } catch (err) {
       console.warn('[ExpiredGlbRecovery] Failed to load recovered GLB:', err);
       recoveryFailedCallbacks.forEach(cb => {

--- a/html/assets/js/scenesync/assets/expired-glb-recovery.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.js
@@ -1,10 +1,19 @@
 import { computeAssetId } from './asset-id.js';
 
+function cloneJsonSafe(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
 const RECOVERY_TIMEOUT_MS = 30000;
 const PEER_RETRY_INTERVAL_MS = 4000;
 const COOLDOWN_MS = 30000;
-const MAX_GLB_SIZE = 50 * 1024 * 1024;
+const DEFAULT_MAX_GLB_SIZE = 500 * 1024 * 1024;
 const MAX_ACTIVE_OUTGOING = 1;
+const MAX_OUTGOING_QUEUE = 8;
 
 function getOtherPeers(presenceState) {
   let peers = presenceState.peers;
@@ -28,9 +37,12 @@ export function createExpiredGlbRecovery({
 }) {
   const pendingRecoveries = new Map();
   const responderCooldowns = new Map();
+  const outgoingQueue = [];
+  const recoveryFailedCallbacks = [];
+  const recoverySuccessCallbacks = [];
   let activeOutgoingTransfer = null;
 
-  async function handleMissingGlb(objectId, meshPath, expectedSize, assetId) {
+  async function handleMissingGlb(objectId, meshPath, expectedSize, assetId, info = null) {
     const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
     console.log('[ExpiredGlbRecovery] Missing GLB detected:', {
@@ -46,6 +58,7 @@ export function createExpiredGlbRecovery({
       assetId: assetId || null,
       meshPath: meshPath || null,
       expectedSize: expectedSize || null,
+      info: info ? cloneJsonSafe(info) : null,
       requestedAt: Date.now(),
       requestedPeerIds: new Set(),
     };
@@ -57,9 +70,14 @@ export function createExpiredGlbRecovery({
     const peers = getOtherPeers(presenceState);
     if (peers.length === 0) {
       console.log('[ExpiredGlbRecovery] No other peers available');
-      setTimeout(() => {
-        pendingRecoveries.delete(requestId);
-      }, RECOVERY_TIMEOUT_MS);
+      pendingRecoveries.delete(requestId);
+      recoveryFailedCallbacks.forEach(cb => {
+        try {
+          cb({ objectId, requestId, reason: 'no-peers' });
+        } catch (err) {
+          console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
+        }
+      });
       return;
     }
 
@@ -81,6 +99,13 @@ export function createExpiredGlbRecovery({
       if (peerIndex >= peers.length) {
         console.log('[ExpiredGlbRecovery] All peers exhausted for requestId:', requestId);
         pendingRecoveries.delete(requestId);
+        recoveryFailedCallbacks.forEach(cb => {
+          try {
+            cb({ objectId, requestId, reason: 'no-response' });
+          } catch (err) {
+            console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
+          }
+        });
         return;
       }
 
@@ -111,6 +136,13 @@ export function createExpiredGlbRecovery({
       if (pendingRecoveries.has(requestId)) {
         console.log('[ExpiredGlbRecovery] Recovery timeout for requestId:', requestId);
         pendingRecoveries.delete(requestId);
+        recoveryFailedCallbacks.forEach(cb => {
+          try {
+            cb({ objectId, requestId, reason: 'timeout' });
+          } catch (err) {
+            console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
+          }
+        });
       }
     }, RECOVERY_TIMEOUT_MS);
   }
@@ -129,12 +161,6 @@ export function createExpiredGlbRecovery({
       from: from.id,
     });
 
-    const obj = getObjectById(objectId);
-    if (!obj) {
-      console.log('[ExpiredGlbRecovery] Object not found locally:', objectId);
-      return;
-    }
-
     const cacheKey = assetId || meshPath;
     if (!cacheKey) {
       console.log('[ExpiredGlbRecovery] No cacheKey for matching');
@@ -148,10 +174,23 @@ export function createExpiredGlbRecovery({
       return;
     }
 
+    const request = { requestId, objectId, assetId, meshPath, expectedSize, fromPeerId: from.id };
+
     if (activeOutgoingTransfer) {
-      console.log('[ExpiredGlbRecovery] Already transferring, skipping');
+      if (outgoingQueue.length >= MAX_OUTGOING_QUEUE) {
+        console.warn('[ExpiredGlbRecovery] Outgoing queue full, dropping request', requestId);
+        return;
+      }
+      console.log('[ExpiredGlbRecovery] Queuing request for later');
+      outgoingQueue.push(request);
       return;
     }
+
+    await processOutgoingRequest(request);
+  }
+
+  async function processOutgoingRequest(request) {
+    const { requestId, objectId, assetId, meshPath, expectedSize, fromPeerId } = request;
 
     let cachedRecord = null;
     if (assetId) {
@@ -161,17 +200,20 @@ export function createExpiredGlbRecovery({
     }
 
     if (!cachedRecord || !cachedRecord.blob) {
-      console.log('[ExpiredGlbRecovery] Asset not in local cache:', cacheKey);
+      console.log('[ExpiredGlbRecovery] Asset not in local cache:', assetId || meshPath);
+      processNextOutgoingRequest();
       return;
     }
 
     const blob = cachedRecord.blob;
-    if (blob.size > MAX_GLB_SIZE) {
+    if (blob.size > DEFAULT_MAX_GLB_SIZE) {
       console.warn('[ExpiredGlbRecovery] Cached GLB too large, skipping');
+      processNextOutgoingRequest();
       return;
     }
 
-    responderCooldowns.set(cooldownKey, Date.now());
+    const cacheKey = assetId || meshPath;
+    responderCooldowns.set(`${cacheKey}-${fromPeerId}`, Date.now());
     activeOutgoingTransfer = requestId;
 
     try {
@@ -180,31 +222,40 @@ export function createExpiredGlbRecovery({
 
       console.log('[ExpiredGlbRecovery] Sending GLB to peer:', {
         requestId,
-        peerId: from.id,
+        peerId: fromPeerId,
         fileName,
         size: blob.size,
       });
 
-      await fileTransfer.sendFileToPeer(from.id, file);
+      await fileTransfer.sendFileToPeer(fromPeerId, file, { requestId, assetId, meshPath, objectId });
     } catch (err) {
       console.warn('[ExpiredGlbRecovery] Failed to send GLB:', err);
     } finally {
       activeOutgoingTransfer = null;
+      processNextOutgoingRequest();
     }
   }
 
-  async function handleReceivedFile({ file, fromPeerId, from }) {
+  function processNextOutgoingRequest() {
+    if (outgoingQueue.length > 0) {
+      const nextRequest = outgoingQueue.shift();
+      processOutgoingRequest(nextRequest);
+    }
+  }
+
+  async function handleReceivedFile({ file, fromPeerId, from, recoveryRequestId }) {
     if (!file) {
       return;
     }
 
     console.log('[ExpiredGlbRecovery] File received from peer:', {
       fromPeerId,
+      recoveryRequestId,
       fileName: file.name,
       size: file.size,
     });
 
-    if (file.size > MAX_GLB_SIZE) {
+    if (file.size > DEFAULT_MAX_GLB_SIZE) {
       console.warn('[ExpiredGlbRecovery] Received file too large, ignoring');
       return;
     }
@@ -216,16 +267,23 @@ export function createExpiredGlbRecovery({
     }
 
     let recovery = null;
-    for (const [, rec] of pendingRecoveries) {
-      if (!rec.requestedPeerIds.has(fromPeerId)) {
-        continue;
+
+    if (recoveryRequestId) {
+      recovery = pendingRecoveries.get(recoveryRequestId);
+    }
+
+    if (!recovery && fromPeerId) {
+      for (const [, rec] of pendingRecoveries) {
+        if (!rec.requestedPeerIds.has(fromPeerId)) {
+          continue;
+        }
+        recovery = rec;
+        break;
       }
-      recovery = rec;
-      break;
     }
 
     if (!recovery) {
-      console.log('[ExpiredGlbRecovery] No matching pending recovery for this file from requestedPeerIds');
+      console.log('[ExpiredGlbRecovery] No matching pending recovery for this file');
       return;
     }
 
@@ -265,7 +323,19 @@ export function createExpiredGlbRecovery({
       });
 
       console.log('[ExpiredGlbRecovery] Loading recovered GLB into object');
-      await loadGlbBlobForObject(recovery.objectId, file);
+      await loadGlbBlobForObject(recovery.objectId, file, {
+        info: recovery.info,
+        meshPath: recovery.meshPath,
+        assetId: computedAssetId || recovery.assetId,
+      });
+
+      recoverySuccessCallbacks.forEach(cb => {
+        try {
+          cb({ objectId: recovery.objectId, requestId: recovery.requestId });
+        } catch (err) {
+          console.warn('[ExpiredGlbRecovery] Error in recovery success callback:', err);
+        }
+      });
 
       showToast('GLBアセットが別の参加者から復元されました。');
     } catch (err) {
@@ -273,13 +343,21 @@ export function createExpiredGlbRecovery({
     }
   }
 
-  function canAcceptFileHandoff({ fromPeerId, filename, size, mime }) {
-    if (!fromPeerId || !filename || !size || !mime) {
+  function canAcceptFileHandoff({ fromPeerId, filename, size, mime, recoveryRequestId }) {
+    if (!filename || !size || !mime) {
       return false;
     }
 
     const isGlb = (mime === 'model/gltf-binary' || filename.toLowerCase().endsWith('.glb'));
     if (!isGlb) {
+      return false;
+    }
+
+    if (recoveryRequestId && pendingRecoveries.has(recoveryRequestId)) {
+      return true;
+    }
+
+    if (!fromPeerId) {
       return false;
     }
 
@@ -300,10 +378,24 @@ export function createExpiredGlbRecovery({
     return recovery !== null;
   }
 
+  function onRecoveryFailed(callback) {
+    if (typeof callback === 'function') {
+      recoveryFailedCallbacks.push(callback);
+    }
+  }
+
+  function onRecoverySuccess(callback) {
+    if (typeof callback === 'function') {
+      recoverySuccessCallbacks.push(callback);
+    }
+  }
+
   return {
     handleMissingGlb,
     handleSceneAssetRequest,
     handleReceivedFile,
     canAcceptFileHandoff,
+    onRecoveryFailed,
+    onRecoverySuccess,
   };
 }

--- a/html/assets/js/scenesync/assets/expired-glb-recovery.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.js
@@ -40,7 +40,7 @@ export function createExpiredGlbRecovery({
   const outgoingQueue = [];
   const recoveryFailedCallbacks = [];
   const recoverySuccessCallbacks = [];
-  let activeOutgoingTransfer = null;
+  let outgoingProcessing = false;
 
   async function handleMissingGlb(objectId, meshPath, expectedSize, assetId, info = null) {
     const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -73,7 +73,7 @@ export function createExpiredGlbRecovery({
       pendingRecoveries.delete(requestId);
       recoveryFailedCallbacks.forEach(cb => {
         try {
-          cb({ objectId, requestId, reason: 'no-peers' });
+          cb({ objectId, requestId, reason: 'no-peers', info: recovery.info });
         } catch (err) {
           console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
         }
@@ -98,10 +98,11 @@ export function createExpiredGlbRecovery({
 
       if (peerIndex >= peers.length) {
         console.log('[ExpiredGlbRecovery] All peers exhausted for requestId:', requestId);
+        const recovery = pendingRecoveries.get(requestId);
         pendingRecoveries.delete(requestId);
         recoveryFailedCallbacks.forEach(cb => {
           try {
-            cb({ objectId, requestId, reason: 'no-response' });
+            cb({ objectId, requestId, reason: 'no-response', info: recovery?.info });
           } catch (err) {
             console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
           }
@@ -135,10 +136,11 @@ export function createExpiredGlbRecovery({
     setTimeout(() => {
       if (pendingRecoveries.has(requestId)) {
         console.log('[ExpiredGlbRecovery] Recovery timeout for requestId:', requestId);
+        const recovery = pendingRecoveries.get(requestId);
         pendingRecoveries.delete(requestId);
         recoveryFailedCallbacks.forEach(cb => {
           try {
-            cb({ objectId, requestId, reason: 'timeout' });
+            cb({ objectId, requestId, reason: 'timeout', info: recovery?.info });
           } catch (err) {
             console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
           }
@@ -176,45 +178,63 @@ export function createExpiredGlbRecovery({
 
     const request = { requestId, objectId, assetId, meshPath, expectedSize, fromPeerId: from.id };
 
-    if (activeOutgoingTransfer) {
-      if (outgoingQueue.length >= MAX_OUTGOING_QUEUE) {
-        console.warn('[ExpiredGlbRecovery] Outgoing queue full, dropping request', requestId);
-        return;
-      }
-      console.log('[ExpiredGlbRecovery] Queuing request for later');
-      outgoingQueue.push(request);
+    if (outgoingQueue.length >= MAX_OUTGOING_QUEUE) {
+      console.warn('[ExpiredGlbRecovery] Outgoing queue full, dropping request', requestId);
       return;
     }
 
-    await processOutgoingRequest(request);
+    console.log('[ExpiredGlbRecovery] Queuing request for processing');
+    outgoingQueue.push(request);
+    drainOutgoingQueue();
+  }
+
+  async function drainOutgoingQueue() {
+    if (outgoingProcessing || outgoingQueue.length === 0) {
+      return;
+    }
+
+    outgoingProcessing = true;
+
+    while (outgoingQueue.length > 0) {
+      const request = outgoingQueue.shift();
+      try {
+        await processOutgoingRequest(request);
+      } catch (err) {
+        console.warn('[ExpiredGlbRecovery] Error processing outgoing request:', err);
+      }
+    }
+
+    outgoingProcessing = false;
   }
 
   async function processOutgoingRequest(request) {
     const { requestId, objectId, assetId, meshPath, expectedSize, fromPeerId } = request;
 
     let cachedRecord = null;
-    if (assetId) {
-      cachedRecord = await assetCache.getByAssetId(assetId);
-    } else if (meshPath) {
-      cachedRecord = await assetCache.getByMeshPath(meshPath);
+    try {
+      if (assetId) {
+        cachedRecord = await assetCache.getByAssetId(assetId);
+      } else if (meshPath) {
+        cachedRecord = await assetCache.getByMeshPath(meshPath);
+      }
+    } catch (err) {
+      console.warn('[ExpiredGlbRecovery] Error looking up asset cache:', err);
+      return;
     }
 
     if (!cachedRecord || !cachedRecord.blob) {
       console.log('[ExpiredGlbRecovery] Asset not in local cache:', assetId || meshPath);
-      processNextOutgoingRequest();
       return;
     }
 
     const blob = cachedRecord.blob;
     if (blob.size > DEFAULT_MAX_GLB_SIZE) {
       console.warn('[ExpiredGlbRecovery] Cached GLB too large, skipping');
-      processNextOutgoingRequest();
       return;
     }
 
     const cacheKey = assetId || meshPath;
     responderCooldowns.set(`${cacheKey}-${fromPeerId}`, Date.now());
-    activeOutgoingTransfer = requestId;
 
     try {
       const fileName = assetId ? `${assetId}.glb` : `${objectId}.glb`;
@@ -230,16 +250,6 @@ export function createExpiredGlbRecovery({
       await fileTransfer.sendFileToPeer(fromPeerId, file, { requestId, assetId, meshPath, objectId });
     } catch (err) {
       console.warn('[ExpiredGlbRecovery] Failed to send GLB:', err);
-    } finally {
-      activeOutgoingTransfer = null;
-      processNextOutgoingRequest();
-    }
-  }
-
-  function processNextOutgoingRequest() {
-    if (outgoingQueue.length > 0) {
-      const nextRequest = outgoingQueue.shift();
-      processOutgoingRequest(nextRequest);
     }
   }
 
@@ -340,6 +350,13 @@ export function createExpiredGlbRecovery({
       showToast('GLBアセットが別の参加者から復元されました。');
     } catch (err) {
       console.warn('[ExpiredGlbRecovery] Failed to load recovered GLB:', err);
+      recoveryFailedCallbacks.forEach(cb => {
+        try {
+          cb({ objectId: recovery.objectId, requestId: recovery.requestId, reason: 'load-failed', info: recovery.info });
+        } catch (cbErr) {
+          console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', cbErr);
+        }
+      });
     }
   }
 

--- a/html/assets/js/scenesync/assets/file-transfer-adapter.js
+++ b/html/assets/js/scenesync/assets/file-transfer-adapter.js
@@ -2,6 +2,37 @@ function generateRandomPath() {
   return Math.random().toString(36).slice(2, 10);
 }
 
+async function fetchWithRetry(url, options = {}, maxAttempts = 4) {
+  const delays = [0, 500, 1500, 3000];
+  let lastError;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    if (i > 0) {
+      await new Promise(r => setTimeout(r, delays[i - 1]));
+    }
+
+    try {
+      const response = await fetch(url, options);
+      if (response.ok) {
+        return response;
+      }
+
+      if (response.status >= 400 && response.status < 500) {
+        lastError = new Error(`HTTP ${response.status}`);
+        if (response.status === 404) {
+          throw lastError;
+        }
+      } else {
+        lastError = new Error(`HTTP ${response.status}`);
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  throw lastError || new Error('Failed to fetch after retries');
+}
+
 export function createSceneSyncFileTransferAdapter({
   presenceState,
   sendHandoff,
@@ -13,13 +44,14 @@ export function createSceneSyncFileTransferAdapter({
     : 'https://pipe.afjk.jp';
   const PIPE_DISPLAY_URL = `${location.origin}/pipe`;
 
-  async function sendFileToPeer(peerId, file) {
+  async function sendFileToPeer(peerId, file, metadata = {}) {
     if (!file || !peerId) {
       throw new Error('sendFileToPeer requires peerId and file');
     }
 
     const path = generateRandomPath();
     const fileInfo = {
+      kind: 'file',
       path,
       filename: file.name || 'file.glb',
       size: file.size,
@@ -27,15 +59,29 @@ export function createSceneSyncFileTransferAdapter({
       url: `${PIPE_DISPLAY_URL}/#${path}`,
     };
 
+    if (metadata.requestId) {
+      fileInfo.recoveryRequestId = metadata.requestId;
+    }
+    if (metadata.assetId) {
+      fileInfo.assetId = metadata.assetId;
+    }
+    if (metadata.meshPath) {
+      fileInfo.meshPath = metadata.meshPath;
+    }
+    if (metadata.objectId) {
+      fileInfo.objectId = metadata.objectId;
+    }
+
     console.log('[FileTransferAdapter] Sending file to peer:', {
       peerId,
       filename: fileInfo.filename,
       size: fileInfo.size,
+      recoveryRequestId: fileInfo.recoveryRequestId,
     });
 
     sendHandoff({
       targetId: peerId,
-      payload: { kind: 'file', ...fileInfo },
+      payload: fileInfo,
     });
 
     try {
@@ -87,10 +133,11 @@ export function createSceneSyncFileTransferAdapter({
       fromPeerId: from?.id,
       filename: payload.filename,
       size: payload.size,
+      recoveryRequestId: payload.recoveryRequestId,
     });
 
     try {
-      const response = await fetch(`${PIPING_BASE}/${payload.path}`);
+      const response = await fetchWithRetry(`${PIPING_BASE}/${payload.path}`);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status} fetching file`);
       }
@@ -102,11 +149,15 @@ export function createSceneSyncFileTransferAdapter({
         file,
         fromPeerId: from?.id,
         from,
+        recoveryRequestId: payload.recoveryRequestId,
+        assetId: payload.assetId,
+        meshPath: payload.meshPath,
+        objectId: payload.objectId,
       });
 
       return true;
     } catch (err) {
-      console.warn('[FileTransferAdapter] Failed to receive file:', err);
+      console.warn('[FileTransferAdapter] Failed to receive file after retries:', err);
       return false;
     }
   }

--- a/html/assets/js/scenesync/assets/file-transfer-adapter.js
+++ b/html/assets/js/scenesync/assets/file-transfer-adapter.js
@@ -8,7 +8,7 @@ async function fetchWithRetry(url, options = {}, maxAttempts = 4) {
 
   for (let i = 0; i < maxAttempts; i++) {
     if (i > 0) {
-      await new Promise(r => setTimeout(r, delays[i - 1]));
+      await new Promise(r => setTimeout(r, delays[i]));
     }
 
     try {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1682,6 +1682,7 @@ function removeLockOverlay(objectId) {
 
 // objectId → { group, placeholder }
 const loadingOverlays = new Map();
+const recoveryOverlays = new Map();
 const temporaryImagePreviews = new Map();
 
 function createLoadingLabel(text) {
@@ -1786,6 +1787,45 @@ function createLoadingPlaceholder() {
   return group;
 }
 
+function createRecoveringPlaceholder() {
+  const group = new THREE.Group();
+
+  const geo = new THREE.BoxGeometry(1, 1, 1);
+  const edges = new THREE.EdgesGeometry(geo);
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xffaa44,
+    transparent: true,
+    opacity: 0.8,
+  });
+  const box = new THREE.LineSegments(edges, mat);
+  box.raycast = () => {};
+  group.add(box);
+  geo.dispose();
+
+  group.userData._animation = 'pulsing';
+  group.userData._startTime = performance.now();
+
+  return group;
+}
+
+function createFailedPlaceholder() {
+  const group = new THREE.Group();
+
+  const geo = new THREE.BoxGeometry(1, 1, 1);
+  const edges = new THREE.EdgesGeometry(geo);
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xff6666,
+    transparent: true,
+    opacity: 0.6,
+  });
+  const box = new THREE.LineSegments(edges, mat);
+  box.raycast = () => {};
+  group.add(box);
+  geo.dispose();
+
+  return group;
+}
+
 function addLoadingOverlay(objectId, name, info) {
   removeLoadingOverlay(objectId);
 
@@ -1821,6 +1861,56 @@ function removeLoadingOverlay(objectId) {
   });
 
   loadingOverlays.delete(objectId);
+}
+
+function addRecoveringOverlay(objectId, info) {
+  removeRecoveringOverlay(objectId);
+
+  const group = new THREE.Group();
+  group.userData._isRecoveringOverlay = true;
+  group.raycast = () => {};
+
+  const placeholder = createRecoveringPlaceholder();
+  group.add(placeholder);
+
+  if (info?.position) group.position.fromArray(info.position);
+
+  scene.add(group);
+  recoveryOverlays.set(objectId, { group, placeholder });
+}
+
+function removeRecoveringOverlay(objectId) {
+  const entry = recoveryOverlays.get(objectId);
+  if (!entry) return;
+
+  const { group } = entry;
+  scene.remove(group);
+  group.traverse(child => {
+    if (child.geometry) child.geometry.dispose();
+    if (child.material) {
+      if (child.material.map) child.material.map.dispose();
+      child.material.dispose();
+    }
+  });
+
+  recoveryOverlays.delete(objectId);
+}
+
+function updateRecoveringOverlaysAnimation() {
+  recoveryOverlays.forEach(entry => {
+    const { placeholder } = entry;
+    if (!placeholder || !placeholder.userData._animation) return;
+
+    const elapsed = performance.now() - placeholder.userData._startTime;
+    const phase = (elapsed / 1000) % 2;
+    const opacity = Math.abs(Math.sin(phase * Math.PI)) * 0.5 + 0.3;
+
+    placeholder.children.forEach(child => {
+      if (child.material && child.material.opacity !== undefined) {
+        child.material.opacity = opacity;
+      }
+    });
+  });
 }
 
 // ── GLB Animation Setup and Updates ──────────────────────
@@ -3728,6 +3818,8 @@ renderer.setAnimationLoop((time, frame) => {
     }
   }
 
+  updateRecoveringOverlaysAnimation();
+
   for (const helper of selectionHelpers.values()) {
     helper.update?.();
   }
@@ -5600,20 +5692,16 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
             });
             return;
           }
+
+          addRecoveringOverlay(objectId, info);
           await expiredGlbRecovery.handleMissingGlb(
             objectId,
             meshPath,
             expectedSize,
-            assetId
+            assetId,
+            info
           );
 
-          if (!existing && !skipFallbackOnFailure) {
-            replaceManagedObject(
-              objectId,
-              buildDefaultBoxObject(objectId, info, 0xffaa44),
-              info
-            );
-          }
           return;
         }
         throw new Error(`HTTP ${response.status} loading mesh`);
@@ -6402,6 +6490,28 @@ const expiredGlbRecovery = createExpiredGlbRecovery({
 
 fileTransferAdapter.onFileReceived((event) => {
   expiredGlbRecovery.handleReceivedFile(event);
+});
+
+expiredGlbRecovery.onRecoverySuccess(({ objectId, requestId }) => {
+  console.log('[SceneSync] Recovery succeeded:', { objectId, requestId });
+  removeRecoveringOverlay(objectId);
+});
+
+expiredGlbRecovery.onRecoveryFailed(({ objectId, requestId, reason }) => {
+  console.log('[SceneSync] Recovery failed:', { objectId, requestId, reason });
+  removeRecoveringOverlay(objectId);
+
+  const info = managedObjects.get(objectId)?.userData || {};
+  const failedGroup = new THREE.Group();
+  failedGroup.userData._isFailedPlaceholder = true;
+  failedGroup.raycast = () => {};
+
+  const placeholder = createFailedPlaceholder();
+  failedGroup.add(placeholder);
+
+  if (info?.position) failedGroup.position.fromArray(info.position);
+
+  scene.add(failedGroup);
 });
 
 // ── 公開 API（scene.js 内から利用） ──────────────────────

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6525,11 +6525,8 @@ const expiredGlbRecovery = createExpiredGlbRecovery({
   assetCache,
   fileTransfer: fileTransferAdapter,
   presenceState,
-  broadcast,
   sendHandoff,
   loadGlbBlobForObject,
-  getObjectById,
-  showToast,
 });
 
 fileTransferAdapter.onFileReceived((event) => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1683,6 +1683,7 @@ function removeLockOverlay(objectId) {
 // objectId → { group, placeholder }
 const loadingOverlays = new Map();
 const recoveryOverlays = new Map();
+const failedOverlays = new Map();
 const temporaryImagePreviews = new Map();
 
 function createLoadingLabel(text) {
@@ -1873,7 +1874,9 @@ function addRecoveringOverlay(objectId, info) {
   const placeholder = createRecoveringPlaceholder();
   group.add(placeholder);
 
-  if (info?.position) group.position.fromArray(info.position);
+  if (info) {
+    applySceneTransform(group, info);
+  }
 
   scene.add(group);
   recoveryOverlays.set(objectId, { group, placeholder });
@@ -1894,6 +1897,41 @@ function removeRecoveringOverlay(objectId) {
   });
 
   recoveryOverlays.delete(objectId);
+}
+
+function addFailedOverlay(objectId, info) {
+  removeFailedOverlay(objectId);
+
+  const group = new THREE.Group();
+  group.userData._isFailedPlaceholder = true;
+  group.raycast = () => {};
+
+  const placeholder = createFailedPlaceholder();
+  group.add(placeholder);
+
+  if (info) {
+    applySceneTransform(group, info);
+  }
+
+  scene.add(group);
+  failedOverlays.set(objectId, { group, placeholder });
+}
+
+function removeFailedOverlay(objectId) {
+  const entry = failedOverlays.get(objectId);
+  if (!entry) return;
+
+  const { group } = entry;
+  scene.remove(group);
+  group.traverse(child => {
+    if (child.geometry) child.geometry.dispose();
+    if (child.material) {
+      if (child.material.map) child.material.map.dispose();
+      child.material.dispose();
+    }
+  });
+
+  failedOverlays.delete(objectId);
 }
 
 function updateRecoveringOverlaysAnimation() {
@@ -3458,6 +3496,9 @@ function deleteObjectById(objectId, options = {}) {
   }
 
   removeLockOverlay(objectId);
+  removeLoadingOverlay(objectId);
+  removeRecoveringOverlay(objectId);
+  removeFailedOverlay(objectId);
   locks.delete(objectId);
 
   disposeObjectGlbAnimation(objectId);
@@ -5615,6 +5656,8 @@ function addOrUpdateObject(objectId, info, options = {}) {
 }
 
 function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
+  removeFailedOverlay(objectId);
+  removeRecoveringOverlay(objectId);
   addLoadingOverlay(objectId, info.name || objectId, info);
   const url = BLOB_BASE + '/' + meshPath;
   const skipFallbackOnFailure = options.skipFallbackOnFailure === true;
@@ -5714,6 +5757,7 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
       glbLoader.loadFromUrl(objectUrl, initialPosition, scene, async (model) => {
         try {
           removeLoadingOverlay(objectId);
+          removeFailedOverlay(objectId);
           model.userData.objectId = objectId;
           model.userData.name = info.name;
           model.userData.meshPath = meshPath;
@@ -6495,23 +6539,13 @@ fileTransferAdapter.onFileReceived((event) => {
 expiredGlbRecovery.onRecoverySuccess(({ objectId, requestId }) => {
   console.log('[SceneSync] Recovery succeeded:', { objectId, requestId });
   removeRecoveringOverlay(objectId);
+  removeFailedOverlay(objectId);
 });
 
-expiredGlbRecovery.onRecoveryFailed(({ objectId, requestId, reason }) => {
+expiredGlbRecovery.onRecoveryFailed(({ objectId, requestId, reason, info }) => {
   console.log('[SceneSync] Recovery failed:', { objectId, requestId, reason });
   removeRecoveringOverlay(objectId);
-
-  const info = managedObjects.get(objectId)?.userData || {};
-  const failedGroup = new THREE.Group();
-  failedGroup.userData._isFailedPlaceholder = true;
-  failedGroup.raycast = () => {};
-
-  const placeholder = createFailedPlaceholder();
-  failedGroup.add(placeholder);
-
-  if (info?.position) failedGroup.position.fromArray(info.position);
-
-  scene.add(failedGroup);
+  addFailedOverlay(objectId, info);
 });
 
 // ── 公開 API（scene.js 内から利用） ──────────────────────


### PR DESCRIPTION
P0 requirements:
- Increase client-side GLB size limit from 50MB to 500MB across asset-cache and expired-glb-recovery
- Add recoveryRequestId to file handoff payload for deterministic matching
- Use requestId directly to look up pending recoveries, reducing mismatch risk
- Preserve recovery metadata (info, meshPath, assetId) throughout recovery flow
- Remove fallback box after 404; show recovering placeholder instead

P1 requirements:
- Remove objectId requirement from responder; use assetId/meshPath cache lookup
- Implement responder outgoing queue (max 8) for reliable asset transfer
- Add fetchWithRetry to file transfer with exponential backoff
- Track recovery state: loading → recovering → (loaded|failed)

Visual changes:
- loading: standard placeholder with animation
- recovering: orange placeholder with pulsing opacity (processing state)
- failed: red placeholder, no animation (stopped state)

Recovery success/fail callbacks:
- onRecoverySuccess: cleanup recovering overlay
- onRecoveryFailed: replace with failed placeholder

Updated docs to clarify:
- Asset recovery sources: local cache + active peers only
- Responder queue, size limits, and requestId matching
- Recovery state descriptions
- No Wasabi backup in user-facing restore flow

https://claude.ai/code/session_01231DDQzPm2tzXYjhNVjKy5