### PR TITLE
PR1: Clipboard Markdown不具合修正

### DIFF
--- a/html/assets/js/scenesync/components/clipboard-import-manager.js
+++ b/html/assets/js/scenesync/components/clipboard-import-manager.js
@@ -5,6 +5,7 @@
 import {
   parseClipboardDataTransfer,
   parseNavigatorClipboardItems,
+  createPlainTextClipboardPayload,
 } from '../loaders/clipboard-parser.js';
 
 function defaultIsEditingTarget(target) {
@@ -139,7 +140,7 @@ export class ClipboardImportManager {
         const isUrl = text.trim().startsWith('http://') || text.trim().startsWith('https://');
         const payload = isUrl
           ? { kind: 'url', url: text.trim() }
-          : { kind: 'text', text, filename: 'clipboard.txt' };
+          : createPlainTextClipboardPayload(text);
         return await this.importPayload(payload, position || this._resolvePosition());
       } catch (err) {
         console.warn('[clipboard] navigator.clipboard.readText failed:', err);

--- a/html/assets/js/scenesync/loaders/clipboard-parser.js
+++ b/html/assets/js/scenesync/loaders/clipboard-parser.js
@@ -14,6 +14,44 @@ function isLikelyHttpUrl(text) {
   }
 }
 
+export function looksLikeMarkdownText(text) {
+  if (!text || typeof text !== 'string') return false;
+
+  const value = text.slice(0, 20000);
+  const lines = value.split(/\r?\n/);
+  let score = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^#{1,6}\s+\S/.test(trimmed)) score += 2;
+    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) score += 3;
+    if (/^[-*+]\s+\S/.test(trimmed)) score += 1;
+    if (/^\d+\.\s+\S/.test(trimmed)) score += 1;
+    if (/^>\s+\S/.test(trimmed)) score += 1;
+    if (/\[[^\]]+\]\([^)]+\)/.test(trimmed)) score += 1;
+    if (/!\[[^\]]*\]\([^)]+\)/.test(trimmed)) score += 2;
+    if (/^\|.+\|$/.test(trimmed)) score += 1;
+    if (/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(trimmed)) score += 3;
+    if (score >= 3) return true;
+  }
+
+  return false;
+}
+
+export function createPlainTextClipboardPayload(text) {
+  const sliced = String(text || '').slice(0, MAX_TEXT_LENGTH);
+
+  if (!sliced) {
+    return { kind: 'empty' };
+  }
+
+  return {
+    kind: 'text',
+    text: sliced,
+    filename: looksLikeMarkdownText(sliced) ? 'clipboard.md' : 'clipboard.txt',
+  };
+}
+
 function extractHtmlUrls(html) {
   const doc = new DOMParser().parseFromString(html, 'text/html');
 
@@ -85,10 +123,7 @@ export function parseClipboardDataTransfer(dataTransfer) {
     }
 
     // 優先順位6: 通常テキスト
-    const text = plainText.slice(0, MAX_TEXT_LENGTH);
-    if (text) {
-      return { kind: 'text', text, filename: 'clipboard.txt' };
-    }
+    return createPlainTextClipboardPayload(plainText);
   }
 
   return { kind: 'empty' };
@@ -157,10 +192,7 @@ export async function parseNavigatorClipboardItems(items) {
           return { kind: 'url', url: trimmed };
         }
 
-        const sliced = text.slice(0, MAX_TEXT_LENGTH);
-        if (sliced) {
-          return { kind: 'text', text: sliced, filename: 'clipboard.txt' };
-        }
+        return createPlainTextClipboardPayload(text);
       } catch (err) {
         console.warn('[clipboard] text extraction failed:', err);
       }

--- a/html/assets/js/scenesync/loaders/url-classifier.js
+++ b/html/assets/js/scenesync/loaders/url-classifier.js
@@ -37,6 +37,28 @@ function classifyTwitterImageUrl(u) {
   return null;
 }
 
