### PR TITLE
Show room name in Welcome dialog primary button

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -9038,7 +9038,10 @@ function shouldShowWelcome() {
 function initializeWelcome() {
   if (shouldShowWelcome()) {
     const savedDisplayName = localStorage.getItem('sceneSync.displayName') || '';
-    welcomeDialog.open('first-run', savedDisplayName);
+    const explicitRoomCode = sanitizeRoomCode(new URLSearchParams(location.search).get('room'));
+    welcomeDialog.open('first-run', savedDisplayName, {
+      roomCode: explicitRoomCode || '',
+    });
   }
 }
 

--- a/html/assets/js/scenesync/ui/welcome-dialog.js
+++ b/html/assets/js/scenesync/ui/welcome-dialog.js
@@ -12,6 +12,12 @@ function shouldAutoFocusInput() {
   return !window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 }
 
+function formatRoomLabel(roomCode) {
+  const value = String(roomCode || '').trim();
+  if (!value) return '';
+  return value.length > 16 ? `${value.slice(0, 16)}…` : value;
+}
+
 export class WelcomeDialog {
   constructor({ onStartInRoom, onCreateNewRoom }) {
     this.onStartInRoom = onStartInRoom;
@@ -20,6 +26,8 @@ export class WelcomeDialog {
     this.el = null;
     this.inputEl = null;
     this.errorEl = null;
+    this.startButtonEl = null;
+    this.roomCode = '';
   }
 
   createDialogElement() {
@@ -59,8 +67,9 @@ export class WelcomeDialog {
     return dialog;
   }
 
-  open(mode = 'first-run', savedDisplayName = '') {
+  open(mode = 'first-run', savedDisplayName = '', options = {}) {
     this.mode = mode;
+    this.roomCode = options.roomCode || '';
 
     if (!this.el) {
       this.el = this.createDialogElement();
@@ -68,8 +77,9 @@ export class WelcomeDialog {
 
       this.inputEl = this.el.querySelector('#welcome-display-name');
       this.errorEl = this.el.querySelector('#welcome-error');
+      this.startButtonEl = this.el.querySelector('#welcome-start-room');
 
-      this.el.querySelector('#welcome-start-room').addEventListener('click', () => this.handleStartRoom());
+      this.startButtonEl.addEventListener('click', () => this.handleStartRoom());
       this.el.querySelector('#welcome-new-room').addEventListener('click', () => this.handleNewRoom());
       this.el.querySelector('#welcome-close').addEventListener('click', () => this.close());
 
@@ -85,6 +95,7 @@ export class WelcomeDialog {
       this.inputEl.focus();
     }
     this.clearError();
+    this.updateStartButtonLabel();
 
     if (mode === 'help') {
       this.el.querySelector('#welcome-close').style.display = 'block';
@@ -95,6 +106,13 @@ export class WelcomeDialog {
     }
 
     this.el.style.display = 'flex';
+  }
+
+  updateStartButtonLabel() {
+    const roomLabel = formatRoomLabel(this.roomCode);
+    this.startButtonEl.textContent = roomLabel
+      ? `このルーム（${roomLabel}）に入る`
+      : 'このルームで始める';
   }
 
   close() {

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -895,6 +895,8 @@
       font: 13px/1.4 monospace;
       cursor: pointer;
       transition: background 0.2s;
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
     .welcome-btn:hover {
       background: rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
Update the Welcome dialog to display the current room name when a user joins from
a shared room URL (e.g., /scenesync/?room=my-room).

Changes:
- Pass explicit room code from URL to Welcome dialog
- Add formatRoomLabel() helper to truncate long room names (>16 chars) for display
- Update primary button label to show room name: 'このルーム（room-name）に入る'
- Keep default label when no explicit room: 'このルームで始める'
- Add CSS to allow button text wrapping on mobile devices

This helps first-time users clearly understand which room they are joining from
a shared URL, while keeping inferred LAN room names hidden.

https://claude.ai/code/session_01LHce9Bi5sA1UUGVBM1ZSAo