### PR TITLE
Handle scene switching to prevent hierarchy change conflicts

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -73,6 +73,7 @@ namespace Afjk.SceneSync.Editor
         private bool _showQuickGuide = false;
         private bool _showManagedUnityObjects = true;
         private Vector2 _scrollPosition;
+        private bool _isSceneSwitching = false;
 
         private void OnEnable()
         {
@@ -117,12 +118,16 @@ namespace Afjk.SceneSync.Editor
 
             EditorApplication.update += EditorUpdate;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
+            EditorSceneManager.sceneClosing += OnSceneClosing;
+            EditorSceneManager.sceneOpened += OnSceneOpened;
         }
 
         private void OnDisable()
         {
             EditorApplication.update -= EditorUpdate;
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
+            EditorSceneManager.sceneClosing -= OnSceneClosing;
+            EditorSceneManager.sceneOpened -= OnSceneOpened;
             _client?.Disconnect();
         }
 
@@ -714,6 +719,12 @@ namespace Afjk.SceneSync.Editor
 
         private void OnHierarchyChanged()
         {
+            if (_isSceneSwitching)
+            {
+                Debug.Log("[SceneSync] OnHierarchyChanged: scene switching in progress, skipping");
+                return;
+            }
+
             if (!_connected) return;
             var currentIds = new HashSet<string>();
             var currentInstanceIds = new HashSet<int>();
@@ -794,6 +805,45 @@ namespace Afjk.SceneSync.Editor
                 _instanceToObjectId.Remove(key);
 
             _knownObjectIds = currentIds;
+        }
+
+        private void OnSceneClosing(Scene scene, bool removingScene)
+        {
+            if (!_connected)
+            {
+                Debug.Log("[SceneSync] OnSceneClosing: not connected, no action needed. scene=" + scene.name);
+                return;
+            }
+
+            Debug.Log("[SceneSync] OnSceneClosing: scene switching in progress. scene=" + scene.name);
+            _isSceneSwitching = true;
+
+            // Lifecycle disconnect: do not send scene-remove messages
+            Debug.Log("[SceneSync] Lifecycle disconnect: clearing tracking state without sending scene-remove");
+            _connected = false;
+            _client?.Disconnect();
+
+            // Clear Editor Window tracking state (but do NOT call ClearTemporaryObjects)
+            _knownObjectIds.Clear();
+            _managedObjects.Clear();
+            _instanceToObjectId.Clear();
+            _meshPaths.Clear();
+            _locks.Clear();
+            _currentlyLockedObjectId = null;
+            _sceneReceived = false;
+            _firstPeersReceived = false;
+            _lastSnapshots.Clear();
+
+            Repaint();
+        }
+
+        private void OnSceneOpened(Scene scene, OpenSceneMode mode)
+        {
+            Debug.Log("[SceneSync] OnSceneOpened: scene=" + scene.name + ", mode=" + mode);
+            _isSceneSwitching = false;
+
+            // Restore _connected from _client state
+            // (The next manual Connect action will establish a fresh connection)
         }
 
         private void RebindPublishedUnityObjects()

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -809,16 +809,14 @@ namespace Afjk.SceneSync.Editor
 
         private void OnSceneClosing(Scene scene, bool removingScene)
         {
+            Debug.Log("[SceneSync] OnSceneClosing: scene=" + scene.name + ", connected=" + _connected);
+            _isSceneSwitching = true;
+
             if (!_connected)
             {
-                Debug.Log("[SceneSync] OnSceneClosing: not connected, no action needed. scene=" + scene.name);
                 return;
             }
 
-            Debug.Log("[SceneSync] OnSceneClosing: scene switching in progress. scene=" + scene.name);
-            _isSceneSwitching = true;
-
-            // Lifecycle disconnect: do not send scene-remove messages
             Debug.Log("[SceneSync] Lifecycle disconnect: clearing tracking state without sending scene-remove");
             _connected = false;
             _client?.Disconnect();


### PR DESCRIPTION
## 概要

Unity エディタでシーン切り替え時に `OnHierarchyChanged` が誤発火するのを防ぐため、シーン切り替え中フラグを追加し、その間のハイラーキー変更イベントをスキップするようにしました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **シーン切り替え中フラグの追加**
   - `_isSceneSwitching` フラグを追加して、シーン切り替え中の状態を追跡

2. **エディタシーンマネージャーイベントの登録**
   - `EditorSceneManager.sceneClosing` と `EditorSceneManager.sceneOpened` イベントをリッスン
   - `OnEnable()` で登録、`OnDisable()` で解除

3. **OnHierarchyChanged の保護**
   - シーン切り替え中は `OnHierarchyChanged` を早期リターンしてスキップ
   - デバッグログで状態を可視化

4. **OnSceneClosing ハンドラの実装**
   - シーン閉鎖時に接続状態をクリア
   - トラッキング状態（`_knownObjectIds`, `_managedObjects` など）をリセット
   - `ClearTemporaryObjects` は呼び出さない（ライフサイクル切断）

5. **OnSceneOpened ハンドラの実装**
   - シーン開放時にフラグをリセット
   - 次の手動接続に備える

### staging で見てほしい点

- シーン切り替え時に不要なシーン同期メッセージが送信されないこと
- エディタウィンドウのトラッキング状態が正しくリセットされること
- 新しいシーンで再接続できること

## 変更していないこと

- `ClearTemporaryObjects` の呼び出しは意図的に除外（ライフサイクル管理の一部）
- 既存の接続・切断ロジックは変更なし
- ネットワーク通信部分は変更なし

## staging確認

- 未確認

## テスト/チェック

- コンパイル確認のみ
- 実際のシーン切り替え動作は staging で確認が必要

## リスク

- シーン切り替え中のイベント順序に依存しているため、Unity バージョンによる動作差異の可能性
- `_isSceneSwitching` フラグのリセットタイミングが重要

## follow-up tasks

- staging での実際のシーン切り替え動作確認
- 複数シーン同時操作時の動作確認

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01ATK6skWW3qPdjhdum9xNgC