### PR TITLE
feat: Add UnityGLTF installer UI and animation detection

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
@@ -15,8 +15,43 @@ namespace Afjk.SceneSync.Editor
         internal const string PackageUrl = "https://github.com/KhronosGroup/UnityGLTF.git";
 
         private static AddRequest _addRequest;
+        private static ListRequest _listRequest;
+        private static bool? _isUnityGltfPackageInstalled;
 
         public static bool IsInstalling => _addRequest != null;
+        public static bool IsCheckingPackageStatus => _listRequest != null;
+        public static bool IsUnityGltfPackageInstalled => _isUnityGltfPackageInstalled == true;
+
+        public static void RefreshUnityGltfPackageStatus()
+        {
+            if (_listRequest != null) return;
+
+            _listRequest = Client.List(true);
+            EditorApplication.update += PollPackageList;
+        }
+
+        private static void PollPackageList()
+        {
+            if (_listRequest == null) return;
+            if (!_listRequest.IsCompleted) return;
+
+            if (_listRequest.Status == StatusCode.Success)
+            {
+                _isUnityGltfPackageInstalled = _listRequest.Result.Any(package =>
+                    package.name == "com.khronos.unitygltf" ||
+                    package.displayName.Contains("UnityGLTF") ||
+                    package.packageId.Contains("KhronosGroup/UnityGLTF")
+                );
+            }
+            else
+            {
+                Debug.LogWarning("[SceneSync] Failed to check UnityGLTF package status: " + _listRequest.Error.message);
+                _isUnityGltfPackageInstalled = null;
+            }
+
+            _listRequest = null;
+            EditorApplication.update -= PollPackageList;
+        }
 
         public static bool IsUnityGltfDefineEnabled()
         {
@@ -74,6 +109,7 @@ namespace Afjk.SceneSync.Editor
             if (_addRequest.Status == StatusCode.Success)
             {
                 Debug.Log("[SceneSync] UnityGLTF installed: " + _addRequest.Result.packageId);
+                _isUnityGltfPackageInstalled = true;
                 EnsureUnityGltfDefine();
 
                 EditorUtility.DisplayDialog(

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
@@ -1,0 +1,100 @@
+#if UNITY_EDITOR
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Editor
+{
+    internal static class SceneSyncUnityGltfInstaller
+    {
+        internal const string Define = "SCENESYNC_USE_UNITYGLTF";
+        internal const string PackageUrl = "https://github.com/KhronosGroup/UnityGLTF.git";
+
+        private static AddRequest _addRequest;
+
+        public static bool IsInstalling => _addRequest != null;
+
+        public static bool IsUnityGltfDefineEnabled()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var target = NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(target);
+#else
+            var group = EditorUserBuildSettings.selectedBuildTargetGroup;
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(group);
+#endif
+            return defines.Split(';').Any(x => x == Define);
+        }
+
+        public static void EnsureUnityGltfDefine()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var target = NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(target);
+            if (defines.Split(';').Any(x => x == Define)) return;
+
+            PlayerSettings.SetScriptingDefineSymbols(
+                target,
+                string.IsNullOrWhiteSpace(defines) ? Define : defines + ";" + Define
+            );
+#else
+            var group = EditorUserBuildSettings.selectedBuildTargetGroup;
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(group);
+            if (defines.Split(';').Any(x => x == Define)) return;
+
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(
+                group,
+                string.IsNullOrWhiteSpace(defines) ? Define : defines + ";" + Define
+            );
+#endif
+        }
+
+        public static void InstallUnityGltf()
+        {
+            if (_addRequest != null)
+            {
+                Debug.Log("[SceneSync] UnityGLTF installation is already running.");
+                return;
+            }
+
+            Debug.Log("[SceneSync] Installing UnityGLTF: " + PackageUrl);
+            _addRequest = Client.Add(PackageUrl);
+            EditorApplication.update += PollInstall;
+        }
+
+        private static void PollInstall()
+        {
+            if (_addRequest == null) return;
+            if (!_addRequest.IsCompleted) return;
+
+            if (_addRequest.Status == StatusCode.Success)
+            {
+                Debug.Log("[SceneSync] UnityGLTF installed: " + _addRequest.Result.packageId);
+                EnsureUnityGltfDefine();
+
+                EditorUtility.DisplayDialog(
+                    "Scene Sync",
+                    "UnityGLTF has been installed. Unity may recompile scripts now.",
+                    "OK"
+                );
+            }
+            else if (_addRequest.Status == StatusCode.Failure)
+            {
+                Debug.LogError("[SceneSync] Failed to install UnityGLTF: " + _addRequest.Error.message);
+                EditorUtility.DisplayDialog(
+                    "Scene Sync",
+                    "Failed to install UnityGLTF:\n" + _addRequest.Error.message,
+                    "OK"
+                );
+            }
+
+            _addRequest = null;
+            EditorApplication.update -= PollInstall;
+        }
+    }
+}
+#endif

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
@@ -38,6 +38,7 @@ namespace Afjk.SceneSync.Editor
             if (_listRequest.Status == StatusCode.Success)
             {
                 _isUnityGltfPackageInstalled = _listRequest.Result.Any(package =>
+                    package.name == "org.khronos.unitygltf" ||
                     package.name == "com.khronos.unitygltf" ||
                     package.displayName.Contains("UnityGLTF") ||
                     package.packageId.Contains("KhronosGroup/UnityGLTF")

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -467,11 +467,15 @@ namespace Afjk.SceneSync.Editor
             }
 
             EditorGUILayout.HelpBox(
-                "Auto: Detects animations and uses UnityGLTF if available\n" +
-                "glTFast: Always use glTFast (no animations)\n" +
-                "UnityGltf: Always use UnityGLTF (Editor-only)",
+                "Auto: Uses glTFast for normal objects. If animation is detected and UnityGLTF is available, UnityGLTF is used.\n" +
+                "glTFast: Lightweight static GLB export. Animation is not exported.\n" +
+                "UnityGltf: Uses UnityGLTF for GLB export with animation support. Editor only.",
                 MessageType.Info
             );
+
+            GUILayout.Space(8);
+
+            DrawUnityGltfStatusSection();
 
             GUILayout.Space(8);
 
@@ -489,6 +493,54 @@ namespace Afjk.SceneSync.Editor
                 "The server may still reject uploads with its own limit.",
                 MessageType.Info
             );
+        }
+
+        private void DrawUnityGltfStatusSection()
+        {
+            GUILayout.Label("UnityGLTF", EditorStyles.boldLabel);
+
+            var defineEnabled = SceneSyncUnityGltfInstaller.IsUnityGltfDefineEnabled();
+            var exporterAvailable = GlbExporter.IsUnityGltfExportAvailable;
+            var isInstalling = SceneSyncUnityGltfInstaller.IsInstalling;
+
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+            {
+                GUILayout.Label("UnityGLTF is optional. Install it to export Animator / Animation clips in GLB.", EditorStyles.wordWrappedLabel);
+                GUILayout.Label("glTFast remains the default lightweight exporter for non-animated objects.", EditorStyles.wordWrappedLabel);
+
+                GUILayout.Space(4);
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUILayout.Label("Exporter: " + (exporterAvailable ? "Available" : "Not available"), EditorStyles.miniLabel);
+                    GUILayout.Label("Define: " + (defineEnabled ? "Enabled" : "Disabled"), EditorStyles.miniLabel);
+                }
+
+                GUILayout.Space(4);
+
+                using (new EditorGUI.DisabledScope(isInstalling))
+                {
+                    if (!exporterAvailable)
+                    {
+                        if (GUILayout.Button("Install UnityGLTF", GUILayout.Height(32)))
+                        {
+                            SceneSyncUnityGltfInstaller.InstallUnityGltf();
+                        }
+                    }
+                    else if (!defineEnabled)
+                    {
+                        if (GUILayout.Button("Enable UnityGLTF Support", GUILayout.Height(32)))
+                        {
+                            SceneSyncUnityGltfInstaller.EnsureUnityGltfDefine();
+                        }
+                    }
+                }
+
+                if (isInstalling)
+                {
+                    EditorGUILayout.HelpBox("Installing UnityGLTF...", MessageType.Info);
+                }
+            }
         }
 
         private static void MarkManagerDirty(SceneSyncManager manager)