+export function normalizeGitHubBlobUrl(urlString) {
+  try {
+    const u = new URL(urlString);
+    if (u.hostname !== 'github.com') return urlString;
+
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length < 5) return urlString;
+    if (parts[2] !== 'blob') return urlString;
+
+    const owner = parts[0];
+    const repo = parts[1];
+    const ref = parts[3];
+    const filePath = parts.slice(4).join('/');
+
+    if (!owner || !repo || !ref || !filePath) return urlString;
+
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${filePath}`;
+  } catch {
+    return urlString;
+  }
+}
+
 /**
  * URL 文字列を分類する純関数。
  * @param {string} urlString
@@ -50,9 +72,12 @@ export function classifyUrl(urlString) {
   if (!/^https?:\/\//i.test(trimmed)) {
     return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
   }
+
+  const normalized = normalizeGitHubBlobUrl(trimmed);
+
   let u;
   try {
-    u = new URL(trimmed);
+    u = new URL(normalized);
   } catch {
     return { kind: URL_KIND.INVALID, url: null, ext: '', host: '' };
   }
@@ -62,7 +87,7 @@ export function classifyUrl(urlString) {
 
   const ext = (u.pathname.split('.').pop() || '').toLowerCase();
   const host = u.host;
-  const url = u.toString();
+  const url = normalized;
   if (AUDIO_EXTS.includes(ext)) return { kind: URL_KIND.AUDIO, url, ext, host };
   if (VIDEO_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO, url, ext, host };
   if (HLS_EXTS.includes(ext)) return { kind: URL_KIND.VIDEO_HLS, url, ext, host };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8047,8 +8047,12 @@ async function urlImporterCallback(url, position, context = {}) {
     ? position.toArray()
     : [0, 1, 0];
 
+  // Classify and normalize URL (e.g., GitHub blob -> raw)
+  const classified = classifyUrl(resolved.resolvedUrl);
+  const normalizedUrl = classified.url || resolved.resolvedUrl;
+  const urlKind = classified.kind;
+
   // Skybox intent takes priority for image URLs when looking up.
-  const urlKind = classifyUrl(resolved.resolvedUrl)?.kind;
   const isImageUrl = urlKind === URL_KIND.IMAGE;
   const urlSkybox =
     isImageUrl &&
@@ -8068,7 +8072,10 @@ async function urlImporterCallback(url, position, context = {}) {
         await replaceObjectContent(replaceTarget.userData.objectId, {
           kind: inputKind,
           source: 'url',
-          url: resolved.resolvedUrl,
+          url: normalizedUrl,
+          ...(inputKind === 'text' && /\.(md|markdown)(?:$|[?#])/i.test(normalizedUrl)
+            ? { format: 'markdown' }
+            : {}),
         });
         return;
       }
@@ -8093,7 +8100,7 @@ async function urlImporterCallback(url, position, context = {}) {
     sourceContext: context,
   });
 
-  await dispatchUrlImport(resolved.resolvedUrl, ctx);
+  await dispatchUrlImport(normalizedUrl, ctx);
 }
 
 const dragDropManager = new DragDropManager({

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8355,7 +8355,11 @@ async function pasteFromClipboardAtDefaultPosition() {
   return null;
 }
 
-pasteBtn?.addEventListener('click', pasteFromClipboardAtDefaultPosition);
+pasteBtn?.addEventListener('click', () => {
+  pasteFromClipboardAtDefaultPosition().catch((error) => {
+    console.warn('[paste] failed:', error);
+  });
+});
 mobileActionSheetCloseBtn?.addEventListener('click', closeMobileActionSheet);
 mobileAddImageBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
@@ -8367,7 +8371,9 @@ mobileAddGlbBtn?.addEventListener('click', () => {
 });
 mobilePasteBtn?.addEventListener('click', () => {
   closeMobileActionSheet();
-  pasteFromClipboardAtDefaultPosition();
+  pasteFromClipboardAtDefaultPosition().catch((error) => {
+    console.warn('[mobile-paste] failed:', error);
+  });
 });
 dom.mobileImageInput?.addEventListener('change', (event) => {
   const input = event.target;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8325,12 +8325,34 @@ function closePasteSheet() {
   }
 }
 
-function pasteFromClipboardAtDefaultPosition() {
+function openPasteSheet() {
+  if (!pasteSheet) return;
+  pasteSheet.removeAttribute('hidden');
+  requestAnimationFrame(() => {
+    clipboardPasteTarget?.focus?.();
+  });
+}
+
+async function pasteFromClipboardAtDefaultPosition() {
   showToast('クリップボードを読み込みます…');
-  return clipboardImportManager.pasteFromNavigatorClipboard(getClipboardPlacementContext())
-    .catch(() => {
-      showToast('クリップボードを読み取れません。通常の貼り付け操作を使ってください');
+  const result = await clipboardImportManager.pasteFromNavigatorClipboard(getClipboardPlacementContext())
+    .catch((error) => {
+      console.warn('[clipboard] navigator clipboard paste failed:', error);
+      return null;
     });
+
+  if (result) {
+    return result;
+  }
+
+  if (isMobileUi()) {
+    openPasteSheet();
+    showToast('枠内を長押しして貼り付けてください');
+    return null;
+  }
+
+  showToast('クリップボードを読み取れません。通常の貼り付け操作を使ってください');
+  return null;
 }
 
 pasteBtn?.addEventListener('click', pasteFromClipboardAtDefaultPosition);


### PR DESCRIPTION
- looksLikeMarkdownText(): テキストがMarkdownっぽいかを推定
- createPlainTextClipboardPayload(): plain text / Markdown を自動判定してfilenameを設定
- parseClipboardDataTransfer() と parseNavigatorClipboardItems() で clipboard.txt 固定を置き換え
- normalizeGitHubBlobUrl(): GitHub blob URL を raw.githubusercontent.com に正規化
- classifyUrl() で GitHub blob URL の自動正規化
- clipboard-import-manager.js の readText() fallback を Markdown判定対応
- pasteFromClipboardAtDefaultPosition() にスマホ paste sheet fallback を追加
- openPasteSheet() 関数を新規追加

スマホでnavigator.clipboardが使えない場合、paste sheetにフォールバック。
Markdown本文をコピーした場合は自動検出で clipboard.md として扱う。
GitHub blob URLは自動的にraw URLに正規化される。

https://claude.ai/code/session_01YFhfZsVAdArpcAM1ePQE1X