### PR TITLE
Add GLB normalizer: Spec/Gloss → Metal/Rough via glTF Transform

### DIFF
--- a/html/assets/js/scenesync/loaders/glb-file-loader.js
+++ b/html/assets/js/scenesync/loaders/glb-file-loader.js
@@ -142,33 +142,23 @@ export class GLBFileLoader {
 
     let normalizedFile = file;
     let normalizedArrayBuffer = null;
-    let normalizationInfo = {
-      changed: false,
-      warnings: [],
-    };
+    let normalized = { changed: false, skipped: false, skipReason: null, warnings: [] };
 
     try {
-      // Normalize GLB if it uses Spec/Gloss materials
-      const normalized = await normalizeGlbForSceneSync(file);
-      normalizationInfo = {
-        changed: normalized.changed,
-        warnings: normalized.warnings || [],
-      };
+      normalized = await normalizeGlbForSceneSync(file);
 
       if (normalized.changed) {
-        // Create a new File from the converted ArrayBuffer
         normalizedFile = new File(
           [normalized.arrayBuffer],
           file.name,
-          { type: 'model/gltf-binary' }
+          { type: 'model/gltf-binary' },
         );
         normalizedArrayBuffer = normalized.arrayBuffer;
-        console.info('[glb-loader] GLB normalized for Scene Sync');
+        console.info('[glb-loader] GLB normalized (Spec/Gloss → Metal/Rough)');
       }
     } catch (error) {
-      // If normalization fails, fall back to original file
-      console.warn('[glb-loader] GLB normalization failed, using original file', error);
-      normalizationInfo.error = error.message;
+      console.warn('[glb-loader] normalizeGlbForSceneSync threw unexpectedly', error);
+      normalized = { changed: false, skipped: true, skipReason: 'unexpectedError', warnings: [error.message], error };
     }
 
     const objectURL = URL.createObjectURL(normalizedFile);
@@ -177,22 +167,16 @@ export class GLBFileLoader {
       const model = await this.loadFromUrl(objectURL, position, scene, null, asset);
       const metadata = model.userData?.scenesync?.glbMetadata;
       if (metadata) {
-        metadata.fileName = file.name; // Keep original name
+        metadata.fileName = file.name;
         metadata.fileSize = file.size;
         metadata.source = 'file';
-        metadata.normalized = normalizationInfo.changed;
-        if (normalizationInfo.changed) {
-          metadata.normalizedFrom = ['KHR_materials_pbrSpecularGlossiness'];
-        }
-        if (normalizationInfo.warnings?.length > 0) {
-          metadata.normalizationWarnings = normalizationInfo.warnings;
-        }
-        if (normalizationInfo.error) {
-          metadata.normalizationError = normalizationInfo.error;
-        }
+        metadata.normalized = normalized.changed;
+        metadata.normalizedFrom = normalized.changed ? ['KHR_materials_pbrSpecularGlossiness'] : [];
+        metadata.normalizationSkipped = normalized.skipped === true;
+        metadata.normalizationSkipReason = normalized.skipReason ?? null;
+        metadata.normalizationWarnings = normalized.warnings ?? [];
       }
 
-      // Store normalized ArrayBuffer in userData for later use
       if (normalizedArrayBuffer) {
         model.userData.normalizedGlbArrayBuffer = normalizedArrayBuffer;
       }

--- a/html/assets/js/scenesync/loaders/glb-file-loader.js
+++ b/html/assets/js/scenesync/loaders/glb-file-loader.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { normalizeGlbForSceneSync } from './glb-normalizer.js';
 
 function toVector3(position) {
   if (!position) return null;
@@ -139,16 +140,63 @@ export class GLBFileLoader {
       throw new Error('必要なパラメータが不足しています');
     }
 
-    const objectURL = URL.createObjectURL(file);
+    let normalizedFile = file;
+    let normalizedArrayBuffer = null;
+    let normalizationInfo = {
+      changed: false,
+      warnings: [],
+    };
+
+    try {
+      // Normalize GLB if it uses Spec/Gloss materials
+      const normalized = await normalizeGlbForSceneSync(file);
+      normalizationInfo = {
+        changed: normalized.changed,
+        warnings: normalized.warnings || [],
+      };
+
+      if (normalized.changed) {
+        // Create a new File from the converted ArrayBuffer
+        normalizedFile = new File(
+          [normalized.arrayBuffer],
+          file.name,
+          { type: 'model/gltf-binary' }
+        );
+        normalizedArrayBuffer = normalized.arrayBuffer;
+        console.info('[glb-loader] GLB normalized for Scene Sync');
+      }
+    } catch (error) {
+      // If normalization fails, fall back to original file
+      console.warn('[glb-loader] GLB normalization failed, using original file', error);
+      normalizationInfo.error = error.message;
+    }
+
+    const objectURL = URL.createObjectURL(normalizedFile);
 
     try {
       const model = await this.loadFromUrl(objectURL, position, scene, null, asset);
       const metadata = model.userData?.scenesync?.glbMetadata;
       if (metadata) {
-        metadata.fileName = file.name;
+        metadata.fileName = file.name; // Keep original name
         metadata.fileSize = file.size;
         metadata.source = 'file';
+        metadata.normalized = normalizationInfo.changed;
+        if (normalizationInfo.changed) {
+          metadata.normalizedFrom = ['KHR_materials_pbrSpecularGlossiness'];
+        }
+        if (normalizationInfo.warnings?.length > 0) {
+          metadata.normalizationWarnings = normalizationInfo.warnings;
+        }
+        if (normalizationInfo.error) {
+          metadata.normalizationError = normalizationInfo.error;
+        }
       }
+
+      // Store normalized ArrayBuffer in userData for later use
+      if (normalizedArrayBuffer) {
+        model.userData.normalizedGlbArrayBuffer = normalizedArrayBuffer;
+      }
+
       if (onLoaded) {
         await onLoaded(model, metadata);
       }

--- a/html/assets/js/scenesync/loaders/glb-normalizer.js
+++ b/html/assets/js/scenesync/loaders/glb-normalizer.js
@@ -1,0 +1,349 @@
+// GLB Normalizer: Converts KHR_materials_pbrSpecularGlossiness to standard pbrMetallicRoughness
+// Spec: https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness
+
+const EXT_SPEC_GLOSS = 'KHR_materials_pbrSpecularGlossiness';
+const EXT_SPEC_GLOSS_TEXTURE = 'KHR_materials_pbrSpecularGlossiness::texture';
+
+/**
+ * Inspect GLB extensions without full parsing
+ * @param {ArrayBuffer} arrayBuffer - GLB file as ArrayBuffer
+ * @returns {Object} Inspection result with extension info
+ */
+export function inspectGlbExtensions(arrayBuffer) {
+  if (!arrayBuffer || arrayBuffer.byteLength < 20) {
+    return {
+      valid: false,
+      hasSpecGloss: false,
+      requiresSpecGloss: false,
+      extensionsUsed: [],
+      extensionsRequired: [],
+    };
+  }
+
+  try {
+    const view = new DataView(arrayBuffer);
+    const magic = view.getUint32(0, true);
+    const version = view.getUint32(4, true);
+
+    if (magic !== 0x46546C67) { // 'glTF' in little-endian
+      return {
+        valid: false,
+        hasSpecGloss: false,
+        requiresSpecGloss: false,
+        extensionsUsed: [],
+        extensionsRequired: [],
+      };
+    }
+
+    if (version !== 2) {
+      return {
+        valid: false,
+        hasSpecGloss: false,
+        requiresSpecGloss: false,
+        extensionsUsed: [],
+        extensionsRequired: [],
+      };
+    }
+
+    // Skip to first chunk (JSON)
+    // GLB header: 4 (magic) + 4 (version) + 4 (length)
+    // Chunk header: 4 (length) + 4 (type)
+    const jsonChunkLength = view.getUint32(12, true);
+    const jsonChunkType = view.getUint32(16, true);
+
+    if (jsonChunkType !== 0x4E4F534A) { // 'JSON' in little-endian
+      return {
+        valid: false,
+        hasSpecGloss: false,
+        requiresSpecGloss: false,
+        extensionsUsed: [],
+        extensionsRequired: [],
+      };
+    }
+
+    const jsonStart = 20;
+    const jsonEnd = jsonStart + jsonChunkLength;
+
+    if (jsonEnd > arrayBuffer.byteLength) {
+      return {
+        valid: false,
+        hasSpecGloss: false,
+        requiresSpecGloss: false,
+        extensionsUsed: [],
+        extensionsRequired: [],
+      };
+    }
+
+    const jsonBytes = new Uint8Array(arrayBuffer, jsonStart, jsonChunkLength);
+    const jsonString = new TextDecoder().decode(jsonBytes);
+    const json = JSON.parse(jsonString);
+
+    const extensionsUsed = json.extensionsUsed || [];
+    const extensionsRequired = json.extensionsRequired || [];
+
+    const hasSpecGloss =
+      extensionsUsed.includes(EXT_SPEC_GLOSS) ||
+      extensionsRequired.includes(EXT_SPEC_GLOSS);
+
+    const requiresSpecGloss = extensionsRequired.includes(EXT_SPEC_GLOSS);
+
+    return {
+      valid: true,
+      hasSpecGloss,
+      requiresSpecGloss,
+      extensionsUsed,
+      extensionsRequired,
+      materialCount: json.materials?.length || 0,
+    };
+  } catch (error) {
+    console.warn('[glb-normalizer] Failed to inspect GLB extensions', error);
+    return {
+      valid: false,
+      hasSpecGloss: false,
+      requiresSpecGloss: false,
+      extensionsUsed: [],
+      extensionsRequired: [],
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * Convert Spec/Gloss material extension to Metal/Rough
+ * Based on the conversion formulas from the glTF extension spec
+ */
+function convertSpecGlossToMetalRough(specGlossExt) {
+  if (!specGlossExt) return {};
+
+  const result = {};
+
+  // diffuseFactor -> baseColorFactor
+  if (specGlossExt.diffuseFactor) {
+    result.baseColorFactor = [...specGlossExt.diffuseFactor];
+  }
+
+  // diffuseTexture -> baseColorTexture
+  if (specGlossExt.diffuseTexture) {
+    result.baseColorTexture = { ...specGlossExt.diffuseTexture };
+  }
+
+  // specularFactor + glossinessFactor -> metallicFactor + roughnessFactor
+  // Use a simplified conversion: assume non-metallic (typical for most models)
+  // metallic = 0.0, roughness = 1.0 - glossiness
+  const glossiness = specGlossExt.glossinessFactor ?? 1.0;
+  result.roughnessFactor = 1.0 - glossiness;
+  result.metallicFactor = 0.0; // Assume non-metallic by default
+
+  // Handle specularGlossiness texture -> roughness texture
+  // This is more complex; we'll create a placeholder approach
+  if (specGlossExt.specularGlossinessTexture) {
+    // In a real conversion, we'd need to process the texture data
+    // For now, we'll note that the texture exists but skip texture conversion
+    result._specularGlossTextureExists = true;
+  }
+
+  return result;
+}
+
+/**
+ * Normalize GLB by converting Spec/Gloss materials to Metal/Rough
+ * @param {File|ArrayBuffer} fileOrArrayBuffer - GLB file or ArrayBuffer
+ * @param {Object} options - Conversion options
+ * @returns {Promise<Object>} Result object
+ */
+export async function normalizeGlbForSceneSync(fileOrArrayBuffer, options = {}) {
+  try {
+    const arrayBuffer =
+      fileOrArrayBuffer instanceof File
+        ? await fileOrArrayBuffer.arrayBuffer()
+        : fileOrArrayBuffer;
+
+    if (!arrayBuffer || arrayBuffer.byteLength < 20) {
+      return {
+        arrayBuffer,
+        changed: false,
+        inspection: { valid: false },
+        warnings: [],
+      };
+    }
+
+    const inspection = inspectGlbExtensions(arrayBuffer);
+
+    if (!inspection.valid || !inspection.hasSpecGloss) {
+      return {
+        arrayBuffer,
+        changed: false,
+        inspection,
+        warnings: [],
+      };
+    }
+
+    // Parse GLB and convert materials
+    const result = convertGlbMaterials(arrayBuffer);
+
+    if (result.error) {
+      console.warn('[glb-normalizer] Failed to convert', result.error);
+      return {
+        arrayBuffer,
+        changed: false,
+        inspection,
+        warnings: [result.error],
+      };
+    }
+
+    return {
+      arrayBuffer: result.arrayBuffer,
+      changed: true,
+      inspection,
+      warnings: result.warnings || [],
+    };
+  } catch (error) {
+    console.warn('[glb-normalizer] Normalization failed', error);
+    throw error;
+  }
+}
+
+/**
+ * Convert materials in GLB from Spec/Gloss to Metal/Rough
+ */
+function convertGlbMaterials(arrayBuffer) {
+  try {
+    const view = new DataView(arrayBuffer);
+
+    // Parse GLB header
+    const magic = view.getUint32(0, true);
+    const version = view.getUint32(4, true);
+    const totalLength = view.getUint32(8, true);
+
+    if (magic !== 0x46546C67 || version !== 2) {
+      return { error: 'Invalid GLB format' };
+    }
+
+    // Parse JSON chunk
+    const jsonChunkLength = view.getUint32(12, true);
+    const jsonChunkType = view.getUint32(16, true);
+
+    if (jsonChunkType !== 0x4E4F534A) {
+      return { error: 'No JSON chunk found' };
+    }
+
+    const jsonStart = 20;
+    const jsonBytes = new Uint8Array(arrayBuffer, jsonStart, jsonChunkLength);
+    const jsonString = new TextDecoder().decode(jsonBytes);
+    const json = JSON.parse(jsonString);
+
+    const warnings = [];
+
+    // Convert materials
+    if (json.materials && Array.isArray(json.materials)) {
+      for (let i = 0; i < json.materials.length; i++) {
+        const material = json.materials[i];
+
+        if (material.extensions && material.extensions[EXT_SPEC_GLOSS]) {
+          const specGloss = material.extensions[EXT_SPEC_GLOSS];
+
+          // Convert to Metal/Rough
+          const converted = convertSpecGlossToMetalRough(specGloss);
+
+          // Merge converted properties
+          if (!material.pbrMetallicRoughness) {
+            material.pbrMetallicRoughness = {};
+          }
+
+          Object.assign(material.pbrMetallicRoughness, converted);
+
+          // Remove Spec/Gloss extension
+          delete material.extensions[EXT_SPEC_GLOSS];
+
+          // Clean up empty extensions object
+          if (Object.keys(material.extensions).length === 0) {
+            delete material.extensions;
+          }
+
+          warnings.push(`Material ${i}: Converted from Spec/Gloss to Metal/Rough`);
+
+          if (converted._specularGlossTextureExists) {
+            warnings.push(`Material ${i}: Specular-Glossiness texture not converted`);
+            delete converted._specularGlossTextureExists;
+          }
+        }
+      }
+    }
+
+    // Update extensionsUsed and extensionsRequired
+    if (json.extensionsUsed) {
+      json.extensionsUsed = json.extensionsUsed.filter(
+        (ext) => ext !== EXT_SPEC_GLOSS
+      );
+      if (json.extensionsUsed.length === 0) {
+        delete json.extensionsUsed;
+      }
+    }
+
+    if (json.extensionsRequired) {
+      json.extensionsRequired = json.extensionsRequired.filter(
+        (ext) => ext !== EXT_SPEC_GLOSS
+      );
+      if (json.extensionsRequired.length === 0) {
+        delete json.extensionsRequired;
+      }
+    }
+
+    // Rebuild GLB with modified JSON
+    const newJsonString = JSON.stringify(json);
+    const newJsonBytes = new TextEncoder().encode(newJsonString);
+    const newJsonLength = newJsonBytes.length;
+
+    // GLB binary chunk starts after JSON chunk + padding
+    const jsonPaddingLength = (4 - (jsonChunkLength % 4)) % 4;
+    const binaryChunkStart = jsonStart + jsonChunkLength + jsonPaddingLength;
+
+    const binaryChunkLength = totalLength - binaryChunkStart;
+    const binaryChunkData = new Uint8Array(arrayBuffer, binaryChunkStart, binaryChunkLength);
+
+    // Calculate new total length
+    const newJsonPaddingLength = (4 - (newJsonLength % 4)) % 4;
+    const newTotalLength = 12 + (8 + newJsonLength + newJsonPaddingLength) + (8 + binaryChunkLength);
+
+    // Build new GLB
+    const newGlb = new ArrayBuffer(newTotalLength);
+    const newView = new DataView(newGlb);
+    const newUint8 = new Uint8Array(newGlb);
+
+    // Header
+    newView.setUint32(0, 0x46546C67, true); // magic
+    newView.setUint32(4, 2, true); // version
+    newView.setUint32(8, newTotalLength, true); // length
+
+    // JSON chunk header
+    newView.setUint32(12, newJsonLength, true);
+    newView.setUint32(16, 0x4E4F534A, true); // 'JSON'
+
+    // JSON data
+    newUint8.set(newJsonBytes, 20);
+
+    // JSON padding
+    const jsonPadStart = 20 + newJsonLength;
+    for (let i = 0; i < newJsonPaddingLength; i++) {
+      newUint8[jsonPadStart + i] = 0x20; // space character
+    }
+
+    // Binary chunk header
+    const binChunkHeaderStart = 20 + newJsonLength + newJsonPaddingLength;
+    newView.setUint32(binChunkHeaderStart, binaryChunkLength, true);
+    newView.setUint32(binChunkHeaderStart + 4, 0x004E4942, true); // 'BIN\0'
+
+    // Binary data
+    const binDataStart = binChunkHeaderStart + 8;
+    newUint8.set(binaryChunkData, binDataStart);
+
+    return {
+      arrayBuffer: newGlb,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  } catch (error) {
+    return {
+      error: error.message,
+    };
+  }
+}

--- a/html/assets/js/scenesync/loaders/glb-normalizer.js
+++ b/html/assets/js/scenesync/loaders/glb-normalizer.js
@@ -1,82 +1,58 @@
 // GLB Normalizer: Converts KHR_materials_pbrSpecularGlossiness to standard pbrMetallicRoughness
-// Spec: https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness
+// Uses glTF Transform metalRough() for proper conversion including texture handling.
+
+import { WebIO } from '@gltf-transform/core';
+import {
+  KHRMaterialsPBRSpecularGlossiness,
+  KHRMaterialsIOR,
+  KHRMaterialsSpecular,
+} from '@gltf-transform/extensions';
+import { metalRough } from '@gltf-transform/functions';
 
 const EXT_SPEC_GLOSS = 'KHR_materials_pbrSpecularGlossiness';
-const EXT_SPEC_GLOSS_TEXTURE = 'KHR_materials_pbrSpecularGlossiness::texture';
+
+let _io = null;
+
+function getIO() {
+  if (!_io) {
+    _io = new WebIO().registerExtensions([
+      KHRMaterialsPBRSpecularGlossiness,
+      KHRMaterialsIOR,
+      KHRMaterialsSpecular,
+    ]);
+  }
+  return _io;
+}
 
 /**
- * Inspect GLB extensions without full parsing
- * @param {ArrayBuffer} arrayBuffer - GLB file as ArrayBuffer
- * @returns {Object} Inspection result with extension info
+ * Inspect GLB extensions without full parsing (lightweight, no external deps).
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {{ valid, hasSpecGloss, requiresSpecGloss, extensionsUsed, extensionsRequired, materialCount }}
  */
 export function inspectGlbExtensions(arrayBuffer) {
-  if (!arrayBuffer || arrayBuffer.byteLength < 20) {
-    return {
-      valid: false,
-      hasSpecGloss: false,
-      requiresSpecGloss: false,
-      extensionsUsed: [],
-      extensionsRequired: [],
-    };
-  }
+  const fail = (extra = {}) => ({
+    valid: false,
+    hasSpecGloss: false,
+    requiresSpecGloss: false,
+    extensionsUsed: [],
+    extensionsRequired: [],
+    ...extra,
+  });
+
+  if (!arrayBuffer || arrayBuffer.byteLength < 20) return fail();
 
   try {
     const view = new DataView(arrayBuffer);
-    const magic = view.getUint32(0, true);
-    const version = view.getUint32(4, true);
 
-    if (magic !== 0x46546C67) { // 'glTF' in little-endian
-      return {
-        valid: false,
-        hasSpecGloss: false,
-        requiresSpecGloss: false,
-        extensionsUsed: [],
-        extensionsRequired: [],
-      };
-    }
+    if (view.getUint32(0, true) !== 0x46546C67) return fail(); // magic 'glTF'
+    if (view.getUint32(4, true) !== 2) return fail();          // version 2
 
-    if (version !== 2) {
-      return {
-        valid: false,
-        hasSpecGloss: false,
-        requiresSpecGloss: false,
-        extensionsUsed: [],
-        extensionsRequired: [],
-      };
-    }
-
-    // Skip to first chunk (JSON)
-    // GLB header: 4 (magic) + 4 (version) + 4 (length)
-    // Chunk header: 4 (length) + 4 (type)
     const jsonChunkLength = view.getUint32(12, true);
-    const jsonChunkType = view.getUint32(16, true);
+    if (view.getUint32(16, true) !== 0x4E4F534A) return fail(); // chunk type 'JSON'
+    if (20 + jsonChunkLength > arrayBuffer.byteLength) return fail();
 
-    if (jsonChunkType !== 0x4E4F534A) { // 'JSON' in little-endian
-      return {
-        valid: false,
-        hasSpecGloss: false,
-        requiresSpecGloss: false,
-        extensionsUsed: [],
-        extensionsRequired: [],
-      };
-    }
-
-    const jsonStart = 20;
-    const jsonEnd = jsonStart + jsonChunkLength;
-
-    if (jsonEnd > arrayBuffer.byteLength) {
-      return {
-        valid: false,
-        hasSpecGloss: false,
-        requiresSpecGloss: false,
-        extensionsUsed: [],
-        extensionsRequired: [],
-      };
-    }
-
-    const jsonBytes = new Uint8Array(arrayBuffer, jsonStart, jsonChunkLength);
-    const jsonString = new TextDecoder().decode(jsonBytes);
-    const json = JSON.parse(jsonString);
+    const jsonBytes = new Uint8Array(arrayBuffer, 20, jsonChunkLength);
+    const json = JSON.parse(new TextDecoder().decode(jsonBytes));
 
     const extensionsUsed = json.extensionsUsed || [];
     const extensionsRequired = json.extensionsRequired || [];
@@ -85,265 +61,89 @@ export function inspectGlbExtensions(arrayBuffer) {
       extensionsUsed.includes(EXT_SPEC_GLOSS) ||
       extensionsRequired.includes(EXT_SPEC_GLOSS);
 
-    const requiresSpecGloss = extensionsRequired.includes(EXT_SPEC_GLOSS);
-
     return {
       valid: true,
       hasSpecGloss,
-      requiresSpecGloss,
+      requiresSpecGloss: extensionsRequired.includes(EXT_SPEC_GLOSS),
       extensionsUsed,
       extensionsRequired,
       materialCount: json.materials?.length || 0,
     };
   } catch (error) {
     console.warn('[glb-normalizer] Failed to inspect GLB extensions', error);
-    return {
-      valid: false,
-      hasSpecGloss: false,
-      requiresSpecGloss: false,
-      extensionsUsed: [],
-      extensionsRequired: [],
-      error: error.message,
-    };
+    return fail({ error: error.message });
   }
 }
 
 /**
- * Convert Spec/Gloss material extension to Metal/Rough
- * Based on the conversion formulas from the glTF extension spec
+ * Normalize GLB for Scene Sync: converts KHR_materials_pbrSpecularGlossiness
+ * to standard pbrMetallicRoughness using glTF Transform's metalRough() transform.
+ *
+ * @param {File|ArrayBuffer} fileOrArrayBuffer
+ * @returns {Promise<{
+ *   arrayBuffer: ArrayBuffer,
+ *   changed: boolean,
+ *   skipped: boolean,
+ *   skipReason: string|null,
+ *   inspection: object,
+ *   warnings: string[],
+ *   error?: Error,
+ * }>}
  */
-function convertSpecGlossToMetalRough(specGlossExt) {
-  if (!specGlossExt) return {};
+export async function normalizeGlbForSceneSync(fileOrArrayBuffer) {
+  const arrayBuffer =
+    fileOrArrayBuffer instanceof File
+      ? await fileOrArrayBuffer.arrayBuffer()
+      : fileOrArrayBuffer;
 
-  const result = {};
+  const ok = (changed, skipped, skipReason, inspection, warnings = [], extra = {}) => ({
+    arrayBuffer,
+    changed,
+    skipped,
+    skipReason,
+    inspection,
+    warnings,
+    ...extra,
+  });
 
-  // diffuseFactor -> baseColorFactor
-  if (specGlossExt.diffuseFactor) {
-    result.baseColorFactor = [...specGlossExt.diffuseFactor];
+  if (!arrayBuffer || arrayBuffer.byteLength < 20) {
+    return ok(false, false, null, { valid: false });
   }
 
-  // diffuseTexture -> baseColorTexture
-  if (specGlossExt.diffuseTexture) {
-    result.baseColorTexture = { ...specGlossExt.diffuseTexture };
+  const inspection = inspectGlbExtensions(arrayBuffer);
+
+  if (!inspection.valid || !inspection.hasSpecGloss) {
+    return ok(false, false, null, inspection);
   }
 
-  // specularFactor + glossinessFactor -> metallicFactor + roughnessFactor
-  // Use a simplified conversion: assume non-metallic (typical for most models)
-  // metallic = 0.0, roughness = 1.0 - glossiness
-  const glossiness = specGlossExt.glossinessFactor ?? 1.0;
-  result.roughnessFactor = 1.0 - glossiness;
-  result.metallicFactor = 0.0; // Assume non-metallic by default
-
-  // Handle specularGlossiness texture -> roughness texture
-  // This is more complex; we'll create a placeholder approach
-  if (specGlossExt.specularGlossinessTexture) {
-    // In a real conversion, we'd need to process the texture data
-    // For now, we'll note that the texture exists but skip texture conversion
-    result._specularGlossTextureExists = true;
-  }
-
-  return result;
-}
-
-/**
- * Normalize GLB by converting Spec/Gloss materials to Metal/Rough
- * @param {File|ArrayBuffer} fileOrArrayBuffer - GLB file or ArrayBuffer
- * @param {Object} options - Conversion options
- * @returns {Promise<Object>} Result object
- */
-export async function normalizeGlbForSceneSync(fileOrArrayBuffer, options = {}) {
   try {
-    const arrayBuffer =
-      fileOrArrayBuffer instanceof File
-        ? await fileOrArrayBuffer.arrayBuffer()
-        : fileOrArrayBuffer;
+    const io = getIO();
+    const input = new Uint8Array(arrayBuffer);
 
-    if (!arrayBuffer || arrayBuffer.byteLength < 20) {
-      return {
-        arrayBuffer,
-        changed: false,
-        inspection: { valid: false },
-        warnings: [],
-      };
-    }
+    const document = await io.readBinary(input);
 
-    const inspection = inspectGlbExtensions(arrayBuffer);
+    await document.transform(metalRough());
 
-    if (!inspection.valid || !inspection.hasSpecGloss) {
-      return {
-        arrayBuffer,
-        changed: false,
-        inspection,
-        warnings: [],
-      };
-    }
+    const output = await io.writeBinary(document);
 
-    // Parse GLB and convert materials
-    const result = convertGlbMaterials(arrayBuffer);
-
-    if (result.error) {
-      console.warn('[glb-normalizer] Failed to convert', result.error);
-      return {
-        arrayBuffer,
-        changed: false,
-        inspection,
-        warnings: [result.error],
-      };
-    }
+    const normalizedBuffer = output.buffer.slice(
+      output.byteOffset,
+      output.byteOffset + output.byteLength,
+    );
 
     return {
-      arrayBuffer: result.arrayBuffer,
+      arrayBuffer: normalizedBuffer,
       changed: true,
+      skipped: false,
+      skipReason: null,
       inspection,
-      warnings: result.warnings || [],
+      warnings: [],
     };
   } catch (error) {
-    console.warn('[glb-normalizer] Normalization failed', error);
-    throw error;
-  }
-}
+    console.warn('[glb-normalizer] glTF Transform metalRough failed', error);
 
-/**
- * Convert materials in GLB from Spec/Gloss to Metal/Rough
- */
-function convertGlbMaterials(arrayBuffer) {
-  try {
-    const view = new DataView(arrayBuffer);
-
-    // Parse GLB header
-    const magic = view.getUint32(0, true);
-    const version = view.getUint32(4, true);
-    const totalLength = view.getUint32(8, true);
-
-    if (magic !== 0x46546C67 || version !== 2) {
-      return { error: 'Invalid GLB format' };
-    }
-
-    // Parse JSON chunk
-    const jsonChunkLength = view.getUint32(12, true);
-    const jsonChunkType = view.getUint32(16, true);
-
-    if (jsonChunkType !== 0x4E4F534A) {
-      return { error: 'No JSON chunk found' };
-    }
-
-    const jsonStart = 20;
-    const jsonBytes = new Uint8Array(arrayBuffer, jsonStart, jsonChunkLength);
-    const jsonString = new TextDecoder().decode(jsonBytes);
-    const json = JSON.parse(jsonString);
-
-    const warnings = [];
-
-    // Convert materials
-    if (json.materials && Array.isArray(json.materials)) {
-      for (let i = 0; i < json.materials.length; i++) {
-        const material = json.materials[i];
-
-        if (material.extensions && material.extensions[EXT_SPEC_GLOSS]) {
-          const specGloss = material.extensions[EXT_SPEC_GLOSS];
-
-          // Convert to Metal/Rough
-          const converted = convertSpecGlossToMetalRough(specGloss);
-
-          // Merge converted properties
-          if (!material.pbrMetallicRoughness) {
-            material.pbrMetallicRoughness = {};
-          }
-
-          Object.assign(material.pbrMetallicRoughness, converted);
-
-          // Remove Spec/Gloss extension
-          delete material.extensions[EXT_SPEC_GLOSS];
-
-          // Clean up empty extensions object
-          if (Object.keys(material.extensions).length === 0) {
-            delete material.extensions;
-          }
-
-          warnings.push(`Material ${i}: Converted from Spec/Gloss to Metal/Rough`);
-
-          if (converted._specularGlossTextureExists) {
-            warnings.push(`Material ${i}: Specular-Glossiness texture not converted`);
-            delete converted._specularGlossTextureExists;
-          }
-        }
-      }
-    }
-
-    // Update extensionsUsed and extensionsRequired
-    if (json.extensionsUsed) {
-      json.extensionsUsed = json.extensionsUsed.filter(
-        (ext) => ext !== EXT_SPEC_GLOSS
-      );
-      if (json.extensionsUsed.length === 0) {
-        delete json.extensionsUsed;
-      }
-    }
-
-    if (json.extensionsRequired) {
-      json.extensionsRequired = json.extensionsRequired.filter(
-        (ext) => ext !== EXT_SPEC_GLOSS
-      );
-      if (json.extensionsRequired.length === 0) {
-        delete json.extensionsRequired;
-      }
-    }
-
-    // Rebuild GLB with modified JSON
-    const newJsonString = JSON.stringify(json);
-    const newJsonBytes = new TextEncoder().encode(newJsonString);
-    const newJsonLength = newJsonBytes.length;
-
-    // GLB binary chunk starts after JSON chunk + padding
-    const jsonPaddingLength = (4 - (jsonChunkLength % 4)) % 4;
-    const binaryChunkStart = jsonStart + jsonChunkLength + jsonPaddingLength;
-
-    const binaryChunkLength = totalLength - binaryChunkStart;
-    const binaryChunkData = new Uint8Array(arrayBuffer, binaryChunkStart, binaryChunkLength);
-
-    // Calculate new total length
-    const newJsonPaddingLength = (4 - (newJsonLength % 4)) % 4;
-    const newTotalLength = 12 + (8 + newJsonLength + newJsonPaddingLength) + (8 + binaryChunkLength);
-
-    // Build new GLB
-    const newGlb = new ArrayBuffer(newTotalLength);
-    const newView = new DataView(newGlb);
-    const newUint8 = new Uint8Array(newGlb);
-
-    // Header
-    newView.setUint32(0, 0x46546C67, true); // magic
-    newView.setUint32(4, 2, true); // version
-    newView.setUint32(8, newTotalLength, true); // length
-
-    // JSON chunk header
-    newView.setUint32(12, newJsonLength, true);
-    newView.setUint32(16, 0x4E4F534A, true); // 'JSON'
-
-    // JSON data
-    newUint8.set(newJsonBytes, 20);
-
-    // JSON padding
-    const jsonPadStart = 20 + newJsonLength;
-    for (let i = 0; i < newJsonPaddingLength; i++) {
-      newUint8[jsonPadStart + i] = 0x20; // space character
-    }
-
-    // Binary chunk header
-    const binChunkHeaderStart = 20 + newJsonLength + newJsonPaddingLength;
-    newView.setUint32(binChunkHeaderStart, binaryChunkLength, true);
-    newView.setUint32(binChunkHeaderStart + 4, 0x004E4942, true); // 'BIN\0'
-
-    // Binary data
-    const binDataStart = binChunkHeaderStart + 8;
-    newUint8.set(binaryChunkData, binDataStart);
-
-    return {
-      arrayBuffer: newGlb,
-      warnings: warnings.length > 0 ? warnings : undefined,
-    };
-  } catch (error) {
-    return {
-      error: error.message,
-    };
+    return ok(false, true, 'metalRoughFailed', inspection, [
+      `Failed to convert ${EXT_SPEC_GLOSS}: ${error.message}`,
+    ], { error });
   }
 }

--- a/html/assets/js/scenesync/loaders/glb-normalizer.test.js
+++ b/html/assets/js/scenesync/loaders/glb-normalizer.test.js
@@ -1,0 +1,247 @@
+// Tests for GLB Normalizer
+// Run with: node --test glb-normalizer.test.js (after setting up ESM environment)
+
+import { inspectGlbExtensions, normalizeGlbForSceneSync } from './glb-normalizer.js';
+import { test } from 'node:test';
+import { strictEqual, deepEqual, ok, match } from 'node:assert';
+
+// Helper for floating-point comparison with tolerance
+function assertClose(actual, expected, tolerance = 0.0001) {
+  ok(Math.abs(actual - expected) < tolerance, `Expected ${actual} to be close to ${expected}`);
+}
+
+/**
+ * Helper to create a minimal valid GLB with JSON chunk
+ */
+function createMinimalGlb(json) {
+  const jsonString = JSON.stringify(json);
+  const jsonBytes = new TextEncoder().encode(jsonString);
+  const jsonLength = jsonBytes.length;
+
+  // Minimal binary chunk (empty)
+  const binaryChunkLength = 0;
+
+  // Total length: 12 (header) + 8 (JSON chunk header) + jsonLength + padding
+  const jsonPaddingLength = (4 - (jsonLength % 4)) % 4;
+  const totalLength = 12 + (8 + jsonLength + jsonPaddingLength) + (8 + binaryChunkLength);
+
+  const glb = new ArrayBuffer(totalLength);
+  const view = new DataView(glb);
+  const uint8 = new Uint8Array(glb);
+
+  // Header
+  view.setUint32(0, 0x46546C67, true); // magic: 'glTF'
+  view.setUint32(4, 2, true); // version
+  view.setUint32(8, totalLength, true); // length
+
+  // JSON chunk header
+  view.setUint32(12, jsonLength, true);
+  view.setUint32(16, 0x4E4F534A, true); // type: 'JSON'
+
+  // JSON data
+  uint8.set(jsonBytes, 20);
+
+  // JSON padding
+  const jsonPadStart = 20 + jsonLength;
+  for (let i = 0; i < jsonPaddingLength; i++) {
+    uint8[jsonPadStart + i] = 0x20; // space
+  }
+
+  return glb;
+}
+
+test('inspectGlbExtensions - detects KHR_materials_pbrSpecularGlossiness', (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    extensionsRequired: [],
+    materials: [],
+  });
+
+  const result = inspectGlbExtensions(glb);
+  strictEqual(result.valid, true);
+  strictEqual(result.hasSpecGloss, true);
+  strictEqual(result.requiresSpecGloss, false);
+});
+
+test('inspectGlbExtensions - detects required KHR_materials_pbrSpecularGlossiness', (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    extensionsRequired: ['KHR_materials_pbrSpecularGlossiness'],
+    materials: [],
+  });
+
+  const result = inspectGlbExtensions(glb);
+  strictEqual(result.valid, true);
+  strictEqual(result.hasSpecGloss, true);
+  strictEqual(result.requiresSpecGloss, true);
+});
+
+test('inspectGlbExtensions - returns false when extension not present', (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_clearcoat'],
+    extensionsRequired: [],
+    materials: [],
+  });
+
+  const result = inspectGlbExtensions(glb);
+  strictEqual(result.valid, true);
+  strictEqual(result.hasSpecGloss, false);
+  strictEqual(result.requiresSpecGloss, false);
+});
+
+test('inspectGlbExtensions - returns valid=false for invalid GLB', (t) => {
+  const invalidGlb = new ArrayBuffer(10); // Too short
+  const result = inspectGlbExtensions(invalidGlb);
+  strictEqual(result.valid, false);
+  strictEqual(result.hasSpecGloss, false);
+});
+
+test('normalizeGlbForSceneSync - returns unchanged when no Spec/Gloss', async (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: [],
+    materials: [
+      {
+        pbrMetallicRoughness: {
+          baseColorFactor: [1, 1, 1, 1],
+          metallicFactor: 0,
+          roughnessFactor: 1,
+        },
+      },
+    ],
+  });
+
+  const result = await normalizeGlbForSceneSync(glb);
+  strictEqual(result.changed, false);
+  deepEqual(result.arrayBuffer, glb);
+});
+
+test('normalizeGlbForSceneSync - converts Spec/Gloss material', async (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    materials: [
+      {
+        name: 'TestMaterial',
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [0.5, 0.5, 0.5, 1.0],
+            glossinessFactor: 0.8,
+          },
+        },
+      },
+    ],
+  });
+
+  const result = await normalizeGlbForSceneSync(glb);
+  strictEqual(result.changed, true);
+  ok(result.warnings?.length > 0);
+
+  // Verify the converted JSON
+  const view = new DataView(result.arrayBuffer);
+  const jsonChunkLength = view.getUint32(12, true);
+  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
+  const jsonString = new TextDecoder().decode(jsonBytes);
+  const json = JSON.parse(jsonString);
+
+  strictEqual(json.materials[0].extensions?.KHR_materials_pbrSpecularGlossiness, undefined);
+  ok(json.materials[0].pbrMetallicRoughness);
+  deepEqual(json.materials[0].pbrMetallicRoughness.baseColorFactor, [0.5, 0.5, 0.5, 1.0]);
+  assertClose(json.materials[0].pbrMetallicRoughness.roughnessFactor, 0.2); // 1 - 0.8
+  strictEqual(json.materials[0].pbrMetallicRoughness.metallicFactor, 0);
+});
+
+test('normalizeGlbForSceneSync - removes extension from extensionsUsed', async (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness', 'KHR_materials_clearcoat'],
+    materials: [
+      {
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [1, 1, 1, 1],
+            glossinessFactor: 0.5,
+          },
+        },
+      },
+    ],
+  });
+
+  const result = await normalizeGlbForSceneSync(glb);
+  strictEqual(result.changed, true);
+
+  // Verify the converted JSON
+  const view = new DataView(result.arrayBuffer);
+  const jsonChunkLength = view.getUint32(12, true);
+  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
+  const jsonString = new TextDecoder().decode(jsonBytes);
+  const json = JSON.parse(jsonString);
+
+  ok(json.extensionsUsed.includes('KHR_materials_clearcoat'));
+  strictEqual(json.extensionsUsed.includes('KHR_materials_pbrSpecularGlossiness'), false);
+});
+
+test('normalizeGlbForSceneSync - removes extensionsUsed when empty', async (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    materials: [
+      {
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [1, 1, 1, 1],
+            glossinessFactor: 0.5,
+          },
+        },
+      },
+    ],
+  });
+
+  const result = await normalizeGlbForSceneSync(glb);
+  strictEqual(result.changed, true);
+
+  // Verify the converted JSON
+  const view = new DataView(result.arrayBuffer);
+  const jsonChunkLength = view.getUint32(12, true);
+  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
+  const jsonString = new TextDecoder().decode(jsonBytes);
+  const json = JSON.parse(jsonString);
+
+  strictEqual(json.extensionsUsed, undefined);
+});
+
+test('normalizeGlbForSceneSync - handles multiple materials', async (t) => {
+  const glb = createMinimalGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    materials: [
+      {
+        name: 'Mat1',
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [1, 0, 0, 1],
+            glossinessFactor: 0.7,
+          },
+        },
+      },
+      {
+        name: 'Mat2',
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [0, 1, 0, 1],
+            glossinessFactor: 0.9,
+          },
+        },
+      },
+    ],
+  });
+
+  const result = await normalizeGlbForSceneSync(glb);
+  strictEqual(result.changed, true);
+
+  // Verify the converted JSON
+  const view = new DataView(result.arrayBuffer);
+  const jsonChunkLength = view.getUint32(12, true);
+  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
+  const jsonString = new TextDecoder().decode(jsonBytes);
+  const json = JSON.parse(jsonString);
+
+  strictEqual(json.materials.length, 2);
+  assertClose(json.materials[0].pbrMetallicRoughness.roughnessFactor, 0.3); // 1 - 0.7
+  assertClose(json.materials[1].pbrMetallicRoughness.roughnessFactor, 0.1); // 1 - 0.9
+});

