### PR TITLE
Skip room connection limit for inferred local rooms

### DIFF
--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -143,6 +143,10 @@ function inferRoomFromReq(req) {
   return sanitizeRoom(ip) || 'global';
 }
 
+function shouldEnforceRoomConnectionLimit({ roomOverride }) {
+  return Boolean(roomOverride);
+}
+
 function isValidScope(scope) {
   if (scope === 'scene') return true;
   if (typeof scope === 'object' && scope !== null && !Array.isArray(scope)) {
@@ -1514,13 +1518,16 @@ function createPresenceServer() {
       return;
     }
     const roomOverride = sanitizeRoom(url.searchParams.get('room'));
+    const isInferredRoom = !roomOverride;
     const roomId = roomOverride || inferRoomFromReq(req) || 'global';
     const actorId = getActorIdFromRequest(req, sceneSyncConfig.actorHashSalt);
     const conn = acceptWebSocket(req, socket);
     if (!conn) return;
     const currentRoom = rooms.get(roomId);
-    if ((currentRoom?.size || 0) >= sceneSyncConfig.maxRoomConnections) {
-      sceneSyncLogger.log('room_full', { roomId, actorId, reason: 'max connections reached' });
+
+    const shouldEnforceLimit = shouldEnforceRoomConnectionLimit({ roomOverride });
+    if (shouldEnforceLimit && (currentRoom?.size || 0) >= sceneSyncConfig.maxRoomConnections) {
+      sceneSyncLogger.log('room_full', { roomId, actorId, reason: 'max connections reached', inferredRoom: isInferredRoom });
       safeSend(conn, {
         type: 'error',
         error: 'room_full',
@@ -1532,7 +1539,7 @@ function createPresenceServer() {
 
     const client = makeClient(conn, roomId);
     log('client connected', client.id, 'room', roomId);
-    sceneSyncLogger.log('ws_connect', { roomId, actorId });
+    sceneSyncLogger.log('ws_connect', { roomId, actorId, inferredRoom: isInferredRoom });
 
     conn.send({ type: 'welcome', id: client.id, room: roomId });
     broadcastPeers(roomId);

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -1535,33 +1535,3 @@ describe('presence AI wrapper alias API', () => {
     assert.equal(body.kind, 'scene-add');
   });
 });
-
-describe('room connection limits', () => {
-  it('explicit rooms include inferredRoom: false in logs', async () => {
-    const roomId = 'explicit-log-test';
-    const ws = await connectClient(roomId);
-    try {
-      assert.equal(ws.readyState, WebSocket.OPEN);
-    } finally {
-      await closeClient(ws);
-    }
-  });
-
-  it('inferred rooms include inferredRoom: true in logs', async () => {
-    const ws = new WebSocket(wsBaseUrl);
-    const welcomePromise = waitForMessage(ws, message => message.type === 'welcome');
-    await waitForEvent(ws, 'open');
-    ws.send(JSON.stringify({
-      type: 'hello',
-      nickname: 'InferredRoomTest',
-      device: 'Test',
-    }));
-    const welcome = await welcomePromise;
-    try {
-      assert.ok(welcome.room, 'should have a room ID');
-      assert.equal(ws.readyState, WebSocket.OPEN);
-    } finally {
-      await closeClient(ws);
-    }
-  });
-});

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -1535,3 +1535,33 @@ describe('presence AI wrapper alias API', () => {
     assert.equal(body.kind, 'scene-add');
   });
 });
+
+describe('room connection limits', () => {
+  it('explicit rooms include inferredRoom: false in logs', async () => {
+    const roomId = 'explicit-log-test';
+    const ws = await connectClient(roomId);
+    try {
+      assert.equal(ws.readyState, WebSocket.OPEN);
+    } finally {
+      await closeClient(ws);
+    }
+  });
+
+  it('inferred rooms include inferredRoom: true in logs', async () => {
+    const ws = new WebSocket(wsBaseUrl);
+    const welcomePromise = waitForMessage(ws, message => message.type === 'welcome');
+    await waitForEvent(ws, 'open');
+    ws.send(JSON.stringify({
+      type: 'hello',
+      nickname: 'InferredRoomTest',
+      device: 'Test',
+    }));
+    const welcome = await welcomePromise;
+    try {
+      assert.ok(welcome.room, 'should have a room ID');
+      assert.equal(ws.readyState, WebSocket.OPEN);
+    } finally {
+      await closeClient(ws);
+    }
+  });
+});

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -351,10 +351,10 @@ describe('Scene Sync server guards', () => {
     assert.equal(add3.status, 429);
   });
 
-  it('enforces room connection limit', async () => {
-    const ws1 = new WebSocket(`${wsBaseUrl}?room=room-limit`);
-    const ws2 = new WebSocket(`${wsBaseUrl}?room=room-limit`);
-    const ws3 = new WebSocket(`${wsBaseUrl}?room=room-limit`);
+  it('enforces room connection limit for explicit rooms', async () => {
+    const ws1 = new WebSocket(`${wsBaseUrl}?room=room-limit-explicit`);
+    const ws2 = new WebSocket(`${wsBaseUrl}?room=room-limit-explicit`);
+    const ws3 = new WebSocket(`${wsBaseUrl}?room=room-limit-explicit`);
     const thirdEvents = [];
     ws3.on('message', (raw) => {
       thirdEvents.push(JSON.parse(raw.toString()));
@@ -379,6 +379,54 @@ describe('Scene Sync server guards', () => {
     ws1.terminate();
     ws2.terminate();
     ws3.terminate();
+  });
+
+  it('skips room connection limit for inferred rooms', async () => {
+    const wsClients = [];
+    const openEvents = [];
+
+    for (let i = 0; i < 4; i++) {
+      const ws = new WebSocket(wsBaseUrl);
+      wsClients.push(ws);
+
+      ws.on('open', () => {
+        openEvents.push({ index: i, event: 'open' });
+      });
+
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'welcome') {
+          openEvents.push({ index: i, event: 'welcome', roomId: msg.room });
+        }
+        if (msg.error === 'room_full') {
+          openEvents.push({ index: i, event: 'room_full_error' });
+        }
+      });
+
+      ws.on('close', () => {
+        openEvents.push({ index: i, event: 'close' });
+      });
+    }
+
+    await Promise.all([
+      new Promise((resolve) => wsClients[0].once('open', resolve)),
+      new Promise((resolve) => wsClients[1].once('open', resolve)),
+      new Promise((resolve) => wsClients[2].once('open', resolve)),
+      new Promise((resolve) => wsClients[3].once('open', resolve)),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const closeEvents = openEvents.filter(e => e.event === 'close');
+    const roomFullErrors = openEvents.filter(e => e.event === 'room_full_error');
+
+    assert.equal(closeEvents.length, 0, 'no clients should have been closed by room_full');
+    assert.equal(roomFullErrors.length, 0, 'no room_full errors should be received');
+
+    const allOpen = wsClients.every(ws => ws.readyState === WebSocket.OPEN);
+    assert.equal(allOpen, true, 'all 4 clients should remain connected despite limit of 2');
+
+    wsClients.forEach(ws => ws.terminate());
   });
 });
 


### PR DESCRIPTION
- Add shouldEnforceRoomConnectionLimit helper that returns true only for explicit rooms (?room=...)
- Track isInferredRoom flag to distinguish between explicit and inferred rooms
- Apply maxRoomConnections limit only to explicit rooms
- Add inferredRoom flag to ws_connect and room_full logs for better diagnostics
- Add tests for explicit and inferred room connections

This allows local/same-network devices (inferred rooms) to connect without hitting
the connection limit, while still protecting internet/shared URL rooms (explicit rooms).

https://claude.ai/code/session_0133yGhVxg5KV8Vq78cuF5Zs