### PR TITLE
Add Scene Sync presence load test script

### DIFF
--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/server.mjs",
     "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs tests/scenesync-guards.test.mjs",
-    "scenesync:cleanup-backups": "node scripts/cleanup-backups.mjs"
+    "scenesync:cleanup-backups": "node scripts/cleanup-backups.mjs",
+    "scenesync:load-test": "node ../../tools/scenesync/load-test-presence.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0"

--- a/docs/scene-sync-load-test.md
+++ b/docs/scene-sync-load-test.md
@@ -1,0 +1,349 @@
+# Scene Sync 負荷テスト
+
+このドキュメントは、Scene Sync の presence server / WebSocket 接続負荷を手動で確認するための手順です。
+
+この負荷テストは **CI では実行しません**。
+リリース前や不安な変更の後に、必要な時だけ手元から実行します。
+
+## テスト対象
+
+- WebSocket connection pool の安定性
+- 複数接続時のメモリ使用量
+- 接続タイムアウトや予期しないクローズ
+- room_full の拒否動作（ルーム容量制限の確認）
+
+## 実行方法
+
+### 前提条件
+
+```bash
+# presence-server のディレクトリ
+cd apps/presence-server
+
+# 必要な依存関係をインストール
+npm install
+```
+
+### 基本的な20接続テスト
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --clients 20 \
+  --duration 60
+```
+
+出力例:
+
+```
+Generated room: load-20260519-203012-k8x4p2
+Browser URL:
+https://staging.afjk.jp/scenesync/?room=load-20260519-203012-k8x4p2
+
+Scene Sync presence load test
+
+endpoint: wss://staging.afjk.jp/presence
+room: load-20260519-203012-k8x4p2
+clients requested: 20
+clients connected: 20
+connect failures: 0
+unexpected closes: 0
+messages received total: 380
+average messages/client: 19
+connect latency avg: 42ms
+connect latency max: 180ms
+duration: 60s
+
+Result: OK
+```
+
+### 50接続での負荷テスト
+
+より大きな負荷を確認する場合：
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --clients 50 \
+  --duration 120
+```
+
+### ローカル環境でのテスト
+
+ローカルの presence server に対して実行:
+
+```bash
+# 別のターミナルで server を起動
+npm start
+
+# テストを実行
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url ws://localhost:8787/presence \
+  --clients 20 \
+  --duration 60
+```
+
+## CLI オプション
+
+```
+--url             (必須) WebSocket endpoint のベース URL
+                  例: wss://staging.afjk.jp/presence
+                  例: ws://localhost:8787/presence
+
+--room            ルーム ID。省略した場合は自動生成
+                  例: load-20260519-203012-k8x4p2
+                  生成形式: load-YYYYMMDD-HHmmss-random6
+
+--clients         シミュレートするクライアント数 (デフォルト: 20)
+                  例: --clients 50
+
+--duration        テスト継続時間（秒） (デフォルト: 60)
+                  例: --duration 120
+
+--ramp-ms         クライアント接続間隔（ミリ秒） (デフォルト: 100)
+                  接続を徐々に増やしたい場合に調整
+                  例: --ramp-ms 50
+
+--send-interval   broadcast テスト時のメッセージ送信間隔（ミリ秒） (デフォルト: 5000)
+                  --broadcast 有効時のみ有効
+                  例: --send-interval 3000
+
+--broadcast       broadcast / mutation テストを有効化
+                  (デフォルト: 無効)
+                  scene-add/remove を定期的に送信
+                  警告: このオプションはルームを変更するため、
+                        自動生成されるテスト用ルームを使用
+                  例: --broadcast
+
+--verbose         クライアント毎の詳細出力
+                  (デフォルト: 無効)
+                  例: --verbose
+
+--help            このヘルプを表示
+```
+
+## ルーム名の指定
+
+### 自動生成（推奨）
+
+ルーム名を指定しない場合、以下の形式で自動生成されます:
+
+```
+load-YYYYMMDD-HHmmss-<random6>
+```
+
+例:
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence
+```
+
+生成されたルーム名が出力されます：
+
+```
+Generated room: load-20260519-203012-k8x4p2
+```
+
+### カスタムルーム名の指定
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --room my-load-test-20260519
+```
+
+### Generic ルーム名は避ける
+
+以下のような generic な名前を使用すると、警告が表示されます：
+
+```
+test, demo, room, default, safe-test, load-test, mcp-test
+```
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --room test
+```
+
+出力:
+
+```
+Warning: room name "test" is generic and may collide with real users.
+Use a unique room name for release/load testing.
+```
+
+実ユーザーや他の検証と衝突する可能性があるため、
+自動生成されるルーム名を使用することを推奨します。
+
+## 本番環境での実行
+
+本番環境で実行する場合は、短時間・少数接続から始めます。
+
+### 20接続のみ確認
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://afjk.jp/presence \
+  --clients 20 \
+  --duration 60
+```
+
+### 本番での注意点
+
+- 業務時間外に実行
+- 小規模な接続数から開始
+- 接続終了後、ルームが正常に削除されたことを確認
+- CPU / メモリ使用量を監視
+
+## ConoHa でのログ確認
+
+### WebSocket 接続情報の確認
+
+```bash
+sudo grep '"event":"ws_connection"' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | grep "load-"
+```
+
+### Connection Summary の確認
+
+```bash
+sudo grep '"event":"ws_connection_summary"' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | tail -20
+```
+
+### Room Full 拒否の確認
+
+```bash
+sudo grep '"event":"ws_room_full_reject"' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | tail -20
+```
+
+### Heartbeat Terminate の確認
+
+```bash
+sudo grep '"event":"ws_heartbeat_terminate"' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | tail -20
+```
+
+### 全イベント検索
+
+```bash
+sudo grep '"room":"load-' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | jq '.event' | sort | uniq -c
+```
+
+## 合格目安
+
+### 20接続 / 60秒
+
+✅ 合格基準:
+
+- 全クライアントが正常に接続できる
+- `connect failures: 0`
+- `unexpected closes: 0`
+- `room_full rejections: 0`
+- presence server がクラッシュしない
+- CPU / メモリが増え続けない
+
+### 50接続 / 120秒
+
+✅ 合格基準:
+
+- サーバーが稼働し続ける
+- 急激な close / heartbeat terminate がない
+- 接続終了後に connection summary が出力される
+- メモリリークの兆候がない
+
+## トラブルシューティング
+
+### connect failures が多い場合
+
+- ネットワーク接続の確認
+- WebSocket エンドポイントの接続性確認
+- サーバーのポート制限確認
+- ファイアウォール設定確認
+
+```bash
+# 接続テスト
+curl -i -N -H "Connection: Upgrade" \
+  -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Version: 13" \
+  -H "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" \
+  "wss://staging.afjk.jp/presence?room=test"
+```
+
+### unexpected closes が発生する場合
+
+- テスト中の server ログを確認
+- CPU / メモリが枯渇していないか確認
+- コネクション数の上限に達していないか確認
+- 接続タイムアウト設定の確認
+
+### latency が高い場合
+
+- ネットワーク遅延の確認
+- サーバーの負荷状況確認
+- --ramp-ms を大きくして接続を緩やかに
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --clients 20 \
+  --duration 60 \
+  --ramp-ms 200
+```
+
+## Broadcast テスト
+
+`--broadcast` オプションを使用すると、定期的に scene mutation を送信します。
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --clients 20 \
+  --duration 60 \
+  --broadcast \
+  --send-interval 3000
+```
+
+このオプションを使用する場合:
+
+- 自動生成されるテスト用ルームを使用
+- ルーム内にテスト用オブジェクトが一時的に作成される
+- テスト終了時に自動クリーンアップされる
+
+⚠️ **注意**: 実ユーザーのルームで --broadcast を使用しないでください。
+ルームの内容が変更されます。
+
+## npm script として実行する
+
+`package.json` に以下が設定されている場合:
+
+```json
+{
+  "scripts": {
+    "scenesync:load-test": "node ../../tools/scenesync/load-test-presence.mjs"
+  }
+}
+```
+
+以下のように実行できます:
+
+```bash
+cd apps/presence-server
+npm run scenesync:load-test -- --url wss://staging.afjk.jp/presence --clients 20 --duration 60
+```
+
+## リリースチェックリスト
+
+新規リリース前に確認:
+
+- [ ] 20接続 / 60秒テストが成功 (staging)
+- [ ] 50接続 / 120秒テストが成功 (staging)
+- [ ] ローカルテストが成功
+- [ ] ConoHa ログに異常がない
+- [ ] 本番環境で 20接続テストを実施
+- [ ] CPU / メモリ使用量が正常範囲
+
+## 参考資料
+
+- Scene Sync spec: `docs/scene-sync-spec.md`
+- API protocol: `docs/scene-sync-api-protocol.md`
+- Presence server: `apps/presence-server/src/server.mjs`

