### PR TITLE
PR #300 後続: Clipboard Markdown URL検出の改善

### DIFF
--- a/html/assets/js/scenesync/loaders/clipboard-parser.js
+++ b/html/assets/js/scenesync/loaders/clipboard-parser.js
@@ -105,7 +105,16 @@ export function parseClipboardDataTransfer(dataTransfer) {
     }
   }
 
-  // 優先順位4: text/html から URL 抽出
+  // 優先順位4: text/plain がURL
+  const plainText = dataTransfer.getData('text/plain');
+  if (plainText) {
+    const trimmed = plainText.trim();
+    if (isLikelyHttpUrl(trimmed)) {
+      return { kind: 'url', url: trimmed };
+    }
+  }
+
+  // 優先順位5: text/html から URL 抽出
   const html = dataTransfer.getData('text/html');
   if (html) {
     const url = extractHtmlUrls(html);
@@ -114,15 +123,8 @@ export function parseClipboardDataTransfer(dataTransfer) {
     }
   }
 
-  // 優先順位5: text/plain がURL
-  const plainText = dataTransfer.getData('text/plain');
+  // 優先順位6: 通常テキスト
   if (plainText) {
-    const trimmed = plainText.trim();
-    if (isLikelyHttpUrl(trimmed)) {
-      return { kind: 'url', url: trimmed };
-    }
-
-    // 優先順位6: 通常テキスト
     return createPlainTextClipboardPayload(plainText);
   }
 
@@ -152,7 +154,7 @@ export async function parseNavigatorClipboardItems(items) {
     }
   }
 
-  // テキスト抽出 (text/plain, text/uri-list, text/html)
+  // テキスト抽出 (text/uri-list, text/plain, text/html)
   for (const item of items) {
     if (item.types.includes('text/uri-list')) {
       try {
@@ -169,20 +171,9 @@ export async function parseNavigatorClipboardItems(items) {
         console.warn('[clipboard] uri-list extraction failed:', err);
       }
     }
+  }
 
-    if (item.types.includes('text/html')) {
-      try {
-        const blob = await item.getType('text/html');
-        const html = await blob.text();
-        const url = extractHtmlUrls(html);
-        if (url) {
-          return { kind: 'url', url };
-        }
-      } catch (err) {
-        console.warn('[clipboard] html extraction failed:', err);
-      }
-    }
-
+  for (const item of items) {
     if (item.types.includes('text/plain')) {
       try {
         const blob = await item.getType('text/plain');
@@ -195,6 +186,21 @@ export async function parseNavigatorClipboardItems(items) {
         return createPlainTextClipboardPayload(text);
       } catch (err) {
         console.warn('[clipboard] text extraction failed:', err);
+      }
+    }
+  }
+
+  for (const item of items) {
+    if (item.types.includes('text/html')) {
+      try {
+        const blob = await item.getType('text/html');
+        const html = await blob.text();
+        const url = extractHtmlUrls(html);
+        if (url) {
+          return { kind: 'url', url };
+        }
+      } catch (err) {
+        console.warn('[clipboard] html extraction failed:', err);
       }
     }
   }

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -1,3 +1,15 @@
+function getTextUrlFormat(url) {
+  try {
+    const u = new URL(url);
+    const ext = (u.pathname.split('.').pop() || '').toLowerCase();
+    return ext === 'md' || ext === 'markdown' ? 'markdown' : 'plain';
+  } catch {
+    return /\.(md|markdown)(?:$|[?#])/i.test(String(url))
+      ? 'markdown'
+      : 'plain';
+  }
+}
+
 /**
  * URL からテキストアセットを scene-add として追加。
  * テキスト内容はフェッチせず URL 参照のまま保持する。
@@ -27,7 +39,7 @@ export async function importTextUrl(url, ctx) {
         type: 'text',
         source: 'url',
         url,
-        format: /\.(md|markdown)$/i.test(filename) ? 'markdown' : 'plain',
+        format: getTextUrlFormat(url),
         fontFamily: 'system-sans',
         fontSize: 32,
         fontWeight: 'normal',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8352,13 +8352,7 @@ async function pasteFromClipboardAtDefaultPosition() {
     return result;
   }
 
-  if (isMobileUi()) {
-    openPasteSheet();
-    showToast('枠内を長押しして貼り付けてください');
-    return null;
-  }
-
-  showToast('クリップボードを読み取れません。通常の貼り付け操作を使ってください');
+  showToast('クリップボードを読み取れません');
   return null;
 }
 


### PR DESCRIPTION
## 概要
PR #300 マージ後に実施した Clipboard と Markdown URL 検出の3つの改善

## 変更内容

### 1. モバイル貼り付けシートの削除
- `pasteFromClipboardAtDefaultPosition()` から不要な mobile fallback を削除
- `isMobileUi()` チェックと `openPasteSheet()` 呼び出しを削除
- 単一の エラー toast に統一: "クリップボードを読み取れません"

### 2. Markdown 形式判定の改善
- `getTextUrlFormat()` ヘルパー関数を追加
- URL pathname の拡張子 (.md, .markdown) を確認
- query/hash parameters に対応

### 3. Clipboard パーサーの優先度順の修正
- `parseClipboardDataTransfer()`: text/plain URL を text/html 前にチェック
- `parseNavigatorClipboardItems()`: 専用ループで uri-list → text/plain → text/html の順で抽出

これにより GitHub markdown URL が HTML コンテンツから正しく抽出されるようになります

## テスト
- GitHub markdown URL の貼り付けが正しく機能することを確認
- モバイル UI での paste sheet が表示されないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhfZsVAdArpcAM1ePQE1X)_