### PR TITLE
スマホ版 Scene Sync で背景（Skybox）画像を設定・削除できるようにする

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -152,6 +152,30 @@ function updateEnvironmentMenuSkyboxControls() {
   if (dom.deleteSkyboxBtn) {
     dom.deleteSkyboxBtn.hidden = !hasSkybox;
   }
+  const mobileDeleteSkyboxBtn = document.getElementById('mobile-delete-skybox-btn');
+  if (mobileDeleteSkyboxBtn) {
+    mobileDeleteSkyboxBtn.hidden = !hasSkybox;
+  }
+}
+
+function removeSkyboxSpheres() {
+  const skyObjects = getSkySphereObjects();
+
+  if (skyObjects.length === 0) {
+    showToast('削除できる背景画像がありません');
+    return false;
+  }
+
+  const count = skyObjects.length;
+  for (const obj of skyObjects) {
+    deleteObjectById(obj.objectId);
+  }
+
+  showToast('背景画像を削除しました');
+  updateEnvironmentMenuSkyboxControls();
+  notifySceneStateChanged('skybox-removed');
+
+  return true;
 }
 
 function syncSceneUiState() {
@@ -167,27 +191,7 @@ dom.envSelect?.addEventListener('change', () => {
 });
 
 dom.deleteSkyboxBtn?.addEventListener('click', () => {
-  const skyObjects = getSkySphereObjects();
-
-  if (skyObjects.length === 0) {
-    showToast('削除するSkyboxはありません');
-    updateEnvironmentMenuSkyboxControls();
-    return;
-  }
-
-  const count = skyObjects.length;
-  for (const obj of skyObjects) {
-    deleteObjectById(obj.objectId);
-  }
-
-  showToast(
-    count === 1
-      ? 'Skyboxを削除しました'
-      : `Skyboxを${count}個削除しました`
-  );
-
-  updateEnvironmentMenuSkyboxControls();
-  notifySceneStateChanged('skybox-deleted');
+  removeSkyboxSpheres();
 });
 
 dom.clearBgmButton?.addEventListener('click', () => {
@@ -7360,6 +7364,8 @@ const mobileRoomSheetCloseBtn = document.getElementById('mobile-room-sheet-close
 const mobileEnvOpenBtn = document.getElementById('mobile-env-open-btn');
 const mobileEnvSheetCloseBtn = document.getElementById('mobile-env-sheet-close');
 const mobileEnvSelect = document.getElementById('mobile-env-select');
+const mobileSetSkyboxBtn = document.getElementById('mobile-set-skybox-btn');
+const mobileDeleteSkyboxBtn = document.getElementById('mobile-delete-skybox-btn');
 const mobileLinkOpenBtn = document.getElementById('mobile-link-open-btn');
 const mobileHelpBtn = document.getElementById('mobile-help-btn');
 const mobileDevOpenBtn = document.getElementById('mobile-dev-open-btn');
@@ -7426,6 +7432,35 @@ dom.mobileGlbInput?.addEventListener('change', (event) => {
     input.value = '';
   }
 });
+const mobileSkyboxImageInput = document.getElementById('mobile-skybox-image-input');
+mobileSkyboxImageInput?.addEventListener('change', async (event) => {
+  const input = event.target;
+  const file = input?.files?.[0];
+
+  try {
+    if (file) {
+      showToast('背景画像を準備中…');
+
+      await imageImporterCallback(file, getDefaultImportPosition(), {
+        targetKind: 'sky',
+        surfaceKind: 'skybox',
+        upness: 1,
+        metadata: {
+          source: 'mobile-background-sheet',
+        },
+      });
+
+      closeSheet('mobile-env-sheet');
+    }
+  } catch (error) {
+    console.warn('[mobile-skybox-input] failed to set skybox:', error);
+    showToast(error?.message || '背景画像の設定に失敗しました');
+  } finally {
+    if (input) {
+      input.value = '';
+    }
+  }
+});
 mobileRoomOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
   openMobileRoomSheet();
@@ -7440,6 +7475,16 @@ mobileEnvOpenBtn?.addEventListener('click', () => {
 });
 mobileEnvSheetCloseBtn?.addEventListener('click', () => {
   closeSheet('mobile-env-sheet');
+});
+mobileSetSkyboxBtn?.addEventListener('click', () => {
+  const mobileSkboxImageInput = document.getElementById('mobile-skybox-image-input');
+  mobileSkboxImageInput?.click();
+});
+mobileDeleteSkyboxBtn?.addEventListener('click', () => {
+  const removed = removeSkyboxSpheres();
+  if (removed) {
+    closeSheet('mobile-env-sheet');
+  }
 });
 mobileLinkOpenBtn?.addEventListener('click', () => {
   closeMobileActionSheet();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -166,7 +166,6 @@ function removeSkyboxSpheres() {
     return false;
   }
 
-  const count = skyObjects.length;
   for (const obj of skyObjects) {
     deleteObjectById(obj.objectId);
   }
@@ -7477,8 +7476,7 @@ mobileEnvSheetCloseBtn?.addEventListener('click', () => {
   closeSheet('mobile-env-sheet');
 });
 mobileSetSkyboxBtn?.addEventListener('click', () => {
-  const mobileSkboxImageInput = document.getElementById('mobile-skybox-image-input');
-  mobileSkboxImageInput?.click();
+  mobileSkyboxImageInput?.click();
 });
 mobileDeleteSkyboxBtn?.addEventListener('click', () => {
   const removed = removeSkyboxSpheres();

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1038,9 +1038,9 @@
       </select>
     </div>
     <div class="row mobile-collapsible-row">
-      <button id="delete-skybox-btn" class="chip" type="button" title="Skyboxを削除" hidden>
+      <button id="delete-skybox-btn" class="chip" type="button" title="背景画像を削除" hidden>
         <span>🗑️</span>
-        <span>Skyboxを削除</span>
+        <span>背景画像を削除</span>
       </button>
       <button id="clear-bgm-btn" class="chip" type="button" title="BGMを削除" hidden>
         <span>🔇</span>
@@ -1209,6 +1209,12 @@
     id="mobile-glb-input"
     style="display:none"
   >
+  <input
+    type="file"
+    id="mobile-skybox-image-input"
+    accept="image/png,image/jpeg,image/webp"
+    style="display:none"
+  >
   <div id="drop-overlay">GLB / 画像 / テキストをドロップして追加</div>
   <div id="paste-sheet" hidden>
     <div id="paste-sheet-panel">
@@ -1231,7 +1237,7 @@
         <button id="mobile-add-glb-btn" class="chip" type="button">ファイルを追加</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
-        <button id="mobile-env-open-btn" class="chip" type="button">環境設定</button>
+        <button id="mobile-env-open-btn" class="chip" type="button">背景</button>
         <button id="mobile-link-open-btn" class="chip" type="button">AIにリンク</button>
         <button id="mobile-help-btn" class="chip" type="button">ヘルプ</button>
         <button id="mobile-dev-open-btn" class="chip" type="button" hidden>Dev</button>
@@ -1255,7 +1261,7 @@
     <div class="mobile-sheet-panel">
       <div class="mobile-sheet-handle"></div>
       <div class="mobile-sheet-header">
-        <h2>環境</h2>
+        <h2>背景</h2>
         <button id="mobile-env-sheet-close" class="chip" type="button">閉じる</button>
       </div>
       <select id="mobile-env-select" class="chip">
@@ -1265,6 +1271,14 @@
         <option value="indoor_warm">室内 暖色</option>
         <option value="studio">Studio</option>
       </select>
+      <div class="mobile-sheet-actions mobile-background-actions">
+        <button id="mobile-set-skybox-btn" class="chip primary" type="button">
+          画像を背景に設定
+        </button>
+        <button id="mobile-delete-skybox-btn" class="chip danger" type="button" hidden>
+          背景画像を削除
+        </button>
+      </div>
     </div>
   </div>
   <div id="mode">W: 移動 &nbsp; E: 回転 &nbsp; R: スケール</div>


### PR DESCRIPTION
- UI表記を「環境設定」→「背景」に変更
- 背景シート内に「画像を背景に設定」ボタンを追加
- 背景シート内に「背景画像を削除」ボタンを追加（画像がある時だけ表示）
- PC側の削除テキストを「Skyboxを削除」→「背景画像を削除」に変更
- Skybox削除処理を共通関数化（removeSkyboxSpheres）
- スマホ専用の背景画像 file input を追加
- updateEnvironmentMenuSkyboxControls() を拡張（スマホ削除ボタンも対象に）

既存機能への影響なし：
- 通常の画像追加は別の mobile-image-input を使用
- PC側の Skybox 設定・削除は壊れていない
- 背景プリセット変更は既存通り

https://claude.ai/code/session_014rHuaZ7E1bbQUtTs3aoRuT