### PR TITLE
Add Undo/Redo support for media and text content replacement

### DIFF
--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -166,6 +166,36 @@ export class HistoryManager {
       },
     };
   }
+
+  static createContentReplaceEntry(objectId, name, before, after) {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: `Replaced content of ${name || objectId}`,
+      forward: {
+        kind: 'scene-delta',
+        objectId,
+        ...(after.name !== undefined ? { name: after.name } : {}),
+        ...(after.position ? { position: after.position } : {}),
+        ...(after.rotation ? { rotation: after.rotation } : {}),
+        ...(after.scale ? { scale: after.scale } : {}),
+        ...(after.asset !== undefined ? { asset: after.asset } : {}),
+        ...(after.metadata !== undefined ? { metadata: after.metadata } : {}),
+        ...(after.visible !== undefined ? { visible: after.visible } : {}),
+      },
+      backward: {
+        kind: 'scene-delta',
+        objectId,
+        ...(before.name !== undefined ? { name: before.name } : {}),
+        ...(before.position ? { position: before.position } : {}),
+        ...(before.rotation ? { rotation: before.rotation } : {}),
+        ...(before.scale ? { scale: before.scale } : {}),
+        ...(before.asset !== undefined ? { asset: before.asset } : {}),
+        ...(before.metadata !== undefined ? { metadata: before.metadata } : {}),
+        ...(before.visible !== undefined ? { visible: before.visible } : {}),
+      },
+    };
+  }
 }
 
 export function createHistoryManager() {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4800,6 +4800,7 @@ function handleHandoff(data) {
         const newAssetType = payload.asset.type;
         if (newAssetType === 'image' || newAssetType === 'video' || newAssetType === 'text') {
           // Full re-render for content type changes (image/video/text)
+          const beforeSnapshot = createContentReplaceSnapshot(obj, payload.objectId);
           const mergedInfo = {
             objectId: payload.objectId,
             name: typeof payload.name === 'string' ? payload.name : (obj.userData?.name || payload.objectId),
@@ -4812,6 +4813,29 @@ function handleHandoff(data) {
               : obj.userData?.metadata,
           };
           addOrUpdateObject(payload.objectId, mergedInfo);
+
+          if (shouldTrackHistory && isOnBehalfOf && beforeSnapshot) {
+            const afterSnapshot = {
+              objectId: payload.objectId,
+              name: mergedInfo.name,
+              position: mergedInfo.position,
+              rotation: mergedInfo.rotation,
+              scale: mergedInfo.scale,
+              visible: mergedInfo.visible ?? true,
+              asset: cloneJsonSafe(mergedInfo.asset),
+              metadata: cloneJsonSafe(mergedInfo.metadata || null),
+            };
+
+            presenceState.historyManager?.push(
+              HistoryManager.createContentReplaceEntry(
+                payload.objectId,
+                mergedInfo.name || payload.objectId,
+                beforeSnapshot,
+                afterSnapshot
+              )
+            );
+          }
+
           notifySceneStateChanged('scene-delta-content-replace');
           break;
         }
@@ -6461,9 +6485,28 @@ function isCurrentLocalImageReplacementPreview(objectId, token) {
   return pendingMediaReplacementPreviews.get(objectId)?.token === token;
 }
 
+function createContentReplaceSnapshot(obj, fallbackObjectId = null) {
+  if (!obj) return null;
+
+  const objectId = obj.userData?.objectId || fallbackObjectId;
+
+  return {
+    objectId,
+    name: obj.userData?.name || obj.name || objectId,
+    position: obj.position.toArray(),
+    rotation: obj.quaternion.toArray(),
+    scale: obj.scale.toArray(),
+    visible: obj.visible !== false,
+    asset: cloneJsonSafe(obj.userData?.asset || null),
+    metadata: cloneJsonSafe(obj.userData?.metadata || null),
+  };
+}
+
 async function replaceObjectContent(objectId, input, options = {}) {
   const existing = managedObjects.get(objectId);
   if (!existing) return;
+
+  const beforeSnapshot = createContentReplaceSnapshot(existing, objectId);
 
   const existingMeta = existing.userData?.metadata || {};
   let newAsset;
@@ -6535,7 +6578,29 @@ async function replaceObjectContent(objectId, input, options = {}) {
     asset: newAsset,
     metadata: newMetadata,
   };
-  addOrUpdateObject(objectId, mergedInfo, options);
+  addOrUpdateObject(objectId, mergedInfo, { ...options, pushHistory: false });
+
+  if (beforeSnapshot && options.pushHistory !== false) {
+    const afterSnapshot = {
+      objectId,
+      name: nextName,
+      position: existing.position.toArray(),
+      rotation: existing.quaternion.toArray(),
+      scale: existing.scale.toArray(),
+      visible: existing.visible !== false,
+      asset: cloneJsonSafe(newAsset),
+      metadata: cloneJsonSafe(newMetadata),
+    };
+
+    presenceState.historyManager?.push(
+      HistoryManager.createContentReplaceEntry(
+        objectId,
+        nextName,
+        beforeSnapshot,
+        afterSnapshot
+      )
+    );
+  }
 
   showToast(input.kind === 'text' ? 'テキストを差し替えました' : 'メディアを差し替えました');
 }
@@ -6957,6 +7022,46 @@ function applyOperationToScene(operation) {
     case 'scene-delta': {
       const obj = managedObjects.get(operation.objectId);
       if (obj) {
+        const isContentAsset =
+          operation.asset &&
+          ['image', 'video', 'text'].includes(operation.asset.type);
+
+        if (isContentAsset) {
+          const mergedInfo = {
+            objectId: operation.objectId,
+            name: typeof operation.name === 'string'
+              ? operation.name
+              : (obj.userData?.name || operation.objectId),
+            position: Array.isArray(operation.position)
+              ? operation.position
+              : obj.position.toArray(),
+            rotation: Array.isArray(operation.rotation)
+              ? operation.rotation
+              : obj.quaternion.toArray(),
+            scale: Array.isArray(operation.scale)
+              ? operation.scale
+              : obj.scale.toArray(),
+            visible: typeof operation.visible === 'boolean'
+              ? operation.visible
+              : obj.visible !== false,
+            asset: cloneJsonSafe(operation.asset),
+            metadata: operation.metadata
+              ? {
+                  ...(cloneJsonSafe(obj.userData?.metadata || {}) || {}),
+                  ...(cloneJsonSafe(operation.metadata) || {}),
+                }
+              : cloneJsonSafe(obj.userData?.metadata || null),
+          };
+
+          addOrUpdateObject(operation.objectId, mergedInfo, {
+            source: 'undo-redo-content-replace',
+            pushHistory: false,
+          });
+
+          notifySceneStateChanged('undo-redo-content-replace');
+          break;
+        }
+
         if (typeof operation.name === 'string') applyObjectName(obj, operation.name);
         applyTransform(obj, operation);
         if (typeof operation.visible === 'boolean') applyObjectVisibility(obj, operation.visible);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4801,6 +4801,7 @@ function handleHandoff(data) {
         if (newAssetType === 'image' || newAssetType === 'video' || newAssetType === 'text') {
           // Full re-render for content type changes (image/video/text)
           const beforeSnapshot = createContentReplaceSnapshot(obj, payload.objectId);
+          const hasPayloadMetadata = Object.prototype.hasOwnProperty.call(payload, 'metadata');
           const mergedInfo = {
             objectId: payload.objectId,
             name: typeof payload.name === 'string' ? payload.name : (obj.userData?.name || payload.objectId),
@@ -4808,8 +4809,8 @@ function handleHandoff(data) {
             rotation: Array.isArray(payload.rotation) ? payload.rotation : obj.quaternion.toArray(),
             scale: Array.isArray(payload.scale) ? payload.scale : obj.scale.toArray(),
             asset: payload.asset,
-            metadata: payload.metadata
-              ? { ...(obj.userData?.metadata || {}), ...payload.metadata }
+            metadata: hasPayloadMetadata
+              ? cloneJsonSafe(payload.metadata)
               : obj.userData?.metadata,
           };
           addOrUpdateObject(payload.objectId, mergedInfo);
@@ -6575,6 +6576,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
     position: existing.position.toArray(),
     rotation: existing.quaternion.toArray(),
     scale: existing.scale.toArray(),
+    visible: existing.visible !== false,
     asset: newAsset,
     metadata: newMetadata,
   };
@@ -7027,6 +7029,7 @@ function applyOperationToScene(operation) {
           ['image', 'video', 'text'].includes(operation.asset.type);
 
         if (isContentAsset) {
+          const hasMetadata = Object.prototype.hasOwnProperty.call(operation, 'metadata');
           const mergedInfo = {
             objectId: operation.objectId,
             name: typeof operation.name === 'string'
@@ -7045,11 +7048,8 @@ function applyOperationToScene(operation) {
               ? operation.visible
               : obj.visible !== false,
             asset: cloneJsonSafe(operation.asset),
-            metadata: operation.metadata
-              ? {
-                  ...(cloneJsonSafe(obj.userData?.metadata || {}) || {}),
-                  ...(cloneJsonSafe(operation.metadata) || {}),
-                }
+            metadata: hasMetadata
+              ? cloneJsonSafe(operation.metadata)
               : cloneJsonSafe(obj.userData?.metadata || null),
           };
 


### PR DESCRIPTION
Implement full Undo/Redo workflow for image/video/text replacements:

1. Add HistoryManager.createContentReplaceEntry() to track content
   replacements with asset and metadata changes

2. Add createContentReplaceSnapshot() helper to capture object state
   before content replacement

3. Track history in replaceObjectContent() for local D&D/paste
   operations, respecting options.pushHistory flag

4. Enhance applyOperationToScene() to properly handle image/video/text
   content replacements by calling addOrUpdateObject() instead of
   applyAssetDelta()

5. Track history in handleHandoff() for AI/MCP content replacements
   when isOnBehalfOf is set

History entries now include asset, metadata, name, and transform
state changes to fully restore/redo content replacements.

https://claude.ai/code/session_012y35MorGo1XERQYBk1WT1V