### PR TITLE
Add mobile Help button to Scene Sync welcome dialog

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7267,6 +7267,7 @@ const mobileEnvOpenBtn = document.getElementById('mobile-env-open-btn');
 const mobileEnvSheetCloseBtn = document.getElementById('mobile-env-sheet-close');
 const mobileEnvSelect = document.getElementById('mobile-env-select');
 const mobileLinkOpenBtn = document.getElementById('mobile-link-open-btn');
+const mobileHelpBtn = document.getElementById('mobile-help-btn');
 const mobileDevOpenBtn = document.getElementById('mobile-dev-open-btn');
 
 function closePasteSheet() {
@@ -7314,6 +7315,10 @@ mobileEnvSheetCloseBtn?.addEventListener('click', () => {
 mobileLinkOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
   linkBtn?.click();
+});
+mobileHelpBtn?.addEventListener('click', () => {
+  closeMobileActionSheet();
+  openHelpDialog();
 });
 mobileDevOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1207,6 +1207,7 @@
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>
         <button id="mobile-link-open-btn" class="chip" type="button">AIにリンク</button>
+        <button id="mobile-help-btn" class="chip" type="button">ヘルプ</button>
         <button id="mobile-dev-open-btn" class="chip" type="button" hidden>Dev</button>
         <a class="chip" href="/scenesync/privacy/">プライバシーポリシー</a>
       </div>


### PR DESCRIPTION
- Add ヘルプ button to mobile action sheet
- Wire button to openHelpDialog() to reuse desktop Help logic
- Mobile action sheet closes when Help is opened
- Display name is prefilled from localStorage
- Help mode does not reset first-run state or change rooms

https://claude.ai/code/session_01AH4jUaubcdovxXm5uCBaCL