### PR TITLE
モバイル GLB ファイル入力の制約を緩和

### DIFF
--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1196,7 +1196,6 @@
   <input
     type="file"
     id="mobile-glb-input"
-    accept=".glb,model/gltf-binary"
     style="display:none"
   >
   <div id="drop-overlay">GLB / 画像 / テキストをドロップして追加</div>
@@ -1218,7 +1217,7 @@
       </div>
       <div class="mobile-sheet-actions">
         <button id="mobile-add-image-btn" class="chip primary" type="button">画像を追加</button>
-        <button id="mobile-add-glb-btn" class="chip" type="button">3Dモデルを追加</button>
+        <button id="mobile-add-glb-btn" class="chip" type="button">ファイルを追加</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>


### PR DESCRIPTION
## 概要

モバイル環境でのファイル追加機能を拡張するため、GLB ファイル入力の `accept` 属性を削除し、ボタンラベルを汎用的に変更しました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `mobile-glb-input` の `accept=".glb,model/gltf-binary"` 属性を削除
  - これにより、GLB ファイル以外のファイル形式もアップロード可能に
  - ファイルピッカーの制約が緩和され、より柔軟なファイル操作が可能
- `mobile-add-glb-btn` のボタンラベルを「3Dモデルを追加」から「ファイルを追加」に変更
  - ボタンの機能がGLBに限定されないことを明確化

## 変更していないこと

- ファイル処理のバックエンド実装
- ドラッグ&ドロップ機能
- その他のモバイルUI要素

## staging確認

未確認

## テスト/チェック

- HTML 構文確認: 属性削除とテキスト変更のみで、機能的な影響は最小限
- 実装側でのファイル形式バリデーションが存在することを前提

## リスク

- 低: UI の制約を削除するのみで、バックエンド処理は変更なし
- ファイル形式の検証がバックエンド側で適切に実装されていることが前提

## follow-up tasks

- バックエンド側でサポートするファイル形式の明確化
- ユーザーへのファイル形式ガイダンスの追加（必要に応じて）

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01RLWZZ5rDA3deDmjYmz8vNe