@@ -1189,6 +1241,8 @@ namespace Afjk.SceneSync.Editor
                 if (root == null || !seen.Add(root)) continue;
                 if (ShouldSkipPublishObject(root)) continue;
 
+                if (!RecommendUnityGltfForAnimatedObjectIfNeeded(root)) continue;
+
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, root);
                 if (identity == null) continue;
 
@@ -1218,6 +1272,8 @@ namespace Afjk.SceneSync.Editor
                 if (go == null || !seen.Add(go)) continue;
                 if (ShouldSkipPublishObject(go)) continue;
 
+                if (!RecommendUnityGltfForAnimatedObjectIfNeeded(go)) continue;
+
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, go);
                 if (identity == null) continue;
 
@@ -1242,6 +1298,36 @@ namespace Afjk.SceneSync.Editor
             if (identity.Temporary || identity.Origin == SceneSyncOrigin.Remote)
             {
                 Debug.Log("[SceneSync] Skipping temporary object: " + identity.gameObject.name);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool RecommendUnityGltfForAnimatedObjectIfNeeded(GameObject go)
+        {
+            if (go == null) return true;
+            if (GlbExporter.ConfiguredBackend == SceneSyncGlbExportBackend.GltfFast) return true;
+            if (!GlbExporter.ShouldRecommendUnityGltf(go)) return true;
+
+            var result = EditorUtility.DisplayDialogComplex(
+                "Scene Sync: Animation detected",
+                "This GameObject appears to contain animation.\n\n" +
+                "Scene Sync can publish static GLB with glTFast, but animations may not be exported.\n" +
+                "Install UnityGLTF to publish GLB with animation support.",
+                "Install UnityGLTF",
+                "Continue with glTFast",
+                "Cancel"
+            );
+
+            if (result == 0)
+            {
+                SceneSyncUnityGltfInstaller.InstallUnityGltf();
+                return false;
+            }
+
+            if (result == 1)
+            {
                 return true;
             }
 

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -82,6 +82,8 @@ namespace Afjk.SceneSync.Editor
                 _maxGlbUploadMiB = DefaultMaxGlbUploadMiB;
             }
 
+            SceneSyncUnityGltfInstaller.RefreshUnityGltfPackageStatus();
+
             _client = new PresenceClient();
             _client.OnConnected += () =>
             {
@@ -499,6 +501,8 @@ namespace Afjk.SceneSync.Editor
         {
             GUILayout.Label("UnityGLTF", EditorStyles.boldLabel);
 
+            var packageInstalled = SceneSyncUnityGltfInstaller.IsUnityGltfPackageInstalled;
+            var isCheckingPackage = SceneSyncUnityGltfInstaller.IsCheckingPackageStatus;
             var defineEnabled = SceneSyncUnityGltfInstaller.IsUnityGltfDefineEnabled();
             var exporterAvailable = GlbExporter.IsUnityGltfExportAvailable;
             var isInstalling = SceneSyncUnityGltfInstaller.IsInstalling;
@@ -508,37 +512,61 @@ namespace Afjk.SceneSync.Editor
                 GUILayout.Label("UnityGLTF is optional. Install it to export Animator / Animation clips in GLB.", EditorStyles.wordWrappedLabel);
                 GUILayout.Label("glTFast remains the default lightweight exporter for non-animated objects.", EditorStyles.wordWrappedLabel);
 
-                GUILayout.Space(4);
+                GUILayout.Space(8);
 
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    GUILayout.Label("Exporter: " + (exporterAvailable ? "Available" : "Not available"), EditorStyles.miniLabel);
+                    var packageStatus = isCheckingPackage ? "Checking..." : (packageInstalled ? "Installed" : "Not installed");
+                    GUILayout.Label("Package: " + packageStatus, EditorStyles.miniLabel);
                     GUILayout.Label("Define: " + (defineEnabled ? "Enabled" : "Disabled"), EditorStyles.miniLabel);
+                    GUILayout.Label("Exporter: " + (exporterAvailable ? "Available" : "Not available"), EditorStyles.miniLabel);
                 }
 
-                GUILayout.Space(4);
+                GUILayout.Space(8);
 
-                using (new EditorGUI.DisabledScope(isInstalling))
+                using (new EditorGUI.DisabledScope(isInstalling || isCheckingPackage))
                 {
-                    if (!exporterAvailable)
+                    if (!packageInstalled && !isCheckingPackage)
                     {
                         if (GUILayout.Button("Install UnityGLTF", GUILayout.Height(32)))
                         {
                             SceneSyncUnityGltfInstaller.InstallUnityGltf();
                         }
                     }
-                    else if (!defineEnabled)
+                    else if (packageInstalled && !defineEnabled)
                     {
                         if (GUILayout.Button("Enable UnityGLTF Support", GUILayout.Height(32)))
                         {
                             SceneSyncUnityGltfInstaller.EnsureUnityGltfDefine();
                         }
                     }
+                    else if (defineEnabled && !exporterAvailable)
+                    {
+                        EditorGUILayout.HelpBox(
+                            "UnityGLTF support is enabled but exporter not yet registered. " +
+                            "This may require script recompilation or restarting Unity.",
+                            MessageType.Info
+                        );
+                    }
+                    else if (exporterAvailable)
+                    {
+                        EditorGUILayout.HelpBox(
+                            "UnityGLTF is ready. Animated GameObjects will be exported with animations.",
+                            MessageType.Info
+                        );
+                    }
                 }
 
                 if (isInstalling)
                 {
                     EditorGUILayout.HelpBox("Installing UnityGLTF...", MessageType.Info);
+                }
+
+                GUILayout.Space(4);
+
+                if (GUILayout.Button("Refresh UnityGLTF Status", GUILayout.Height(24)))
+                {
+                    SceneSyncUnityGltfInstaller.RefreshUnityGltfPackageStatus();
                 }
             }
         }
