### PR TITLE
PR A: Text Panel v2 から scroll 操作を削除

### DIFF
--- a/html/assets/js/scenesync/components/text-panel-renderer.js
+++ b/html/assets/js/scenesync/components/text-panel-renderer.js
@@ -411,8 +411,7 @@ export function renderTextPanelCanvas(asset, options = {}) {
   }
 
   const viewportHeight = canvasHeight - 2 * paddingPx;
-  const maxScrollY = Math.max(0, contentHeight - viewportHeight);
-  const scrollY = clamp(asset.scroll?.y || 0, 0, maxScrollY);
+  const scrollY = 0;
 
   // Draw background
   ctx.fillStyle = asset.backgroundColor;
@@ -445,28 +444,11 @@ export function renderTextPanelCanvas(asset, options = {}) {
 
   ctx.restore();
 
-  // Draw scrollbar if needed
-  if (maxScrollY > 0) {
-    const scrollbarWidth = 4;
-    const scrollbarHeight = (viewportHeight / contentHeight) * viewportHeight;
-    const scrollbarY = (scrollY / maxScrollY) * (viewportHeight - scrollbarHeight);
-
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
-    ctx.fillRect(
-      canvasWidth - scrollbarWidth - 4,
-      paddingPx + scrollbarY,
-      scrollbarWidth,
-      scrollbarHeight,
-    );
-  }
-
   return {
     canvas,
     metrics: {
       contentHeight,
       viewportHeight,
-      maxScrollY,
-      scrollY,
       lineCount: layoutLines.length,
       overflow: contentHeight > viewportHeight,
     },

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2825,8 +2825,6 @@ let singleTapTimer = null;
 
 renderer.domElement.addEventListener('touchstart', (e) => {
   touchMoved = false;
-  textPanelScrollActive = false;
-  textPanelTouchCandidate = null;
 
   const touch = e.touches[0];
   if (!touch) return;
@@ -2835,54 +2833,12 @@ renderer.domElement.addEventListener('touchstart', (e) => {
   pointer.x = ((touch.clientX - rect.left) / rect.width) * 2 - 1;
   pointer.y = -((touch.clientY - rect.top) / rect.height) * 2 + 1;
 
-  raycaster.setFromCamera(pointer, camera);
-  const targets = Array.from(managedObjects.values())
-    .filter((obj) => obj.userData?.role === 'text-panel' && !isSkySphereThreeObject(obj));
-  const hits = raycaster.intersectObjects(targets, true);
-
-  if (hits.length > 0) {
-    const hitObject = findTextPanelRoot(hits[0].object);
-    if (hitObject && canScrollTextPanel(hitObject)) {
-      textPanelTouchCandidate = {
-        panel: hitObject,
-        startX: touch.clientX,
-        startY: touch.clientY,
-        lastY: touch.clientY,
-      };
-    }
-  }
+  lastTapX = touch.clientX;
+  lastTapY = touch.clientY;
 }, { passive: false });
 
 renderer.domElement.addEventListener('touchmove', (e) => {
   touchMoved = true;
-
-  if (!textPanelTouchCandidate || textPanelScrollActive) {
-    if (textPanelScrollActive && textPanelTouchCandidate && e.touches.length > 0) {
-      const touch = e.touches[0];
-      const deltaY = touch.clientY - textPanelTouchCandidate.lastY;
-      textPanelTouchCandidate.lastY = touch.clientY;
-      updateTextPanelScroll(textPanelTouchCandidate.panel.userData.objectId, -deltaY);
-      e.preventDefault();
-    }
-    return;
-  }
-
-  if (e.touches.length > 0) {
-    const touch = e.touches[0];
-    const dx = touch.clientX - textPanelTouchCandidate.startX;
-    const dy = touch.clientY - textPanelTouchCandidate.startY;
-
-    const isVerticalDrag =
-      Math.abs(dy) > SCROLL_DRAG_THRESHOLD_PX &&
-      Math.abs(dy) > Math.abs(dx);
-
-    if (isVerticalDrag) {
-      textPanelScrollActive = true;
-      textPanelTouchCandidate.lastY = touch.clientY;
-      updateTextPanelScroll(textPanelTouchCandidate.panel.userData.objectId, -dy);
-      e.preventDefault();
-    }
-  }
 }, { passive: false });
 
 function handleDoubleTap(clientX, clientY) {
@@ -2890,9 +2846,6 @@ function handleDoubleTap(clientX, clientY) {
 }
 
 renderer.domElement.addEventListener('touchend', (e) => {
-  textPanelTouchCandidate = null;
-  textPanelScrollActive = false;
-
   if (e.touches.length > 0) return;
   const touch = e.changedTouches[0];
   if (!touch) return;
@@ -2936,79 +2889,6 @@ renderer.domElement.addEventListener('touchend', (e) => {
 
 // ── Text Panel Scroll (wheel) ──────────────────────────────
 
-function updateTextPanelScroll(objectId, deltaY) {
-  const object = managedObjects.get(objectId);
-  if (!object) return;
-
-  const asset = object.userData?.asset;
-  const metrics = object.userData?.textPanelMetrics;
-  const resolvedText = object.userData?.resolvedText;
-
-  if (!asset || !metrics) return;
-
-  const currentScrollY = textPanelScrollState.get(objectId) ?? asset.scroll?.y ?? 0;
-  const nextScrollY = clamp(currentScrollY + deltaY, 0, metrics.maxScrollY);
-
-  if (nextScrollY === currentScrollY) return;
-
-  textPanelScrollState.set(objectId, nextScrollY);
-
-  // Rerender text panel with cached text + new scroll position
-  const renderAsset = {
-    ...asset,
-    text: resolvedText || asset.text || '',
-    scroll: { y: nextScrollY },
-  };
-
-  const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });
-  const canvas = result.canvas;
-
-  const mesh = object.children.find((child) => child.isMesh);
-  if (!mesh) return;
-
-  const oldTexture = mesh.material.map;
-  const newTexture = new THREE.CanvasTexture(canvas);
-  newTexture.colorSpace = THREE.SRGBColorSpace;
-  newTexture.magFilter = THREE.LinearFilter;
-  newTexture.minFilter = THREE.LinearFilter;
-
-  mesh.material.map = newTexture;
-  mesh.material.needsUpdate = true;
-
-  object.userData.textPanelMetrics = result.metrics;
-  oldTexture?.dispose();
-}
-
-function handleTextPanelWheel(event) {
-  // Only scroll text panels, not camera, if overflow
-  if (isDragging) return; // Transform drag priority
-  if (event.ctrlKey || event.metaKey) return; // Allow pinch-zoom
-
-  const rect = renderer.domElement.getBoundingClientRect();
-  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
-
-  raycaster.setFromCamera(pointer, camera);
-  const targets = Array.from(managedObjects.values())
-    .filter((obj) => obj.userData?.role === 'text-panel' && !isSkySphereThreeObject(obj));
-  const hits = raycaster.intersectObjects(targets, true);
-
-  if (hits.length === 0) return;
-
-  const hitObject = findTextPanelRoot(hits[0].object);
-  if (!hitObject) return;
-  if (!canScrollTextPanel(hitObject)) return;
-
-  // Text panel is overflowing → prevent default & scroll
-  event.preventDefault();
-  event.stopPropagation();
-
-  const deltaY = event.deltaY > 0 ? 40 : -40;
-  const objectId = hitObject.userData.objectId;
-  updateTextPanelScroll(objectId, deltaY);
-}
-
-renderer.domElement.addEventListener('wheel', handleTextPanelWheel, { passive: false });
 
 // ── 削除ロジック（共通） ──────────────────────────────────
 
@@ -6450,12 +6330,7 @@ function loadImageObject(objectId, info, imageUrl, existing, prebuilt = null, op
   });
 }
 
-// ── Text Panel v2 Scroll State ────────────────────────────────────
-// Local scroll state (not synced to other clients)
-const textPanelScrollState = new Map();
-let textPanelTouchCandidate = null;
-let textPanelScrollActive = false;
-const SCROLL_DRAG_THRESHOLD_PX = 8;
+// ── Text Panel v2 Helpers ────────────────────────────────────
 
 function findTextPanelRoot(object) {
   let current = object;
@@ -6464,11 +6339,6 @@ function findTextPanelRoot(object) {
     current = current.parent;
   }
   return null;
-}
-
-function canScrollTextPanel(textPanel) {
-  const metrics = textPanel?.userData?.textPanelMetrics;
-  return metrics && metrics.maxScrollY > 0;
 }
 
 function loadTextObject(objectId, info, asset, existing) {
@@ -6485,10 +6355,6 @@ function loadTextObject(objectId, info, asset, existing) {
     const renderAsset = {
       ...normalizedAsset,
       text: resolvedText,
-      scroll: {
-        ...normalizedAsset.scroll,
-        y: textPanelScrollState.get(objectId) ?? normalizedAsset.scroll?.y ?? 0,
-      },
     };
 
     const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });


### PR DESCRIPTION
## 概要
Text Panel v2 から スクロール機能を削除し、clipping による固定表示に変更

## 削除内容
- textPanelScrollState, textPanelTouchCandidate, textPanelScrollActive 変数削除
- SCROLL_DRAG_THRESHOLD_PX 定数削除
- updateTextPanelScroll() 関数削除
- handleTextPanelWheel() 関数削除
- wheel listener 削除
- text panel 用 touchstart/touchmove/touchend 処理削除

## 変更内容
- loadTextObject() の scroll state 参照削除
- renderTextPanelCanvas() の scroll offset 処理削除（常に scrollY = 0）
- scrollbar 描画処理削除
- metrics から maxScrollY, scrollY 削除

## 仕様
- long text は panel 高さで clipping
- scroll 機能なし
- text panel 上の wheel/touch は camera 操作に流す
- Phase1 では scroll 不使用（将来用に asset.scroll スキーマは残す）

## テスト
- text panel上で縦dragしてもscroll処理にならない
- text panel上の drag は camera/transform 操作を邪魔しない
- wheel/touch scroll 用の custom handler が残っていない
- scrollbar が表示されない

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhfZsVAdArpcAM1ePQE1X)_