### PR TITLE
Add metadata to sample cube object in scene

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1293,7 +1293,7 @@ const sampleCube = new THREE.Mesh(sampleGeo, sampleMat);
 sampleCube.position.set(0, 0.5, 0);
 sampleCube.userData.objectId = 'sample-cube';
 sampleCube.userData.name = 'Sample Cube';
-const color = sampleMat.color?.getStyle?.() ?? '#4488ff';
+const color = `#${sampleMat.color.getHexString()}`;
 sampleCube.userData.asset = {
   type: 'primitive',
   primitive: 'box',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1292,6 +1292,13 @@ const sampleMat = new THREE.MeshStandardMaterial({ color: 0x4488ff });
 const sampleCube = new THREE.Mesh(sampleGeo, sampleMat);
 sampleCube.position.set(0, 0.5, 0);
 sampleCube.userData.objectId = 'sample-cube';
+sampleCube.userData.name = 'Sample Cube';
+const color = sampleMat.color?.getStyle?.() ?? '#4488ff';
+sampleCube.userData.asset = {
+  type: 'primitive',
+  primitive: 'box',
+  color,
+};
 scene.add(sampleCube);
 
 // ── オブジェクト管理 ─────────────────────────────────────


### PR DESCRIPTION
## 概要

サンプルキューブオブジェクトに `name` と `asset` メタデータを追加し、Scene Sync API の仕様に準拠させました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

`html/assets/js/scenesync/scene.js` のサンプルキューブ初期化時に以下を追加：

- `userData.name`: 日本語表示名 `'Sample Cube'`
- `userData.asset`: プリミティブ型アセット情報
  - `type: 'primitive'`
  - `primitive: 'box'`
  - `color`: マテリアルから抽出した16進数カラーコード

これにより、サンプルキューブが REST API の `scene-add` メッセージ仕様と一致するメタデータを持つようになります。

## 変更していないこと

- サンプルキューブの位置・スケール・ジオメトリ
- その他のシーン初期化処理
- API エンドポイント

## staging確認

未確認（簡易な初期化データ追加のため）

## テスト/チェック

- 変更は初期化時のメタデータ設定のみで、既存機能に影響なし
- ビューアで sample cube が正常に表示されることを確認

## リスク

なし

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01DTSEMkWKm6unuYBwx8KNRa