@@ -1235,13 +1263,16 @@ namespace Afjk.SceneSync.Editor
             }
 
             var seen = new HashSet<GameObject>();
+            var skipRemainingForAnimation = false;
+
             foreach (var selected in Selection.gameObjects)
             {
                 var root = SceneSyncManager.ResolveSceneSyncRoot(selected);
                 if (root == null || !seen.Add(root)) continue;
                 if (ShouldSkipPublishObject(root)) continue;
 
-                if (!RecommendUnityGltfForAnimatedObjectIfNeeded(root)) continue;
+                var animationCheckResult = CheckAnimationRecommendation(root, ref skipRemainingForAnimation);
+                if (!animationCheckResult) continue;
 
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, root);
                 if (identity == null) continue;
@@ -1267,12 +1298,15 @@ namespace Afjk.SceneSync.Editor
             }
 
             var seen = new HashSet<GameObject>();
+            var skipRemainingForAnimation = false;
+
             foreach (var go in manager.GetManagedUnityObjects())
             {
                 if (go == null || !seen.Add(go)) continue;
                 if (ShouldSkipPublishObject(go)) continue;
 
-                if (!RecommendUnityGltfForAnimatedObjectIfNeeded(go)) continue;
+                var animationCheckResult = CheckAnimationRecommendation(go, ref skipRemainingForAnimation);
+                if (!animationCheckResult) continue;
 
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, go);
                 if (identity == null) continue;
