### PR TITLE
feat: AI/MCP Media/Text replace commands

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5594,13 +5594,6 @@ function setObjectAnimationClipByAiCommand(params = {}) {
 
 // ── AI Command: Media/Text Replace ───────────────────────────────────
 
-function canReplaceContent(object, inputKind) {
-  if (!object) return false;
-  const metadata = object.userData?.metadata || {};
-  const accepts = metadata.accepts || [];
-  return accepts.includes(inputKind);
-}
-
 function resolveReplaceTargetObjectId({ objectId, inputKind }) {
   if (objectId) {
     const target = managedObjects.get(objectId);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5592,6 +5592,43 @@ function setObjectAnimationClipByAiCommand(params = {}) {
   };
 }
 
+// ── AI Command: Media/Text Replace ───────────────────────────────────
+
+function canReplaceContent(object, inputKind) {
+  if (!object) return false;
+  const metadata = object.userData?.metadata || {};
+  const accepts = metadata.accepts || [];
+  return accepts.includes(inputKind);
+}
+
+function resolveReplaceTargetObjectId({ objectId, inputKind }) {
+  if (objectId) {
+    const target = managedObjects.get(objectId);
+    if (!target) {
+      throw new Error(`Object not found: ${objectId}`);
+    }
+    if (!canReplaceContent(target, inputKind)) {
+      throw new Error(`Target object does not accept ${inputKind} content.`);
+    }
+    return objectId;
+  }
+
+  const selectedObjects = getSelectedObjects();
+  if (selectedObjects.length === 0) {
+    throw new Error('No target object. Select one replaceable object or provide objectId.');
+  }
+  if (selectedObjects.length > 1) {
+    throw new Error('Select exactly one replaceable object.');
+  }
+
+  const selected = selectedObjects[0];
+  if (!canReplaceContent(selected, inputKind)) {
+    throw new Error(`Selected object does not accept ${inputKind} content.`);
+  }
+
+  return selected.userData.objectId;
+}
+
 async function handleAiCommand(from, payload) {
   const requestId = payload.requestId || `req-${Date.now()}`;
 
@@ -5666,6 +5703,82 @@ async function handleAiCommand(from, payload) {
       case 'setAnimationClip':
         result = setObjectAnimationClipByAiCommand(payload.params || {});
         break;
+      case 'replaceMediaFromUrl': {
+        const params = payload.params || {};
+        const { url, mediaType, name } = params;
+
+        if (!url) {
+          result = { ok: false, error: 'url is required.' };
+          break;
+        }
+        if (!mediaType || !['image', 'video'].includes(mediaType)) {
+          result = { ok: false, error: 'mediaType must be "image" or "video".' };
+          break;
+        }
+
+        try {
+          const targetObjectId = resolveReplaceTargetObjectId({ objectId: params.objectId, inputKind: mediaType });
+          await replaceObjectContent(targetObjectId, {
+            kind: mediaType,
+            source: 'url',
+            url,
+            name,
+          });
+
+          const targetObj = managedObjects.get(targetObjectId);
+          result = {
+            ok: true,
+            action: 'replaceMediaFromUrl',
+            objectId: targetObjectId,
+            assetType: mediaType,
+            url,
+            ...(name ? { name } : {}),
+          };
+        } catch (e) {
+          result = { ok: false, error: e.message };
+        }
+        break;
+      }
+      case 'replaceTextContent': {
+        const params = payload.params || {};
+        const { text, objectId } = params;
+
+        if (text === undefined || text === null) {
+          result = { ok: false, error: 'text is required.' };
+          break;
+        }
+
+        try {
+          const targetObjectId = resolveReplaceTargetObjectId({ objectId, inputKind: 'text' });
+          await replaceObjectContent(targetObjectId, {
+            kind: 'text',
+            source: 'inline',
+            text: String(text),
+            fontFamily: params.fontFamily,
+            fontSize: params.fontSize,
+            fontWeight: params.fontWeight,
+            fontStyle: params.fontStyle,
+            color: params.color,
+            backgroundColor: params.backgroundColor,
+            align: params.align,
+            name: params.name,
+          });
+
+          const targetObj = managedObjects.get(targetObjectId);
+          const asset = targetObj?.userData?.asset || {};
+          result = {
+            ok: true,
+            action: 'replaceTextContent',
+            objectId: targetObjectId,
+            assetType: 'text',
+            textLength: String(text).length,
+            ...(params.name ? { name: params.name } : {}),
+          };
+        } catch (e) {
+          result = { ok: false, error: e.message };
+        }
+        break;
+      }
       default:
         result = { ok: false, error: `unsupported ai-command action: ${payload.action}` };
         break;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6399,9 +6399,15 @@ async function replaceObjectContent(objectId, input) {
     ...(metaFit !== undefined ? { fit: metaFit } : {}),
   };
 
+  const nextName =
+    typeof input.name === 'string' && input.name.trim()
+      ? input.name.trim()
+      : existing.userData?.name || objectId;
+
   const deltaPayload = {
     kind: 'scene-delta',
     objectId,
+    ...(input.name ? { name: nextName } : {}),
     asset: newAsset,
     metadata: newMetadata,
   };
@@ -6410,7 +6416,7 @@ async function replaceObjectContent(objectId, input) {
 
   const mergedInfo = {
     objectId,
-    name: existing.userData?.name || objectId,
+    name: nextName,
     position: existing.position.toArray(),
     rotation: existing.quaternion.toArray(),
     scale: existing.scale.toArray(),

--- a/packages/scene-sync-mcp/README.md
+++ b/packages/scene-sync-mcp/README.md
@@ -341,6 +341,57 @@ Input:
 
 Returns the last N history entries from the browser.
 
+### scene_sync_replace_media
+
+Replace the content of a media panel with an image or video URL. If `objectId` is omitted, the currently selected object is used.
+
+Input:
+```json
+{
+  "objectId": "media-panel-1",
+  "url": "https://example.com/image.png",
+  "mediaType": "image",
+  "name": "Updated Image"
+}
+```
+
+Or for video:
+```json
+{
+  "url": "https://example.com/video.mp4",
+  "mediaType": "video"
+}
+```
+
+Fields: `url` (required), `mediaType` (required, "image" or "video"), `objectId` (optional), `name` (optional).
+
+Notes:
+- Image and video media panels can be interchanged.
+- The URL must be accessible from the browser.
+- CORS headers may be required.
+
+### scene_sync_replace_text
+
+Replace the text content of a text panel. If `objectId` is omitted, the currently selected object is used.
+
+Input:
+```json
+{
+  "objectId": "text-panel-1",
+  "text": "Hello Scene Sync",
+  "fontFamily": "system-sans",
+  "fontSize": 32,
+  "color": "#ffffff",
+  "align": "center"
+}
+```
+
+Fields: `text` (required), `objectId` (optional), `name` (optional), `fontFamily` (optional, "system-sans" / "serif" / "monospace" / "japanese-sans" / "japanese-serif"), `fontSize` (optional, pixels), `fontWeight` (optional), `fontStyle` (optional, "normal" / "italic"), `color` (optional), `backgroundColor` (optional), `align` (optional, "left" / "center" / "right").
+
+Notes:
+- Unspecified text styling fields inherit from the existing asset.
+- If no existing styling exists, default values are used.
+
 ### scene_sync_set_animation_clip
 
 Switch an animated GLB object to a specific animation clip by name or index.

--- a/packages/scene-sync-mcp/src/scene-sync-client.mjs
+++ b/packages/scene-sync-mcp/src/scene-sync-client.mjs
@@ -88,4 +88,12 @@ export class SceneSyncClient {
       clearTimeout(timeoutId)
     }
   }
+
+  async replaceMediaFromUrl(roomId, sessionId, params) {
+    return this.aiCommand(roomId, sessionId, 'replaceMediaFromUrl', params)
+  }
+
+  async replaceTextContent(roomId, sessionId, params) {
+    return this.aiCommand(roomId, sessionId, 'replaceTextContent', params)
+  }
 }

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -35,11 +35,10 @@ function getSession() {
 
 // Helper to check aiCommand response for errors
 function assertAiCommandOk(response) {
-  if (response?.error) {
-    if (typeof response.error === 'object') {
-      throw response.error
-    }
-    throw new Error(response.error)
+  const nested = response?.result
+  const error = response?.error || nested?.error
+  if (response?.ok === false || nested?.ok === false || error) {
+    throw new Error(error || 'ai-command failed')
   }
 
   return response
@@ -1067,7 +1066,6 @@ server.registerTool(
 
       return jsonResult({
         ...response,
-        ok: true,
         action: 'replaceMediaFromUrl'
       })
     } catch (e) {
@@ -1115,7 +1113,6 @@ server.registerTool(
 
       return jsonResult({
         ...response,
-        ok: true,
         action: 'replaceTextContent'
       })
     } catch (e) {

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -1043,6 +1043,90 @@ server.registerTool(
   }
 )
 
+// scene_sync_replace_media
+server.registerTool(
+  'scene_sync_replace_media',
+  {
+    title: 'Replace media panel content',
+    description: 'Replace the content of a media panel with an image or video URL. If objectId is omitted, the currently selected object is used.',
+    inputSchema: z.object({
+      objectId: z.string().optional().describe('Target object ID. If omitted, the single selected object is used.'),
+      url: z.string().url().describe('Image or video URL.'),
+      mediaType: z.enum(['image', 'video']).describe('Type of the URL media.'),
+      name: z.string().optional().describe('Optional new object name.')
+    })
+  },
+  async ({ objectId, url, mediaType, name }) => {
+    try {
+      const response = await runAiCommand('replaceMediaFromUrl', {
+        objectId,
+        url,
+        mediaType,
+        name
+      }, { timeout: 30000 })
+
+      return jsonResult({
+        ...response,
+        ok: true,
+        action: 'replaceMediaFromUrl'
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_replace_text
+server.registerTool(
+  'scene_sync_replace_text',
+  {
+    title: 'Replace text panel content',
+    description: 'Replace the text content of a text panel. If objectId is omitted, the currently selected object is used.',
+    inputSchema: z.object({
+      objectId: z.string().optional().describe('Target object ID. If omitted, the single selected object is used.'),
+      text: z.string().describe('New text content.'),
+      name: z.string().optional().describe('Optional new object name.'),
+      fontFamily: z.enum(['system-sans', 'serif', 'monospace', 'japanese-sans', 'japanese-serif']).optional().describe('Optional font preset.'),
+      fontSize: z.number().optional().describe('Optional font size in pixels.'),
+      fontWeight: z.union([z.string(), z.number()]).optional().describe('Optional font weight.'),
+      fontStyle: z.enum(['normal', 'italic']).optional().describe('Optional font style.'),
+      color: z.string().optional().describe('Optional text color.'),
+      backgroundColor: z.string().optional().describe('Optional background color.'),
+      align: z.enum(['left', 'center', 'right']).optional().describe('Optional text alignment.')
+    })
+  },
+  async ({ objectId, text, name, fontFamily, fontSize, fontWeight, fontStyle, color, backgroundColor, align }) => {
+    try {
+      const response = await runAiCommand('replaceTextContent', {
+        objectId,
+        text,
+        name,
+        fontFamily,
+        fontSize,
+        fontWeight,
+        fontStyle,
+        color,
+        backgroundColor,
+        align
+      }, { timeout: 30000 })
+
+      return jsonResult({
+        ...response,
+        ok: true,
+        action: 'replaceTextContent'
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
 // Optional raw broadcast tool
 if (process.env.SCENE_SYNC_ENABLE_RAW_TOOLS === 'true') {
   server.registerTool(


### PR DESCRIPTION
Add replaceMediaFromUrl and replaceTextContent AI commands to Browser side
- New ai-command actions: replaceMediaFromUrl, replaceTextContent
- Support objectId specification or select single target object
- Reuse existing replaceObjectContent function
- Helper functions: canReplaceContent, resolveReplaceTargetObjectId

Add MCP tools for Media/Text replacement
- scene_sync_replace_media: replace image/video in media panel
- scene_sync_replace_text: replace text content with styling options
- Support objectId omission (use selected object)

Add SceneSyncClient helper methods
- replaceMediaFromUrl(roomId, sessionId, params)
- replaceTextContent(roomId, sessionId, params)

https://claude.ai/code/session_012HNeV4JAGgdLaZxckUg426