### PR TITLE
feat: add IndexedDB fallback to Scene Sync Export

### DIFF
--- a/apps/presence-server/tests/collect-export-assets.test.mjs
+++ b/apps/presence-server/tests/collect-export-assets.test.mjs
@@ -83,7 +83,7 @@ test('collectExportAssets', async (t) => {
 
       assert.equal(result.missingAssets.length, 1);
       assert.equal(result.missingAssets[0].id, 'obj-missing');
-      assert.equal(result.missingAssets[0].reason, 'fetch-failed');
+      assert.equal(result.missingAssets[0].reason, 'blob-fetch-and-cache-miss');
     } finally {
       restore();
     }
@@ -198,6 +198,259 @@ test('collectExportAssets', async (t) => {
       assert.equal(result.assetManifest.length, 1);
       assert.equal(result.assetManifest[0].id, 'obj-a');
       assert.equal(result.assetManifest[0].status, 'included');
+      assert.equal(result.assetManifest[0].source, 'blob');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('includes source field in assetManifest', async () => {
+    const buf = new ArrayBuffer(4);
+    const restore = mockFetch({
+      'http://blob/path1': buf,
+    });
+
+    try {
+      const doc = makeSceneDoc([{
+        id: 'obj-a',
+        asset: { type: 'mesh', meshPath: 'path1', mime: 'model/gltf-binary' },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+      });
+
+      assert.equal(result.assetManifest[0].source, 'blob');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('blob fetch success includes assetId in SceneDocument', async () => {
+    const buf = new ArrayBuffer(4);
+    const restore = mockFetch({
+      'http://blob/path1': buf,
+    });
+
+    try {
+      const doc = makeSceneDoc([{
+        id: 'obj-with-id',
+        asset: {
+          type: 'mesh',
+          meshPath: 'path1',
+          assetId: 'asset-123',
+          mime: 'model/gltf-binary',
+        },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+      });
+
+      const obj = result.document.objects[0];
+      assert.equal(obj.asset.assetId, undefined, 'assetId should be removed from exported asset');
+      assert.ok(obj.asset.path.startsWith('assets/'));
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('IndexedDB fallback by assetId succeeds when blob fetch fails', async () => {
+    const restore = mockFetch({});
+
+    try {
+      const cachedBlob = new Blob([new ArrayBuffer(8)], { type: 'model/gltf-binary' });
+      const mockCache = {
+        getByAssetId: async (id) => {
+          if (id === 'asset-123') {
+            return {
+              assetId: 'asset-123',
+              meshPath: 'path1',
+              blob: cachedBlob,
+              mime: 'model/gltf-binary',
+              size: 8,
+            };
+          }
+          return null;
+        },
+        getByMeshPath: async () => null,
+      };
+
+      const doc = makeSceneDoc([{
+        id: 'obj-cached',
+        asset: {
+          type: 'mesh',
+          meshPath: 'path1',
+          assetId: 'asset-123',
+          mime: 'model/gltf-binary',
+        },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: mockCache,
+      });
+
+      assert.equal(result.missingAssets.length, 0, 'no missing assets');
+      assert.equal(result.assetManifest.length, 1);
+      assert.equal(result.assetManifest[0].status, 'included');
+      assert.equal(result.assetManifest[0].source, 'indexeddb');
+      assert.ok(result.files[result.document.objects[0].asset.path]);
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('IndexedDB fallback by meshPath succeeds when assetId lookup fails', async () => {
+    const restore = mockFetch({});
+
+    try {
+      const cachedBlob = new Blob([new ArrayBuffer(12)], { type: 'model/gltf-binary' });
+      const mockCache = {
+        getByAssetId: async () => null,
+        getByMeshPath: async (path) => {
+          if (path === 'path1') {
+            return {
+              assetId: 'asset-123',
+              meshPath: 'path1',
+              blob: cachedBlob,
+              mime: 'model/gltf-binary',
+              size: 12,
+            };
+          }
+          return null;
+        },
+      };
+
+      const doc = makeSceneDoc([{
+        id: 'obj-cached-by-path',
+        asset: {
+          type: 'mesh',
+          meshPath: 'path1',
+          assetId: 'unknown-id',
+          mime: 'model/gltf-binary',
+        },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: mockCache,
+      });
+
+      assert.equal(result.missingAssets.length, 0);
+      assert.equal(result.assetManifest.length, 1);
+      assert.equal(result.assetManifest[0].source, 'indexeddb');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('missing asset recorded with blob-fetch-and-cache-miss when both fail', async () => {
+    const restore = mockFetch({});
+
+    try {
+      const mockCache = {
+        getByAssetId: async () => null,
+        getByMeshPath: async () => null,
+      };
+
+      const doc = makeSceneDoc([{
+        id: 'obj-missing-both',
+        asset: {
+          type: 'mesh',
+          meshPath: 'path1',
+          assetId: 'asset-123',
+          mime: 'model/gltf-binary',
+        },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: mockCache,
+      });
+
+      assert.equal(result.missingAssets.length, 1);
+      assert.equal(result.missingAssets[0].id, 'obj-missing-both');
+      assert.equal(result.missingAssets[0].assetId, 'asset-123');
+      assert.equal(result.missingAssets[0].meshPath, 'path1');
+      assert.equal(result.missingAssets[0].reason, 'blob-fetch-and-cache-miss');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('cache fallback gracefully handles cache errors', async () => {
+    const restore = mockFetch({});
+
+    try {
+      const mockCache = {
+        getByAssetId: async () => { throw new Error('IndexedDB error'); },
+        getByMeshPath: async () => { throw new Error('IndexedDB error'); },
+      };
+
+      const doc = makeSceneDoc([{
+        id: 'obj-cache-error',
+        asset: {
+          type: 'mesh',
+          meshPath: 'path1',
+          assetId: 'asset-123',
+          mime: 'model/gltf-binary',
+        },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: mockCache,
+      });
+
+      assert.equal(result.missingAssets.length, 1);
+      assert.equal(result.missingAssets[0].reason, 'blob-fetch-and-cache-miss');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('works with null assetCache without error', async () => {
+    const buf = new ArrayBuffer(4);
+    const restore = mockFetch({
+      'http://blob/path1': buf,
+    });
+
+    try {
+      const doc = makeSceneDoc([{
+        id: 'obj-a',
+        asset: { type: 'mesh', meshPath: 'path1', assetId: 'asset-123', mime: 'model/gltf-binary' },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: null,
+      });
+
+      assert.equal(result.missingAssets.length, 0);
+      assert.equal(result.assetManifest.length, 1);
+      assert.equal(result.assetManifest[0].source, 'blob');
     } finally {
       restore();
     }

--- a/apps/presence-server/tests/collect-export-assets.test.mjs
+++ b/apps/presence-server/tests/collect-export-assets.test.mjs
@@ -394,7 +394,7 @@ test('collectExportAssets', async (t) => {
     }
   });
 
-  await t.test('cache fallback gracefully handles cache errors', async () => {
+  await t.test('cache fallback records cache-error when lookup throws', async () => {
     const restore = mockFetch({});
 
     try {
@@ -422,7 +422,7 @@ test('collectExportAssets', async (t) => {
       });
 
       assert.equal(result.missingAssets.length, 1);
-      assert.equal(result.missingAssets[0].reason, 'blob-fetch-and-cache-miss');
+      assert.equal(result.missingAssets[0].reason, 'blob-fetch-and-cache-error', 'should record cache-error when lookup throws');
     } finally {
       restore();
     }
@@ -451,6 +451,50 @@ test('collectExportAssets', async (t) => {
       assert.equal(result.missingAssets.length, 0);
       assert.equal(result.assetManifest.length, 1);
       assert.equal(result.assetManifest[0].source, 'blob');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('distinguishes between cache-miss and cache-error in reason', async () => {
+    const restore = mockFetch({});
+
+    try {
+      // Test cache-miss (lookups return null)
+      const missCache = {
+        getByAssetId: async () => null,
+        getByMeshPath: async () => null,
+      };
+
+      const doc = makeSceneDoc([{
+        id: 'obj-miss',
+        asset: { type: 'mesh', meshPath: 'path1', assetId: 'asset-123', mime: 'model/gltf-binary' },
+        position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1], visible: true,
+      }]);
+
+      const resultMiss = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: missCache,
+      });
+
+      assert.equal(resultMiss.missingAssets[0].reason, 'blob-fetch-and-cache-miss');
+
+      // Test cache-error (lookup throws)
+      const errorCache = {
+        getByAssetId: async () => { throw new Error('DB error'); },
+        getByMeshPath: async () => { throw new Error('DB error'); },
+      };
+
+      const resultError = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: 'http://blob',
+        envOrigin: null,
+        assetCache: errorCache,
+      });
+
+      assert.equal(resultError.missingAssets[0].reason, 'blob-fetch-and-cache-error');
     } finally {
       restore();
     }

--- a/apps/presence-server/tests/export-scene-document.test.mjs
+++ b/apps/presence-server/tests/export-scene-document.test.mjs
@@ -196,6 +196,87 @@ test('createSceneDocumentFromSceneSyncState', async (t) => {
     );
   });
 
+  await t.test('includes assetId in mesh asset entry when present', () => {
+    const managedObjects = new Map();
+    managedObjects.set('model-1', makeMockObject('model-1', {
+      asset: {
+        type: 'mesh',
+        meshPath: 'abc123',
+        assetId: 'asset-456',
+      },
+    }));
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const obj = doc.objects.find(o => o.id === 'model-1');
+    assert.ok(obj, 'object should be in output');
+    assert.equal(obj.asset.assetId, 'asset-456');
+    assert.equal(obj.asset.meshPath, 'abc123');
+  });
+
+  await t.test('reads assetId from userData.scenesync.assetId', () => {
+    const managedObjects = new Map();
+    managedObjects.set('model-nested', makeMockObject('model-nested', {
+      asset: { type: 'mesh', meshPath: 'path1' },
+    }));
+
+    const obj = managedObjects.get('model-nested');
+    obj.userData.scenesync = { assetId: 'from-scenesync' };
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const docObj = doc.objects.find(o => o.id === 'model-nested');
+    assert.equal(docObj.asset.assetId, 'from-scenesync');
+  });
+
+  await t.test('prefers asset.assetId over userData paths', () => {
+    const managedObjects = new Map();
+    managedObjects.set('model-pref', makeMockObject('model-pref', {
+      asset: {
+        type: 'mesh',
+        meshPath: 'path1',
+        assetId: 'from-asset',
+      },
+    }));
+
+    const obj = managedObjects.get('model-pref');
+    obj.userData.assetId = 'from-userdata';
+    obj.userData.scenesync = { assetId: 'from-scenesync' };
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const docObj = doc.objects.find(o => o.id === 'model-pref');
+    assert.equal(docObj.asset.assetId, 'from-asset');
+  });
+
+  await t.test('includes null assetId when not present', () => {
+    const managedObjects = new Map();
+    managedObjects.set('model-no-id', makeMockObject('model-no-id', {
+      asset: { type: 'mesh', meshPath: 'path1' },
+    }));
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const docObj = doc.objects.find(o => o.id === 'model-no-id');
+    assert.equal(docObj.asset.assetId, null);
+  });
+
   await t.test('excludes objects with null asset (no renderable representation)', () => {
     const managedObjects = new Map();
     managedObjects.set('no-asset', makeMockObject('no-asset', { asset: null }));

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -101,6 +101,7 @@ export async function buildExportPackage({
   envId,
   blobBase,
   envOrigin = location.origin,
+  assetCache = null,
 }) {
   // 1. Build SceneDocument from current state
   let sceneDocument;
@@ -120,6 +121,7 @@ export async function buildExportPackage({
       sceneDocument,
       blobBase,
       envOrigin,
+      assetCache,
     });
 
   // 3. Fetch viewer source files

--- a/html/assets/js/scenesync-export/export/collect-export-assets.js
+++ b/html/assets/js/scenesync-export/export/collect-export-assets.js
@@ -30,10 +30,45 @@ async function tryFetch(url) {
   }
 }
 
+async function tryGetCachedAssetBuffer({ assetCache, assetId, meshPath }) {
+  if (!assetCache) return null;
+
+  let record = null;
+
+  try {
+    if (assetId && typeof assetCache.getByAssetId === 'function') {
+      record = await assetCache.getByAssetId(assetId);
+    }
+
+    if (!record && meshPath && typeof assetCache.getByMeshPath === 'function') {
+      record = await assetCache.getByMeshPath(meshPath);
+    }
+  } catch (err) {
+    console.warn('[Export] IndexedDB asset cache lookup failed:', err);
+    return null;
+  }
+
+  const blob = record?.blob;
+  if (!blob) return null;
+
+  try {
+    return {
+      buffer: await blob.arrayBuffer(),
+      mime: record.mime || blob.type || 'model/gltf-binary',
+      size: record.size || blob.size || null,
+      source: 'indexeddb',
+    };
+  } catch (err) {
+    console.warn('[Export] Failed to read cached asset blob:', err);
+    return null;
+  }
+}
+
 export async function collectExportAssets({
   sceneDocument,
   blobBase,
   envOrigin,
+  assetCache = null,
 }) {
   const files = {};
   const assetManifest = [];
@@ -60,6 +95,7 @@ export async function collectExportAssets({
     }
 
     const meshPath = obj.asset.meshPath;
+    const assetId = obj.asset.assetId;
     const mime = obj.asset.mime || 'model/gltf-binary';
     const ext = extensionFor(mime, 'glb');
     const baseName = sanitizeFilename(obj.asset.originalName?.replace(/\.[^.]+$/, '') || obj.id);
@@ -70,18 +106,42 @@ export async function collectExportAssets({
       fetchUrl = `${blobBase}/${meshPath}`;
     }
 
-    const buffer = await tryFetch(fetchUrl);
+    const blobBuffer = await tryFetch(fetchUrl);
 
-    if (buffer) {
-      files[zipPath] = buffer;
-      assetManifest.push({ id: obj.id, kind: 'mesh', path: zipPath, status: 'included' });
+    if (blobBuffer) {
+      files[zipPath] = blobBuffer;
+      assetManifest.push({ id: obj.id, kind: 'mesh', path: zipPath, status: 'included', source: 'blob' });
       updatedObjects.push({
         ...obj,
-        asset: { ...obj.asset, path: zipPath, meshPath: undefined },
+        asset: { ...obj.asset, path: zipPath, meshPath: undefined, assetId: undefined },
       });
     } else {
-      missingAssets.push({ id: obj.id, kind: 'mesh', path: meshPath, reason: 'fetch-failed' });
-      updatedObjects.push({ ...obj, asset: { ...obj.asset, path: null, meshPath: undefined } });
+      // Try IndexedDB cache as fallback
+      const cachedAsset = await tryGetCachedAssetBuffer({ assetCache, assetId, meshPath });
+
+      if (cachedAsset) {
+        files[zipPath] = cachedAsset.buffer;
+        assetManifest.push({
+          id: obj.id,
+          kind: 'mesh',
+          path: zipPath,
+          status: 'included',
+          source: 'indexeddb',
+        });
+        updatedObjects.push({
+          ...obj,
+          asset: { ...obj.asset, path: zipPath, meshPath: undefined, assetId: undefined },
+        });
+      } else {
+        missingAssets.push({
+          id: obj.id,
+          kind: 'mesh',
+          assetId: assetId || null,
+          meshPath: meshPath || null,
+          reason: 'blob-fetch-and-cache-miss',
+        });
+        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: null, meshPath: undefined, assetId: undefined } });
+      }
     }
   }
 

--- a/html/assets/js/scenesync-export/export/collect-export-assets.js
+++ b/html/assets/js/scenesync-export/export/collect-export-assets.js
@@ -31,9 +31,10 @@ async function tryFetch(url) {
 }
 
 async function tryGetCachedAssetBuffer({ assetCache, assetId, meshPath }) {
-  if (!assetCache) return null;
+  if (!assetCache) return { found: false, hasError: false };
 
   let record = null;
+  let hasError = false;
 
   try {
     if (assetId && typeof assetCache.getByAssetId === 'function') {
@@ -45,14 +46,16 @@ async function tryGetCachedAssetBuffer({ assetCache, assetId, meshPath }) {
     }
   } catch (err) {
     console.warn('[Export] IndexedDB asset cache lookup failed:', err);
-    return null;
+    return { found: false, hasError: true };
   }
 
   const blob = record?.blob;
-  if (!blob) return null;
+  if (!blob) return { found: false, hasError: false };
 
   try {
     return {
+      found: true,
+      hasError: false,
       buffer: await blob.arrayBuffer(),
       mime: record.mime || blob.type || 'model/gltf-binary',
       size: record.size || blob.size || null,
@@ -60,7 +63,7 @@ async function tryGetCachedAssetBuffer({ assetCache, assetId, meshPath }) {
     };
   } catch (err) {
     console.warn('[Export] Failed to read cached asset blob:', err);
-    return null;
+    return { found: false, hasError: true };
   }
 }
 
@@ -119,7 +122,7 @@ export async function collectExportAssets({
       // Try IndexedDB cache as fallback
       const cachedAsset = await tryGetCachedAssetBuffer({ assetCache, assetId, meshPath });
 
-      if (cachedAsset) {
+      if (cachedAsset.found) {
         files[zipPath] = cachedAsset.buffer;
         assetManifest.push({
           id: obj.id,
@@ -138,7 +141,7 @@ export async function collectExportAssets({
           kind: 'mesh',
           assetId: assetId || null,
           meshPath: meshPath || null,
-          reason: 'blob-fetch-and-cache-miss',
+          reason: cachedAsset.hasError ? 'blob-fetch-and-cache-error' : 'blob-fetch-and-cache-miss',
         });
         updatedObjects.push({ ...obj, asset: { ...obj.asset, path: null, meshPath: undefined, assetId: undefined } });
       }

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -41,12 +41,14 @@ function buildAssetEntry(obj) {
 
   // mesh / image / text → all stored as GLB via meshPath
   const meshPath = obj.userData?.meshPath || asset.meshPath || null;
+  const assetId = asset.assetId || obj.userData?.assetId || obj.userData?.scenesync?.assetId || null;
 
   return {
     type: 'mesh',
     // path will be filled by collect-export-assets.js
     path: null,
     meshPath,
+    assetId,
     mime: asset.mime || 'model/gltf-binary',
     visualBasis: asset.visualBasis || null,
     originalName: asset.originalName || null,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -9357,6 +9357,7 @@ async function triggerExport() {
       envId: environmentManager.getCurrentEnvId(),
       blobBase: BLOB_BASE,
       envOrigin: location.origin,
+      assetCache,
     });
 
     if (missingAssets.length > 0) {


### PR DESCRIPTION
When exporting a scene, GLB assets are now collected with this priority:

1. Try to fetch from blob URL (${blobBase}/${meshPath})
2. If blob fetch fails, try IndexedDB cache by assetId
3. If assetId lookup fails, try IndexedDB cache by meshPath
4. If both blob fetch and cache lookups fail, record as missing

Changes:
- buildAssetEntry() now includes assetId in exported assets
- buildExportPackage() accepts and passes assetCache parameter
- triggerExport() in scene.js passes the existing assetCache instance
- collectExportAssets() implements IndexedDB fallback logic with
  tryGetCachedAssetBuffer() helper
- Asset manifest now includes source field (blob or indexeddb)
- Missing assets reason changed to blob-fetch-and-cache-miss for clarity

This ensures that TTL-expired presence blobs don't cause asset loss
when the local browser cache still has the GLB.

https://claude.ai/code/session_01QfXGvB4w7YTci5A8J1W7k3