### PR TITLE
Text Panel v2 Phase1 実装（安全性対応版）

### DIFF
--- a/html/assets/js/scenesync/components/text-panel-renderer.js
+++ b/html/assets/js/scenesync/components/text-panel-renderer.js
@@ -1,0 +1,474 @@
+// ── text-panel-renderer.js ──────────────────────────────────────
+// Text Panel v2 renderer (plain text / Markdown, scroll, clipping)
+// 安全性対応：ctx.font設定、character wrap、overflow判定、scroll非奪取
+// ───────────────────────────────────────────────────────────────
+
+export const DEFAULT_TEXT_LAYOUT = {
+  version: 1,
+  width: 2.4,
+  height: 1.6,
+  padding: 0.12,
+  lineHeight: 1.35,
+  mode: 'scroll',
+};
+
+export const DEFAULT_TEXT_SCROLL = {
+  y: 0,
+};
+
+export function normalizeTextAsset(asset, info = {}) {
+  const source = asset && typeof asset === 'object' ? asset : {};
+
+  const layoutSource =
+    source.layout && typeof source.layout === 'object'
+      ? source.layout
+      : {};
+  const scrollSource =
+    source.scroll && typeof source.scroll === 'object'
+      ? source.scroll
+      : {};
+  const fontSize = Number(source.fontSize);
+
+  return {
+    type: 'text',
+    source: source.source || 'inline',
+    ...(source.url ? { url: source.url } : {}),
+    text: typeof source.text === 'string' ? source.text : '',
+    format: source.format === 'markdown' ? 'markdown' : 'plain',
+    fontFamily: source.fontFamily || 'system-sans',
+    fontSize: Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 32,
+    fontWeight: source.fontWeight || 'normal',
+    fontStyle: source.fontStyle || 'normal',
+    color: source.color || '#ffffff',
+    backgroundColor: source.backgroundColor || 'rgba(0,0,0,0.65)',
+    align: ['left', 'center', 'right'].includes(source.align)
+      ? source.align
+      : 'left',
+    layout: {
+      ...DEFAULT_TEXT_LAYOUT,
+      ...layoutSource,
+    },
+    scroll: {
+      ...DEFAULT_TEXT_SCROLL,
+      ...scrollSource,
+    },
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function setCanvasFont(ctx, style) {
+  const fontStyle = style.fontStyle || 'normal';
+  const fontWeight = style.fontWeight || 'normal';
+  const fontSize = Number.isFinite(style.fontSize) ? style.fontSize : 32;
+  const fontFamily = style.fontFamily || 'system-sans';
+  const resolvedFamily =
+    fontFamily === 'system-sans'
+      ? 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+      : fontFamily === 'monospace'
+      ? '"SFMono-Regular", Consolas, "Liberation Mono", monospace'
+      : fontFamily;
+
+  ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${resolvedFamily}`;
+}
+
+function wrapLongToken(ctx, token, maxWidth) {
+  const lines = [];
+  let current = '';
+
+  for (const char of Array.from(token)) {
+    const next = current + char;
+    if (current && ctx.measureText(next).width > maxWidth) {
+      lines.push(current);
+      current = char;
+    } else {
+      current = next;
+    }
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function wrapPlainText(ctx, text, maxWidth, fontSizePx, fontFamily, fontWeight, fontStyle) {
+  const lines = [];
+  const paragraphs = text.split(/\n/);
+
+  for (const para of paragraphs) {
+    if (!para.trim()) {
+      lines.push({ text: '', type: 'blank', fontSize: fontSizePx });
+      continue;
+    }
+
+    let currentLine = '';
+    const words = para.split(/(\s+)/);
+
+    for (const word of words) {
+      if (!word) continue;
+
+      const testLine = currentLine + word;
+      const metrics = ctx.measureText(testLine);
+
+      if (metrics.width <= maxWidth) {
+        currentLine = testLine;
+      } else {
+        if (currentLine.trim()) {
+          lines.push({
+            text: currentLine.trimEnd(),
+            type: 'paragraph',
+            fontSize: fontSizePx,
+            fontFamily,
+            fontWeight,
+            fontStyle,
+          });
+        }
+
+        // Word が maxWidth を超える場合は character wrap
+        if (ctx.measureText(word).width > maxWidth) {
+          const wrappedWords = wrapLongToken(ctx, word, maxWidth);
+          for (const wrappedWord of wrappedWords) {
+            lines.push({
+              text: wrappedWord,
+              type: 'paragraph',
+              fontSize: fontSizePx,
+              fontFamily,
+              fontWeight,
+              fontStyle,
+            });
+          }
+          currentLine = '';
+        } else {
+          currentLine = word;
+        }
+      }
+    }
+
+    if (currentLine.trim()) {
+      lines.push({
+        text: currentLine.trimEnd(),
+        type: 'paragraph',
+        fontSize: fontSizePx,
+        fontFamily,
+        fontWeight,
+        fontStyle,
+      });
+    }
+  }
+
+  return lines;
+}
+
+function parseMarkdownBlocks(markdown) {
+  if (!markdown) return [];
+
+  const blocks = [];
+  const lines = markdown.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      blocks.push({ type: 'blank' });
+      i++;
+      continue;
+    }
+
+    // Heading
+    const headingMatch = /^(#{1,6})\s+(.+)/.exec(trimmed);
+    if (headingMatch) {
+      blocks.push({
+        type: 'heading',
+        level: headingMatch[1].length,
+        text: headingMatch[2],
+      });
+      i++;
+      continue;
+    }
+
+    // Fenced code block
+    if (/^```|^~~~/.test(trimmed)) {
+      const fence = trimmed.slice(0, 3);
+      const codeLines = [];
+      i++;
+      while (i < lines.length) {
+        const codeLine = lines[i];
+        if (new RegExp(`^${fence}`).test(codeLine.trim())) {
+          i++;
+          break;
+        }
+        codeLines.push(codeLine);
+        i++;
+      }
+      blocks.push({
+        type: 'code',
+        text: codeLines.join('\n'),
+      });
+      continue;
+    }
+
+    // Blockquote
+    if (/^>\s+/.test(trimmed)) {
+      blocks.push({
+        type: 'quote',
+        text: trimmed.replace(/^>\s+/, ''),
+      });
+      i++;
+      continue;
+    }
+
+    // Ordered list
+    const orderedMatch = /^(\d+)\.\s+(.+)/.exec(trimmed);
+    if (orderedMatch) {
+      blocks.push({
+        type: 'ordered',
+        index: parseInt(orderedMatch[1], 10),
+        text: orderedMatch[2],
+      });
+      i++;
+      continue;
+    }
+
+    // Bullet list
+    const bulletMatch = /^[-*+]\s+(.+)/.exec(trimmed);
+    if (bulletMatch) {
+      blocks.push({
+        type: 'bullet',
+        text: bulletMatch[1],
+      });
+      i++;
+      continue;
+    }
+
+    // Paragraph
+    blocks.push({
+      type: 'paragraph',
+      text: trimmed,
+    });
+    i++;
+  }
+
+  return blocks;
+}
+
+function wrapMarkdownLine(ctx, text, maxWidth, fontSize, fontFamily, fontWeight, fontStyle) {
+  const lines = [];
+  let currentLine = '';
+  const words = text.split(/(\s+)/);
+
+  for (const word of words) {
+    if (!word) continue;
+
+    const testLine = currentLine + word;
+    const metrics = ctx.measureText(testLine);
+
+    if (metrics.width <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      if (currentLine.trim()) {
+        lines.push(currentLine.trimEnd());
+      }
+
+      // Long word character wrap
+      if (ctx.measureText(word).width > maxWidth) {
+        const wrappedWords = wrapLongToken(ctx, word, maxWidth);
+        for (const wrappedWord of wrappedWords) {
+          lines.push(wrappedWord);
+        }
+        currentLine = '';
+      } else {
+        currentLine = word;
+      }
+    }
+  }
+
+  if (currentLine.trim()) {
+    lines.push(currentLine.trimEnd());
+  }
+
+  return lines;
+}
+
+export function renderTextPanelCanvas(asset, options = {}) {
+  const pixelsPerUnit = options.pixelsPerUnit || 512;
+  const layout = asset.layout || DEFAULT_TEXT_LAYOUT;
+  const fontSizePx = asset.fontSize || 32;
+  const fontFamily = asset.fontFamily || 'system-sans';
+  const fontWeight = asset.fontWeight || 'normal';
+  const fontStyle = asset.fontStyle || 'normal';
+
+  const canvasWidth = Math.max(256, Math.round(layout.width * pixelsPerUnit));
+  const canvasHeight = Math.max(256, Math.round(layout.height * pixelsPerUnit));
+  const paddingPx = layout.padding * pixelsPerUnit;
+  const contentWidth = canvasWidth - 2 * paddingPx;
+  const lineHeightRatio = layout.lineHeight || 1.35;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    return { canvas, metrics: {} };
+  }
+
+  // Set font early for measure operations
+  setCanvasFont(ctx, asset);
+
+  // Parse text
+  const blocks = asset.format === 'markdown'
+    ? parseMarkdownBlocks(asset.text || '')
+    : [];
+
+  const layoutLines = [];
+
+  if (asset.format === 'markdown') {
+    for (const block of blocks) {
+      if (block.type === 'blank') {
+        layoutLines.push({
+          text: '',
+          type: 'blank',
+          fontSize: fontSizePx,
+          fontFamily,
+          fontWeight,
+          fontStyle,
+          height: fontSizePx * lineHeightRatio * 0.5,
+        });
+        continue;
+      }
+
+      let lineFontSize = fontSizePx;
+      let lineText = block.text || '';
+      let lineFamily = fontFamily;
+      let lineWeight = fontWeight;
+      let lineStyle = fontStyle;
+
+      if (block.type === 'heading') {
+        const scales = { 1: 1.45, 2: 1.25, 3: 1.1 };
+        lineFontSize = fontSizePx * (scales[block.level] || 1);
+      } else if (block.type === 'code') {
+        lineFontSize = fontSizePx * 0.9;
+        lineFamily = 'monospace';
+      } else if (block.type === 'quote') {
+        lineFontSize = fontSizePx * 0.95;
+      }
+
+      setCanvasFont(ctx, {
+        fontSize: lineFontSize,
+        fontFamily: lineFamily,
+        fontWeight: lineWeight,
+        fontStyle: lineStyle,
+      });
+
+      const wrappedLines = wrapMarkdownLine(
+        ctx,
+        lineText,
+        contentWidth,
+        lineFontSize,
+        lineFamily,
+        lineWeight,
+        lineStyle,
+      );
+
+      for (const wrappedLine of wrappedLines) {
+        let prefix = '';
+        if (block.type === 'bullet') {
+          prefix = '• ';
+        } else if (block.type === 'ordered') {
+          prefix = `${block.index}. `;
+        } else if (block.type === 'quote') {
+          prefix = '> ';
+        }
+
+        layoutLines.push({
+          text: prefix + wrappedLine,
+          type: block.type,
+          fontSize: lineFontSize,
+          fontFamily: lineFamily,
+          fontWeight: lineWeight,
+          fontStyle: lineStyle,
+          height: lineFontSize * lineHeightRatio,
+        });
+      }
+    }
+  } else {
+    // Plain text
+    setCanvasFont(ctx, asset);
+    const wrappedLines = wrapPlainText(ctx, asset.text || '', contentWidth, fontSizePx, fontFamily, fontWeight, fontStyle);
+    layoutLines.push(...wrappedLines.map(line => ({
+      ...line,
+      height: line.fontSize * lineHeightRatio,
+    })));
+  }
+
+  // Calculate content height
+  let contentHeight = 0;
+  for (const line of layoutLines) {
+    contentHeight += line.height;
+  }
+
+  const viewportHeight = canvasHeight - 2 * paddingPx;
+  const maxScrollY = Math.max(0, contentHeight - viewportHeight);
+  const scrollY = clamp(asset.scroll?.y || 0, 0, maxScrollY);
+
+  // Draw background
+  ctx.fillStyle = asset.backgroundColor;
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+  // Draw content with clipping
+  ctx.save();
+  ctx.rect(paddingPx, paddingPx, contentWidth, viewportHeight);
+  ctx.clip();
+
+  let y = paddingPx - scrollY;
+  for (const line of layoutLines) {
+    setCanvasFont(ctx, line);
+    ctx.fillStyle = asset.color;
+    ctx.textBaseline = 'top';
+
+    if (asset.align === 'center') {
+      ctx.textAlign = 'center';
+      ctx.fillText(line.text, canvasWidth / 2, y);
+    } else if (asset.align === 'right') {
+      ctx.textAlign = 'right';
+      ctx.fillText(line.text, canvasWidth - paddingPx, y);
+    } else {
+      ctx.textAlign = 'left';
+      ctx.fillText(line.text, paddingPx, y);
+    }
+
+    y += line.height;
+  }
+
+  ctx.restore();
+
+  // Draw scrollbar if needed
+  if (maxScrollY > 0) {
+    const scrollbarWidth = 4;
+    const scrollbarHeight = (viewportHeight / contentHeight) * viewportHeight;
+    const scrollbarY = (scrollY / maxScrollY) * (viewportHeight - scrollbarHeight);
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+    ctx.fillRect(
+      canvasWidth - scrollbarWidth - 4,
+      paddingPx + scrollbarY,
+      scrollbarWidth,
+      scrollbarHeight,
+    );
+  }
+
+  return {
+    canvas,
+    metrics: {
+      contentHeight,
+      viewportHeight,
+      maxScrollY,
+      scrollY,
+      lineCount: layoutLines.length,
+      overflow: contentHeight > viewportHeight,
+    },
+  };
+}

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -1,3 +1,16 @@
+const DEFAULT_TEXT_LAYOUT = {
+  version: 1,
+  width: 2.4,
+  height: 1.6,
+  padding: 0.12,
+  lineHeight: 1.35,
+  mode: 'scroll',
+};
+
+const DEFAULT_TEXT_SCROLL = {
+  y: 0,
+};
+
 function getTextUrlFormat(url) {
   try {
     const u = new URL(url);
@@ -46,7 +59,9 @@ export async function importTextUrl(url, ctx) {
         fontStyle: 'normal',
         color: '#ffffff',
         backgroundColor: 'rgba(0,0,0,0.65)',
-        align: 'center',
+        align: 'left',
+        layout: { ...DEFAULT_TEXT_LAYOUT },
+        scroll: { ...DEFAULT_TEXT_SCROLL },
       },
       metadata: {
         ...existingMetadata,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2854,9 +2854,10 @@ renderer.domElement.addEventListener('touchstart', (e) => {
 }, { passive: false });
 
 renderer.domElement.addEventListener('touchmove', (e) => {
+  touchMoved = true;
+
   if (!textPanelTouchCandidate || textPanelScrollActive) {
-    // Already in scroll mode or no candidate
-    if (textPanelScrollActive && e.touches.length > 0) {
+    if (textPanelScrollActive && textPanelTouchCandidate && e.touches.length > 0) {
       const touch = e.touches[0];
       const deltaY = touch.clientY - textPanelTouchCandidate.lastY;
       textPanelTouchCandidate.lastY = touch.clientY;
@@ -2865,8 +2866,6 @@ renderer.domElement.addEventListener('touchmove', (e) => {
     }
     return;
   }
-
-  touchMoved = true;
 
   if (e.touches.length > 0) {
     const touch = e.touches[0];

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2982,7 +2982,7 @@ function updateTextPanelScroll(objectId, deltaY) {
 
 function handleTextPanelWheel(event) {
   // Only scroll text panels, not camera, if overflow
-  if (transformCtrl.object) return; // Transform priority
+  if (isDragging) return; // Transform drag priority
   if (event.ctrlKey || event.metaKey) return; // Allow pinch-zoom
 
   const rect = renderer.domElement.getBoundingClientRect();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -20,6 +20,7 @@ import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
 import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
 import { resolveDroppedUrl } from './loaders/url-resolver.js';
+import { normalizeTextAsset, renderTextPanelCanvas, DEFAULT_TEXT_LAYOUT, DEFAULT_TEXT_SCROLL } from './components/text-panel-renderer.js';
 import { dispatchUrlImport } from './loaders/url-importers/index.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
@@ -2824,17 +2825,75 @@ let singleTapTimer = null;
 
 renderer.domElement.addEventListener('touchstart', (e) => {
   touchMoved = false;
-}, { passive: true });
+  textPanelScrollActive = false;
+  textPanelTouchCandidate = null;
+
+  const touch = e.touches[0];
+  if (!touch) return;
+
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((touch.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((touch.clientY - rect.top) / rect.height) * 2 + 1;
+
+  raycaster.setFromCamera(pointer, camera);
+  const targets = Array.from(managedObjects.values())
+    .filter((obj) => obj.userData?.role === 'text-panel' && !isSkySphereThreeObject(obj));
+  const hits = raycaster.intersectObjects(targets, true);
+
+  if (hits.length > 0) {
+    const hitObject = findTextPanelRoot(hits[0].object);
+    if (hitObject && canScrollTextPanel(hitObject)) {
+      textPanelTouchCandidate = {
+        panel: hitObject,
+        startX: touch.clientX,
+        startY: touch.clientY,
+        lastY: touch.clientY,
+      };
+    }
+  }
+}, { passive: false });
 
 renderer.domElement.addEventListener('touchmove', (e) => {
+  if (!textPanelTouchCandidate || textPanelScrollActive) {
+    // Already in scroll mode or no candidate
+    if (textPanelScrollActive && e.touches.length > 0) {
+      const touch = e.touches[0];
+      const deltaY = touch.clientY - textPanelTouchCandidate.lastY;
+      textPanelTouchCandidate.lastY = touch.clientY;
+      updateTextPanelScroll(textPanelTouchCandidate.panel.userData.objectId, -deltaY);
+      e.preventDefault();
+    }
+    return;
+  }
+
   touchMoved = true;
-}, { passive: true });
+
+  if (e.touches.length > 0) {
+    const touch = e.touches[0];
+    const dx = touch.clientX - textPanelTouchCandidate.startX;
+    const dy = touch.clientY - textPanelTouchCandidate.startY;
+
+    const isVerticalDrag =
+      Math.abs(dy) > SCROLL_DRAG_THRESHOLD_PX &&
+      Math.abs(dy) > Math.abs(dx);
+
+    if (isVerticalDrag) {
+      textPanelScrollActive = true;
+      textPanelTouchCandidate.lastY = touch.clientY;
+      updateTextPanelScroll(textPanelTouchCandidate.panel.userData.objectId, -dy);
+      e.preventDefault();
+    }
+  }
+}, { passive: false });
 
 function handleDoubleTap(clientX, clientY) {
   selectObjectAt(clientX, clientY);
 }
 
 renderer.domElement.addEventListener('touchend', (e) => {
+  textPanelTouchCandidate = null;
+  textPanelScrollActive = false;
+
   if (e.touches.length > 0) return;
   const touch = e.changedTouches[0];
   if (!touch) return;
@@ -2875,6 +2934,82 @@ renderer.domElement.addEventListener('touchend', (e) => {
     }, DOUBLE_TAP_DELAY + 50);
   }
 }, { passive: false });
+
+// ── Text Panel Scroll (wheel) ──────────────────────────────
+
+function updateTextPanelScroll(objectId, deltaY) {
+  const object = managedObjects.get(objectId);
+  if (!object) return;
+
+  const asset = object.userData?.asset;
+  const metrics = object.userData?.textPanelMetrics;
+  const resolvedText = object.userData?.resolvedText;
+
+  if (!asset || !metrics) return;
+
+  const currentScrollY = textPanelScrollState.get(objectId) ?? asset.scroll?.y ?? 0;
+  const nextScrollY = clamp(currentScrollY + deltaY, 0, metrics.maxScrollY);
+
+  if (nextScrollY === currentScrollY) return;
+
+  textPanelScrollState.set(objectId, nextScrollY);
+
+  // Rerender text panel with cached text + new scroll position
+  const renderAsset = {
+    ...asset,
+    text: resolvedText || asset.text || '',
+    scroll: { y: nextScrollY },
+  };
+
+  const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });
+  const canvas = result.canvas;
+
+  const mesh = object.children.find((child) => child.isMesh);
+  if (!mesh) return;
+
+  const oldTexture = mesh.material.map;
+  const newTexture = new THREE.CanvasTexture(canvas);
+  newTexture.colorSpace = THREE.SRGBColorSpace;
+  newTexture.magFilter = THREE.LinearFilter;
+  newTexture.minFilter = THREE.LinearFilter;
+
+  mesh.material.map = newTexture;
+  mesh.material.needsUpdate = true;
+
+  object.userData.textPanelMetrics = result.metrics;
+  oldTexture?.dispose();
+}
+
+function handleTextPanelWheel(event) {
+  // Only scroll text panels, not camera, if overflow
+  if (transformCtrl.object) return; // Transform priority
+  if (event.ctrlKey || event.metaKey) return; // Allow pinch-zoom
+
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+  raycaster.setFromCamera(pointer, camera);
+  const targets = Array.from(managedObjects.values())
+    .filter((obj) => obj.userData?.role === 'text-panel' && !isSkySphereThreeObject(obj));
+  const hits = raycaster.intersectObjects(targets, true);
+
+  if (hits.length === 0) return;
+
+  const hitObject = findTextPanelRoot(hits[0].object);
+  if (!hitObject) return;
+  if (!canScrollTextPanel(hitObject)) return;
+
+  // Text panel is overflowing → prevent default & scroll
+  event.preventDefault();
+  event.stopPropagation();
+
+  const deltaY = event.deltaY > 0 ? 40 : -40;
+  const objectId = hitObject.userData.objectId;
+  updateTextPanelScroll(objectId, deltaY);
+}
+
+renderer.domElement.addEventListener('wheel', handleTextPanelWheel, { passive: false });
 
 // ── 削除ロジック（共通） ──────────────────────────────────
 
@@ -6316,65 +6451,70 @@ function loadImageObject(objectId, info, imageUrl, existing, prebuilt = null, op
   });
 }
 
+// ── Text Panel v2 Scroll State ────────────────────────────────────
+// Local scroll state (not synced to other clients)
+const textPanelScrollState = new Map();
+let textPanelTouchCandidate = null;
+let textPanelScrollActive = false;
+const SCROLL_DRAG_THRESHOLD_PX = 8;
+
+function findTextPanelRoot(object) {
+  let current = object;
+  while (current) {
+    if (current.userData?.role === 'text-panel') return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function canScrollTextPanel(textPanel) {
+  const metrics = textPanel?.userData?.textPanelMetrics;
+  return metrics && metrics.maxScrollY > 0;
+}
+
 function loadTextObject(objectId, info, asset, existing) {
-  const textPromise = (asset.source === 'url' && asset.url)
-    ? fetch(asset.url, { mode: 'cors' }).then((r) => {
+  const normalizedAsset = normalizeTextAsset(asset, info);
+
+  const textPromise = (normalizedAsset.source === 'url' && normalizedAsset.url)
+    ? fetch(normalizedAsset.url, { mode: 'cors' }).then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.text();
       })
-    : Promise.resolve(asset.text || '');
+    : Promise.resolve(normalizedAsset.text || '');
 
-  textPromise.then((text) => {
-    const fontFamily = FONT_PRESETS[asset.fontFamily] || FONT_PRESETS['system-sans'];
-    const fontSize = typeof asset.fontSize === 'number' ? asset.fontSize : 32;
-    const fontWeight = asset.fontWeight || 'normal';
-    const fontStyle = asset.fontStyle || 'normal';
-    const color = asset.color || '#ffffff';
-    const bgColor = asset.backgroundColor || 'rgba(0,0,0,0.65)';
-    const align = asset.align || 'center';
+  textPromise.then((resolvedText) => {
+    const renderAsset = {
+      ...normalizedAsset,
+      text: resolvedText,
+      scroll: {
+        ...normalizedAsset.scroll,
+        y: textPanelScrollState.get(objectId) ?? normalizedAsset.scroll?.y ?? 0,
+      },
+    };
 
-    const canvas = document.createElement('canvas');
-    canvas.width = 1024;
-    canvas.height = 256;
-    const ctx = canvas.getContext('2d');
-
-    ctx.fillStyle = bgColor;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
-    ctx.fillStyle = color;
-    ctx.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
-    ctx.textBaseline = 'middle';
-
-    const lines = text.split('\n');
-    const lineHeight = fontSize * 1.4;
-    const totalHeight = lines.length * lineHeight;
-    const startY = (canvas.height - totalHeight) / 2 + lineHeight / 2;
-    const x = align === 'left' ? 20 : align === 'right' ? canvas.width - 20 : canvas.width / 2;
-
-    for (let i = 0; i < lines.length; i++) {
-      ctx.fillText(lines[i], x, startY + i * lineHeight, canvas.width - 40);
-    }
+    const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });
+    const canvas = result.canvas;
+    const metrics = result.metrics;
 
     const texture = new THREE.CanvasTexture(canvas);
     texture.colorSpace = THREE.SRGBColorSpace;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
 
-    const aspect = canvas.width / canvas.height;
-    const maxEdge = 2;
-    const width = aspect >= 1 ? maxEdge : Math.max(maxEdge * aspect, 0.1);
-    const height = aspect >= 1 ? Math.max(maxEdge / aspect, 0.1) : maxEdge;
+    const layout = normalizedAsset.layout || DEFAULT_TEXT_LAYOUT;
+    const panelWidth = layout.width;
+    const panelHeight = layout.height;
 
-    const geometry = new THREE.PlaneGeometry(width, height);
+    const geometry = new THREE.PlaneGeometry(panelWidth, panelHeight);
     const material = new THREE.MeshBasicMaterial({
       map: texture,
       transparent: true,
-      depthWrite: true,
       side: THREE.DoubleSide,
       toneMapped: false,
     });
 
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.y = height / 2;
+    mesh.position.y = panelHeight / 2;
 
     const group = new THREE.Group();
     group.add(mesh);
@@ -6382,7 +6522,11 @@ function loadTextObject(objectId, info, asset, existing) {
     group.userData.objectId = objectId;
     group.userData.name = info.name;
     group.userData.assetType = 'text';
-    if (info.asset) group.userData.asset = structuredClone(info.asset);
+    group.userData.role = 'text-panel';
+    group.userData.asset = structuredClone(normalizedAsset);
+    group.userData.textPanelMetrics = metrics;
+    group.userData.resolvedText = resolvedText;
+    group.userData.dropRaycastTarget = true;
 
     group.userData.disposable = () => {
       texture.dispose();
@@ -6395,7 +6539,6 @@ function loadTextObject(objectId, info, asset, existing) {
       group.quaternion.copy(existing.quaternion);
       group.scale.copy(existing.scale);
       if (transformCtrl.object === existing) transformCtrl.detach();
-      scene.remove(existing);
     }
 
     if (removedObjectIds.has(objectId)) {
@@ -6591,19 +6734,30 @@ async function replaceObjectContent(objectId, input, options = {}) {
     metaFit = existingMeta.fit || 'contain';
   } else if (input.kind === 'text') {
     const existingAsset = existing.userData?.asset || {};
+
+    const nextFormat =
+      input.format ||
+      (input.source === 'url' &&
+      typeof input.url === 'string' &&
+      /\.(md|markdown)(?:$|[?#])/i.test(input.url)
+        ? 'markdown'
+        : existingAsset.format || 'plain');
+
     newAsset = {
       type: 'text',
-      source: input.source || 'inline',
-      ...(input.url ? { url: input.url } : {}),
-      ...(input.text !== undefined ? { text: input.text } : {}),
-      format: input.format || 'plain',
+      source: input.source || existingAsset.source || 'inline',
+      ...(input.url ? { url: input.url } : existingAsset.url ? { url: existingAsset.url } : {}),
+      ...(input.text !== undefined ? { text: input.text } : existingAsset.text ? { text: existingAsset.text } : {}),
+      format: nextFormat,
       fontFamily: input.fontFamily || existingAsset.fontFamily || 'system-sans',
       fontSize: input.fontSize || existingAsset.fontSize || 32,
       fontWeight: input.fontWeight || existingAsset.fontWeight || 'normal',
       fontStyle: input.fontStyle || existingAsset.fontStyle || 'normal',
       color: input.color || existingAsset.color || '#ffffff',
       backgroundColor: input.backgroundColor || existingAsset.backgroundColor || 'rgba(0,0,0,0.65)',
-      align: input.align || existingAsset.align || 'center',
+      align: input.align || existingAsset.align || 'left',
+      layout: existingAsset.layout || { ...DEFAULT_TEXT_LAYOUT },
+      scroll: existingAsset.scroll || { ...DEFAULT_TEXT_SCROLL },
     };
     metaRole = existingMeta.role || 'text-panel';
     metaAccepts = existingMeta.accepts || ['text'];
@@ -7975,7 +8129,9 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     fontStyle: 'normal',
     color: '#ffffff',
     backgroundColor: 'rgba(0,0,0,0.65)',
-    align: 'center',
+    align: 'left',
+    layout: { ...DEFAULT_TEXT_LAYOUT },
+    scroll: { ...DEFAULT_TEXT_SCROLL },
   };
 
   // Check for replace target


### PR DESCRIPTION
新規ファイル:
- text-panel-renderer.js: Text Panel v2 canvas renderer

実装内容:

【Text Panel Renderer】
- normalizeTextAsset(): asset正規化（DEFAULT_TEXT_LAYOUT/SCROLL補完）
- renderTextPanelCanvas(): canvas描画エンジン
  * setCanvasFont(): ctx.font明確設定（measure前に必須）
  * wrapLongToken(): character fallback wrap（日本語・長い単語対応）
  * wrapPlainText(): plain text word wrap
  * parseMarkdownBlocks(): Markdown簡易parse
  * wrapMarkdownLine(): Markdown line wrap
- DEFAULT_TEXT_LAYOUT / DEFAULT_TEXT_SCROLL const定義
- clipping + scrollbar描画
- layout.width/height対応

【Scene.js修正】
- text-panel-renderer import追加
- textPanelScrollState: local scroll state (非同期)
- textPanelTouchCandidate / textPanelScrollActive: touch scroll state
- SCROLL_DRAG_THRESHOLD_PX = 8: mobile threshold
- helper関数:
  * findTextPanelRoot(): 親方向text-panelを探索
  * canScrollTextPanel(): overflow判定
  * updateTextPanelScroll(): scroll再描画（URL cache利用）
- loadTextObject(): Text Panel v2対応
  * normalizeTextAsset()で正規化
  * local scrollYを反映
  * layout.width/heightでgeometry決定
  * resolvedText cache（毎回fetch回避）
  * existing非破壊（replaceManagedObjectに任せ）
- touch scroll（仕様準拠）:
  * touchstart: candidate記録のみ（preventDefault()しない）
  * touchmove: threshold判定（8px超で初めてpreventDefault）
  * touchend: candidate/state clear
  * isVerticalDrag判定で操作奪わず
  * overflow時のみscroll
- wheel scroll:
  * overflow時のみpreventDefault() + scroll
  * overflow無しは camera/orbitに流す
  * transform操作優先
- textImporterCallback(): layout/scroll初期値追加、align:left
- replaceObjectContent(): format正しく更新、layout/scroll維持

【安全性対応（指摘の12項）】
✅ ctx.font明確設定（measure前）
✅ character wrap fallback（日本語・長い単語）
✅ wheel handler条件式正確（!== 'text-panel'）
✅ mobile touch passive:false
✅ GitHub blob URL正規化済み
✅ format更新ロジック（input.format優先、URL判定）
✅ scroll rerender URL cache（毎回fetch回避）
✅ existing cleanup（replaceManagedObjectに任せ）
✅ overflow無しは操作奪わない
✅ GitHub raw URL結果を使用
✅ findTextPanelRoot() helper実装
✅ 仕様準拠（選択操作を奪わない）

【仕様準拠】
- scroll操作は選択操作を奪わない
- PC wheel: overflow時のみ
- Mobile touch: threshold/isVerticalDrag判定
- TransformControls優先
- 候補記録時にpreventDefault()しない

https://claude.ai/code/session_01YFhfZsVAdArpcAM1ePQE1X