### PR TITLE
Handle room_full error without auto-reconnect

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4249,6 +4249,8 @@ function clearRoom() {
 
 function handleRoomFullError(data) {
   reconnectBlockedReason = 'room_full';
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
   const ws = presenceState.ws;
   presenceState.ws = null;
   if (ws) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4054,6 +4054,7 @@ let sceneReceived = false;
 let sceneRequestTimer = null;
 let sceneRequestAttempt = 0;
 let reconnectTimer = null;
+let reconnectBlockedReason = null;
 let saveRoomSnapshotTimer = null;
 let restoreSnapshotTimer = null;
 let isRestoringRoomSnapshot = false;
@@ -4244,6 +4245,34 @@ function clearRoom() {
   history.replaceState(null, '', u.toString());
   reconnectPresence();
   notifyConnectionStateChanged('room-cleared');
+}
+
+function handleRoomFullError(data) {
+  reconnectBlockedReason = 'room_full';
+  const ws = presenceState.ws;
+  presenceState.ws = null;
+  if (ws) {
+    try { ws.close(); } catch {}
+  }
+  updateStatus(false, 'ルームが満員です');
+  remoteAvatarManager.disposeAllRemoteAvatars();
+  updatePeersList();
+  notifyConnectionStateChanged('presence-closed');
+  showRoomFullDialog();
+}
+
+function showRoomFullDialog() {
+  const dialog = document.getElementById('room-full-dialog');
+  if (dialog) {
+    dialog.style.display = 'flex';
+  }
+}
+
+function hideRoomFullDialog() {
+  const dialog = document.getElementById('room-full-dialog');
+  if (dialog) {
+    dialog.style.display = 'none';
+  }
 }
 
 function copyRoomUrl() {
@@ -4458,6 +4487,10 @@ function connectPresence() {
         handleHandoff(data);
         break;
       case 'error':
+        if (data?.error === 'room_full') {
+          handleRoomFullError(data);
+          return;
+        }
         showToast(data?.message || 'ファイルの読み込みに失敗しました。');
         break;
     }
@@ -4471,6 +4504,12 @@ function connectPresence() {
     remoteAvatarManager.disposeAllRemoteAvatars();
     updatePeersList();
     notifyConnectionStateChanged('presence-closed');
+
+    // room_full の場合は自動再接続をしない
+    if (reconnectBlockedReason === 'room_full') {
+      return;
+    }
+
     clearTimeout(reconnectTimer);
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
@@ -4487,11 +4526,14 @@ function connectPresence() {
   };
 }
 
-function updateStatus(connected) {
+function updateStatus(connected, customMessage) {
   if (connected) {
     const n = presenceState.peers.length;
     dotEl.className = 'dot on';
     statusEl.innerHTML = `<span class="dot on"></span>${escapeHtml(presenceState.nickname)} · ${escapeHtml(presenceState.room || '—')} · ${n} peer${n !== 1 ? 's' : ''}`;
+  } else if (customMessage) {
+    dotEl.className = 'dot off';
+    statusEl.innerHTML = `<span class="dot off"></span>${escapeHtml(customMessage)}`;
   } else {
     dotEl.className = 'dot off';
     statusEl.innerHTML = '<span class="dot off"></span>再接続中…';
@@ -7390,6 +7432,10 @@ const sceneSyncOperatorLink = document.getElementById('scene-sync-operator-link'
 const linkIcon = document.getElementById('link-icon');
 const linkLabel = document.getElementById('link-label');
 
+const roomFullDialog = document.getElementById('room-full-dialog');
+const btnRoomFullRetry = document.getElementById('btn-room-full-retry');
+const btnRoomFullNew = document.getElementById('btn-room-full-new');
+
 let pairingCountdown = null;
 let pairingExpireTime = null;
 
@@ -9058,6 +9104,32 @@ function openHelpDialog() {
   const savedDisplayName = localStorage.getItem('sceneSync.displayName') || '';
   welcomeDialog.open('help', savedDisplayName);
 }
+
+// ── ルーム満員ダイアログ ──────────────────────────────
+
+roomFullDialog?.addEventListener('click', (event) => {
+  if (event.target === roomFullDialog) {
+    // ダイアログの背景をクリックしても何もしない（ユーザーは選択を強要される）
+  }
+});
+
+btnRoomFullRetry?.addEventListener('click', () => {
+  reconnectBlockedReason = null;
+  hideRoomFullDialog();
+  connectPresence();
+});
+
+btnRoomFullNew?.addEventListener('click', () => {
+  reconnectBlockedReason = null;
+  hideRoomFullDialog();
+  generateRoom();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && roomFullDialog?.style.display === 'flex') {
+    // room_full の場合 Escape キーで閉じられない
+  }
+});
 
 // ── 起動 ─────────────────────────────────────────────────
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1103,6 +1103,20 @@
         </div>
       </div>
     </div>
+    <div id="room-full-dialog" class="pairing-dialog" style="display:none;">
+      <div class="pairing-content">
+        <h3>ルームが満員です</h3>
+        <p style="margin: 16px 0; color: #ccc; text-align: center; line-height: 1.6;">
+          このルームは現在混み合っています。<br>
+          <br>
+          少し待つか、新しいルームを作って始めましょう。
+        </p>
+        <div class="pairing-actions">
+          <button id="btn-room-full-retry" class="chip" type="button">もう一度試す</button>
+          <button id="btn-room-full-new" class="chip primary" type="button">新しいルームを作る</button>
+        </div>
+      </div>
+    </div>
     <div class="row mobile-collapsible-row" id="room-section"></div>
     <div class="row meta-link-row mobile-collapsible-row">
       <a class="meta-link" href="/scenesync/privacy/">プライバシーポリシー</a>

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1107,7 +1107,7 @@
       <div class="pairing-content">
         <h3>ルームが満員です</h3>
         <p style="margin: 16px 0; color: #ccc; text-align: center; line-height: 1.6;">
-          このルームは現在混み合っています。<br>
+          このルームは満員です。<br>
           <br>
           少し待つか、新しいルームを作って始めましょう。
         </p>


### PR DESCRIPTION
When the presence server sends error: "room_full", the client now:
- Stops automatic reconnection
- Shows persistent room-full UI with message and action buttons
- Updates status to "ルームが満員です"
- Allows manual retry or room generation

The user-facing message is:
"このルームは満員です。少し待つか、新しいルームを作って始めましょう。"

Actions:
- "もう一度試す" (Retry): manually attempt to reconnect
- "新しいルームを作る" (New Room): generate and switch to a new room

Normal disconnects still auto-reconnect as before.

https://claude.ai/code/session_01UftoWaVdJjsqEFbAYkEC7F