### PR TITLE
Auto-close AI pairing dialog after link success

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7528,6 +7528,12 @@ function formatTime(ms) {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
+function clearPairingCountdown() {
+  if (pairingCountdown) clearInterval(pairingCountdown);
+  pairingCountdown = null;
+  pairingExpireTime = null;
+}
+
 function clearPairingAutoCloseTimer() {
   if (!pairingAutoCloseTimer) return;
   clearTimeout(pairingAutoCloseTimer);
@@ -8922,9 +8928,16 @@ function showPairingDialogLinked(expiresAtMs, { autoClose = false } = {}) {
   btnRevokeLink.style.display = 'inline-block';
   pairingStepCode.style.display = 'none';
   pairingStepLinked.style.display = 'block';
+
+  const autoCloseNote = document.getElementById('pairing-auto-close-note');
+  if (autoCloseNote) {
+    autoCloseNote.style.display = autoClose ? 'block' : 'none';
+  }
+
   pairingDialog.style.display = 'flex';
 
   if (autoClose) {
+    clearPairingCountdown();
     scheduleClosePairingDialogAfterLinked();
   }
 }
@@ -8959,9 +8972,7 @@ async function startPairing() {
 }
 
 function cancelPairing() {
-  if (pairingCountdown) clearInterval(pairingCountdown);
-  pairingCountdown = null;
-  pairingExpireTime = null;
+  clearPairingCountdown();
   clearPairingAutoCloseTimer();
   pairingDialog.style.display = 'none';
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7519,12 +7519,19 @@ const btnRoomFullNew = document.getElementById('btn-room-full-new');
 
 let pairingCountdown = null;
 let pairingExpireTime = null;
+let pairingAutoCloseTimer = null;
 
 function formatTime(ms) {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function clearPairingAutoCloseTimer() {
+  if (!pairingAutoCloseTimer) return;
+  clearTimeout(pairingAutoCloseTimer);
+  pairingAutoCloseTimer = null;
 }
 
 function updatePairingTimer() {
@@ -7543,6 +7550,17 @@ function showPairingDialogCode() {
   pairingStepCode.style.display = 'block';
   pairingStepLinked.style.display = 'none';
   pairingDialog.style.display = 'flex';
+}
+
+function scheduleClosePairingDialogAfterLinked() {
+  clearPairingAutoCloseTimer();
+
+  pairingAutoCloseTimer = window.setTimeout(() => {
+    pairingAutoCloseTimer = null;
+    if (pairingDialog) {
+      pairingDialog.style.display = 'none';
+    }
+  }, 2000);
 }
 
 async function copyText(text, successMessage = 'コピーしました') {
@@ -8898,16 +8916,17 @@ function setSceneInspectorOpen(nextOpen) {
   }
 }
 
-function showPairingDialogLinked(expiresAtMs) {
+function showPairingDialogLinked(expiresAtMs, { autoClose = false } = {}) {
   btnCancelPairing.textContent = '閉じる';
   btnCancelPairing.style.display = 'inline-block';
   btnRevokeLink.style.display = 'inline-block';
   pairingStepCode.style.display = 'none';
   pairingStepLinked.style.display = 'block';
-  const expiresAt = new Date(expiresAtMs);
-  document.getElementById('pairing-expires-at').textContent =
-    `有効期限: ${expiresAt.toLocaleDateString()} ${expiresAt.toLocaleTimeString()}`;
   pairingDialog.style.display = 'flex';
+
+  if (autoClose) {
+    scheduleClosePairingDialogAfterLinked();
+  }
 }
 
 async function startPairing() {
@@ -8943,11 +8962,13 @@ function cancelPairing() {
   if (pairingCountdown) clearInterval(pairingCountdown);
   pairingCountdown = null;
   pairingExpireTime = null;
+  clearPairingAutoCloseTimer();
   pairingDialog.style.display = 'none';
 }
 
 async function revokeLink() {
   try {
+    clearPairingAutoCloseTimer();
     await presenceState.linkManager.revoke();
     cancelPairing();
     updateLinkButtonState();
@@ -9129,6 +9150,18 @@ document.addEventListener('keydown', (event) => {
 
 presenceState.linkManager.onStatusChange = () => {
   updateLinkButtonState();
+
+  if (!presenceState.linkManager.isLinked()) {
+    clearPairingAutoCloseTimer();
+    return;
+  }
+
+  const dialogOpen = pairingDialog?.style.display === 'flex';
+  const wasWaitingForCode = pairingStepCode?.style.display !== 'none';
+
+  if (dialogOpen && wasWaitingForCode) {
+    showPairingDialogLinked(presenceState.linkManager.expiresAt, { autoClose: true });
+  }
 };
 
 setSceneInspectorOpen(false);

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -655,6 +655,12 @@
     .pairing-buttons .chip {
       flex: 1;
     }
+    .pairing-note {
+      margin: 10px 0 0;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #cfcfcf !important;
+    }
 
     body.scene-sync-device-desktop #mobile-toolbar {
       display: none !important;
@@ -1063,6 +1069,9 @@
         <div id="pairing-step-code">
           <p>次のコードを AI に入力してください:</p>
           <button id="pairing-code" class="pairing-code" type="button" title="クリックしてコピー">------</button>
+          <p class="pairing-note">
+            リンク中はScene Syncのページを開いたままにしてください。
+          </p>
           <div class="pairing-actions">
             <button id="btn-copy-pairing-code" class="chip" type="button">コードをコピー</button>
             <a id="scene-sync-operator-link" class="chip" href="#" target="_blank" rel="noopener noreferrer">Scene Sync Operator</a>
@@ -1070,8 +1079,10 @@
           <div id="pairing-timer">5:00</div>
         </div>
         <div id="pairing-step-linked" style="display:none;">
-          <p>✓ AI とリンクしました</p>
-          <p id="pairing-expires-at"></p>
+          <p>✓ リンクしました</p>
+          <p class="pairing-note" id="pairing-auto-close-note">
+            このダイアログは自動で閉じます。
+          </p>
         </div>
         <div id="pairing-error" style="display:none;" class="pairing-error"></div>
         <div class="pairing-buttons">


### PR DESCRIPTION
- Add short warning note while linking: 'リンク中はScene Syncのページを開いたままにしてください。'
- Show 'リンクしました' confirmation message after successful linking
- Automatically close dialog 2 seconds after successful link
- Only auto-close when linking from code display state, not when manually viewing linked status
- Clear auto-close timer on user actions (cancel, revoke)
- Add pairing-note styling for subtle warning text

https://claude.ai/code/session_014y96DgLMCdaLjX4QapUhw1