### PR TITLE
Add device mode detection for mobile/desktop UI separation

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -23,6 +23,7 @@ import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { createWelcomeDialog } from './ui/welcome-dialog.js';
 import { focusTextInputIfSafe, blurActiveEditableElement } from './ui/input-focus-guard.js';
+import { applySceneSyncDeviceMode, isSceneSyncMobileDevice } from './ui/device-mode.js';
 import { normalizeDisplayName } from './utils/display-name.js';
 import { extractYaw } from './utils/math.js';
 import { broadcastObjectDelta } from './objects/object-delta.js';
@@ -54,6 +55,7 @@ const {
   pmremGenerator,
 } = threeApp;
 const dom = getSceneSyncDom();
+applySceneSyncDeviceMode(document.body);
 const glbLoader = new GLBFileLoader({
   dracoPath: '/draco/',
   maxDimension: 10,
@@ -3606,7 +3608,14 @@ const btnDelete = document.getElementById('btn-delete');
 const btnDeselect = document.getElementById('btn-deselect');
 
 function showToolbar() {
-  if (toolbar) toolbar.style.display = 'flex';
+  if (!toolbar) return;
+
+  if (!isSceneSyncMobileDevice()) {
+    toolbar.style.display = 'none';
+    return;
+  }
+
+  toolbar.style.display = 'flex';
 }
 
 function hideToolbar() {

--- a/html/assets/js/scenesync/ui/device-mode.js
+++ b/html/assets/js/scenesync/ui/device-mode.js
@@ -1,0 +1,45 @@
+export function detectSceneSyncDeviceMode() {
+  const ua = navigator.userAgent || '';
+  const platform = navigator.platform || '';
+  const maxTouchPoints = navigator.maxTouchPoints || 0;
+
+  const isIPhoneOrIPod = /iPhone|iPod/.test(ua);
+  const isIPad =
+    /iPad/.test(ua) ||
+    (platform === 'MacIntel' && maxTouchPoints > 1 && /Safari/.test(ua));
+
+  const isAndroid = /Android/.test(ua);
+  const isMobileUa = /Mobi/.test(ua);
+  const isTabletUa = /Tablet/.test(ua);
+
+  if (isIPhoneOrIPod || isIPad || isAndroid || isMobileUa || isTabletUa) {
+    return 'mobile';
+  }
+
+  return 'desktop';
+}
+
+export function applySceneSyncDeviceMode(root = document.body) {
+  const deviceMode = detectSceneSyncDeviceMode();
+
+  root.dataset.sceneSyncDevice = deviceMode;
+  root.classList.toggle('scene-sync-device-mobile', deviceMode === 'mobile');
+  root.classList.toggle('scene-sync-device-desktop', deviceMode === 'desktop');
+
+  console.info('[SceneSync] device mode', {
+    deviceMode,
+    userAgent: navigator.userAgent,
+    platform: navigator.platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+    width: window.innerWidth,
+    height: window.innerHeight,
+    hoverNone: window.matchMedia?.('(hover: none)').matches ?? null,
+    pointerCoarse: window.matchMedia?.('(pointer: coarse)').matches ?? null,
+  });
+
+  return deviceMode;
+}
+
+export function isSceneSyncMobileDevice() {
+  return document.body?.dataset?.sceneSyncDevice === 'mobile';
+}

--- a/html/assets/js/scenesync/ui/input-focus-guard.js
+++ b/html/assets/js/scenesync/ui/input-focus-guard.js
@@ -1,3 +1,6 @@
+// This is an input-behavior guard, not a mobile device detector.
+// Do not use this to decide whether mobile-only UI should be shown.
+// Use device-mode.js (isSceneSyncMobileDevice) for mobile UI visibility.
 export function isTouchLikeDevice() {
   return window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -662,6 +662,11 @@
     #paste-btn:hover {
       background: rgba(68, 136, 255, 0.8);
     }
+    body.scene-sync-device-desktop #mobile-toolbar,
+    body.scene-sync-device-desktop #paste-btn {
+      display: none !important;
+    }
+
     @media (hover: none) and (pointer: coarse) and (max-width: 1024px) {
       #mobile-toolbar {
         display: flex;

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -667,13 +667,8 @@
       display: none !important;
     }
 
-    @media (hover: none) and (pointer: coarse) and (max-width: 1024px) {
-      #mobile-toolbar {
-        display: flex;
-      }
-      #paste-btn {
-        display: flex;
-      }
+    body.scene-sync-device-mobile #paste-btn {
+      display: flex;
     }
     .mobile-sheet {
       position: fixed;


### PR DESCRIPTION
## 概要

Scene Sync ビューアにデバイスモード検出機能を追加し、モバイルデバイスとデスクトップの UI を明確に分離しました。ユーザーエージェント、プラットフォーム、タッチ機能を組み合わせてデバイスを判定し、CSS クラスと data 属性でスタイリングを制御できるようにしました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 新規ファイル: `html/assets/js/scenesync/ui/device-mode.js`
- `detectSceneSyncDeviceMode()`: UA、プラットフォーム、タッチポイント数から 'mobile' または 'desktop' を判定
- `applySceneSyncDeviceMode()`: DOM に `data-sceneSyncDevice` 属性と CSS クラスを適用、デバッグ情報をログ出力
- `isSceneSyncMobileDevice()`: 現在のデバイスモードを確認するヘルパー関数

### `html/assets/js/scenesync/scene.js`
- `device-mode.js` をインポート
- 初期化時に `applySceneSyncDeviceMode(document.body)` を実行
- `showToolbar()` 関数を修正：デスクトップデバイスではツールバーを非表示に

### `html/scenesync/index.html`
- CSS に `body.scene-sync-device-desktop` セレクタを追加
- デスクトップモードでは `#mobile-toolbar` と `#paste-btn` を `display: none !important` で非表示化

### `html/assets/js/scenesync/ui/input-focus-guard.js`
- コメント追加：`isTouchLikeDevice()` はメディアクエリベースの入力判定であり、モバイル UI 表示判定には `device-mode.js` を使用すべきことを明記

## 変更していないこと

- メディアクエリベースの入力判定ロジック（`input-focus-guard.js`）は変更なし
- 既存のツールバー表示/非表示ロジックの基本構造は維持

## staging確認

未確認

## テスト/チェック

- 新規関数の基本的なロジック確認：UA 判定、DOM 操作、ヘルパー関数の動作
- 既存機能への影響：ツールバー表示制御の動作確認

## リスク

- デバイス判定ロジックが UA に依存しているため、新しいデバイスやブラウザでの判定精度に注意が必要
- iPad の MacIntel プラットフォーム判定は Safari 環境に限定されている

## follow-up tasks

- デバイス判定の精度向上（より多くのデバイスでテスト）
- モバイル/デスクトップ UI の統一的なスタイリング戦略の検討

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01JDQGCpvqQCFxbuip6T6aZV