### PR TITLE
Fix mobile input focus and iOS zoom prevention for Scene Sync

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -22,6 +22,7 @@ import { dispatchUrlImport } from './loaders/url-importers/index.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { createWelcomeDialog } from './ui/welcome-dialog.js';
+import { focusTextInputIfSafe, blurActiveEditableElement } from './ui/input-focus-guard.js';
 import { normalizeDisplayName } from './utils/display-name.js';
 import { extractYaw } from './utils/math.js';
 import { broadcastObjectDelta } from './objects/object-delta.js';
@@ -7196,6 +7197,7 @@ function openSheet(id) {
 }
 
 function closeSheet(id) {
+  blurActiveEditableElement();
   const el = document.getElementById(id);
   if (!el) return;
   el.hidden = true;
@@ -7274,6 +7276,7 @@ const mobileHelpBtn = document.getElementById('mobile-help-btn');
 const mobileDevOpenBtn = document.getElementById('mobile-dev-open-btn');
 
 function closePasteSheet() {
+  blurActiveEditableElement();
   if (pasteSheet) {
     pasteSheet.setAttribute('hidden', '');
   }
@@ -8113,11 +8116,14 @@ function enterSceneInspectorEditMode() {
   sceneInspectorState.diffSummary = null;
   sceneInspectorState.lastAppliedSummary = null;
   renderSceneInspector(snapshot);
-  sceneInspectorEditorEl?.focus();
-  sceneInspectorEditorEl?.setSelectionRange(0, 0);
+  const focused = focusTextInputIfSafe(sceneInspectorEditorEl);
+  if (focused) {
+    sceneInspectorEditorEl?.setSelectionRange(0, 0);
+  }
 }
 
 function exitSceneInspectorEditMode() {
+  blurActiveEditableElement();
   sceneInspectorState.isEditing = false;
   sceneInspectorState.baseSnapshot = null;
   sceneInspectorState.parsedSnapshot = null;
@@ -8150,11 +8156,14 @@ function enterSceneInspectorObjectEditMode() {
     lastAppliedSummary: null,
   };
   renderSceneInspector(snapshot);
-  sceneInspectorObjectEditorEl?.focus();
-  sceneInspectorObjectEditorEl?.setSelectionRange(0, 0);
+  const focused = focusTextInputIfSafe(sceneInspectorObjectEditorEl);
+  if (focused) {
+    sceneInspectorObjectEditorEl?.setSelectionRange(0, 0);
+  }
 }
 
 function exitSceneInspectorObjectEditMode() {
+  blurActiveEditableElement();
   resetSceneInspectorObjectEditor();
   refreshSceneInspector();
 }

--- a/html/assets/js/scenesync/ui/input-focus-guard.js
+++ b/html/assets/js/scenesync/ui/input-focus-guard.js
@@ -1,0 +1,33 @@
+export function isTouchLikeDevice() {
+  return window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+}
+
+export function shouldAvoidProgrammaticTextFocus() {
+  return isTouchLikeDevice();
+}
+
+export function focusTextInputIfSafe(element, options = {}) {
+  if (!element || typeof element.focus !== 'function') return false;
+
+  const allowOnTouch = options.allowOnTouch === true;
+  if (!allowOnTouch && shouldAvoidProgrammaticTextFocus()) {
+    return false;
+  }
+
+  element.focus(options.focusOptions || {});
+  return document.activeElement === element;
+}
+
+export function isEditableElement(element) {
+  if (!(element instanceof Element)) return false;
+  return Boolean(element.closest('input, textarea, select, [contenteditable="true"], .cm-editor, .monaco-editor'));
+}
+
+export function blurActiveEditableElement() {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && isEditableElement(active)) {
+    active.blur();
+    return true;
+  }
+  return false;
+}

--- a/html/assets/js/scenesync/ui/welcome-dialog.js
+++ b/html/assets/js/scenesync/ui/welcome-dialog.js
@@ -1,4 +1,5 @@
 import { normalizeDisplayName } from '../utils/display-name.js';
+import { focusTextInputIfSafe, blurActiveEditableElement } from './input-focus-guard.js';
 
 function validateDisplayName(name) {
   const normalized = normalizeDisplayName(name);
@@ -6,10 +7,6 @@ function validateDisplayName(name) {
     return { valid: false, message: '表示名を入力してください。', normalized };
   }
   return { valid: true, normalized };
-}
-
-function shouldAutoFocusInput() {
-  return !window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 }
 
 function formatRoomLabel(roomCode) {
@@ -91,9 +88,7 @@ export class WelcomeDialog {
     }
 
     this.inputEl.value = normalizeDisplayName(savedDisplayName);
-    if (shouldAutoFocusInput()) {
-      this.inputEl.focus();
-    }
+    focusTextInputIfSafe(this.inputEl);
     this.clearError();
     this.updateStartButtonLabel();
 
@@ -116,9 +111,7 @@ export class WelcomeDialog {
   }
 
   close() {
-    if (this.inputEl && document.activeElement === this.inputEl) {
-      this.inputEl.blur();
-    }
+    blurActiveEditableElement();
     if (this.el) {
       this.el.style.display = 'none';
     }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1022,6 +1022,17 @@
         bottom: calc(84px + var(--mobile-safe-bottom));
         z-index: 65;
       }
+
+      /* iOS Safari zoom prevention: 16px font-size prevents auto-zoom on focus */
+      .room-input,
+      .form-input,
+      .scene-inspector-editor,
+      .scene-inspector-number-input,
+      #clipboard-paste-target,
+      #mobile-env-select,
+      #env-select {
+        font-size: 16px !important;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
Implement automatic focus guard and blur management:
- Create input-focus-guard.js utility for safe text input focusing on touch devices
- Replace direct focus() calls with focusTextInputIfSafe() to avoid unwanted keyboard on mobile
- Add blurActiveEditableElement() calls when closing dialogs/sheets to prevent hanging keyboards

iOS Safari auto-zoom fix:
- Set font-size: 16px for input elements on touch devices (prevents auto-zoom on focus)
- Apply to .room-input, .form-input, scene inspector editors, and clipboard UI

Changes:
- Added html/assets/js/scenesync/ui/input-focus-guard.js with touch device detection
- Updated welcome-dialog.js to use focus guard utilities
- Updated scene.js inspector edit/object edit modes and sheet close handlers
- Updated index.html mobile CSS with 16px font-size rule for input elements

Completion criteria met:
✓ Mobile dialogs don't auto-show keyboard on open
✓ iOS Safari doesn't auto-zoom on input focus
✓ PC experience unchanged (auto-focus still works when appropriate)
✓ All direct focus() calls properly managed
✓ All tests passing

https://claude.ai/code/session_01BvpzJn5cFzhHfk5LXhLAZj