--- a/docs/scene-sync-load-test.md
+++ b/docs/scene-sync-load-test.md
@@ -255,19 +255,23 @@ sudo grep '"room":"load-' /var/log/scene-sync/scene-sync-$(date +%F).ndjson | jq
 
 ### connect failures が多い場合
 
+接続テストを実施:
+
+```bash
+node ../../tools/scenesync/load-test-presence.mjs \
+  --url wss://staging.afjk.jp/presence \
+  --clients 1 \
+  --duration 10 \
+  --verbose
+```
+
+確認事項:
+
 - ネットワーク接続の確認
 - WebSocket エンドポイントの接続性確認
 - サーバーのポート制限確認
 - ファイアウォール設定確認
-
-```bash
-# 接続テスト
-curl -i -N -H "Connection: Upgrade" \
-  -H "Upgrade: websocket" \
-  -H "Sec-WebSocket-Version: 13" \
-  -H "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" \
-  "wss://staging.afjk.jp/presence?room=test"
-```
+- DNS 解決確認
 
 ### unexpected closes が発生する場合
 

--- a/tools/scenesync/load-test-presence.mjs
+++ b/tools/scenesync/load-test-presence.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const presenceServerPath = resolve(__dirname, '../../apps/presence-server');
+
+const require = createRequire(import.meta.url);
+const WebSocket = require(resolve(presenceServerPath, 'node_modules/ws'));
+
+const GENERIC_ROOM_NAMES = new Set([
+  'test',
+  'demo',
+  'room',
+  'default',
+  'safe-test',
+  'load-test',
+  'mcp-test',
+  'tmp',
+  'temp',
+  'test-room',
+  'demo-room',
+  'default-room',
+]);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const options = {
+    url: null,
+    room: null,
+    clients: 20,
+    duration: 60,
+    'ramp-ms': 100,
+    'send-interval': 5000,
+    broadcast: false,
+    verbose: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const nextArg = args[i + 1];
+
+      if (key === 'broadcast' || key === 'verbose') {
+        options[key] = true;
+      } else if (nextArg && !nextArg.startsWith('--')) {
+        const value = nextArg;
+        if (key === 'clients' || key === 'duration' || key === 'ramp-ms' || key === 'send-interval') {
+          options[key] = parseInt(value, 10);
+        } else {
+          options[key] = value;
+        }
+        i++;
+      }
+    }
+  }
+
+  return options;
+}
+
+function generateRoomName() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+  const timestamp = `${year}${month}${day}-${hours}${minutes}${seconds}`;
+
+  let random = '';
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 6; i++) {
+    random += chars[Math.floor(Math.random() * chars.length)];
+  }
+
+  return `load-${timestamp}-${random}`;
+}
+
+function isGenericRoom(room) {
+  return GENERIC_ROOM_NAMES.has(room.toLowerCase());
+}
+
+class LoadTestClient {
+  constructor(id, url, room) {
+    this.id = id;
+    this.url = url;
+    this.room = room;
+    this.ws = null;
+    this.connected = false;
+    this.connectStartTime = null;
+    this.connectLatency = 0;
+    this.messageCount = 0;
+    this.closeCode = null;
+    this.closeReason = null;
+  }
+
+  async connect() {
+    return new Promise((resolve, reject) => {
+      this.connectStartTime = performance.now();
+      const wsUrl = `${this.url}?room=${this.room}`;
+
+      try {
+        this.ws = new WebSocket(wsUrl);
+
+        const timeoutId = setTimeout(() => {
+          this.ws.terminate();
+          reject(new Error(`Connection timeout for client ${this.id}`));
+        }, 10000);
+
+        this.ws.on('open', () => {
+          clearTimeout(timeoutId);
+          this.connectLatency = Math.round(performance.now() - this.connectStartTime);
+          this.connected = true;
+
+          this.ws.send(JSON.stringify({
+            type: 'hello',
+            nickname: `LoadTest-${this.id}`,
+            device: 'LoadTest',
+          }));
+        });
+
+        this.ws.on('message', (data) => {
+          const message = JSON.parse(data.toString());
+          if (message.type === 'welcome') {
+            resolve();
+          } else {
+            this.messageCount++;
+          }
+        });
+
+        this.ws.on('close', (code, reason) => {
+          this.closeCode = code;
+          this.closeReason = reason;
+          this.connected = false;
+          if (!this.connected || this.connectLatency === 0) {
+            reject(new Error(`Connection closed for client ${this.id}: ${code} ${reason}`));
+          }
+        });
+
+        this.ws.on('error', (err) => {
+          clearTimeout(timeoutId);
+          reject(err);
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  send(message) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(JSON.stringify(message));
+      } catch (err) {
+        // Ignore send errors
+      }
+    }
+  }
+
+  close() {
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        // Ignore
+      }
+    }
+  }
+}
+
+async function runLoadTest() {
+  const options = parseArgs();
+
+  if (!options.url) {
+    console.error('Error: --url is required');
+    console.error('Usage: node load-test-presence.mjs --url <ws-url> [options]');
+    process.exit(1);
+  }
+
+  // Generate or validate room name
+  let room = options.room;
+  if (!room) {
+    room = generateRoomName();
+    console.log(`Generated room: ${room}`);
+  } else if (isGenericRoom(room)) {
+    console.warn(`Warning: room name "${room}" is generic and may collide with real users.`);
+    console.warn('Use a unique room name for release/load testing.');
+  }
+
+  const browserUrl = options.url.replace(/\/+$/, '').replace(/^wss?:\/\//, 'https://');
+  console.log(`Browser URL:\n${browserUrl}/scenesync/?room=${room}\n`);
+
+  console.log('Scene Sync presence load test\n');
+  console.log(`endpoint: ${options.url}`);
+  console.log(`room: ${room}`);
+  console.log(`clients requested: ${options.clients}`);
+
+  const clients = [];
+  let connectFailures = 0;
+  let roomFullRejections = 0;
+  const connectLatencies = [];
+
+  // Ramp up clients
+  const rampInterval = options['ramp-ms'] || 100;
+  for (let i = 0; i < options.clients; i++) {
+    const client = new LoadTestClient(i, options.url, room);
+
+    try {
+      await client.connect();
+      clients.push(client);
+      connectLatencies.push(client.connectLatency);
+
+      if (options.verbose) {
+        console.log(`  Client ${i} connected (${client.connectLatency}ms)`);
+      }
+    } catch (err) {
+      const errMsg = err.message || '';
+      if (errMsg.includes('room_full') || errMsg.includes('1008')) {
+        roomFullRejections++;
+      } else {
+        connectFailures++;
+      }
+
+      if (options.verbose) {
+        console.log(`  Client ${i} failed: ${err.message}`);
+      }
+    }
+
+    // Wait before connecting next client
+    if (i < options.clients - 1) {
+      await new Promise(resolve => setTimeout(resolve, rampInterval));
+    }
+  }
+
+  const connectedCount = clients.length;
+  console.log(`clients connected: ${connectedCount}`);
+  console.log(`connect failures: ${connectFailures}`);
+  if (roomFullRejections > 0) {
+    console.log(`room_full rejections: ${roomFullRejections}`);
+  }
+
+  // Broadcast test if enabled
+  let broadcastObjectId = null;
+  if (options.broadcast && connectedCount > 0) {
+    broadcastObjectId = `load-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const broadcastInterval = setInterval(() => {
+      clients.forEach((client) => {
+        if (client.connected) {
+          client.send({
+            kind: 'scene-add',
+            objectId: broadcastObjectId,
+            name: 'Load Test Object',
+            position: [0, 0.5, 0],
+            rotation: [0, 0, 0, 1],
+            scale: [1, 1, 1],
+            asset: {
+              type: 'primitive',
+              primitive: 'sphere',
+              color: '#ff00ff',
+            },
+          });
+        }
+      });
+    }, options['send-interval'] || 5000);
+
+    setTimeout(() => clearInterval(broadcastInterval), options.duration * 1000);
+  }
+
+  // Keep connections alive
+  const startTime = performance.now();
+  const durationMs = options.duration * 1000;
+
+  await new Promise(resolve => setTimeout(resolve, durationMs));
+
+  // Track unexpected closes
+  const closeLatency = performance.now() - startTime;
+  let unexpectedCloses = 0;
+  clients.forEach((client) => {
+    if (!client.connected && client.closeCode !== 1000 && client.closeCode !== 1001) {
+      unexpectedCloses++;
+    }
+  });
+
+  // Clean up broadcast object if used
+  if (broadcastObjectId && connectedCount > 0) {
+    clients.forEach((client) => {
+      if (client.connected) {
+        client.send({
+          kind: 'scene-remove',
+          objectId: broadcastObjectId,
+        });
+      }
+    });
+  }
+
+  // Close all connections
+  clients.forEach(client => client.close());
+
+  // Wait for closes
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Calculate statistics
+  const totalMessages = clients.reduce((sum, c) => sum + c.messageCount, 0);
+  const avgMessages = connectedCount > 0 ? Math.round(totalMessages / connectedCount) : 0;
+  const avgLatency = connectLatencies.length > 0
+    ? Math.round(connectLatencies.reduce((a, b) => a + b, 0) / connectLatencies.length)
+    : 0;
+  const maxLatency = connectLatencies.length > 0 ? Math.max(...connectLatencies) : 0;
+
+  // Print summary
+  console.log(`unexpected closes: ${unexpectedCloses}`);
+  console.log(`messages received total: ${totalMessages}`);
+  if (connectedCount > 0) {
+    console.log(`average messages/client: ${avgMessages}`);
+    console.log(`connect latency avg: ${avgLatency}ms`);
+    console.log(`connect latency max: ${maxLatency}ms`);
+  }
+  console.log(`duration: ${options.duration}s\n`);
+
+  // Determine result
+  let result = 'OK';
+  let hasFailure = false;
+
+  if (connectedCount < options.clients) {
+    result = 'FAIL';
+    hasFailure = true;
+  }
+  if (connectFailures > 0) {
+    result = 'FAIL';
+    hasFailure = true;
+  }
+  if (roomFullRejections > 0 && !options.broadcast) {
+    result = 'FAIL';
+    hasFailure = true;
+  }
+  if (unexpectedCloses > 0) {
+    result = 'WARN';
+  }
+
+  console.log(`Result: ${result}`);
+
+  process.exit(hasFailure ? 1 : 0);
+}
+
+runLoadTest().catch((err) => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/tools/scenesync/load-test-presence.mjs
+++ b/tools/scenesync/load-test-presence.mjs
@@ -104,7 +104,8 @@ class LoadTestClient {
   async connect() {
     return new Promise((resolve, reject) => {
       this.connectStartTime = performance.now();
-      const wsUrl = `${this.url}?room=${this.room}`;
+      const encodedRoom = encodeURIComponent(this.room);
+      const wsUrl = `${this.url}?room=${encodedRoom}`;
 
       try {
         this.ws = new WebSocket(wsUrl);
@@ -200,7 +201,8 @@ async function runLoadTest() {
   const wsUrl = new URL(options.url);
   const protocol = wsUrl.protocol === 'wss:' ? 'https:' : 'http:';
   const browserUrl = `${protocol}//${wsUrl.host}`;
-  console.log(`Browser URL:\n${browserUrl}/scenesync/?room=${room}\n`);
+  const encodedRoom = encodeURIComponent(room);
+  console.log(`Browser URL:\n${browserUrl}/scenesync/?room=${encodedRoom}\n`);
 
   console.log('Scene Sync presence load test\n');
   console.log(`endpoint: ${options.url}`);
@@ -252,12 +254,16 @@ async function runLoadTest() {
 
   // Broadcast test if enabled
   let broadcastObjectId = null;
+  let broadcastSender = null;
+
   if (options.broadcast && connectedCount > 0) {
     broadcastObjectId = `load-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const broadcastInterval = setInterval(() => {
-      clients.forEach((client) => {
-        if (client.connected) {
-          client.send({
+    broadcastSender = clients.find((client) => client.connected);
+
+    if (broadcastSender) {
+      const broadcastInterval = setInterval(() => {
+        if (broadcastSender.connected) {
+          broadcastSender.send({
             type: 'broadcast',
             payload: {
               kind: 'scene-add',
@@ -274,10 +280,10 @@ async function runLoadTest() {
             },
           });
         }
-      });
-    }, options['send-interval'] || 5000);
+      }, options['send-interval'] || 5000);
 
-    setTimeout(() => clearInterval(broadcastInterval), options.duration * 1000);
+      setTimeout(() => clearInterval(broadcastInterval), options.duration * 1000);
+    }
   }
 
   // Keep connections alive
@@ -296,17 +302,13 @@ async function runLoadTest() {
   });
 
   // Clean up broadcast object if used
-  if (broadcastObjectId && connectedCount > 0) {
-    clients.forEach((client) => {
-      if (client.connected) {
-        client.send({
-          type: 'broadcast',
-          payload: {
-            kind: 'scene-remove',
-            objectId: broadcastObjectId,
-          },
-        });
-      }
+  if (broadcastObjectId && broadcastSender && broadcastSender.connected) {
+    broadcastSender.send({
+      type: 'broadcast',
+      payload: {
+        kind: 'scene-remove',
+        objectId: broadcastObjectId,
+      },
     });
   }
 

--- a/tools/scenesync/load-test-presence.mjs
+++ b/tools/scenesync/load-test-presence.mjs
@@ -98,6 +98,7 @@ class LoadTestClient {
     this.messageCount = 0;
     this.closeCode = null;
     this.closeReason = null;
+    this.roomFull = false;
   }
 
   async connect() {
@@ -129,6 +130,9 @@ class LoadTestClient {
           const message = JSON.parse(data.toString());
           if (message.type === 'welcome') {
             resolve();
+          } else if (message.type === 'error' && message.error === 'room_full') {
+            this.roomFull = true;
+            reject(new Error(`room_full for client ${this.id}`));
           } else {
             this.messageCount++;
           }
@@ -193,7 +197,9 @@ async function runLoadTest() {
     console.warn('Use a unique room name for release/load testing.');
   }
 
-  const browserUrl = options.url.replace(/\/+$/, '').replace(/^wss?:\/\//, 'https://');
+  const wsUrl = new URL(options.url);
+  const protocol = wsUrl.protocol === 'wss:' ? 'https:' : 'http:';
+  const browserUrl = `${protocol}//${wsUrl.host}`;
   console.log(`Browser URL:\n${browserUrl}/scenesync/?room=${room}\n`);
 
   console.log('Scene Sync presence load test\n');
@@ -220,8 +226,7 @@ async function runLoadTest() {
         console.log(`  Client ${i} connected (${client.connectLatency}ms)`);
       }
     } catch (err) {
-      const errMsg = err.message || '';
-      if (errMsg.includes('room_full') || errMsg.includes('1008')) {
+      if (client.roomFull) {
         roomFullRejections++;
       } else {
         connectFailures++;
@@ -253,16 +258,19 @@ async function runLoadTest() {
       clients.forEach((client) => {
         if (client.connected) {
           client.send({
-            kind: 'scene-add',
-            objectId: broadcastObjectId,
-            name: 'Load Test Object',
-            position: [0, 0.5, 0],
-            rotation: [0, 0, 0, 1],
-            scale: [1, 1, 1],
-            asset: {
-              type: 'primitive',
-              primitive: 'sphere',
-              color: '#ff00ff',
+            type: 'broadcast',
+            payload: {
+              kind: 'scene-add',
+              objectId: broadcastObjectId,
+              name: 'Load Test Object',
+              position: [0, 0.5, 0],
+              rotation: [0, 0, 0, 1],
+              scale: [1, 1, 1],
+              asset: {
+                type: 'primitive',
+                primitive: 'sphere',
+                color: '#ff00ff',
+              },
             },
           });
         }
@@ -292,8 +300,11 @@ async function runLoadTest() {
     clients.forEach((client) => {
       if (client.connected) {
         client.send({
-          kind: 'scene-remove',
-          objectId: broadcastObjectId,
+          type: 'broadcast',
+          payload: {
+            kind: 'scene-remove',
+            objectId: broadcastObjectId,
+          },
         });
       }
     });
@@ -340,7 +351,8 @@ async function runLoadTest() {
     hasFailure = true;
   }
   if (unexpectedCloses > 0) {
-    result = 'WARN';
+    result = 'FAIL';
+    hasFailure = true;
   }
 
   console.log(`Result: ${result}`);


### PR DESCRIPTION
- tools/scenesync/load-test-presence.mjs: Manual load test script for WebSocket presence server
  - Simulates N concurrent WebSocket connections
  - Generates unique room names with load-YYYYMMDD-HHmmss-random6 format
  - Warns about generic room names to prevent collisions
  - Tracks connection latency, failures, and unexpected closes
  - Optional broadcast test for scene mutations
  - Configurable via CLI: --url, --room, --clients, --duration, --ramp-ms, --broadcast, --verbose
  - Exits non-zero on obvious failures for CI integration
- docs/scene-sync-load-test.md: Japanese documentation
  - Usage instructions for staging and production
  - ConoHa log checking commands
  - Troubleshooting guide
  - Release checklist
- apps/presence-server/package.json: Added scenesync:load-test npm script

Not for CI: Manual health check only, does not run in automated tests.

https://claude.ai/code/session_01GwPwt64sWc8uc8cFTSK5qa