### PR TITLE
Fix iOS Safari Welcome dialog zoom and update display name placeholder

### DIFF
--- a/html/assets/js/scenesync/ui/welcome-dialog.js
+++ b/html/assets/js/scenesync/ui/welcome-dialog.js
@@ -8,6 +8,10 @@ function validateDisplayName(name) {
   return { valid: true, normalized };
 }
 
+function shouldAutoFocusInput() {
+  return !window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+}
+
 export class WelcomeDialog {
   constructor({ onStartInRoom, onCreateNewRoom }) {
     this.onStartInRoom = onStartInRoom;
@@ -39,7 +43,7 @@ export class WelcomeDialog {
         <div class="welcome-form">
           <label class="form-group">
             <div class="form-label">表示名</div>
-            <input type="text" id="welcome-display-name" class="form-input" placeholder="例: Akihiro / MacBook / Unity Editor" maxlength="32">
+            <input type="text" id="welcome-display-name" class="form-input" placeholder="例: sync-san" maxlength="32">
             <div id="welcome-error" class="form-error" style="display: none;"></div>
           </label>
         </div>
@@ -77,7 +81,9 @@ export class WelcomeDialog {
     }
 
     this.inputEl.value = normalizeDisplayName(savedDisplayName);
-    this.inputEl.focus();
+    if (shouldAutoFocusInput()) {
+      this.inputEl.focus();
+    }
     this.clearError();
 
     if (mode === 'help') {
@@ -92,6 +98,9 @@ export class WelcomeDialog {
   }
 
   close() {
+    if (this.inputEl && document.activeElement === this.inputEl) {
+      this.inputEl.blur();
+    }
     if (this.el) {
       this.el.style.display = 'none';
     }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -868,7 +868,7 @@
       border-radius: 6px;
       background: rgba(0, 0, 0, 0.4);
       color: #fff;
-      font: 13px/1.4 monospace;
+      font: 16px/1.4 monospace;
       outline: none;
     }
     .form-input:focus {


### PR DESCRIPTION
- Increase form-input font-size to 16px to prevent iOS Safari auto-zoom
- Guard autofocus with shouldAutoFocusInput() to prevent keyboard opening on touch devices
- Add blur logic to close() method to clear focus when dialog closes
- Update display name placeholder from 'Akihiro / MacBook / Unity Editor' to 'sync-san'

https://claude.ai/code/session_01QNrT1UPgHk5ranXEsmiMef