### PR TITLE
Add mobile GLB file upload support to Scene Sync

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7353,6 +7353,7 @@ const clipboardPasteTarget = document.getElementById('clipboard-paste-target');
 const pasteSheetClose = document.getElementById('paste-sheet-close');
 const mobileActionSheetCloseBtn = document.getElementById('mobile-action-sheet-close');
 const mobileAddImageBtn = document.getElementById('mobile-add-image-btn');
+const mobileAddGlbBtn = document.getElementById('mobile-add-glb-btn');
 const mobilePasteBtn = document.getElementById('mobile-paste-btn');
 const mobileRoomOpenBtn = document.getElementById('mobile-room-open-btn');
 const mobileRoomSheetCloseBtn = document.getElementById('mobile-room-sheet-close');
@@ -7387,6 +7388,10 @@ mobileAddImageBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
   dom.mobileImageInput?.click();
 });
+mobileAddGlbBtn?.addEventListener('click', () => {
+  closeMobileActionSheet();
+  dom.mobileGlbInput?.click();
+});
 mobilePasteBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
   pasteFromClipboardAtDefaultPosition();
@@ -7399,6 +7404,21 @@ dom.mobileImageInput?.addEventListener('change', (event) => {
     dragDropManager.handleFile(file, getDefaultImportPosition()).catch((error) => {
       console.warn('[mobile-image-input] failed to add image:', error);
       showToast(error?.message || '画像の追加に失敗しました');
+    });
+  }
+
+  if (input) {
+    input.value = '';
+  }
+});
+dom.mobileGlbInput?.addEventListener('change', (event) => {
+  const input = event.target;
+  const file = input?.files?.[0];
+
+  if (file) {
+    dragDropManager.handleFile(file, getDefaultImportPosition()).catch((error) => {
+      console.warn('[mobile-glb-input] failed to add GLB:', error);
+      showToast(error?.message || '3Dモデルの追加に失敗しました');
     });
   }
 

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -21,6 +21,7 @@ export function getSceneSyncDom() {
     peersList: document.getElementById('peers-list'),
     fileInput: document.getElementById('file-input'),
     mobileImageInput: document.getElementById('mobile-image-input'),
+    mobileGlbInput: document.getElementById('mobile-glb-input'),
     dropOverlay: document.getElementById('drop-overlay'),
     deleteSkyboxBtn: document.getElementById('delete-skybox-btn'),
     bgmUnlockButton: document.getElementById('bgm-unlock-button'),

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1185,6 +1185,12 @@
     accept="image/png,image/jpeg,image/webp"
     style="display:none"
   >
+  <input
+    type="file"
+    id="mobile-glb-input"
+    accept=".glb,model/gltf-binary"
+    style="display:none"
+  >
   <div id="drop-overlay">GLB / 画像 / テキストをドロップして追加</div>
   <div id="paste-sheet" hidden>
     <div id="paste-sheet-panel">
@@ -1204,6 +1210,7 @@
       </div>
       <div class="mobile-sheet-actions">
         <button id="mobile-add-image-btn" class="chip primary" type="button">画像を追加</button>
+        <button id="mobile-add-glb-btn" class="chip" type="button">3Dモデルを追加</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>


### PR DESCRIPTION
## 概要

モバイルデバイスから 3D モデル（GLB ファイル）をアップロードできる機能を追加しました。既存の画像アップロード機能と同様のパターンで実装しています。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **HTML UI の追加** (`html/scenesync/index.html`)
   - `mobile-glb-input` ファイル入力要素を追加（`.glb` と `model/gltf-binary` MIME タイプを受け入れ）
   - モバイルアクションシートに「3Dモデルを追加」ボタンを追加

2. **JavaScript イベントハンドラの実装** (`html/assets/js/scenesync/scene.js`)
   - `mobileAddGlbBtn` 要素の参照を追加
   - ボタンクリック時のイベントリスナーを追加（アクションシートを閉じてファイル入力をトリガー）
   - `mobileGlbInput` の `change` イベントリスナーを追加（ファイル処理ロジック）
     - `dragDropManager.handleFile()` を使用して既存のファイル処理パイプラインを活用
     - エラーハンドリングとトースト通知を実装

3. **DOM 参照の追加** (`html/assets/js/scenesync/ui/dom.js`)
   - `mobileGlbInput` 要素への参照を `getSceneSyncDom()` に追加

### staging で見てほしい点

- モバイルデバイスからの GLB ファイルアップロードが正常に動作すること
- ファイル選択後、既存の `dragDropManager` パイプラインで正しく処理されること
- エラー時に適切なトースト通知が表示されること
- UI が画像アップロード機能と一貫性を保っていること

## 変更していないこと

- `dragDropManager.handleFile()` の実装（既存の GLB 処理ロジックを再利用）
- デスクトップ版のドラッグ&ドロップ機能
- GLB ファイル形式のサポート範囲

## staging確認

未確認

## テスト/チェック

- 変更内容は既存の画像アップロード機能と同じパターンに従っているため、既存の実装が正常に動作していれば問題ないと考えられます
- モバイルデバイスでの実際の動作確認が必要です

## リスク

- なし（既存パターンの拡張のため、影響範囲は限定的）

## follow-up tasks

- なし

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01VfyLjuViZRyipUWGPKos51