### PR TITLE
feat: Media/Text asset types and auto-replace for Scene Sync

### DIFF
--- a/html/assets/js/scenesync-export/export/collect-export-assets.js
+++ b/html/assets/js/scenesync-export/export/collect-export-assets.js
@@ -89,11 +89,77 @@ export async function collectExportAssets({
     return path;
   }
 
-  // Collect mesh assets
+  function videoExtFor(mime) {
+    if (!mime) return 'mp4';
+    if (mime.includes('webm')) return 'webm';
+    if (mime.includes('ogg')) return 'ogv';
+    return 'mp4';
+  }
+
+  // Collect mesh / image / video / text assets
   const updatedObjects = [];
   for (const obj of sceneDocument.objects) {
     if (!obj.asset || obj.asset.type === 'primitive') {
       updatedObjects.push(obj);
+      continue;
+    }
+
+    if (obj.asset.type === 'image') {
+      const imageUrl = obj.asset.url;
+      if (!imageUrl) { updatedObjects.push(obj); continue; }
+
+      const ext = extensionFor(obj.asset.mime || 'image/jpeg', 'jpg');
+      const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
+      const buffer = await tryFetch(imageUrl);
+      if (buffer) {
+        files[zipPath] = buffer;
+        assetManifest.push({ id: obj.id, kind: 'image', path: zipPath, status: 'included' });
+        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+      } else {
+        missingAssets.push({ id: obj.id, kind: 'image', url: imageUrl, reason: 'fetch-failed' });
+        updatedObjects.push(obj); // keep url as fallback for static-asset-resolver
+      }
+      continue;
+    }
+
+    if (obj.asset.type === 'video') {
+      const videoUrl = obj.asset.url;
+      if (!videoUrl) { updatedObjects.push(obj); continue; }
+
+      const ext = videoExtFor(obj.asset.mime);
+      const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
+      const buffer = await tryFetch(videoUrl);
+      if (buffer) {
+        files[zipPath] = buffer;
+        assetManifest.push({ id: obj.id, kind: 'video', path: zipPath, status: 'included' });
+        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+      } else {
+        // Videos often have CORS restrictions; keep url so static viewer can stream
+        missingAssets.push({ id: obj.id, kind: 'video', url: videoUrl, reason: 'fetch-failed' });
+        updatedObjects.push(obj);
+      }
+      continue;
+    }
+
+    if (obj.asset.type === 'text') {
+      if (obj.asset.source === 'inline') {
+        // Text is embedded in scene.json — no file needed
+        updatedObjects.push(obj);
+        continue;
+      }
+      const textUrl = obj.asset.url;
+      if (!textUrl) { updatedObjects.push(obj); continue; }
+
+      const zipPath = uniquePath(sanitizeFilename(obj.id), 'txt');
+      const buffer = await tryFetch(textUrl);
+      if (buffer) {
+        files[zipPath] = buffer;
+        assetManifest.push({ id: obj.id, kind: 'text', path: zipPath, status: 'included' });
+        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+      } else {
+        missingAssets.push({ id: obj.id, kind: 'text', url: textUrl, reason: 'fetch-failed' });
+        updatedObjects.push(obj);
+      }
       continue;
     }
 

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -39,7 +39,49 @@ function buildAssetEntry(obj) {
     };
   }
 
-  // mesh / image / text → all stored as GLB via meshPath
+  if (asset.type === 'image') {
+    return {
+      type: 'image',
+      source: asset.source || 'url',
+      url: asset.url || null,
+      path: null, // filled by collect-export-assets.js
+      mime: asset.mime || 'image/jpeg',
+    };
+  }
+
+  if (asset.type === 'video') {
+    return {
+      type: 'video',
+      source: asset.source || 'url',
+      url: asset.url || null,
+      path: null, // filled by collect-export-assets.js
+      mime: asset.mime || 'video/mp4',
+    };
+  }
+
+  if (asset.type === 'text') {
+    const entry = {
+      type: 'text',
+      source: asset.source || 'inline',
+      format: asset.format || 'plain',
+      fontFamily: asset.fontFamily || 'system-sans',
+      fontSize: asset.fontSize || 32,
+      fontWeight: asset.fontWeight || 'normal',
+      fontStyle: asset.fontStyle || 'normal',
+      color: asset.color || '#ffffff',
+      backgroundColor: asset.backgroundColor || 'rgba(0,0,0,0.65)',
+      align: asset.align || 'center',
+    };
+    if (asset.source === 'inline') {
+      entry.text = asset.text || '';
+    } else {
+      entry.url = asset.url || null;
+      entry.path = null; // filled by collect-export-assets.js
+    }
+    return entry;
+  }
+
+  // mesh → GLB via meshPath
   const meshPath = obj.userData?.meshPath || asset.meshPath || null;
   const assetId = asset.assetId || obj.userData?.assetId || obj.userData?.scenesync?.assetId || null;
 

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -149,6 +149,7 @@ export async function createViewerCore({
         const geo = new THREE.PlaneGeometry(w, h);
         const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
         const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.y = h / 2; // align origin to bottom edge, matching web runtime
 
         const group = new THREE.Group();
         group.add(mesh);
@@ -170,19 +171,31 @@ export async function createViewerCore({
 
       try {
         const video = document.createElement('video');
-        video.src = assetPath;
         video.crossOrigin = 'anonymous';
         video.loop = true;
         video.muted = true;
         video.playsInline = true;
-        video.autoplay = true;
+        video.preload = 'metadata';
+
+        // Wait for real dimensions before building geometry
+        await new Promise((resolve, reject) => {
+          video.addEventListener('loadedmetadata', resolve, { once: true });
+          video.addEventListener('error', () => reject(new Error('video load error')), { once: true });
+          video.src = assetPath;
+        });
+
+        const aspect = (video.videoWidth / video.videoHeight) || (16 / 9);
+        const maxEdge = 2;
+        const videoW = aspect >= 1 ? maxEdge : Math.max(maxEdge * aspect, 0.1);
+        const videoH = aspect >= 1 ? Math.max(maxEdge / aspect, 0.1) : maxEdge;
 
         const texture = new THREE.VideoTexture(video);
         texture.colorSpace = THREE.SRGBColorSpace;
 
-        const geo = new THREE.PlaneGeometry(2, 1.125); // default 16:9
+        const geo = new THREE.PlaneGeometry(videoW, videoH);
         const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
         const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.y = videoH / 2; // align origin to bottom edge, matching web runtime
 
         const group = new THREE.Group();
         group.add(mesh);
@@ -191,6 +204,7 @@ export async function createViewerCore({
         scene.add(group);
         objectMap.set(entry.id, group);
 
+        video.autoplay = true;
         video.play().catch(() => {});
       } catch {
         onMissingAsset?.({ id: entry.id, kind: 'video', path: assetPath });
@@ -252,6 +266,7 @@ export async function createViewerCore({
       const geo = new THREE.PlaneGeometry(2, 0.5); // 4:1 canvas aspect (1024×256)
       const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide, transparent: true });
       const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.y = 0.5 / 2; // align origin to bottom edge, matching web runtime
 
       const group = new THREE.Group();
       group.add(mesh);

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -128,6 +128,137 @@ export async function createViewerCore({
       mesh.userData.objectId = entry.id;
       scene.add(mesh);
       objectMap.set(entry.id, mesh);
+    } else if (assetDef.type === 'image') {
+      const assetPath = resolver.resolveAsset(assetDef);
+      if (!assetPath) {
+        onMissingAsset?.({ id: entry.id, kind: 'image', reason: 'no path or url' });
+        loaded++;
+        onProgress?.(loaded / total);
+        continue;
+      }
+
+      try {
+        const texture = await new THREE.TextureLoader().loadAsync(assetPath);
+        texture.colorSpace = THREE.SRGBColorSpace;
+
+        const aspect = (texture.image.width / texture.image.height) || 1;
+        const maxEdge = 2;
+        const w = aspect >= 1 ? maxEdge : Math.max(maxEdge * aspect, 0.1);
+        const h = aspect >= 1 ? Math.max(maxEdge / aspect, 0.1) : maxEdge;
+
+        const geo = new THREE.PlaneGeometry(w, h);
+        const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+        const mesh = new THREE.Mesh(geo, mat);
+
+        const group = new THREE.Group();
+        group.add(mesh);
+        applyTransform(group, entry);
+        group.userData.objectId = entry.id;
+        scene.add(group);
+        objectMap.set(entry.id, group);
+      } catch {
+        onMissingAsset?.({ id: entry.id, kind: 'image', path: assetPath });
+      }
+    } else if (assetDef.type === 'video') {
+      const assetPath = resolver.resolveAsset(assetDef);
+      if (!assetPath) {
+        onMissingAsset?.({ id: entry.id, kind: 'video', reason: 'no path or url' });
+        loaded++;
+        onProgress?.(loaded / total);
+        continue;
+      }
+
+      try {
+        const video = document.createElement('video');
+        video.src = assetPath;
+        video.crossOrigin = 'anonymous';
+        video.loop = true;
+        video.muted = true;
+        video.playsInline = true;
+        video.autoplay = true;
+
+        const texture = new THREE.VideoTexture(video);
+        texture.colorSpace = THREE.SRGBColorSpace;
+
+        const geo = new THREE.PlaneGeometry(2, 1.125); // default 16:9
+        const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+        const mesh = new THREE.Mesh(geo, mat);
+
+        const group = new THREE.Group();
+        group.add(mesh);
+        applyTransform(group, entry);
+        group.userData.objectId = entry.id;
+        scene.add(group);
+        objectMap.set(entry.id, group);
+
+        video.play().catch(() => {});
+      } catch {
+        onMissingAsset?.({ id: entry.id, kind: 'video', path: assetPath });
+      }
+    } else if (assetDef.type === 'text') {
+      const FONT_PRESETS = {
+        'system-sans':    'system-ui, -apple-system, "Segoe UI", sans-serif',
+        'serif':          'Georgia, "Times New Roman", serif',
+        'monospace':      '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
+        'japanese-sans':  'system-ui, -apple-system, "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif',
+        'japanese-serif': '"Hiragino Mincho ProN", "Yu Mincho", serif',
+      };
+
+      let text = '';
+      if (assetDef.source === 'inline') {
+        text = assetDef.text || '';
+      } else {
+        const assetPath = resolver.resolveAsset(assetDef);
+        if (assetPath) {
+          try {
+            const res = await fetch(assetPath);
+            if (res.ok) text = await res.text();
+          } catch {}
+        }
+      }
+
+      const fontSize = assetDef.fontSize || 32;
+      const fontFamily = FONT_PRESETS[assetDef.fontFamily] || FONT_PRESETS['system-sans'];
+      const fontWeight = assetDef.fontWeight || 'normal';
+      const fontStyle = assetDef.fontStyle || 'normal';
+      const color = assetDef.color || '#ffffff';
+      const bgColor = assetDef.backgroundColor || 'rgba(0,0,0,0.65)';
+      const align = assetDef.align || 'center';
+
+      const cw = 1024, ch = 256;
+      const canvas = document.createElement('canvas');
+      canvas.width = cw;
+      canvas.height = ch;
+      const ctx2d = canvas.getContext('2d');
+
+      ctx2d.clearRect(0, 0, cw, ch);
+      ctx2d.fillStyle = bgColor;
+      ctx2d.fillRect(0, 0, cw, ch);
+
+      ctx2d.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+      ctx2d.fillStyle = color;
+      ctx2d.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
+      ctx2d.textBaseline = 'middle';
+
+      const lines = text.split('\n');
+      const lineHeight = fontSize * 1.2;
+      const startY = (ch - lines.length * lineHeight) / 2 + lineHeight / 2;
+      const x = align === 'left' ? 20 : align === 'right' ? cw - 20 : cw / 2;
+      for (let i = 0; i < lines.length; i++) {
+        ctx2d.fillText(lines[i], x, startY + i * lineHeight);
+      }
+
+      const texture = new THREE.CanvasTexture(canvas);
+      const geo = new THREE.PlaneGeometry(2, 0.5); // 4:1 canvas aspect (1024×256)
+      const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide, transparent: true });
+      const mesh = new THREE.Mesh(geo, mat);
+
+      const group = new THREE.Group();
+      group.add(mesh);
+      applyTransform(group, entry);
+      group.userData.objectId = entry.id;
+      scene.add(group);
+      objectMap.set(entry.id, group);
     } else {
       const assetPath = resolver.resolveAsset(assetDef);
       if (!assetPath) {

--- a/html/assets/js/scenesync-export/viewer/static-asset-resolver.js
+++ b/html/assets/js/scenesync-export/viewer/static-asset-resolver.js
@@ -1,8 +1,8 @@
 export function createStaticAssetResolver() {
   return {
     resolveAsset(asset) {
-      if (!asset || !asset.path) return null;
-      return asset.path;
+      if (!asset) return null;
+      return asset.path || asset.url || null;
     },
   };
 }

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -7,6 +7,15 @@ function isGlbFile(file) {
   return !!file && /\.glb$/i.test(file.name || '');
 }
 
+function findManagedObjectId(hitObject) {
+  let obj = hitObject;
+  while (obj) {
+    if (obj.userData?.objectId) return obj.userData.objectId;
+    obj = obj.parent;
+  }
+  return null;
+}
+
 function isSupportedImageFile(file) {
   if (!file) return false;
   const supportedMimes = ['image/png', 'image/jpeg', 'image/webp'];
@@ -331,12 +340,14 @@ export class DragDropManager {
 
     const debugTargetKind = hit ? 'scene-hit' : 'scene-fallback';
 
+    const hitObjectId = hit ? findManagedObjectId(hit.object) : null;
+
     this.lastDropDetection = {
       ...this.lastDropDetection,
       hit: !!hit,
       hitObject: hit?.object?.name || null,
       hitObjectType: hit?.object?.type || null,
-      hitObjectId: hit?.object?.userData?.objectId || null,
+      hitObjectId: hitObjectId || null,
       hitDistance: hit?.distance ?? null,
       upness: rayInfo.upness,
       threshold: SKY_DROP_UPNESS_THRESHOLD,
@@ -366,7 +377,7 @@ export class DragDropManager {
         hitPoint: hit.point.toArray(),
         placementPosition: (placementPosition || hit.point).toArray(),
         targetKind: 'scene',
-        hitObjectId: hit.object?.userData?.objectId || null,
+        hitObjectId: hitObjectId || null,
         clientX: event.clientX,
         clientY: event.clientY,
         upness: rayInfo.upness,

--- a/html/assets/js/scenesync/loaders/url-importers/image.js
+++ b/html/assets/js/scenesync/loaders/url-importers/image.js
@@ -160,6 +160,9 @@ export async function importImageUrl(url, ctx) {
       asset: { type: 'image', source: 'url', url },
       metadata: {
         ...existingMetadata,
+        role: 'media-panel',
+        accepts: ['image', 'video'],
+        fit: 'contain',
         placement: {
           surfaceKind: ctx.surfaceKind || null,
           normal: ctx.normalArray || null,

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -1,38 +1,61 @@
+/**
+ * URL からテキストアセットを scene-add として追加。
+ * テキスト内容はフェッチせず URL 参照のまま保持する。
+ * ローカルの loadTextObject が描画時にフェッチする。
+ * @param {string} url - 分類済みのテキスト URL（確定済み）
+ * @param {object} ctx - { addOrUpdateObject, broadcastSceneAdd, showToast, generateObjectId, getSpawnTransform }
+ * @returns {Promise<{ objectId, payload }>}
+ */
 export async function importTextUrl(url, ctx) {
-  let response;
   try {
-    response = await fetch(url, { mode: 'cors' });
+    const objectId = ctx.generateObjectId('txt');
+    const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'text');
+    const displayName = (ctx.nameOverride || `text: ${filename}`).slice(0, 60);
+    const spawnTransform = ctx.getSpawnTransform();
+    const existingMetadata = (ctx.metadata && typeof ctx.metadata === 'object')
+      ? ctx.metadata
+      : {};
+
+    const payload = {
+      kind: 'scene-add',
+      objectId,
+      name: displayName,
+      position: spawnTransform.position,
+      rotation: spawnTransform.rotation,
+      scale: spawnTransform.scale,
+      asset: {
+        type: 'text',
+        source: 'url',
+        url,
+        format: /\.(md|markdown)$/i.test(filename) ? 'markdown' : 'plain',
+        fontFamily: 'system-sans',
+        fontSize: 32,
+        fontWeight: 'normal',
+        fontStyle: 'normal',
+        color: '#ffffff',
+        backgroundColor: 'rgba(0,0,0,0.65)',
+        align: 'center',
+      },
+      metadata: {
+        ...existingMetadata,
+        role: 'text-panel',
+        accepts: ['text'],
+        placement: {
+          surfaceKind: ctx.surfaceKind || null,
+          normal: ctx.normalArray || null,
+        },
+      },
+    };
+
+    ctx.broadcastSceneAdd(payload);
+    ctx.addOrUpdateObject(objectId, payload);
+
+    return { objectId, payload };
   } catch (err) {
     ctx.showToast({
       type: 'error',
-      message: `テキストURLのフェッチに失敗しました: ${err?.message || 'Failed to fetch'}`,
+      message: `テキスト URL の追加に失敗しました: ${err?.message || 'エラー'}`,
     });
     throw err;
   }
-
-  if (!response.ok) {
-    const err = new Error(`HTTP ${response.status}`);
-    ctx.showToast({
-      type: 'error',
-      message: `テキストURLの読み込みに失敗しました: ${err.message}`,
-    });
-    throw err;
-  }
-
-  const text = await response.text();
-
-  const filename = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'remote.txt');
-
-  if (typeof ctx.textImporter !== 'function') {
-    const err = new Error('textImporter is not configured');
-    ctx.showToast({
-      type: 'error',
-      message: 'テキストURL importer が設定されていません',
-    });
-    throw err;
-  }
-
-  await ctx.textImporter(text, filename, ctx);
-
-  return { objectId: null, payload: null };
 }

--- a/html/assets/js/scenesync/loaders/url-importers/video.js
+++ b/html/assets/js/scenesync/loaders/url-importers/video.js
@@ -23,6 +23,11 @@ export async function importVideoUrl(url, ctx) {
       rotation: spawnTransform.rotation,
       scale: spawnTransform.scale,
       asset: { type: 'video', source: 'url', url },
+      metadata: {
+        role: 'media-panel',
+        accepts: ['image', 'video'],
+        fit: 'contain',
+      },
     };
 
     ctx.broadcastSceneAdd(payload);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -13,6 +13,7 @@ import { DragDropManager, SKY_DROP_UPNESS_THRESHOLD } from './components/drag-dr
 import { ClipboardImportManager } from './components/clipboard-import-manager.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
 import { buildPlaneGlbFromImage, planeSizeFromImage } from './loaders/image-to-plane.js';
+import { createImageCanvasForScene } from './loaders/image-optimizer.js';
 import { generateTemporaryImageObjectId } from './loaders/image-preview.js';
 import { buildImageSkySphereGlb } from './loaders/image-to-sky-sphere.js';
 import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
@@ -222,6 +223,14 @@ const BLOB_BASE = location.hostname === 'localhost'
   ? 'http://localhost:8787/blob'
   : `${location.origin}/presence/blob`;
 const SCENE_SYNC_OPERATOR_URL = 'https://chatgpt.com/g/g-69eac2f9af04819193334b81da1b7993-scene-sync-operator';
+
+const FONT_PRESETS = {
+  'system-sans': 'system-ui, -apple-system, "Segoe UI", sans-serif',
+  'serif': 'Georgia, "Times New Roman", serif',
+  'monospace': '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
+  'japanese-sans': 'system-ui, -apple-system, "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif',
+  'japanese-serif': '"Hiragino Mincho ProN", "Yu Mincho", serif',
+};
 
 // ── XR コントローラー ──────────────────────────────────────
 // XR セッションへ入るためのモード状態
@@ -4784,6 +4793,24 @@ function handleHandoff(data) {
       if (typeof payload.name === 'string') applyObjectName(obj, payload.name);
       if (typeof payload.visible === 'boolean') applyObjectVisibility(obj, payload.visible);
       if (payload.asset) {
+        const newAssetType = payload.asset.type;
+        if (newAssetType === 'image' || newAssetType === 'video' || newAssetType === 'text') {
+          // Full re-render for content type changes (image/video/text)
+          const mergedInfo = {
+            objectId: payload.objectId,
+            name: typeof payload.name === 'string' ? payload.name : (obj.userData?.name || payload.objectId),
+            position: Array.isArray(payload.position) ? payload.position : obj.position.toArray(),
+            rotation: Array.isArray(payload.rotation) ? payload.rotation : obj.quaternion.toArray(),
+            scale: Array.isArray(payload.scale) ? payload.scale : obj.scale.toArray(),
+            asset: payload.asset,
+            metadata: payload.metadata
+              ? { ...(obj.userData?.metadata || {}), ...payload.metadata }
+              : obj.userData?.metadata,
+          };
+          addOrUpdateObject(payload.objectId, mergedInfo);
+          notifySceneStateChanged('scene-delta-content-replace');
+          break;
+        }
         applyAssetDelta(obj, payload.asset);
       }
       if (payload.animation && typeof payload.animation === 'object') {
@@ -5719,6 +5746,9 @@ function addOrUpdateObject(objectId, info, options = {}) {
           return;
         }
         break;
+      case 'text':
+        loadTextObject(objectId, info, asset, existing);
+        return;
       default:
         console.warn(`unsupported asset type: ${asset.type}`);
         replaceManagedObject(objectId, buildUnsupportedAssetObject(objectId, info), info);
@@ -5982,12 +6012,19 @@ function loadVideoObject(objectId, info, videoUrl, existing, prebuilt = null) {
 
   promise.then((bundle) => {
     removeLoadingOverlay(objectId);
-    const { group } = createVideoPlaneGroup(bundle, THREE);
+    const { group, material, texture } = createVideoPlaneGroup(bundle, THREE);
     group.userData.objectId = objectId;
     group.userData.name = info.name;
     group.userData.video = bundle.video;
     group.userData.assetType = 'video';
     if (info.asset) group.userData.asset = structuredClone(info.asset);
+
+    group.userData.disposable = () => {
+      bundle.video?.pause?.();
+      bundle.video && (bundle.video.src = '');
+      texture.dispose();
+      material.dispose();
+    };
 
     if (existing) {
       group.position.copy(existing.position);
@@ -6074,6 +6111,209 @@ function loadImageObject(objectId, info, imageUrl, existing, prebuilt = null) {
     replaceManagedObject(objectId, buildDefaultBoxObject(objectId, failedInfo, 0xcc3333), failedInfo);
     notifySceneStateChanged('image-load-failed');
   });
+}
+
+function loadTextObject(objectId, info, asset, existing) {
+  const textPromise = (asset.source === 'url' && asset.url)
+    ? fetch(asset.url, { mode: 'cors' }).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.text();
+      })
+    : Promise.resolve(asset.text || '');
+
+  textPromise.then((text) => {
+    const fontFamily = FONT_PRESETS[asset.fontFamily] || FONT_PRESETS['system-sans'];
+    const fontSize = typeof asset.fontSize === 'number' ? asset.fontSize : 32;
+    const fontWeight = asset.fontWeight || 'normal';
+    const fontStyle = asset.fontStyle || 'normal';
+    const color = asset.color || '#ffffff';
+    const bgColor = asset.backgroundColor || 'rgba(0,0,0,0.65)';
+    const align = asset.align || 'center';
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024;
+    canvas.height = 256;
+    const ctx = canvas.getContext('2d');
+
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+    ctx.fillStyle = color;
+    ctx.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
+    ctx.textBaseline = 'middle';
+
+    const lines = text.split('\n');
+    const lineHeight = fontSize * 1.4;
+    const totalHeight = lines.length * lineHeight;
+    const startY = (canvas.height - totalHeight) / 2 + lineHeight / 2;
+    const x = align === 'left' ? 20 : align === 'right' ? canvas.width - 20 : canvas.width / 2;
+
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], x, startY + i * lineHeight, canvas.width - 40);
+    }
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+
+    const aspect = canvas.width / canvas.height;
+    const maxEdge = 2;
+    const width = aspect >= 1 ? maxEdge : Math.max(maxEdge * aspect, 0.1);
+    const height = aspect >= 1 ? Math.max(maxEdge / aspect, 0.1) : maxEdge;
+
+    const geometry = new THREE.PlaneGeometry(width, height);
+    const material = new THREE.MeshBasicMaterial({
+      map: texture,
+      transparent: true,
+      depthWrite: true,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = height / 2;
+
+    const group = new THREE.Group();
+    group.add(mesh);
+
+    group.userData.objectId = objectId;
+    group.userData.name = info.name;
+    group.userData.assetType = 'text';
+    if (info.asset) group.userData.asset = structuredClone(info.asset);
+
+    group.userData.disposable = () => {
+      texture.dispose();
+      geometry.dispose();
+      material.dispose();
+    };
+
+    if (existing) {
+      group.position.copy(existing.position);
+      group.quaternion.copy(existing.quaternion);
+      group.scale.copy(existing.scale);
+      if (transformCtrl.object === existing) transformCtrl.detach();
+      scene.remove(existing);
+    }
+
+    replaceManagedObject(objectId, group, info);
+  }).catch((err) => {
+    console.warn('Failed to load text object for', objectId, ':', err);
+    const failedInfo = { ...info, name: `${info.name || objectId} (text load failed)` };
+    replaceManagedObject(objectId, buildDefaultBoxObject(objectId, failedInfo, 0x996633), failedInfo);
+  });
+}
+
+function canReplaceContent(object, inputKind) {
+  if (!object) return false;
+
+  const assetType = object.userData?.asset?.type || object.userData?.assetType;
+  const role = object.userData?.metadata?.role;
+  const accepts = object.userData?.metadata?.accepts;
+
+  if (Array.isArray(accepts)) {
+    return accepts.includes(inputKind);
+  }
+
+  if (role === 'media-panel') {
+    return inputKind === 'image' || inputKind === 'video';
+  }
+
+  if (assetType === 'image' || assetType === 'video') {
+    return inputKind === 'image' || inputKind === 'video';
+  }
+
+  if (role === 'text-panel' || assetType === 'text') {
+    return inputKind === 'text';
+  }
+
+  return false;
+}
+
+function getReplaceTarget(inputKind, hitObjectId = null) {
+  if (hitObjectId) {
+    const hitObj = managedObjects.get(hitObjectId);
+    if (canReplaceContent(hitObj, inputKind)) return hitObj;
+  }
+
+  const selected = getSelectedObjects();
+  if (selected.length === 1 && canReplaceContent(selected[0], inputKind)) {
+    return selected[0];
+  }
+
+  return null;
+}
+
+async function replaceObjectContent(objectId, input) {
+  const existing = managedObjects.get(objectId);
+  if (!existing) return;
+
+  const existingMeta = existing.userData?.metadata || {};
+  let newAsset;
+  let metaRole, metaAccepts, metaFit;
+
+  if (input.kind === 'image' || input.kind === 'video') {
+    newAsset = {
+      type: input.kind,
+      source: input.source || 'url',
+      url: input.url,
+      ...(input.mime ? { mime: input.mime } : {}),
+      ...(input.width ? { width: input.width } : {}),
+      ...(input.height ? { height: input.height } : {}),
+      ...(input.assetId ? { assetId: input.assetId } : {}),
+    };
+    metaRole = existingMeta.role || 'media-panel';
+    metaAccepts = existingMeta.accepts || ['image', 'video'];
+    metaFit = existingMeta.fit || 'contain';
+  } else if (input.kind === 'text') {
+    const existingAsset = existing.userData?.asset || {};
+    newAsset = {
+      type: 'text',
+      source: input.source || 'inline',
+      ...(input.url ? { url: input.url } : {}),
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      format: input.format || 'plain',
+      fontFamily: input.fontFamily || existingAsset.fontFamily || 'system-sans',
+      fontSize: input.fontSize || existingAsset.fontSize || 32,
+      fontWeight: input.fontWeight || existingAsset.fontWeight || 'normal',
+      fontStyle: input.fontStyle || existingAsset.fontStyle || 'normal',
+      color: input.color || existingAsset.color || '#ffffff',
+      backgroundColor: input.backgroundColor || existingAsset.backgroundColor || 'rgba(0,0,0,0.65)',
+      align: input.align || existingAsset.align || 'center',
+    };
+    metaRole = existingMeta.role || 'text-panel';
+    metaAccepts = existingMeta.accepts || ['text'];
+  } else {
+    return;
+  }
+
+  const newMetadata = {
+    ...existingMeta,
+    role: metaRole,
+    accepts: metaAccepts,
+    ...(metaFit !== undefined ? { fit: metaFit } : {}),
+  };
+
+  const deltaPayload = {
+    kind: 'scene-delta',
+    objectId,
+    asset: newAsset,
+    metadata: newMetadata,
+  };
+
+  broadcast(deltaPayload);
+
+  const mergedInfo = {
+    objectId,
+    name: existing.userData?.name || objectId,
+    position: existing.position.toArray(),
+    rotation: existing.quaternion.toArray(),
+    scale: existing.scale.toArray(),
+    asset: newAsset,
+    metadata: newMetadata,
+  };
+  addOrUpdateObject(objectId, mergedInfo);
+
+  showToast(input.kind === 'text' ? 'テキストを差し替えました' : 'メディアを差し替えました');
 }
 
 function disposeMaterial(material) {
@@ -7052,42 +7292,37 @@ async function imageImporterCallback(file, position, context = {}) {
       return result;
     }
 
-    const buildStart = performance.now();
-    let optimizationInfo = null;
-    console.debug('[image-import] build glb start', logContext);
-    const arrayBuffer = await buildPlaneGlbFromImage(file, {
-      THREE,
-      GLTFExporter,
-      maxPixel: 2048,
-      onOptimized: (info) => {
-        optimizationInfo = info;
-      },
-    });
-    console.debug('[image-import] build glb complete', {
+    // Optimize image and upload as raw blob (not GLB)
+    const optimizeStart = performance.now();
+    console.debug('[image-import] optimize start', logContext);
+    const optimized = await createImageCanvasForScene(file, { maxPixel: 2048, label: file.name });
+    console.debug('[image-import] optimize complete', {
       ...logContext,
-      ms: Math.round(performance.now() - buildStart),
+      ms: Math.round(performance.now() - optimizeStart),
+      originalWidth: optimized.originalWidth,
+      originalHeight: optimized.originalHeight,
+      textureWidth: optimized.textureWidth,
+      textureHeight: optimized.textureHeight,
+      resized: optimized.resized,
     });
-    console.debug('[image-import] optimized', {
-      ...logContext,
-      originalWidth: optimizationInfo?.originalWidth,
-      originalHeight: optimizationInfo?.originalHeight,
-      textureWidth: optimizationInfo?.textureWidth,
-      textureHeight: optimizationInfo?.textureHeight,
-      resized: optimizationInfo?.resized,
-      optimizeMs: optimizationInfo?.durationMs,
+
+    const imageBlob = await new Promise((resolve, reject) => {
+      optimized.canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('canvas.toBlob failed'))),
+        'image/jpeg',
+        0.92,
+      );
     });
 
     const uploadStart = performance.now();
     console.debug('[image-import] upload start', logContext);
-    const meshPath = await uploadCarrierGlb(arrayBuffer);
+    const uploaded = await uploadBlobToStore(imageBlob, 'image/jpeg', '.jpg');
     console.debug('[image-import] upload complete', {
       ...logContext,
       ms: Math.round(performance.now() - uploadStart),
-      meshPath,
+      url: uploaded.url,
     });
 
-    const objectId = `img-${meshPath.slice(0, 8)}`;
-    const displayName = `image: ${file.name}`.slice(0, 60);
     const positionArray = (position && typeof position.toArray === 'function')
       ? position.toArray()
       : [0, 1, 0];
@@ -7098,6 +7333,34 @@ async function imageImporterCallback(file, position, context = {}) {
       ? placementQuaternion.toArray()
       : [0, 0, 0, 1];
 
+    const newAsset = {
+      type: 'image',
+      source: 'blob',
+      url: uploaded.url,
+      mime: 'image/jpeg',
+      width: optimized.textureWidth,
+      height: optimized.textureHeight,
+    };
+
+    // Check for replace target
+    const replaceTarget = getReplaceTarget('image', context.hitObjectId);
+    if (replaceTarget) {
+      const targetId = replaceTarget.userData.objectId;
+      console.debug('[image-import] replacing existing object', { ...logContext, targetId });
+      await replaceObjectContent(targetId, {
+        kind: 'image',
+        source: 'blob',
+        url: uploaded.url,
+        mime: 'image/jpeg',
+        width: optimized.textureWidth,
+        height: optimized.textureHeight,
+      });
+      return { objectId: targetId };
+    }
+
+    const objectId = generateObjectId('img');
+    const displayName = `image: ${file.name}`.slice(0, 60);
+
     const payload = {
       kind: 'scene-add',
       objectId,
@@ -7105,18 +7368,20 @@ async function imageImporterCallback(file, position, context = {}) {
       position: positionArray,
       rotation,
       scale: [1, 1, 1],
-      asset: { type: 'mesh', meshPath },
+      asset: newAsset,
       metadata: {
         ...existingMetadata,
-        role: 'image-plane',
+        role: 'media-panel',
+        accepts: ['image', 'video'],
+        fit: 'contain',
         image: {
-          originalWidth: optimizationInfo?.originalWidth,
-          originalHeight: optimizationInfo?.originalHeight,
-          textureWidth: optimizationInfo?.textureWidth,
-          textureHeight: optimizationInfo?.textureHeight,
-          originalBytes: optimizationInfo?.originalBytes,
-          maxPixel: optimizationInfo?.maxPixel,
-          optimized: !!optimizationInfo?.resized,
+          originalWidth: optimized.originalWidth,
+          originalHeight: optimized.originalHeight,
+          textureWidth: optimized.textureWidth,
+          textureHeight: optimized.textureHeight,
+          originalBytes: file.size,
+          maxPixel: 2048,
+          optimized: optimized.resized,
         },
         placement: {
           surfaceKind: context.surfaceKind || 'unknown',
@@ -7156,20 +7421,7 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
   const existingMetadata = (context.metadata && typeof context.metadata === 'object')
     ? context.metadata
     : {};
-  const { arrayBuffer } = await buildTextPlaneGlb(text, {
-    THREE,
-    GLTFExporter,
-    markdown: /\.(md|markdown)$/i.test(filename),
-  });
 
-  const meshPath = await uploadCarrierGlb(arrayBuffer);
-
-  const objectId = (typeof context.objectId === 'string' && context.objectId.trim())
-    ? context.objectId.trim()
-    : `txt-${meshPath.slice(0, 8)}`;
-  const displayName = (typeof context.name === 'string' && context.name.trim())
-    ? context.name.trim().slice(0, 60)
-    : `text: ${filename}`.slice(0, 60);
   const positionArray = (position && typeof position.toArray === 'function')
     ? position.toArray()
     : [0, 1, 0];
@@ -7181,6 +7433,40 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     : readQuaternionArray(context.rotation, [0, 0, 0, 1]);
   const scale = readVector3Array(context.scale, [1, 1, 1]);
 
+  const newAsset = {
+    type: 'text',
+    source: 'inline',
+    text,
+    format: /\.(md|markdown)$/i.test(filename) ? 'markdown' : 'plain',
+    fontFamily: 'system-sans',
+    fontSize: 32,
+    fontWeight: 'normal',
+    fontStyle: 'normal',
+    color: '#ffffff',
+    backgroundColor: 'rgba(0,0,0,0.65)',
+    align: 'center',
+  };
+
+  // Check for replace target
+  const replaceTarget = getReplaceTarget('text', context.hitObjectId);
+  if (replaceTarget) {
+    const targetId = replaceTarget.userData.objectId;
+    await replaceObjectContent(targetId, {
+      kind: 'text',
+      source: 'inline',
+      text,
+      format: newAsset.format,
+    });
+    return { objectId: targetId };
+  }
+
+  const objectId = (typeof context.objectId === 'string' && context.objectId.trim())
+    ? context.objectId.trim()
+    : generateObjectId('txt');
+  const displayName = (typeof context.name === 'string' && context.name.trim())
+    ? context.name.trim().slice(0, 60)
+    : `text: ${filename}`.slice(0, 60);
+
   const payload = {
     kind: 'scene-add',
     objectId,
@@ -7188,9 +7474,11 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     position: positionArray,
     rotation,
     scale,
-    asset: { type: 'mesh', meshPath },
+    asset: newAsset,
     metadata: {
       ...existingMetadata,
+      role: 'text-panel',
+      accepts: ['text'],
       placement: {
         surfaceKind: context.surfaceKind || 'unknown',
         normal: context.normalArray || null,
@@ -7199,8 +7487,6 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
   };
 
   broadcast(payload);
-
-  // ローカルにも反映
   addOrUpdateObject(objectId, payload);
 
   return { objectId, payload };
@@ -7234,6 +7520,27 @@ async function urlImporterCallback(url, position, context = {}) {
     isImageUrl &&
     context.upness !== undefined &&
     context.upness > SKY_DROP_UPNESS_THRESHOLD;
+
+  // Auto-replace detection (not for skybox targets)
+  if (!urlSkybox) {
+    let inputKind = null;
+    if (urlKind === URL_KIND.IMAGE) inputKind = 'image';
+    else if (urlKind === URL_KIND.VIDEO || urlKind === URL_KIND.VIDEO_HLS) inputKind = 'video';
+    else if (urlKind === URL_KIND.TEXT) inputKind = 'text';
+
+    if (inputKind) {
+      const replaceTarget = getReplaceTarget(inputKind, context.hitObjectId);
+      if (replaceTarget) {
+        await replaceObjectContent(replaceTarget.userData.objectId, {
+          kind: inputKind,
+          source: 'url',
+          url: resolved.resolvedUrl,
+        });
+        return;
+      }
+    }
+  }
+
   const effectiveTargetKind = urlSkybox ? 'sky' : (context?.targetKind || 'scene');
   const effectiveSurfaceKind = urlSkybox ? 'skybox' : (context.surfaceKind || null);
   const effectivePlacementRotation = urlSkybox ? null : (context.placementRotation || null);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7314,6 +7314,8 @@ async function imageImporterCallback(file, position, context = {}) {
       );
     });
 
+    // TODO: presence blobs have a server-side TTL; long-lived rooms may see broken image URLs.
+    // Future: cache the blob in IndexedDB and re-upload on session reconnect if the URL 404s.
     const uploadStart = performance.now();
     console.debug('[image-import] upload start', logContext);
     const uploaded = await uploadBlobToStore(imageBlob, 'image/jpeg', '.jpg');

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1306,7 +1306,14 @@ namespace Afjk.SceneSync
             }
             else
             {
-                // メッシュなしの場合は Cube を作成
+                // Extract asset type for diagnostic logging
+                var assetTypeMatch = System.Text.RegularExpressions.Regex.Match(
+                    raw, "\"asset\"\\s*:\\s*\\{[^}]*\"type\"\\s*:\\s*\"([^\"]+)\"");
+                var assetType = assetTypeMatch.Success ? assetTypeMatch.Groups[1].Value : "unknown";
+
+                // image / video / text are browser-only assets; Unity shows a Cube placeholder
+                Debug.Log("[SceneSync] scene-add: assetType=" + assetType + " (no meshPath) → Cube placeholder for objectId=" + objectId);
+
                 var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 go.name = name;
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);


### PR DESCRIPTION
## PR 1 + PR 2: Media/Text asset基盤 + 自動差し替え

### asset.type = "text" 対応
- `loadTextObject` 追加: CanvasTexture でテキストを描画する Plane を生成
- `FONT_PRESETS` 追加: system-sans / serif / monospace / japanese-sans / japanese-serif
- `addOrUpdateObject` に `case 'text':` 分岐追加
- `textImporterCallback` を GLB → `asset.type=text, source=inline` に変更
- `importTextUrl` を fetch → `asset.type=text, source=url` に変更 (loadTextObject がレンダー時にfetch)

### asset.type = "image" (file upload) 対応
- `imageImporterCallback` を GLB → raw JPEG blob upload + `asset.type=image, source=blob` に変更
- 新規画像に `metadata.role=media-panel, accepts=[image,video], fit=contain` を付与

### media-panel metadata
- `importImageUrl` に role/accepts/fit メタデータ追加
- `importVideoUrl` に role/accepts/fit メタデータ追加

### 自動差し替え
- `canReplaceContent(object, inputKind)` 追加: image/video/text/GLBの差し替え可否判定
- `getReplaceTarget(inputKind, hitObjectId)` 追加: D&D先または選択オブジェクトから差し替え対象を決定
- `replaceObjectContent(objectId, input)` 追加: scene-delta broadcast + ローカル更新
- `imageImporterCallback` / `textImporterCallback` / `urlImporterCallback` に replace logic 追加
- 複数選択時は自動差し替えしない

### scene-delta content re-render
- asset.type が image/video/text の scene-delta 受信時に addOrUpdateObject を呼んで全再描画
- 他ブラウザへの image↔video/text 差し替え同期対応

### DragDropManager の hitObjectId 修正
- `findManagedObjectId` 追加: 子 mesh ヒット時も親グループの objectId を正しく取得
- image/video グループ上での D&D ヒット検出が正常に動作

### video の disposable 追加
- `loadVideoObject` で video element pause + src クリアの disposable を設定
- 動画が video→image 差し替え後も再生し続ける問題を修正

### 互換性
- 既存 mesh/GLB アセットは差し替え対象外のまま
- 既存 image/text GLBオブジェクトは従来通り表示継続

https://claude.ai/code/session_01JSb56LToXtaPhjHHPXLEK3