### PR TITLE
スマホUIのクリップボード貼り付けでカメラ中央Rayの配置Contextを使用する

### DIFF
--- a/html/assets/js/scenesync/components/clipboard-import-manager.js
+++ b/html/assets/js/scenesync/components/clipboard-import-manager.js
@@ -18,6 +18,11 @@ function defaultIsEditingTarget(target) {
   return false;
 }
 
+function getPlacementPosition(placement) {
+  if (placement?.position) return placement.position;
+  return placement;
+}
+
 export class ClipboardImportManager {
   constructor(options) {
     const {
@@ -78,11 +83,13 @@ export class ClipboardImportManager {
     return true;
   }
 
-  async importPayload(payload, position) {
+  async importPayload(payload, placement) {
+    const position = getPlacementPosition(placement);
+
     switch (payload.kind) {
       case 'file':
         try {
-          await this.handleFile(payload.file, position);
+          await this.handleFile(payload.file, placement);
         } catch (err) {
           console.warn('[clipboard] file import failed:', err);
           this.showToast?.(err?.message || 'ファイルの読み込みに失敗しました');
@@ -92,7 +99,7 @@ export class ClipboardImportManager {
       case 'url':
         try {
           this.showToast?.('クリップボードからURLを読み込みます');
-          await this.handleUrl(payload.url, position);
+          await this.handleUrl(payload.url, position, placement);
         } catch (err) {
           console.warn('[clipboard] url import failed:', err);
           this.showToast?.(err?.message || 'URLの追加に失敗しました');
@@ -101,7 +108,7 @@ export class ClipboardImportManager {
 
       case 'text':
         try {
-          await this.handleText(payload.text, position, payload.filename);
+          await this.handleText(payload.text, position, payload.filename, placement);
           this.showToast?.('クリップボードからテキストを追加しました');
         } catch (err) {
           console.warn('[clipboard] text import failed:', err);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8269,9 +8269,15 @@ function getCenterRayPlacementContext() {
     || getDefaultImportPosition();
 }
 
+function getClipboardPlacementContext() {
+  return isSceneSyncMobileDevice()
+    ? getCenterRayPlacementContext()
+    : getDefaultImportPosition();
+}
+
 const clipboardImportManager = new ClipboardImportManager({
   container: document,
-  getDefaultPosition: getDefaultImportPosition,
+  getDefaultPosition: getClipboardPlacementContext,
   showToast,
   isEditingTarget: (target) => {
     const el = target instanceof Element ? target : null;
@@ -8283,9 +8289,9 @@ const clipboardImportManager = new ClipboardImportManager({
 
     return false;
   },
-  handleFile: (file, position) => dragDropManager.handleFile(file, position),
-  handleUrl: (url, position) => urlImporterCallback(url, position),
-  handleText: (text, position, filename) => textImporterCallback(text, position, filename),
+  handleFile: (file, placement) => dragDropManager.handleFile(file, placement),
+  handleUrl: (url, position, placement) => urlImporterCallback(url, position, placement),
+  handleText: (text, position, filename, placement) => textImporterCallback(text, position, filename, placement),
 });
 
 // ── クリップボード貼り付けUI のイベントバインディング ─────────────────
@@ -8321,7 +8327,7 @@ function closePasteSheet() {
 
 function pasteFromClipboardAtDefaultPosition() {
   showToast('クリップボードを読み込みます…');
-  return clipboardImportManager.pasteFromNavigatorClipboard(getDefaultImportPosition())
+  return clipboardImportManager.pasteFromNavigatorClipboard(getClipboardPlacementContext())
     .catch(() => {
       showToast('クリップボードを読み取れません。通常の貼り付け操作を使ってください');
     });
@@ -8488,7 +8494,7 @@ if (clipboardPasteTarget) {
   clipboardPasteTarget.addEventListener('paste', async (event) => {
     const handled = await clipboardImportManager.handlePasteEvent(event, {
       force: true,
-      position: getDefaultImportPosition(),
+      position: getClipboardPlacementContext(),
     });
 
     if (handled) {


### PR DESCRIPTION
- 新関数 getClipboardPlacementContext() を追加
  - スマホUIではcamera center ray contextを使用
  - PCでは従来通りgetDefaultImportPosition()を使用
  - 将来的にPC側も統一する際は、ここだけ変更すればよい
- ClipboardImportManager.importPayload()の引数をpositionからplacementに変更
  - placement context（position, normal, surfaceKind等を含む）をサポート
  - 既存のVector3引数も対応（後方互換性維持）
- scene.jsの各callback（handleFile, handleUrl, handleText）をplacement contextに対応
- clipboardPasteTarget のpaste handlerもgetClipboardPlacementContext()を使用

これにより、スマホでクリップボード貼り付けする場合、PC D&DやスマホUI画像追加と同じく、
壁・床・既存メッシュに沿った配置が可能になる

https://claude.ai/code/session_01Xo1QZjFGnGEupaZiqDWBQE