### PR TITLE
Fix mobile image picker to only allow supported image formats

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7378,19 +7378,6 @@ function getDefaultImportPosition() {
   );
 }
 
-function isSupportedMobileImageFile(file) {
-  if (!file) return false;
-
-  const supportedMimes = new Set([
-    'image/png',
-    'image/jpeg',
-    'image/webp',
-  ]);
-
-  const supportedExts = /\.(png|jpe?g|webp)$/i;
-  return supportedMimes.has(file.type) || supportedExts.test(file.name || '');
-}
-
 const clipboardImportManager = new ClipboardImportManager({
   container: document,
   getDefaultPosition: getDefaultImportPosition,
@@ -7460,23 +7447,16 @@ dom.mobileImageInput?.addEventListener('change', (event) => {
   const input = event.target;
   const file = input?.files?.[0];
 
-  if (!file) {
-    if (input) input.value = '';
-    return;
+  if (file) {
+    dragDropManager.handleFile(file, getDefaultImportPosition()).catch((error) => {
+      console.warn('[mobile-image-input] failed to add image:', error);
+      showToast(error?.message || '画像の追加に失敗しました');
+    });
   }
 
-  if (!isSupportedMobileImageFile(file)) {
-    showToast('PNG / JPEG / WebP の画像を選択してください');
+  if (input) {
     input.value = '';
-    return;
   }
-
-  dragDropManager.handleFile(file, getDefaultImportPosition()).catch((error) => {
-    console.warn('[mobile-image-input] failed to add image:', error);
-    showToast(error?.message || '画像の追加に失敗しました');
-  }).finally(() => {
-    input.value = '';
-  });
 });
 mobileRoomOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7378,6 +7378,19 @@ function getDefaultImportPosition() {
   );
 }
 
+function isSupportedMobileImageFile(file) {
+  if (!file) return false;
+
+  const supportedMimes = new Set([
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+  ]);
+
+  const supportedExts = /\.(png|jpe?g|webp)$/i;
+  return supportedMimes.has(file.type) || supportedExts.test(file.name || '');
+}
+
 const clipboardImportManager = new ClipboardImportManager({
   container: document,
   getDefaultPosition: getDefaultImportPosition,
@@ -7437,11 +7450,33 @@ pasteBtn?.addEventListener('click', pasteFromClipboardAtDefaultPosition);
 mobileActionSheetCloseBtn?.addEventListener('click', closeMobileActionSheet);
 mobileAddImageBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
-  dom.fileInput?.click();
+  dom.mobileImageInput?.click();
 });
 mobilePasteBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
   pasteFromClipboardAtDefaultPosition();
+});
+dom.mobileImageInput?.addEventListener('change', (event) => {
+  const input = event.target;
+  const file = input?.files?.[0];
+
+  if (!file) {
+    if (input) input.value = '';
+    return;
+  }
+
+  if (!isSupportedMobileImageFile(file)) {
+    showToast('PNG / JPEG / WebP の画像を選択してください');
+    input.value = '';
+    return;
+  }
+
+  dragDropManager.handleFile(file, getDefaultImportPosition()).catch((error) => {
+    console.warn('[mobile-image-input] failed to add image:', error);
+    showToast(error?.message || '画像の追加に失敗しました');
+  }).finally(() => {
+    input.value = '';
+  });
 });
 mobileRoomOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -20,6 +20,7 @@ export function getSceneSyncDom() {
     peersPanel: document.getElementById('peers-panel'),
     peersList: document.getElementById('peers-list'),
     fileInput: document.getElementById('file-input'),
+    mobileImageInput: document.getElementById('mobile-image-input'),
     dropOverlay: document.getElementById('drop-overlay'),
     deleteSkyboxBtn: document.getElementById('delete-skybox-btn'),
     bgmUnlockButton: document.getElementById('bgm-unlock-button'),

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1207,12 +1207,7 @@
   </aside>
   <button id="add-btn" title="GLB/画像を追加">＋</button>
   <button id="paste-btn" title="クリップボードから追加">📋</button>
-  <input
-    type="file"
-    id="file-input"
-    accept=".glb,model/gltf-binary,image/png,image/jpeg,image/webp,text/plain,text/markdown,.txt,.md,.markdown"
-    style="display:none"
-  >
+  <input type="file" id="file-input" style="display:none">
   <input
     type="file"
     id="mobile-image-input"

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1207,7 +1207,18 @@
   </aside>
   <button id="add-btn" title="GLB/画像を追加">＋</button>
   <button id="paste-btn" title="クリップボードから追加">📋</button>
-  <input type="file" id="file-input" style="display:none">
+  <input
+    type="file"
+    id="file-input"
+    accept=".glb,model/gltf-binary,image/png,image/jpeg,image/webp,text/plain,text/markdown,.txt,.md,.markdown"
+    style="display:none"
+  >
+  <input
+    type="file"
+    id="mobile-image-input"
+    accept="image/png,image/jpeg,image/webp"
+    style="display:none"
+  >
   <div id="drop-overlay">GLB / 画像 / テキストをドロップして追加</div>
   <div id="paste-sheet" hidden>
     <div id="paste-sheet-panel">
@@ -1226,7 +1237,7 @@
         <button id="mobile-action-sheet-close" class="chip" type="button">閉じる</button>
       </div>
       <div class="mobile-sheet-actions">
-        <button id="mobile-add-image-btn" class="chip primary" type="button">ファイルを追加</button>
+        <button id="mobile-add-image-btn" class="chip primary" type="button">画像を追加</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>


### PR DESCRIPTION
- Add accept attribute to file-input for all supported formats (GLB, images, text)
- Add dedicated mobile-image-input for image-only file selection
- Change mobile menu button text from "ファイルを追加" to "画像を追加"
- Add isSupportedMobileImageFile helper to validate image formats (PNG, JPEG, WebP)
- Add change handler for mobile-image-input with format validation
- Ensure mobile image picker only accepts PNG, JPEG, and WebP formats

https://claude.ai/code/session_012CK9SZCLuCCydmjcHKE1js