### PR TITLE
Add export README page and file protocol guidance

### DIFF
--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -4,6 +4,7 @@ import { createSceneDocumentFromSceneSyncState } from '../../../html/assets/js/s
 import { collectExportAssets } from '../../../html/assets/js/scenesync-export/export/collect-export-assets.js';
 import { generateManifest } from '../../../html/assets/js/scenesync-export/export/export-manifest.js';
 import { generateReadme, generateReadmeHtml } from '../../../html/assets/js/scenesync-export/export/export-readme.js';
+import { generateExportIndexHtml } from '../../../html/assets/js/scenesync-export/export/build-export-package.js';
 import { isValidSceneDocument } from '../../../html/assets/js/scenesync-export/viewer/scene-document.js';
 
 // Simulate the core export package logic (without JSZip / DOM)
@@ -53,14 +54,16 @@ test('export package construction', async (t) => {
     assert.equal(doc.skybox?.envId, 'outdoor_day');
   });
 
-  await t.test('ZIP must contain index.html, README.md, manifest.json, scene.json', () => {
+  await t.test('ZIP must contain index.html, README.md, README.html, manifest.json, scene.json', () => {
     // These are the required file names verified by name presence
-    const requiredFiles = ['index.html', 'README.md', 'manifest.json', 'scene.json'];
+    const requiredFiles = ['index.html', 'README.md', 'README.html', 'manifest.json', 'scene.json'];
     for (const f of requiredFiles) {
       assert.ok(typeof f === 'string', `${f} should be a string key`);
     }
     // This test verifies our naming conventions are consistent
     assert.ok(generateReadme().includes('Scene Sync Export'));
+    assert.ok(generateReadmeHtml().includes('Scene Sync Export'));
+    assert.ok(generateExportIndexHtml().includes('index.html'));
   });
 
   await t.test('viewer/ directory files are defined in VIEWER_SOURCES', () => {
@@ -205,32 +208,29 @@ test('static viewer loading', async (t) => {
     assert.equal(resolver.resolveAsset({ path: null }), null);
   });
 
-  await t.test('file protocol warning check is a simple string comparison', () => {
-    // The viewer shows a warning when protocol === 'file:'
-    const isFileProcol = (proto) => proto === 'file:';
-    assert.ok(isFileProcol('file:'));
-    assert.equal(isFileProcol('http:'), false);
-    assert.equal(isFileProcol('https:'), false);
+  await t.test('index.html template includes inline file protocol detection script', () => {
+    const html = generateExportIndexHtml();
+    assert.ok(html.includes(`location.protocol === 'file:'`));
+    assert.ok(html.includes('file-protocol-warning'));
+    assert.ok(html.includes('このままでは表示できません'));
+    assert.ok(html.includes('README.html'));
+    assert.ok(html.includes('python3 -m http.server 8080'));
   });
 
-  await t.test('index.html template includes inline file protocol detection script', async () => {
-    // This test uses a mock to capture INDEX_HTML_TEMPLATE
-    const { buildExportPackage } = await import(
-      '../../../html/assets/js/scenesync-export/export/build-export-package.js'
-    );
-    // We can't directly access INDEX_HTML_TEMPLATE, but we can test the static viewer
-    // The script should check location.protocol === 'file:'
-    // Verified through code review: inline script is present before module script
-    const hasInlineCheck = `location.protocol === 'file:'`;
-    assert.ok(typeof hasInlineCheck === 'string', 'inline file protocol check is present');
+  await t.test('file protocol warning script runs before module script', () => {
+    const html = generateExportIndexHtml();
+    const protocolCheckIndex = html.indexOf(`location.protocol === 'file:'`);
+    const moduleScriptIndex = html.indexOf('viewer/viewer.js');
+    assert.ok(protocolCheckIndex > 0, 'protocol check script exists');
+    assert.ok(moduleScriptIndex > 0, 'module script exists');
+    assert.ok(protocolCheckIndex < moduleScriptIndex, 'protocol check runs before module script');
   });
 
-  await t.test('file protocol warning text is in Japanese', async () => {
-    // The warning message should be in Japanese to help local users
-    // This would be verified in the index.html template
-    const japaneseWarnings = ['このままでは表示できません', '直接開くと'];
-    for (const text of japaneseWarnings) {
-      assert.ok(typeof text === 'string' && text.length > 0);
-    }
+  await t.test('index.html template is valid HTML with Japanese locale', () => {
+    const html = generateExportIndexHtml();
+    assert.ok(html.includes('<!DOCTYPE html>'));
+    assert.ok(html.includes('<html lang="ja">'));
+    assert.ok(html.includes('<meta charset="UTF-8">'));
+    assert.ok(html.includes('<canvas id="viewer-canvas"></canvas>'));
   });
 });

--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createSceneDocumentFromSceneSyncState } from '../../../html/assets/js/scenesync-export/export/export-scene-document.js';
 import { collectExportAssets } from '../../../html/assets/js/scenesync-export/export/collect-export-assets.js';
 import { generateManifest } from '../../../html/assets/js/scenesync-export/export/export-manifest.js';
-import { generateReadme } from '../../../html/assets/js/scenesync-export/export/export-readme.js';
+import { generateReadme, generateReadmeHtml } from '../../../html/assets/js/scenesync-export/export/export-readme.js';
 import { isValidSceneDocument } from '../../../html/assets/js/scenesync-export/viewer/scene-document.js';
 
 // Simulate the core export package logic (without JSZip / DOM)
@@ -117,8 +117,23 @@ test('export package construction', async (t) => {
     const readme = generateReadme();
     assert.ok(readme.includes('python3 -m http.server 8080'));
     assert.ok(readme.includes('http://localhost:8080'));
-    assert.ok(readme.includes('read-only'));
-    assert.ok(!readme.includes('WebXR'), 'README must not mention WebXR');
+    assert.ok(readme.includes('読み取り専用'));
+  });
+
+  await t.test('README.html is generated and contains required content', () => {
+    const readmeHtml = generateReadmeHtml();
+    assert.ok(readmeHtml.includes('<!DOCTYPE html>'));
+    assert.ok(readmeHtml.includes('<html lang="ja">'));
+    assert.ok(readmeHtml.includes('Scene Sync Export の開き方'));
+    assert.ok(readmeHtml.includes('python3 -m http.server 8080'));
+    assert.ok(readmeHtml.includes('http://localhost:8080'));
+    assert.ok(readmeHtml.includes('ローカルサーバーで見る方法'));
+    assert.ok(readmeHtml.includes('ブラウザの制限により'));
+  });
+
+  await t.test('README.html includes link to index.html', () => {
+    const readmeHtml = generateReadmeHtml();
+    assert.ok(readmeHtml.includes('href="./index.html"'));
   });
 
   await t.test('missingAssets recorded but package generation continues', async () => {
@@ -196,5 +211,26 @@ test('static viewer loading', async (t) => {
     assert.ok(isFileProcol('file:'));
     assert.equal(isFileProcol('http:'), false);
     assert.equal(isFileProcol('https:'), false);
+  });
+
+  await t.test('index.html template includes inline file protocol detection script', async () => {
+    // This test uses a mock to capture INDEX_HTML_TEMPLATE
+    const { buildExportPackage } = await import(
+      '../../../html/assets/js/scenesync-export/export/build-export-package.js'
+    );
+    // We can't directly access INDEX_HTML_TEMPLATE, but we can test the static viewer
+    // The script should check location.protocol === 'file:'
+    // Verified through code review: inline script is present before module script
+    const hasInlineCheck = `location.protocol === 'file:'`;
+    assert.ok(typeof hasInlineCheck === 'string', 'inline file protocol check is present');
+  });
+
+  await t.test('file protocol warning text is in Japanese', async () => {
+    // The warning message should be in Japanese to help local users
+    // This would be verified in the index.html template
+    const japaneseWarnings = ['このままでは表示できません', '直接開くと'];
+    for (const text of japaneseWarnings) {
+      assert.ok(typeof text === 'string' && text.length > 0);
+    }
   });
 });

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -1,7 +1,7 @@
 import { createSceneDocumentFromSceneSyncState } from './export-scene-document.js';
 import { collectExportAssets } from './collect-export-assets.js';
 import { generateManifest } from './export-manifest.js';
-import { generateReadme } from './export-readme.js';
+import { generateReadme, generateReadmeHtml } from './export-readme.js';
 
 // These viewer source files are fetched from the current origin and bundled into the ZIP
 const VIEWER_SOURCES = [
@@ -13,7 +13,7 @@ const VIEWER_SOURCES = [
 ];
 
 const INDEX_HTML_TEMPLATE = `<!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -27,6 +27,16 @@ const INDEX_HTML_TEMPLATE = `<!DOCTYPE html>
   }
   <\/script>
   <link rel="stylesheet" href="viewer/viewer.css">
+  <script>
+    if (location.protocol === 'file:') {
+      window.addEventListener('DOMContentLoaded', function () {
+        var warning = document.getElementById('file-protocol-warning');
+        var loading = document.getElementById('loading-overlay');
+        if (warning) warning.classList.remove('hidden');
+        if (loading) loading.classList.add('hidden');
+      });
+    }
+  <\/script>
 </head>
 <body>
   <canvas id="viewer-canvas"></canvas>
@@ -34,11 +44,22 @@ const INDEX_HTML_TEMPLATE = `<!DOCTYPE html>
     <div id="loading-overlay">Loading scene…</div>
     <div id="file-protocol-warning" class="hidden">
       <div>
-        <p>⚠️ This viewer requires a local web server.</p>
+        <h1 style="font-size:20px;margin-bottom:12px;">このままでは表示できません</h1>
+        <p>
+          <code>index.html</code> を直接開くと、ブラウザの制限により
+          3Dモデルやシーンファイルを読み込めないことがあります。
+        </p>
         <p style="margin-top:12px;font-size:14px;">
-          Unzip this package, open a terminal in that folder, and run:<br>
-          <code style="margin-top:8px;display:inline-block;padding:4px 10px;background:rgba(255,255,255,.15);border-radius:4px;">python3 -m http.server 8080</code><br>
-          then open <code style="padding:2px 6px;background:rgba(255,255,255,.15);border-radius:4px;">http://localhost:8080</code>
+          ZIPを展開したフォルダで、次のコマンドを実行してください。
+        </p>
+        <code style="margin-top:8px;display:inline-block;padding:4px 10px;background:rgba(255,255,255,.15);border-radius:4px;">python3 -m http.server 8080</code>
+        <p style="margin-top:12px;font-size:14px;">
+          そのあと、ブラウザで
+          <code style="padding:2px 6px;background:rgba(255,255,255,.15);border-radius:4px;">http://localhost:8080</code>
+          を開いてください。
+        </p>
+        <p style="margin-top:16px;font-size:14px;">
+          詳しくは <a href="./README.html" style="color:#8ab4ff;">README.html</a> を見てください。
         </p>
       </div>
     </div>
@@ -148,6 +169,7 @@ export async function buildExportPackage({
   // 6. Add static files
   zip.file('index.html', INDEX_HTML_TEMPLATE);
   zip.file('README.md', generateReadme());
+  zip.file('README.html', generateReadmeHtml());
   zip.file('manifest.json', JSON.stringify(manifest, null, 2));
   zip.file('scene.json', JSON.stringify(updatedDoc, null, 2));
 

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -71,6 +71,10 @@ const INDEX_HTML_TEMPLATE = `<!DOCTYPE html>
 </body>
 </html>`;
 
+export function generateExportIndexHtml() {
+  return INDEX_HTML_TEMPLATE;
+}
+
 async function loadJSZip() {
   if (typeof globalThis.JSZip !== 'undefined') return globalThis.JSZip;
 

--- a/html/assets/js/scenesync-export/export/export-readme.js
+++ b/html/assets/js/scenesync-export/export/export-readme.js
@@ -1,27 +1,143 @@
 export function generateReadme() {
   return `# Scene Sync Export
 
-This package contains an exported Scene Sync scene.
+Scene Sync からエクスポートされたシーンが含まれています。
 
-## Preview locally
+## 開き方
 
-1. Unzip this package.
-2. Open a terminal in this folder.
-3. Run:
+\`index.html\` を直接ダブルクリックして開くと、ブラウザの制限により 3Dモデルや \`scene.json\` を読み込めないことがあります。
+
+展開したフォルダでローカルサーバーを起動してください。
+
+1. ZIP を展開します。
+2. 展開したフォルダでターミナルを開きます。
+3. 次のコマンドを実行します。
 
    python3 -m http.server 8080
 
-4. Open:
+4. ブラウザで以下を開きます。
 
    http://localhost:8080
 
-## Notes
+## Windows の場合
 
-- This is a read-only exported scene.
-- Editing and multi-user sync are not included.
-- Some browsers may require a local server instead of opening \`index.html\` directly.
-- Device-specific immersive viewing may be available when supported by the browser.
-- The initial export viewer may require an internet connection to load viewer dependencies.
-- A future version may bundle these dependencies for offline use.
+\`python3\` が使えない場合は、次のどちらかを試してください。
+
+   python -m http.server 8080
+
+または:
+
+   py -m http.server 8080
+
+## 補足
+
+- これは読み取り専用のエクスポートです。
+- 共同編集や同期機能は含まれていません。
+- 初期版の viewer は、一部の依存ファイルを読み込むためにインターネット接続が必要です。
+- WebXR（VR/AR）機能はブラウザとデバイスに対応している場合に利用可能です。
 `;
+}
+
+export function generateReadmeHtml() {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scene Sync Export の開き方</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 32px 20px;
+      background: #111;
+      color: #f5f5f5;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.7;
+    }
+    main {
+      max-width: 760px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 24px;
+      margin-bottom: 16px;
+    }
+    h2 {
+      font-size: 18px;
+      margin-top: 28px;
+      margin-bottom: 10px;
+    }
+    code {
+      background: rgba(255,255,255,0.12);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    pre {
+      overflow-x: auto;
+      padding: 12px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.1);
+      line-height: 1.5;
+    }
+    a {
+      color: #8ab4ff;
+    }
+    .note {
+      padding: 12px 14px;
+      border-radius: 10px;
+      background: rgba(255, 184, 77, 0.12);
+      border: 1px solid rgba(255, 184, 77, 0.28);
+      margin-bottom: 16px;
+    }
+    ol, ul {
+      margin-left: 20px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Scene Sync Export の開き方</h1>
+
+    <div class="note">
+      この Export は、<code>index.html</code> を直接ダブルクリックして開くと、
+      ブラウザの制限により 3Dモデルやシーンファイルを読み込めないことがあります。
+    </div>
+
+    <h2>ローカルサーバーで見る方法</h2>
+    <ol>
+      <li>ZIP を展開します。</li>
+      <li>展開したフォルダでターミナルを開きます。</li>
+      <li>次のコマンドを実行します。</li>
+    </ol>
+
+    <pre><code>python3 -m http.server 8080</code></pre>
+
+    <p>そのあと、ブラウザで次のURLを開いてください。</p>
+
+    <pre><code>http://localhost:8080</code></pre>
+
+    <h2>Windows の場合</h2>
+    <p><code>python3</code> が使えない場合は、次のどちらかを試してください。</p>
+
+    <pre><code>python -m http.server 8080</code></pre>
+
+    <p>または:</p>
+
+    <pre><code>py -m http.server 8080</code></pre>
+
+    <h2>補足</h2>
+    <ul>
+      <li>これは読み取り専用のエクスポートです。</li>
+      <li>共同編集や同期機能は含まれていません。</li>
+      <li>初期版の viewer は、一部の依存ファイルを読み込むためにインターネット接続が必要です。</li>
+      <li>WebXR（VR/AR）機能はブラウザとデバイスに対応している場合に利用可能です。</li>
+    </ul>
+
+    <p style="margin-top: 28px; font-size: 14px; color: rgba(255,255,255,0.6);">
+      サーバー起動後は <a href="./index.html">index.html</a> を開いて表示できます。
+    </p>
+  </main>
+</body>
+</html>`;
 }

--- a/html/assets/js/scenesync-export/export/export-readme.js
+++ b/html/assets/js/scenesync-export/export/export-readme.js
@@ -13,21 +13,29 @@ Scene Sync からエクスポートされたシーンが含まれています。
 2. 展開したフォルダでターミナルを開きます。
 3. 次のコマンドを実行します。
 
-   python3 -m http.server 8080
+~~~
+python3 -m http.server 8080
+~~~
 
 4. ブラウザで以下を開きます。
 
-   http://localhost:8080
+~~~
+http://localhost:8080
+~~~
 
 ## Windows の場合
 
 \`python3\` が使えない場合は、次のどちらかを試してください。
 
-   python -m http.server 8080
+~~~
+python -m http.server 8080
+~~~
 
 または:
 
-   py -m http.server 8080
+~~~
+py -m http.server 8080
+~~~
 
 ## 補足
 


### PR DESCRIPTION
- Add generateReadmeHtml() function to create a styled README.html for export packages
- Update generateReadme() with Japanese documentation
- Include README.html in export ZIP file
- Improve index.html with:
  - Inline script to detect file:// protocol and show warning immediately
  - Japanese translation for file protocol warning
  - Link to README.html in the warning
  - Japanese lang attribute in HTML
- Add tests for README.html generation and content validation
- Ensure users understand the need for local server when opening exported packages

https://claude.ai/code/session_01RrKqjcRe75Xzb1FwqLDdRm