### PR TITLE
Add diagnostic switches for large GLB crash isolation

### DIFF
--- a/html/assets/js/scenesync/assets/asset-cache.js
+++ b/html/assets/js/scenesync/assets/asset-cache.js
@@ -1,3 +1,6 @@
+import { markCrashProbe } from '../utils/crash-probe-helper.js';
+import { isAssetCacheReadDisabled, isAssetCacheWriteDisabled } from '../utils/diagnostic-flags.js';
+
 const DB_NAME = 'scene-sync-assets';
 const STORE_NAME = 'assets';
 const DEFAULT_MAX_GLB_SIZE = 500 * 1024 * 1024;
@@ -30,9 +33,21 @@ export function createSceneAssetCache(options = {}) {
   }
 
   async function putAsset({ assetId, meshPath, blob, source = 'recovered' }) {
+    if (isAssetCacheWriteDisabled()) {
+      console.warn('[SceneSync] asset cache write disabled by query');
+      return;
+    }
+
     if (!assetId || !blob) {
       throw new Error('putAsset requires assetId and blob');
     }
+
+    markCrashProbe('asset-cache-put-start', {
+      assetId,
+      meshPath,
+      size: blob?.size,
+      source,
+    });
 
     if (blob.size > DEFAULT_MAX_GLB_SIZE) {
       console.warn(`[AssetCache] GLB too large (${blob.size} bytes), skipping cache`);
@@ -64,11 +79,13 @@ export function createSceneAssetCache(options = {}) {
 
       req.onsuccess = () => {
         console.log(`[AssetCache] Stored asset ${assetId} (${blob.size} bytes)`);
+        markCrashProbe('asset-cache-put-success', { assetId, size: blob.size });
         resolve();
       };
 
       req.onerror = () => {
         console.warn('[AssetCache] Failed to store asset:', req.error);
+        markCrashProbe('asset-cache-put-error', { assetId, message: req.error?.message });
         reject(req.error);
       };
     });
@@ -76,6 +93,13 @@ export function createSceneAssetCache(options = {}) {
 
   async function getByAssetId(assetId) {
     if (!assetId) return null;
+
+    if (isAssetCacheReadDisabled()) {
+      console.warn('[SceneSync] asset cache read disabled by query');
+      return null;
+    }
+
+    markCrashProbe('asset-cache-get-start', { assetId });
 
     await initDb();
 
@@ -90,6 +114,10 @@ export function createSceneAssetCache(options = {}) {
           record.lastUsedAt = Date.now();
           const txWrite = db.transaction([STORE_NAME], 'readwrite');
           txWrite.objectStore(STORE_NAME).put(record);
+          markCrashProbe('asset-cache-get-success', {
+            assetId,
+            size: record?.size || record?.blob?.size || null,
+          });
         }
         resolve(record || null);
       };
@@ -103,6 +131,13 @@ export function createSceneAssetCache(options = {}) {
 
   async function getByMeshPath(meshPath) {
     if (!meshPath) return null;
+
+    if (isAssetCacheReadDisabled()) {
+      console.warn('[SceneSync] asset cache read disabled by query');
+      return null;
+    }
+
+    markCrashProbe('asset-cache-get-start', { meshPath });
 
     await initDb();
 
@@ -118,6 +153,10 @@ export function createSceneAssetCache(options = {}) {
           record.lastUsedAt = Date.now();
           const txWrite = db.transaction([STORE_NAME], 'readwrite');
           txWrite.objectStore(STORE_NAME).put(record);
+          markCrashProbe('asset-cache-get-success', {
+            meshPath,
+            size: record?.size || record?.blob?.size || null,
+          });
         }
         resolve(record || null);
       };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -39,6 +39,8 @@ import { createSceneAssetCache } from './assets/asset-cache.js';
 import { createSceneSyncFileTransferAdapter } from './assets/file-transfer-adapter.js';
 import { createExpiredGlbRecovery } from './assets/expired-glb-recovery.js';
 import { createRoomSnapshotCache } from './assets/scene-snapshot-cache.js';
+import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './utils/crash-probe-helper.js';
+import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
 
@@ -5687,6 +5689,23 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
     visualBasis: info.asset?.visualBasis,
   });
 
+  if (isGlbLoadDisabled()) {
+    console.warn('[SceneSync] GLB load disabled by ?noGlbLoad=1, creating diagnostic placeholder');
+    removeLoadingOverlay(objectId);
+    const placeholder = buildGlbDiagnosticPlaceholder(objectId, info);
+    applySceneTransform(placeholder, info);
+    if (existing) {
+      placeholder.position.copy(existing.position);
+      placeholder.quaternion.copy(existing.quaternion);
+      placeholder.scale.copy(existing.scale);
+      if (transformCtrl.object === existing) transformCtrl.detach();
+      scene.remove(existing);
+    }
+    scene.add(placeholder);
+    replaceManagedObject(objectId, placeholder, info);
+    return;
+  }
+
   (async () => {
     try {
       const incomingAssetId = info.asset?.assetId || info.assetId || null;
@@ -5768,8 +5787,21 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
       const objectUrl = URL.createObjectURL(blob);
       let loadCompleted = false;
 
+      markCrashProbe('glb-load-start', {
+        objectId,
+        meshPath,
+        sizeBytes: blob.size,
+        source: 'network',
+      });
+
       glbLoader.loadFromUrl(objectUrl, initialPosition, scene, async (model) => {
         try {
+          markCrashProbe('glb-load-success', {
+            objectId,
+            meshPath,
+          });
+          markCrashProbe('glb-scene-attach-start', { objectId });
+
           removeLoadingOverlay(objectId);
           removeFailedOverlay(objectId);
           model.userData.objectId = objectId;
@@ -5834,6 +5866,9 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
           } catch (cacheErr) {
             console.warn('[SceneSync] Failed to cache mesh:', cacheErr);
           }
+
+          markCrashProbe('glb-scene-attach-success', { objectId });
+          clearCrashProbe('glb-object-ready');
         } finally {
           loadCompleted = true;
           URL.revokeObjectURL(objectUrl);
@@ -6106,6 +6141,22 @@ function buildDefaultBoxObject(objectId, info, color = 0x4488ff) {
   object.userData.objectId = objectId;
   applyObjectName(object, info.name);
   return object;
+}
+
+function buildGlbDiagnosticPlaceholder(objectId, info) {
+  const geometry = new THREE.BoxGeometry(1, 1, 1);
+  const material = new THREE.MeshStandardMaterial({ color: 0xffaa00 });
+  const placeholder = new THREE.Mesh(geometry, material);
+  placeholder.userData.objectId = objectId;
+  placeholder.userData.name = info.name || objectId;
+  placeholder.userData.asset = cloneJsonSafe(info.asset || null);
+  placeholder.userData.meshPath = info.meshPath || info.asset?.meshPath || null;
+  placeholder.userData.metadata = {
+    ...(cloneJsonSafe(info.metadata || null) || {}),
+    glbLoadSkippedForDiagnostic: true,
+  };
+  applyObjectName(placeholder, info.name);
+  return placeholder;
 }
 
 function buildPrimitiveObject(objectId, info, asset) {
@@ -6442,7 +6493,19 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
 
   const url = URL.createObjectURL(blob);
   try {
+    markCrashProbe('glb-load-start', {
+      objectId,
+      meshPath: options.meshPath,
+      sizeBytes: blob.size,
+      source: 'cache',
+    });
+
     const gltf = await new GLTFLoader().loadAsync(url);
+    markCrashProbe('glb-load-success', {
+      objectId,
+      meshPath: options.meshPath,
+    });
+    markCrashProbe('glb-scene-attach-start', { objectId });
 
     // Apply visual-only correction for Unity-authored GLBs
     const asset = obj?.userData?.asset || info?.asset || null;
@@ -6531,6 +6594,8 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
     scene.add(wrapper);
     registerLoadedGlbAnimation(objectId, wrapper, 'glb-blob-loaded');
     notifySceneStateChanged('glb-blob-loaded');
+    markCrashProbe('glb-scene-attach-success', { objectId });
+    clearCrashProbe('glb-object-ready');
   } finally {
     URL.revokeObjectURL(url);
   }
@@ -8580,6 +8645,11 @@ async function maybeRestoreRoomSnapshot(reason = 'unknown') {
   const roomId = getCurrentRoomId();
   if (!roomId) return;
 
+  if (isSnapshotRestoreDisabled()) {
+    console.warn('[SceneSync] room snapshot restore disabled by ?noRestore=1');
+    return;
+  }
+
   if (hasSnapshotRestorableObjects()) {
     console.debug('[scene-snapshot] skip restore: scene already has objects', {
       roomId,
@@ -9060,6 +9130,9 @@ function openHelpDialog() {
 }
 
 // ── 起動 ─────────────────────────────────────────────────
+
+reportPreviousCrashProbe();
+logDiagnosticFlags();
 
 nicknameChip?.addEventListener('click', editNickname);
 document.getElementById('help-btn')?.addEventListener('click', openHelpDialog);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5690,7 +5690,7 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
   });
 
   if (isGlbLoadDisabled()) {
-    console.warn('[SceneSync] GLB load disabled by ?noGlbLoad=1, creating diagnostic placeholder');
+    console.warn('[SceneSync] GLB load disabled by diagnostic flag, creating diagnostic placeholder');
     removeLoadingOverlay(objectId);
     const placeholder = buildGlbDiagnosticPlaceholder(objectId, info);
     applySceneTransform(placeholder, info);
@@ -6488,6 +6488,21 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
   const info = options.info || null;
   if (!obj && !info) {
     console.warn('[SceneSync] Object not found for loading recovered GLB:', objectId);
+    return;
+  }
+
+  if (isGlbLoadDisabled()) {
+    console.warn('[SceneSync] GLB blob load disabled by diagnostic flag, keeping placeholder', {
+      objectId,
+      meshPath: options.meshPath,
+      sizeBytes: blob?.size || null,
+    });
+    if (info && !obj) {
+      const placeholder = buildGlbDiagnosticPlaceholder(objectId, info);
+      applySceneTransform(placeholder, info);
+      scene.add(placeholder);
+      replaceManagedObject(objectId, placeholder, info);
+    }
     return;
   }
 

--- a/html/assets/js/scenesync/utils/crash-probe-helper.js
+++ b/html/assets/js/scenesync/utils/crash-probe-helper.js
@@ -1,0 +1,44 @@
+const CRASH_PROBE_KEY = 'sceneSync.crashProbe';
+
+export function isCrashProbeEnabled() {
+  return new URLSearchParams(location.search).get('probe') === '1';
+}
+
+export function markCrashProbe(phase, details = {}) {
+  if (!isCrashProbeEnabled()) return;
+  try {
+    localStorage.setItem(CRASH_PROBE_KEY, JSON.stringify({
+      phase,
+      details,
+      at: Date.now(),
+      href: location.href,
+    }));
+    console.warn('[SceneSync crash-probe]', phase, details);
+  } catch (error) {
+    console.warn('[SceneSync crash-probe] failed to write', error);
+  }
+}
+
+export function clearCrashProbe(phase = 'complete') {
+  if (!isCrashProbeEnabled()) return;
+  try {
+    localStorage.setItem(CRASH_PROBE_KEY, JSON.stringify({
+      phase,
+      completed: true,
+      at: Date.now(),
+      href: location.href,
+    }));
+  } catch {}
+}
+
+export function reportPreviousCrashProbe() {
+  if (!isCrashProbeEnabled()) return;
+  try {
+    const raw = localStorage.getItem(CRASH_PROBE_KEY);
+    if (!raw) return;
+    const value = JSON.parse(raw);
+    if (!value?.completed) {
+      console.warn('[SceneSync crash-probe] previous session may have crashed near:', value);
+    }
+  } catch {}
+}

--- a/html/assets/js/scenesync/utils/diagnostic-flags.js
+++ b/html/assets/js/scenesync/utils/diagnostic-flags.js
@@ -1,5 +1,10 @@
+export function isSafeModeEnabled() {
+  return new URLSearchParams(location.search).get('safe') === '1';
+}
+
 export function isSnapshotRestoreDisabled() {
-  return new URLSearchParams(location.search).get('noRestore') === '1';
+  const params = new URLSearchParams(location.search);
+  return isSafeModeEnabled() || params.get('noRestore') === '1';
 }
 
 export function isAssetCacheReadDisabled() {
@@ -13,17 +18,19 @@ export function isAssetCacheWriteDisabled() {
 }
 
 export function isGlbLoadDisabled() {
-  return new URLSearchParams(location.search).get('noGlbLoad') === '1';
+  const params = new URLSearchParams(location.search);
+  return isSafeModeEnabled() || params.get('noGlbLoad') === '1';
 }
 
 export function logDiagnosticFlags() {
   const params = new URLSearchParams(location.search);
   const flags = {
-    noRestore: params.get('noRestore') === '1',
+    safe: isSafeModeEnabled(),
+    noRestore: isSnapshotRestoreDisabled(),
     noAssetCache: params.get('noAssetCache') === '1',
     noAssetCacheRead: params.get('noAssetCacheRead') === '1',
     noAssetCacheWrite: params.get('noAssetCacheWrite') === '1',
-    noGlbLoad: params.get('noGlbLoad') === '1',
+    noGlbLoad: isGlbLoadDisabled(),
     probe: params.get('probe') === '1',
   };
 

--- a/html/assets/js/scenesync/utils/diagnostic-flags.js
+++ b/html/assets/js/scenesync/utils/diagnostic-flags.js
@@ -1,0 +1,39 @@
+export function isSnapshotRestoreDisabled() {
+  return new URLSearchParams(location.search).get('noRestore') === '1';
+}
+
+export function isAssetCacheReadDisabled() {
+  const params = new URLSearchParams(location.search);
+  return params.get('noAssetCache') === '1' || params.get('noAssetCacheRead') === '1';
+}
+
+export function isAssetCacheWriteDisabled() {
+  const params = new URLSearchParams(location.search);
+  return params.get('noAssetCache') === '1' || params.get('noAssetCacheWrite') === '1';
+}
+
+export function isGlbLoadDisabled() {
+  return new URLSearchParams(location.search).get('noGlbLoad') === '1';
+}
+
+export function logDiagnosticFlags() {
+  const params = new URLSearchParams(location.search);
+  const flags = {
+    noRestore: params.get('noRestore') === '1',
+    noAssetCache: params.get('noAssetCache') === '1',
+    noAssetCacheRead: params.get('noAssetCacheRead') === '1',
+    noAssetCacheWrite: params.get('noAssetCacheWrite') === '1',
+    noGlbLoad: params.get('noGlbLoad') === '1',
+    probe: params.get('probe') === '1',
+  };
+
+  const enabledFlags = Object.entries(flags)
+    .filter(([, value]) => value)
+    .map(([key]) => key);
+
+  if (enabledFlags.length > 0) {
+    console.warn('[SceneSync diagnostic] Flags enabled:', enabledFlags);
+  }
+
+  return flags;
+}


### PR DESCRIPTION
- Add crash-probe-helper.js with localStorage-based breadcrumb logging
- Add diagnostic-flags.js with URL parameter checks
- Implement ?noRestore=1 to disable room snapshot auto restore
- Implement ?noAssetCache=1/noAssetCacheRead=1/noAssetCacheWrite=1 flags
- Implement ?noGlbLoad=1 to create lightweight diagnostic placeholder
- Implement ?probe=1 to enable crash breadcrumbs in localStorage
- Add breadcrumbs around risky GLB phases:
  - asset-cache-put-start/success/error
  - asset-cache-get-start/success
  - glb-load-start/success
  - glb-scene-attach-start/success
- Report previous crash probe on startup
- Create buildGlbDiagnosticPlaceholder() for diagnostic mode
- Normal behavior unchanged without diagnostic flags

https://claude.ai/code/session_01ErnUNUhZNTLs5nRZADkv3s