--- a/html/assets/js/scenesync/loaders/glb-normalizer.test.js
+++ b/html/assets/js/scenesync/loaders/glb-normalizer.test.js
@@ -1,129 +1,176 @@
-// Tests for GLB Normalizer
-// Run with: node --test glb-normalizer.test.js (after setting up ESM environment)
+// Tests for glb-normalizer.js
+// Run: node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js
 
-import { inspectGlbExtensions, normalizeGlbForSceneSync } from './glb-normalizer.js';
 import { test } from 'node:test';
-import { strictEqual, deepEqual, ok, match } from 'node:assert';
+import { strictEqual, ok, deepEqual } from 'node:assert';
+import { inspectGlbExtensions, normalizeGlbForSceneSync } from './glb-normalizer.js';
 
-// Helper for floating-point comparison with tolerance
-function assertClose(actual, expected, tolerance = 0.0001) {
-  ok(Math.abs(actual - expected) < tolerance, `Expected ${actual} to be close to ${expected}`);
-}
+// ── GLB fixture helpers ──────────────────────────────────────────────────────
 
 /**
- * Helper to create a minimal valid GLB with JSON chunk
+ * Build a minimal valid GLB (binary glTF v2) with a single empty binary chunk.
+ * The binary chunk is required; some parsers reject GLBs without it.
  */
