### PR TITLE
feat: Implement optimistic local preview for image replacement

### DIFF
--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -116,6 +116,7 @@ export class DragDropManager {
       urlImporter,
       wallSurfaceOffset = 0.01,
       THREE: ThreeModule,
+      getReplaceTargetForContent = null,
     } = options || {};
 
     if (!camera || !renderer || !scene) {
@@ -136,6 +137,7 @@ export class DragDropManager {
     this.imageImporter = imageImporter;
     this.textImporter = textImporter;
     this.urlImporter = urlImporter;
+    this.getReplaceTargetForContent = getReplaceTargetForContent;
     this.wallSurfaceOffset = wallSurfaceOffset;
     this.getPlacementTargets = getPlacementTargets;
     this.THREE = ThreeModule || (globalThis.THREE || {});
@@ -459,7 +461,6 @@ export class DragDropManager {
     }
 
     if (this.imageImporter && isSupportedImageFile(file)) {
-      const objectId = generateTemporaryImageObjectId();
       // Skybox intent takes priority for images when looking up.
       const imageSkybox =
         normalized.upness !== undefined &&
@@ -468,13 +469,27 @@ export class DragDropManager {
       const effectiveSurfaceKind = imageSkybox ? 'skybox' : surfaceKind;
       const effectiveSurfaceQuaternion = imageSkybox ? null : surfaceQuaternion;
       const effectivePlacementRotation = effectiveSurfaceQuaternion?.toArray?.() || null;
+
+      // Determine replacement target BEFORE calling onLoadStart
+      let replaceTargetObjectId = null;
+      if (effectiveTargetKind !== 'sky') {
+        replaceTargetObjectId = this.getReplaceTargetForContent?.('image', {
+          hitObjectId: normalized.hitObjectId,
+          targetKind: effectiveTargetKind,
+          source: 'file',
+          file,
+        }) || null;
+      }
+
+      const isReplacement = !!replaceTargetObjectId;
+      const objectId = isReplacement ? null : generateTemporaryImageObjectId();
       const loadInfo = {
         objectId,
         file,
         position: normalized.position,
         source: 'image',
         targetKind: effectiveTargetKind,
-        temporary: true,
+        temporary: !isReplacement,
         normal: normalized.normal,
         normalArray: normalized.normalArray,
         surfaceKind: effectiveSurfaceKind,
@@ -484,7 +499,7 @@ export class DragDropManager {
 
       const toastMessage = effectiveTargetKind === 'sky'
         ? 'Skybox画像を準備中…'
-        : '画像を準備中…';
+        : (isReplacement ? '画像を差し替え中…' : '画像を準備中…');
       this.showToast?.(toastMessage);
       console.debug('[drag-drop] image placement', {
         targetKind: effectiveTargetKind,
@@ -492,8 +507,12 @@ export class DragDropManager {
         surfaceKind: effectiveSurfaceKind,
         placementRotation: effectivePlacementRotation,
         skyboxOverride: imageSkybox,
+        isReplacement,
+        replaceTargetObjectId,
       });
-      if (this.onLoadStart) {
+
+      // Only call onLoadStart for new additions, not replacements
+      if (!isReplacement && this.onLoadStart) {
         Promise.resolve(this.onLoadStart(loadInfo)).catch((error) => {
           console.warn('[drag-drop] image onLoadStart failed:', error);
         });
@@ -511,7 +530,9 @@ export class DragDropManager {
           surfaceKind: effectiveSurfaceKind,
           placementQuaternion: effectiveSurfaceQuaternion,
           placementRotation: effectivePlacementRotation,
-          tempObjectId: objectId,
+          tempObjectId: isReplacement ? null : objectId,
+          replaceTargetObjectId,
+          isReplacement,
         });
       } catch (error) {
         console.warn('[drag-drop] image import failed:', error);

--- a/html/assets/js/scenesync/components/drag-drop-manager.js
+++ b/html/assets/js/scenesync/components/drag-drop-manager.js
@@ -497,10 +497,15 @@ export class DragDropManager {
         placementQuaternion: effectiveSurfaceQuaternion,
       };
 
-      const toastMessage = effectiveTargetKind === 'sky'
-        ? 'Skybox画像を準備中…'
-        : (isReplacement ? '画像を差し替え中…' : '画像を準備中…');
-      this.showToast?.(toastMessage);
+      // Only show toast for new additions and skybox
+      // (replacements show local preview immediately, so toast is unnecessary)
+      const shouldShowToast = effectiveTargetKind === 'sky' || !isReplacement;
+      if (shouldShowToast) {
+        const toastMessage = effectiveTargetKind === 'sky'
+          ? 'Skybox画像を準備中…'
+          : '画像を準備中…';
+        this.showToast?.(toastMessage);
+      }
       console.debug('[drag-drop] image placement', {
         targetKind: effectiveTargetKind,
         normal: normalized.normalArray,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -7522,7 +7522,11 @@ async function replaceImageFileOptimistically(objectId, file, context = {}) {
       clearLocalImageReplacementPreview(objectId, preview.token);
     }
 
-    throw error;
+    const replacementError = new Error(
+      error?.message || '画像の差し替えに失敗しました'
+    );
+    replacementError.original = error;
+    throw replacementError;
   }
 }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6384,7 +6384,17 @@ async function showLocalImageReplacementPreview(objectId, file) {
     return null;
   }
 
-  const texture = new THREE.TextureLoader().load(objectUrl);
+  let texture;
+  try {
+    texture = await new Promise((resolve, reject) => {
+      new THREE.TextureLoader().load(objectUrl, resolve, undefined, reject);
+    });
+  } catch (error) {
+    console.warn('[image-import] failed to load replacement preview texture:', error);
+    URL.revokeObjectURL(objectUrl);
+    return null;
+  }
+
   texture.colorSpace = THREE.SRGBColorSpace;
 
   const material = new THREE.MeshBasicMaterial({

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5819,9 +5819,17 @@ function normalizeSceneAsset(asset, payload = {}) {
 }
 
 function cleanupPreviewForLoadedObject(options = {}) {
-  if (!options.previewObjectId) return;
-  removeTemporaryImagePreview(options.previewObjectId);
-  removeLoadingOverlay(options.previewObjectId);
+  if (options.previewObjectId) {
+    removeTemporaryImagePreview(options.previewObjectId);
+    removeLoadingOverlay(options.previewObjectId);
+  }
+
+  if (options.localReplacementObjectId) {
+    clearLocalImageReplacementPreview(
+      options.localReplacementObjectId,
+      options.localReplacementPreviewToken || null
+    );
+  }
 }
 
 function addOrUpdateObject(objectId, info, options = {}) {
@@ -6453,7 +6461,7 @@ function isCurrentLocalImageReplacementPreview(objectId, token) {
   return pendingMediaReplacementPreviews.get(objectId)?.token === token;
 }
 
-async function replaceObjectContent(objectId, input) {
+async function replaceObjectContent(objectId, input, options = {}) {
   const existing = managedObjects.get(objectId);
   if (!existing) return;
 
@@ -6527,7 +6535,7 @@ async function replaceObjectContent(objectId, input) {
     asset: newAsset,
     metadata: newMetadata,
   };
-  addOrUpdateObject(objectId, mergedInfo);
+  addOrUpdateObject(objectId, mergedInfo, options);
 
   showToast(input.kind === 'text' ? 'テキストを差し替えました' : 'メディアを差し替えました');
 }
@@ -7499,19 +7507,24 @@ async function replaceImageFileOptimistically(objectId, file, context = {}) {
       return { objectId, stale: true };
     }
 
-    await replaceObjectContent(objectId, {
-      kind: 'image',
-      source: 'blob',
-      url: uploadedUrl.url,
-      mime: 'image/jpeg',
-      width: optimized.textureWidth,
-      height: optimized.textureHeight,
-      name: file.name,
-    });
-
-    if (preview) {
-      clearLocalImageReplacementPreview(objectId, preview.token);
-    }
+    await replaceObjectContent(
+      objectId,
+      {
+        kind: 'image',
+        source: 'blob',
+        url: uploadedUrl.url,
+        mime: 'image/jpeg',
+        width: optimized.textureWidth,
+        height: optimized.textureHeight,
+        name: file.name,
+      },
+      preview
+        ? {
+            localReplacementObjectId: objectId,
+            localReplacementPreviewToken: preview.token,
+          }
+        : {}
+    );
 
     return {
       objectId,
@@ -7535,7 +7548,7 @@ async function imageImporterCallback(file, position, context = {}) {
     throw new Error('この画像は非常に大きいため処理できません');
   }
 
-  const { targetKind = 'scene', tempObjectId, replaceTargetObjectId, isReplacement } = context;
+  const { targetKind = 'scene', tempObjectId, replaceTargetObjectId } = context;
   const isSkyTarget = targetKind === 'sky';
   const existingMetadata = (context.metadata && typeof context.metadata === 'object')
     ? context.metadata

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1302,6 +1302,10 @@ managedObjects.set('sample-cube', sampleCube);
 const selectedObjectIds = new Set();
 const selectionHelpers = new Map();
 
+// Local image replacement preview management
+// objectId → { token, objectUrl, overlayObject, cleanup }
+const pendingMediaReplacementPreviews = new Map();
+
 // objectId → lockOwnerId
 const locks = new Map();
 
@@ -6354,6 +6358,91 @@ function getReplaceTarget(inputKind, hitObjectId = null) {
   return null;
 }
 
+function findPrimaryMediaMesh(root) {
+  let found = null;
+  root.traverse((child) => {
+    if (found) return;
+    if (child.isMesh && child.geometry) {
+      found = child;
+    }
+  });
+  return found;
+}
+
+async function showLocalImageReplacementPreview(objectId, file) {
+  const target = managedObjects.get(objectId);
+  if (!target) return null;
+
+  clearLocalImageReplacementPreview(objectId);
+
+  const token = crypto.randomUUID?.() || `${Date.now()}-${Math.random()}`;
+  const objectUrl = URL.createObjectURL(file);
+
+  const baseMesh = findPrimaryMediaMesh(target);
+  if (!baseMesh) {
+    URL.revokeObjectURL(objectUrl);
+    return null;
+  }
+
+  const texture = new THREE.TextureLoader().load(objectUrl);
+  texture.colorSpace = THREE.SRGBColorSpace;
+
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    side: THREE.DoubleSide,
+  });
+
+  const overlay = new THREE.Mesh(baseMesh.geometry.clone(), material);
+  overlay.position.copy(baseMesh.position);
+  overlay.rotation.copy(baseMesh.rotation);
+  overlay.scale.copy(baseMesh.scale);
+
+  overlay.position.z += 0.002;
+  overlay.renderOrder = (baseMesh.renderOrder || 0) + 1;
+
+  overlay.userData.localReplacementPreview = true;
+  overlay.userData.ignoreSceneExport = true;
+
+  baseMesh.parent.add(overlay);
+
+  const cleanup = () => {
+    if (overlay.parent) overlay.parent.remove(overlay);
+    overlay.geometry?.dispose?.();
+    overlay.material?.map?.dispose?.();
+    overlay.material?.dispose?.();
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  pendingMediaReplacementPreviews.set(objectId, {
+    token,
+    objectUrl,
+    overlayObject: overlay,
+    cleanup,
+  });
+
+  return { token, objectUrl };
+}
+
+function clearLocalImageReplacementPreview(objectId, token = null) {
+  const preview = pendingMediaReplacementPreviews.get(objectId);
+  if (!preview) return;
+
+  if (token && preview.token !== token) return;
+
+  try {
+    preview.cleanup?.();
+  } catch (error) {
+    console.warn('[image-import] failed to cleanup local replacement preview:', error);
+  }
+
+  pendingMediaReplacementPreviews.delete(objectId);
+}
+
+function isCurrentLocalImageReplacementPreview(objectId, token) {
+  return pendingMediaReplacementPreviews.get(objectId)?.token === token;
+}
+
 async function replaceObjectContent(objectId, input) {
   const existing = managedObjects.get(objectId);
   if (!existing) return;
@@ -7374,12 +7463,65 @@ async function replaceSkyboxSphereFromBlob(blob, sourceName = 'skybox', context 
   };
 }
 
+async function replaceImageFileOptimistically(objectId, file, context = {}) {
+  const preview = await showLocalImageReplacementPreview(objectId, file);
+
+  try {
+    // Optimize and upload
+    const optimized = await createImageCanvasForScene(file, {
+      maxPixel: 2048,
+      label: file.name,
+    });
+
+    const imageBlob = await new Promise((resolve, reject) => {
+      optimized.canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('canvas.toBlob failed'))),
+        'image/jpeg',
+        0.92,
+      );
+    });
+
+    const uploadedUrl = await uploadBlobToStore(imageBlob, 'image/jpeg', '.jpg');
+
+    // Check if this preview is still current
+    if (preview && !isCurrentLocalImageReplacementPreview(objectId, preview.token)) {
+      console.debug('[image-import] stale image replacement ignored', { objectId });
+      return { objectId, stale: true };
+    }
+
+    await replaceObjectContent(objectId, {
+      kind: 'image',
+      source: 'blob',
+      url: uploadedUrl.url,
+      mime: 'image/jpeg',
+      width: optimized.textureWidth,
+      height: optimized.textureHeight,
+      name: file.name,
+    });
+
+    if (preview) {
+      clearLocalImageReplacementPreview(objectId, preview.token);
+    }
+
+    return {
+      objectId,
+      url: uploadedUrl.url,
+    };
+  } catch (error) {
+    if (preview) {
+      clearLocalImageReplacementPreview(objectId, preview.token);
+    }
+
+    throw error;
+  }
+}
+
 async function imageImporterCallback(file, position, context = {}) {
   if (file.size > ABSOLUTE_IMAGE_FILE_LIMIT_BYTES) {
     throw new Error('この画像は非常に大きいため処理できません');
   }
 
-  const { targetKind = 'scene', tempObjectId } = context;
+  const { targetKind = 'scene', tempObjectId, replaceTargetObjectId, isReplacement } = context;
   const isSkyTarget = targetKind === 'sky';
   const existingMetadata = (context.metadata && typeof context.metadata === 'object')
     ? context.metadata
@@ -7409,7 +7551,35 @@ async function imageImporterCallback(file, position, context = {}) {
       return result;
     }
 
-    // Optimize image and upload as raw blob (not GLB)
+    // Determine replacement target early
+    const effectiveReplaceTargetId = replaceTargetObjectId || null;
+    const effectiveReplaceTarget = effectiveReplaceTargetId
+      ? managedObjects.get(effectiveReplaceTargetId)
+      : getReplaceTarget('image', context.hitObjectId || null);
+
+    if (effectiveReplaceTarget) {
+      const targetId = effectiveReplaceTarget.userData.objectId;
+      console.debug('[image-import] replacing existing object (optimistic)', { ...logContext, targetId });
+      try {
+        const result = await replaceImageFileOptimistically(targetId, file, context);
+        previewHandedOff = true;
+        console.debug('[image-import] optimistic replacement complete', {
+          ...logContext,
+          targetId,
+          result,
+        });
+        return result;
+      } catch (error) {
+        console.warn('[image-import] optimistic replacement failed', {
+          ...logContext,
+          targetId,
+          error,
+        });
+        throw error;
+      }
+    }
+
+    // Optimize image and upload as raw blob (not GLB) - for new additions
     const optimizeStart = performance.now();
     console.debug('[image-import] optimize start', logContext);
     const optimized = await createImageCanvasForScene(file, { maxPixel: 2048, label: file.name });
@@ -7460,22 +7630,6 @@ async function imageImporterCallback(file, position, context = {}) {
       width: optimized.textureWidth,
       height: optimized.textureHeight,
     };
-
-    // Check for replace target
-    const replaceTarget = getReplaceTarget('image', context.hitObjectId);
-    if (replaceTarget) {
-      const targetId = replaceTarget.userData.objectId;
-      console.debug('[image-import] replacing existing object', { ...logContext, targetId });
-      await replaceObjectContent(targetId, {
-        kind: 'image',
-        source: 'blob',
-        url: uploaded.url,
-        mime: 'image/jpeg',
-        width: optimized.textureWidth,
-        height: optimized.textureHeight,
-      });
-      return { objectId: targetId };
-    }
 
     const objectId = generateObjectId('img');
     const displayName = `image: ${file.name}`.slice(0, 60);
@@ -7711,6 +7865,12 @@ const dragDropManager = new DragDropManager({
       }
     });
     return targets;
+  },
+  getReplaceTargetForContent: (inputKind, context = {}) => {
+    if (context.targetKind === 'sky') return null;
+
+    const target = getReplaceTarget(inputKind, context.hitObjectId || null);
+    return target?.userData?.objectId || null;
   },
   onLoadStart: async ({
     objectId,


### PR DESCRIPTION
Add immediate visual feedback when replacing image assets by showing a local
preview overlay while the image is being optimized and uploaded. This improves
UX by avoiding the temporary preview appearance and providing instant feedback.

Changes:
- Add getReplaceTargetForContent callback to DragDropManager to determine if
  content is a replacement before calling onLoadStart
- Skip temporary preview for replacements (new additions still use it)
- Add local replacement preview management functions:
  - showLocalImageReplacementPreview() creates overlay mesh with blob URL
  - clearLocalImageReplacementPreview() cleans up resources
  - isCurrentLocalImageReplacementPreview() prevents stale updates
- Add replaceImageFileOptimistically() for optimistic replacement flow
- Modify imageImporterCallback to use optimistic path when replacing
- Track pending previews with token to prevent race conditions

Key features:
- Local preview uses blob: URL for immediate display
- Official sync uses HTTP URL only (no blob: URLs in payload)
- Preview overlay doesn't enter scene state or exports
- Failed uploads preserve original image (overlay cleanup only)
- Continuous replacements handled with token matching

https://claude.ai/code/session_01M9P6eFn4u7Da821KTY3eFu