@@ -1304,11 +1338,16 @@ namespace Afjk.SceneSync.Editor
             return false;
         }
 
-        private bool RecommendUnityGltfForAnimatedObjectIfNeeded(GameObject go)
+        private bool CheckAnimationRecommendation(GameObject go, ref bool skipRemaining)
         {
             if (go == null) return true;
             if (GlbExporter.ConfiguredBackend == SceneSyncGlbExportBackend.GltfFast) return true;
             if (!GlbExporter.ShouldRecommendUnityGltf(go)) return true;
+
+            if (skipRemaining)
+            {
+                return true;
+            }
 
             var result = EditorUtility.DisplayDialogComplex(
                 "Scene Sync: Animation detected",
@@ -1328,6 +1367,7 @@ namespace Afjk.SceneSync.Editor
 
             if (result == 1)
             {
+                skipRemaining = true;
                 return true;
             }
 

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1272,7 +1272,7 @@ namespace Afjk.SceneSync.Editor
                 if (ShouldSkipPublishObject(root)) continue;
 
                 var animationCheckResult = CheckAnimationRecommendation(root, ref skipRemainingForAnimation);
-                if (!animationCheckResult) continue;
+                if (!animationCheckResult) return;
 
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, root);
                 if (identity == null) continue;
@@ -1306,7 +1306,7 @@ namespace Afjk.SceneSync.Editor
                 if (ShouldSkipPublishObject(go)) continue;
 
                 var animationCheckResult = CheckAnimationRecommendation(go, ref skipRemainingForAnimation);
-                if (!animationCheckResult) continue;
+                if (!animationCheckResult) return;
 
                 var identity = EnsureUniqueManagedUnityIdentityForPublish(manager, go);
                 if (identity == null) continue;

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -20,6 +20,13 @@ namespace Afjk.SceneSync
 
 #if UNITY_EDITOR
         public static Func<GameObject, byte[]> UnityGltfExportHandler { get; set; }
+
+        public static bool IsUnityGltfExportAvailable => UnityGltfExportHandler != null;
+
+        public static bool ShouldRecommendUnityGltf(GameObject root)
+        {
+            return HasExportableAnimation(root) && UnityGltfExportHandler == null;
+        }
 #endif
 
         public static async Task<byte[]> ExportGameObjectAsGlb(GameObject go)
@@ -113,7 +120,7 @@ namespace Afjk.SceneSync
             return SceneSyncGlbExportBackend.GltfFast;
         }
 
-        private static bool HasExportableAnimation(GameObject root)
+        public static bool HasExportableAnimation(GameObject root)
         {
             if (!root) return false;
 


### PR DESCRIPTION
- Create SceneSyncUnityGltfInstaller to manage UnityGLTF package installation
  and SCENESYNC_USE_UNITYGLTF define management
- Add IsUnityGltfExportAvailable and ShouldRecommendUnityGltf properties to GlbExporter
- Make HasExportableAnimation public for Window to check animation presence
- Add UnityGLTF status display in Export Settings section with Install/Enable buttons
- Show recommendation dialog when publishing animated objects without UnityGLTF
  - Users can choose to install UnityGLTF, continue with glTFast, or cancel
- Update export backend help text to better explain each option

https://claude.ai/code/session_01Dw5yuyNH4qSv1CGxUHbbJA