-function createMinimalGlb(json) {
-  const jsonString = JSON.stringify(json);
-  const jsonBytes = new TextEncoder().encode(jsonString);
-  const jsonLength = jsonBytes.length;
+function buildGlb(json) {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const jsonPad = (4 - (jsonBytes.length % 4)) % 4;
+  const paddedJsonLen = jsonBytes.length + jsonPad;
 
-  // Minimal binary chunk (empty)
-  const binaryChunkLength = 0;
+  // empty binary chunk
+  const binLen = 0;
+  const totalLen = 12 + 8 + paddedJsonLen + 8 + binLen;
 
-  // Total length: 12 (header) + 8 (JSON chunk header) + jsonLength + padding
-  const jsonPaddingLength = (4 - (jsonLength % 4)) % 4;
-  const totalLength = 12 + (8 + jsonLength + jsonPaddingLength) + (8 + binaryChunkLength);
+  const buf = new ArrayBuffer(totalLen);
+  const view = new DataView(buf);
+  const u8 = new Uint8Array(buf);
 
-  const glb = new ArrayBuffer(totalLength);
-  const view = new DataView(glb);
-  const uint8 = new Uint8Array(glb);
+  // GLB header
+  view.setUint32(0, 0x46546C67, true); // magic 'glTF'
+  view.setUint32(4, 2, true);          // version
+  view.setUint32(8, totalLen, true);
 
-  // Header
-  view.setUint32(0, 0x46546C67, true); // magic: 'glTF'
-  view.setUint32(4, 2, true); // version
-  view.setUint32(8, totalLength, true); // length
+  // JSON chunk
+  view.setUint32(12, paddedJsonLen, true);
+  view.setUint32(16, 0x4E4F534A, true); // 'JSON'
+  u8.set(jsonBytes, 20);
+  for (let i = 0; i < jsonPad; i++) u8[20 + jsonBytes.length + i] = 0x20; // space padding
 
-  // JSON chunk header
-  view.setUint32(12, jsonLength, true);
-  view.setUint32(16, 0x4E4F534A, true); // type: 'JSON'
+  // BIN chunk (empty)
+  const binOffset = 20 + paddedJsonLen;
+  view.setUint32(binOffset, 0, true);
+  view.setUint32(binOffset + 4, 0x004E4942, true); // 'BIN\0'
 
-  // JSON data
-  uint8.set(jsonBytes, 20);
-
-  // JSON padding
-  const jsonPadStart = 20 + jsonLength;
-  for (let i = 0; i < jsonPaddingLength; i++) {
-    uint8[jsonPadStart + i] = 0x20; // space
-  }
-
-  return glb;
+  return buf;
 }
 
-test('inspectGlbExtensions - detects KHR_materials_pbrSpecularGlossiness', (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
-    extensionsRequired: [],
-    materials: [],
-  });
+/** Re-parse JSON from a GLB ArrayBuffer */
+function readGlbJson(ab) {
+  const view = new DataView(ab);
+  const jsonLen = view.getUint32(12, true);
+  const bytes = new Uint8Array(ab, 20, jsonLen);
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
 
-  const result = inspectGlbExtensions(glb);
-  strictEqual(result.valid, true);
-  strictEqual(result.hasSpecGloss, true);
-  strictEqual(result.requiresSpecGloss, false);
+// ── Tests: inspectGlbExtensions ──────────────────────────────────────────────
+
+test('inspectGlbExtensions – detects KHR_materials_pbrSpecularGlossiness in extensionsUsed', () => {
+  const ab = buildGlb({
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+  });
+  const r = inspectGlbExtensions(ab);
+  strictEqual(r.valid, true);
+  strictEqual(r.hasSpecGloss, true);
+  strictEqual(r.requiresSpecGloss, false);
 });
 
-test('inspectGlbExtensions - detects required KHR_materials_pbrSpecularGlossiness', (t) => {
-  const glb = createMinimalGlb({
+test('inspectGlbExtensions – requiresSpecGloss true when in extensionsRequired', () => {
+  const ab = buildGlb({
     extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
     extensionsRequired: ['KHR_materials_pbrSpecularGlossiness'],
-    materials: [],
   });
-
-  const result = inspectGlbExtensions(glb);
-  strictEqual(result.valid, true);
-  strictEqual(result.hasSpecGloss, true);
-  strictEqual(result.requiresSpecGloss, true);
+  const r = inspectGlbExtensions(ab);
+  strictEqual(r.valid, true);
+  strictEqual(r.hasSpecGloss, true);
+  strictEqual(r.requiresSpecGloss, true);
 });
 
-test('inspectGlbExtensions - returns false when extension not present', (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: ['KHR_materials_clearcoat'],
-    extensionsRequired: [],
-    materials: [],
+test('inspectGlbExtensions – returns false for standard Metal/Rough GLB', () => {
+  const ab = buildGlb({
+    materials: [{ pbrMetallicRoughness: { baseColorFactor: [1, 1, 1, 1] } }],
   });
-
-  const result = inspectGlbExtensions(glb);
-  strictEqual(result.valid, true);
-  strictEqual(result.hasSpecGloss, false);
-  strictEqual(result.requiresSpecGloss, false);
+  const r = inspectGlbExtensions(ab);
+  strictEqual(r.valid, true);
+  strictEqual(r.hasSpecGloss, false);
 });
 
-test('inspectGlbExtensions - returns valid=false for invalid GLB', (t) => {
-  const invalidGlb = new ArrayBuffer(10); // Too short
-  const result = inspectGlbExtensions(invalidGlb);
-  strictEqual(result.valid, false);
-  strictEqual(result.hasSpecGloss, false);
+test('inspectGlbExtensions – returns valid=false for too-short buffer', () => {
+  const r = inspectGlbExtensions(new ArrayBuffer(10));
+  strictEqual(r.valid, false);
+  strictEqual(r.hasSpecGloss, false);
 });
 
-test('normalizeGlbForSceneSync - returns unchanged when no Spec/Gloss', async (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: [],
+test('inspectGlbExtensions – returns valid=false for wrong magic', () => {
+  const ab = new ArrayBuffer(24);
+  // leave magic as 0 (invalid)
+  const r = inspectGlbExtensions(ab);
+  strictEqual(r.valid, false);
+});
+
+// ── Tests: normalizeGlbForSceneSync ─────────────────────────────────────────
+
+test('normalizeGlbForSceneSync – changed=false for standard Metal/Rough GLB', async () => {
+  const ab = buildGlb({
+    materials: [{ pbrMetallicRoughness: { baseColorFactor: [1, 0, 0, 1] } }],
+  });
+  const r = await normalizeGlbForSceneSync(ab);
+  strictEqual(r.changed, false);
+  strictEqual(r.skipped, false);
+  strictEqual(r.skipReason, null);
+  // should return original buffer unchanged
+  deepEqual(new Uint8Array(r.arrayBuffer), new Uint8Array(ab));
+});
+
+test('normalizeGlbForSceneSync – converts Spec/Gloss GLB (factor-only, no textures)', async () => {
+  const ab = buildGlb({
+    asset: { version: '2.0' },
+    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
+    extensionsRequired: ['KHR_materials_pbrSpecularGlossiness'],
     materials: [
       {
-        pbrMetallicRoughness: {
-          baseColorFactor: [1, 1, 1, 1],
-          metallicFactor: 0,
-          roughnessFactor: 1,
+        name: 'TestMat',
+        extensions: {
+          KHR_materials_pbrSpecularGlossiness: {
+            diffuseFactor: [0.8, 0.1, 0.1, 1.0],
+            specularFactor: [0.1, 0.1, 0.1],
+            glossinessFactor: 0.5,
+          },
         },
       },
     ],
   });
 
-  const result = await normalizeGlbForSceneSync(glb);
-  strictEqual(result.changed, false);
-  deepEqual(result.arrayBuffer, glb);
+  const r = await normalizeGlbForSceneSync(ab);
+
+  strictEqual(r.changed, true, 'changed should be true');
+  strictEqual(r.skipped, false, 'skipped should be false');
+  strictEqual(r.skipReason, null, 'skipReason should be null');
+  ok(r.arrayBuffer instanceof ArrayBuffer, 'should return ArrayBuffer');
+
+  // Re-inspect: KHR_materials_pbrSpecularGlossiness must no longer be in extensionsRequired
+  const postInspect = inspectGlbExtensions(r.arrayBuffer);
+  strictEqual(postInspect.requiresSpecGloss, false,
+    'KHR_materials_pbrSpecularGlossiness must be removed from extensionsRequired');
+
+  // The converted JSON must have standard pbrMetallicRoughness
+  const json = readGlbJson(r.arrayBuffer);
+  ok(json.materials, 'materials should exist');
+  ok(json.materials[0].pbrMetallicRoughness, 'pbrMetallicRoughness should exist after conversion');
 });
 
-test('normalizeGlbForSceneSync - converts Spec/Gloss material', async (t) => {
-  const glb = createMinimalGlb({
+test('normalizeGlbForSceneSync – accepts File input', async () => {
+  const ab = buildGlb({ asset: { version: '2.0' } });
+  const file = new File([ab], 'test.glb', { type: 'model/gltf-binary' });
+  const r = await normalizeGlbForSceneSync(file);
+  // standard GLB → no change
+  strictEqual(r.changed, false);
+});
+
+test('normalizeGlbForSceneSync – returns skipped=true for invalid GLB (empty buffer)', async () => {
+  const r = await normalizeGlbForSceneSync(new ArrayBuffer(0));
+  strictEqual(r.changed, false);
+  strictEqual(r.skipped, false); // not a Spec/Gloss GLB, just invalid → no skip
+});
+
+test('normalizeGlbForSceneSync – converted GLB has no internal flag properties', async () => {
+  const ab = buildGlb({
+    asset: { version: '2.0' },
     extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
     materials: [
       {
-        name: 'TestMaterial',
         extensions: {
           KHR_materials_pbrSpecularGlossiness: {
-            diffuseFactor: [0.5, 0.5, 0.5, 1.0],
+            diffuseFactor: [1, 1, 1, 1],
+            specularFactor: [0.04, 0.04, 0.04],
             glossinessFactor: 0.8,
           },
         },
@@ -131,117 +178,15 @@ test('normalizeGlbForSceneSync - converts Spec/Gloss material', async (t) => {
     ],
   });
 
-  const result = await normalizeGlbForSceneSync(glb);
-  strictEqual(result.changed, true);
-  ok(result.warnings?.length > 0);
+  const r = await normalizeGlbForSceneSync(ab);
+  if (!r.changed) return; // if conversion failed, skip this assertion
 
-  // Verify the converted JSON
-  const view = new DataView(result.arrayBuffer);
-  const jsonChunkLength = view.getUint32(12, true);
-  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
-  const jsonString = new TextDecoder().decode(jsonBytes);
-  const json = JSON.parse(jsonString);
+  const json = readGlbJson(r.arrayBuffer);
+  const mat = json.materials?.[0];
+  if (!mat?.pbrMetallicRoughness) return;
 
-  strictEqual(json.materials[0].extensions?.KHR_materials_pbrSpecularGlossiness, undefined);
-  ok(json.materials[0].pbrMetallicRoughness);
-  deepEqual(json.materials[0].pbrMetallicRoughness.baseColorFactor, [0.5, 0.5, 0.5, 1.0]);
-  assertClose(json.materials[0].pbrMetallicRoughness.roughnessFactor, 0.2); // 1 - 0.8
-  strictEqual(json.materials[0].pbrMetallicRoughness.metallicFactor, 0);
-});
-
-test('normalizeGlbForSceneSync - removes extension from extensionsUsed', async (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness', 'KHR_materials_clearcoat'],
-    materials: [
-      {
-        extensions: {
-          KHR_materials_pbrSpecularGlossiness: {
-            diffuseFactor: [1, 1, 1, 1],
-            glossinessFactor: 0.5,
-          },
-        },
-      },
-    ],
-  });
-
-  const result = await normalizeGlbForSceneSync(glb);
-  strictEqual(result.changed, true);
-
-  // Verify the converted JSON
-  const view = new DataView(result.arrayBuffer);
-  const jsonChunkLength = view.getUint32(12, true);
-  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
-  const jsonString = new TextDecoder().decode(jsonBytes);
-  const json = JSON.parse(jsonString);
-
-  ok(json.extensionsUsed.includes('KHR_materials_clearcoat'));
-  strictEqual(json.extensionsUsed.includes('KHR_materials_pbrSpecularGlossiness'), false);
-});
-
-test('normalizeGlbForSceneSync - removes extensionsUsed when empty', async (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
-    materials: [
-      {
-        extensions: {
-          KHR_materials_pbrSpecularGlossiness: {
-            diffuseFactor: [1, 1, 1, 1],
-            glossinessFactor: 0.5,
-          },
-        },
-      },
-    ],
-  });
-
-  const result = await normalizeGlbForSceneSync(glb);
-  strictEqual(result.changed, true);
-
-  // Verify the converted JSON
-  const view = new DataView(result.arrayBuffer);
-  const jsonChunkLength = view.getUint32(12, true);
-  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
-  const jsonString = new TextDecoder().decode(jsonBytes);
-  const json = JSON.parse(jsonString);
-
-  strictEqual(json.extensionsUsed, undefined);
-});
-
-test('normalizeGlbForSceneSync - handles multiple materials', async (t) => {
-  const glb = createMinimalGlb({
-    extensionsUsed: ['KHR_materials_pbrSpecularGlossiness'],
-    materials: [
-      {
-        name: 'Mat1',
-        extensions: {
-          KHR_materials_pbrSpecularGlossiness: {
-            diffuseFactor: [1, 0, 0, 1],
-            glossinessFactor: 0.7,
-          },
-        },
-      },
-      {
-        name: 'Mat2',
-        extensions: {
-          KHR_materials_pbrSpecularGlossiness: {
-            diffuseFactor: [0, 1, 0, 1],
-            glossinessFactor: 0.9,
-          },
-        },
-      },
-    ],
-  });
-
-  const result = await normalizeGlbForSceneSync(glb);
-  strictEqual(result.changed, true);
-
-  // Verify the converted JSON
-  const view = new DataView(result.arrayBuffer);
-  const jsonChunkLength = view.getUint32(12, true);
-  const jsonBytes = new Uint8Array(result.arrayBuffer, 20, jsonChunkLength);
-  const jsonString = new TextDecoder().decode(jsonBytes);
-  const json = JSON.parse(jsonString);
-
-  strictEqual(json.materials.length, 2);
-  assertClose(json.materials[0].pbrMetallicRoughness.roughnessFactor, 0.3); // 1 - 0.7
-  assertClose(json.materials[1].pbrMetallicRoughness.roughnessFactor, 0.1); // 1 - 0.9
+  // Must not contain any internal flags like _specularGlossTextureExists
+  for (const key of Object.keys(mat.pbrMetallicRoughness)) {
+    ok(!key.startsWith('_'), `No internal flag properties allowed: found "${key}"`);
+  }
 });

--- a/html/assets/js/scenesync/loaders/url-importers/glb.js
+++ b/html/assets/js/scenesync/loaders/url-importers/glb.js
@@ -1,8 +1,11 @@
+import { normalizeGlbForSceneSync } from '../glb-normalizer.js';
+
 /**
  * GLB (binary glTF) をフェッチして GLTFLoader で読み込む。
+ * KHR_materials_pbrSpecularGlossiness を含む場合は metalRough() で変換する。
  * @param {string} url
  * @param {object} opts - { THREE, GLTFLoader, timeoutMs = 30000 }
- * @returns {Promise<{ model: THREE.Group, sizeBytes: number, contentType: string }>}
+ * @returns {Promise<{ model: THREE.Group, sizeBytes: number, contentType: string, normalization: object }>}
  */
 export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000 } = {}) {
   if (!THREE || !GLTFLoader) {
@@ -55,12 +58,26 @@ export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000
     throw new Error('GLB ファイルが大きすぎます (上限 50 MB)');
   }
 
+  // KHR_materials_pbrSpecularGlossiness を検出したら metalRough() で変換
+  let normalization = { changed: false, skipped: false, skipReason: null, warnings: [] };
+  let parseBuffer = arrayBuffer;
+  try {
+    const n = await normalizeGlbForSceneSync(arrayBuffer);
+    normalization = n;
+    if (n.changed) {
+      parseBuffer = n.arrayBuffer;
+    }
+  } catch (error) {
+    console.warn('[glb-url] normalizeGlbForSceneSync threw unexpectedly', error);
+    normalization = { changed: false, skipped: true, skipReason: 'unexpectedError', warnings: [error.message] };
+  }
+
   // GLTFLoader で parse
   let gltf;
   try {
     const loader = new GLTFLoader();
     gltf = await new Promise((resolve, reject) => {
-      loader.parse(arrayBuffer, '', resolve, reject);
+      loader.parse(parseBuffer, '', resolve, reject);
     });
   } catch (err) {
     throw new Error(`GLB ファイルの解析に失敗しました: ${err?.message || '不明なエラー'}`);
@@ -77,11 +94,20 @@ export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000
     animationState,
   };
 
+  // 変換後の ArrayBuffer を保持（upload/broadcast 用）
+  if (normalization.changed) {
+    gltf.scene.userData.normalizedGlbArrayBuffer = normalization.arrayBuffer;
+    gltf.scene.userData.normalization = normalization;
+  } else {
+    gltf.scene.userData.normalization = normalization;
+  }
+
   return {
     model: gltf.scene,
     animations,
     sizeBytes: arrayBuffer.byteLength,
     contentType,
+    normalization,
   };
 }
 
@@ -93,7 +119,7 @@ export async function loadGlbFromUrl(url, { THREE, GLTFLoader, timeoutMs = 30000
  */
 export async function importGlbUrl(url, ctx) {
   try {
-    const { model, animations } = await loadGlbFromUrl(url, {
+    const { model, animations, normalization } = await loadGlbFromUrl(url, {
       THREE: ctx.THREE,
       GLTFLoader: ctx.GLTFLoader,
     });
@@ -146,6 +172,13 @@ export async function importGlbUrl(url, ctx) {
 
     // ローカルにも反映: prebuilt model を渡してロードを省略
     ctx.addOrUpdateObject(objectId, payload, { prebuiltGlbModel: model });
+
+    // 正規化の結果をトーストで通知
+    if (normalization?.changed) {
+      ctx.showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
+    } else if (normalization?.skipped) {
+      ctx.showToast('このモデルはScene Syncで正しく表示できない可能性があるマテリアルを使用しています');
+    }
 
     return { objectId, payload };
   } catch (err) {

--- a/html/assets/js/scenesync/loaders/url-importers/glb.js
+++ b/html/assets/js/scenesync/loaders/url-importers/glb.js
@@ -154,6 +154,39 @@ export async function importGlbUrl(url, ctx) {
       });
     }
 
+    // 変換後GLBがある場合はpresence blobへuploadしてから broadcast する。
+    // これにより他クライアント・後参加者・reload・exportすべてが変換後GLBを参照できる。
+    let asset = { type: 'mesh', source: 'url', url };
+    let uploadSucceeded = false;
+
+    if (normalization?.changed && ctx.uploadGlbAsset) {
+      try {
+        const { meshPath, assetId, size } = await ctx.uploadGlbAsset(
+          normalization.arrayBuffer,
+          displayName,
+        );
+        asset = {
+          type: 'mesh',
+          source: 'carrier',
+          assetId: assetId || null,
+          meshPath,
+          size,
+          mime: 'model/gltf-binary',
+          originalName: displayName,
+        };
+        // ローカルモデルのuserDataにも記録（export / snapshot用）
+        model.userData.meshPath = meshPath;
+        model.userData.assetId = assetId;
+        model.userData.asset = { ...asset };
+        uploadSucceeded = true;
+        console.info('[glb-url] Uploaded normalized GLB to presence blob', { meshPath, assetId });
+      } catch (uploadError) {
+        // upload失敗時は元URLで共有（表示は変換済み、共有は元URL）
+        console.warn('[glb-url] Failed to upload normalized GLB, sharing original URL', uploadError);
+        ctx.showToast('変換済みGLBのアップロードに失敗しました。元URLで共有されます');
+      }
+    }
+
     const payload = {
       kind: 'scene-add',
       objectId,
@@ -161,8 +194,12 @@ export async function importGlbUrl(url, ctx) {
       position: spawnTransform.position,
       rotation: spawnTransform.rotation,
       scale: spawnTransform.scale,
-      asset: { type: 'mesh', source: 'url', url },
+      asset,
     };
+
+    if (asset.meshPath) {
+      payload.meshPath = asset.meshPath;
+    }
 
     if (animations.length > 0) {
       payload.animation = { enabled: true, clip: 0, mode: 'loop', speed: 1 };
@@ -174,7 +211,8 @@ export async function importGlbUrl(url, ctx) {
     ctx.addOrUpdateObject(objectId, payload, { prebuiltGlbModel: model });
 
     // 正規化の結果をトーストで通知
-    if (normalization?.changed) {
+    // upload失敗時はすでにtoastを出しているので重複させない
+    if (normalization?.changed && uploadSucceeded) {
       ctx.showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
     } else if (normalization?.skipped) {
       ctx.showToast('このモデルはScene Syncで正しく表示できない可能性があるマテリアルを使用しています');

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5206,7 +5206,19 @@ async function uploadGlbFromUrl(url, params = {}) {
   selectManagedObject(model);
   notifySceneStateChanged('glb-uploaded-from-url');
 
-  const arrayBuffer = await blob.arrayBuffer();
+  // Use normalized ArrayBuffer if available, otherwise use original blob
+  const arrayBuffer = model.userData.normalizedGlbArrayBuffer
+    ? model.userData.normalizedGlbArrayBuffer
+    : await blob.arrayBuffer();
+
+  // Show feedback if GLB was normalized
+  const metadata = model.userData?.scenesync?.glbMetadata;
+  if (metadata?.normalized) {
+    showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
+  } else if (metadata?.normalizationError) {
+    showToast('このモデルのマテリアル変換に失敗しました。表示が正しくない可能性があります');
+  }
+
   await uploadAndBroadcast(
     model.userData.objectId,
     file.name,
@@ -7254,7 +7266,19 @@ const dragDropManager = new DragDropManager({
     selectManagedObject(model);
     notifySelectionChanged('drag-drop-object-selected');
 
-    const arrayBuffer = await file.arrayBuffer();
+    // Show feedback if GLB was normalized
+    const metadata = model.userData?.scenesync?.glbMetadata;
+    if (metadata?.normalized) {
+      showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
+    } else if (metadata?.normalizationError) {
+      showToast('このモデルのマテリアル変換に失敗しました。表示が正しくない可能性があります');
+    }
+
+    // Use normalized ArrayBuffer if available, otherwise use original file
+    const arrayBuffer = model.userData.normalizedGlbArrayBuffer
+      ? model.userData.normalizedGlbArrayBuffer
+      : await file.arrayBuffer();
+
     await uploadAndBroadcast(
       model.userData.objectId,
       file.name,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5298,6 +5298,46 @@ function createSceneUrlImportContext(options = {}) {
     GLTFLoader,
     targetKind,
     replaceSkyboxSphereFromBlob,
+    /**
+     * Spec/Gloss変換後GLBをpresence blobへアップロードしてasset cacheへも記録する。
+     * URL import時に normalization.changed === true の場合に使う。
+     * @param {ArrayBuffer} arrayBuffer - 変換後GLB
+     * @param {string} name - 表示名
+     * @returns {Promise<{ meshPath: string, assetId: string|null, size: number }>}
+     */
+    uploadGlbAsset: async (arrayBuffer, name) => {
+      const uploadBlob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
+      const meshPath = generateRandomPath();
+      let assetId = null;
+
+      try {
+        assetId = await computeAssetId(arrayBuffer);
+        await assetCache.putAsset({
+          assetId,
+          meshPath: null,
+          blob: uploadBlob,
+          source: 'url-normalized',
+        });
+      } catch {}
+
+      const uploadRes = await fetch(`${BLOB_BASE}/${meshPath}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'model/gltf-binary' },
+        body: arrayBuffer,
+      });
+
+      if (!uploadRes.ok) {
+        let errPayload = null;
+        try { errPayload = await uploadRes.json(); } catch {}
+        throw new Error(errPayload?.message || `Upload failed: ${uploadRes.status}`);
+      }
+
+      if (assetId) {
+        try { await assetCache.rememberMeshPathAlias(assetId, meshPath); } catch {}
+      }
+
+      return { meshPath, assetId, size: arrayBuffer.byteLength };
+    },
   };
 }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5206,17 +5206,17 @@ async function uploadGlbFromUrl(url, params = {}) {
   selectManagedObject(model);
   notifySceneStateChanged('glb-uploaded-from-url');
 
-  // Use normalized ArrayBuffer if available, otherwise use original blob
+  // 変換後 ArrayBuffer を優先（upload / broadcast / cache すべてに変換後を使う）
   const arrayBuffer = model.userData.normalizedGlbArrayBuffer
     ? model.userData.normalizedGlbArrayBuffer
     : await blob.arrayBuffer();
 
-  // Show feedback if GLB was normalized
+  // 正規化の結果をトーストで通知
   const metadata = model.userData?.scenesync?.glbMetadata;
   if (metadata?.normalized) {
     showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
-  } else if (metadata?.normalizationError) {
-    showToast('このモデルのマテリアル変換に失敗しました。表示が正しくない可能性があります');
+  } else if (metadata?.normalizationSkipped) {
+    showToast('このモデルはScene Syncで正しく表示できない可能性があるマテリアルを使用しています');
   }
 
   await uploadAndBroadcast(
@@ -7266,15 +7266,15 @@ const dragDropManager = new DragDropManager({
     selectManagedObject(model);
     notifySelectionChanged('drag-drop-object-selected');
 
-    // Show feedback if GLB was normalized
+    // 正規化の結果をトーストで通知
     const metadata = model.userData?.scenesync?.glbMetadata;
     if (metadata?.normalized) {
       showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
-    } else if (metadata?.normalizationError) {
-      showToast('このモデルのマテリアル変換に失敗しました。表示が正しくない可能性があります');
+    } else if (metadata?.normalizationSkipped) {
+      showToast('このモデルはScene Syncで正しく表示できない可能性があるマテリアルを使用しています');
     }
 
-    // Use normalized ArrayBuffer if available, otherwise use original file
+    // 変換後 ArrayBuffer を優先（upload / broadcast / cache すべてに変換後を使う）
     const arrayBuffer = model.userData.normalizedGlbArrayBuffer
       ? model.userData.normalizedGlbArrayBuffer
       : await file.arrayBuffer();

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1313,7 +1313,10 @@
   {
     "imports": {
       "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/",
+      "@gltf-transform/core": "https://esm.sh/@gltf-transform/core@4.3.0",
+      "@gltf-transform/extensions": "https://esm.sh/@gltf-transform/extensions@4.3.0",
+      "@gltf-transform/functions": "https://esm.sh/@gltf-transform/functions@4.3.0"
     }
   }
   </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,736 @@
+{
+  "name": "afjk-jp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "afjk-jp",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@gltf-transform/core": "^4.3.0",
+        "@gltf-transform/extensions": "^4.3.0",
+        "@gltf-transform/functions": "^4.3.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gltf-transform/core": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-ZeaQfszGJ9LYwELszu45CuDQCsE26lJNNe36FVmN8xclaT6WDdCj7fwGpQXo0/l/YgAVAHX+uO7YNBW75/SRYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "property-graph": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/extensions": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/extensions/-/extensions-4.3.0.tgz",
+      "integrity": "sha512-XDAjQPYVMHa/VDpSbfCBwI+/1muwRJCaXhUpLgnUzAjn0D//PgvIAcbNm1EwBl3LIWBSwjDUCn2LiMAjp+aXVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.3.0",
+        "ktx-parse": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/functions": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/functions/-/functions-4.3.0.tgz",
+      "integrity": "sha512-FZggHVgt3DHOezgESBrf2vDzuD2FYQYaNT2sT/aP316SIwhuiIwby3z7rhV9joDvWqqUaPkf1UmkjlOaY9riSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.3.0",
+        "@gltf-transform/extensions": "^4.3.0",
+        "ktx-parse": "^1.0.1",
+        "ndarray": "^1.0.19",
+        "ndarray-lanczos": "^0.3.0",
+        "ndarray-pixels": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@types/ndarray": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.14.tgz",
+      "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ktx-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-1.1.0.tgz",
+      "integrity": "sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-lanczos": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ndarray-lanczos/-/ndarray-lanczos-0.3.0.tgz",
+      "integrity": "sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.11",
+        "ndarray": "^1.0.19"
+      }
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-pixels": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pixels/-/ndarray-pixels-5.0.1.tgz",
+      "integrity": "sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.14",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/property-graph": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-4.1.0.tgz",
+      "integrity": "sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "afjk-jp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js"
+  },
+  "devDependencies": {
+    "@gltf-transform/core": "^4.3.0",
+    "@gltf-transform/extensions": "^4.3.0",
+    "@gltf-transform/functions": "^4.3.0"
+  }
+}


### PR DESCRIPTION
## 概要

Sketchfab などから取得した GLB ファイルが `KHR_materials_pbrSpecularGlossiness` 拡張を使用している場合、GLB 読み込み時に **glTF Transform の `metalRough()` transform** を使って標準 `pbrMetallicRoughness` GLB へ自動変換する機能を追加しました。

変換後 GLB を以下すべてに統一して使います。

- ローカル表示
- presence blob へのアップロード
- broadcast（他クライアントへの共有）
- asset cache
- export / snapshot
- 後参加者の復元

## 変更内容

### glb-normalizer.js（完全書き換え）

- `@gltf-transform/core` の `WebIO`・`@gltf-transform/extensions` の Spec/Gloss / IOR / Specular 拡張・`@gltf-transform/functions` の `metalRough` を使用
- 独自の JSON 書き換え変換ロジックを完全削除
- `inspectGlbExtensions()` は軽量バイナリ inspect（外部依存なし）として維持
- 戻り値: `changed` / `skipped` / `skipReason` / `warnings`
- 変換失敗時は `changed: false, skipped: true, skipReason: 'metalRoughFailed'` で元 GLB にフォールバック

### glb-file-loader.js

- metadata を新 shape に統一: `normalized`, `normalizedFrom`, `normalizationSkipped`, `normalizationSkipReason`, `normalizationWarnings`
- `changed === true` の場合のみ `model.userData.normalizedGlbArrayBuffer` に保持

### url-importers/glb.js

- `loadGlbFromUrl()`: URL 取得後に `normalizeGlbForSceneSync()` を通す
- `importGlbUrl()`: `normalization.changed === true` の場合、変換後 ArrayBuffer を `ctx.uploadGlbAsset()` で presence blob へアップロードし、broadcast payload を `source: 'carrier', meshPath` に変更
- upload 失敗時は元 URL で共有しつつ警告 toast を表示

### scene.js

- `createSceneUrlImportContext()` に `uploadGlbAsset()` を追加（presence blob upload + asset cache 記録）
- `uploadGlbFromUrl()` も変換後 ArrayBuffer を優先使用
- Toast: 変換成功 / skip の 2 種類（upload 失敗は別 toast、重複しない）

### html/scenesync/index.html

- importmap に `@gltf-transform/core`, `/extensions`, `/functions` を追加（`esm.sh` CDN 経由）

### package.json / package-lock.json

- テスト用 devDependencies として `@gltf-transform/*` を追加

### glb-normalizer.test.js

- 新 API に合わせてテストを書き直し（10 件全通過）
- 内部フラグが GLB に混入しないことを確認するテストを追加

## 変換の適用範囲

| 経路 | 変換 | upload先 | broadcast |
|------|------|----------|-----------|
| ローカルファイル D&D | ✅ metalRough() | carrier (blob) | meshPath |
| URL D&D / URL import | ✅ metalRough() | carrier (blob) | meshPath |
| AI uploadGlbFromUrl | ✅ metalRough() | carrier (blob) | meshPath |

## 変換失敗時の挙動

1. `changed: false, skipped: true` で元 GLB にフォールバック
2. Toast で「正しく表示できない可能性がある」と通知
3. console に詳細エラーを出力

## Limitations

- `.gltf + textures` 形式や Sketchfab zip の変換は対象外（別 PR）
- staging での実機確認（実 Sketchfab GLB を使った目視確認）は別途必要
- URL import で upload 失敗時は元 URL で broadcast（表示のみ変換済み）

https://claude.ai/code/session_01XPbk2R9FmXkhhqBJcp5y4s