### PR TITLE
PR B: Text Panel v2 scale 変更を layout に bake

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -961,6 +961,11 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
   } else {
     clearInterval(dragIntervalId);
     dragIntervalId = null;
+
+    // Text Panel scale bake (sendSelectedDelta と history 記録より前)
+    const wasBaked = transformCtrl.object &&
+      bakeTextPanelScaleToLayout(transformCtrl.object);
+
     sendSelectedDelta();
 
     // ドラッグ終了時に履歴に追加
@@ -989,11 +994,6 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
         }
       }
       dragStartState = null;
-    }
-
-    // Text Panel scale bake
-    if (transformCtrl.object && transformCtrl.object.userData?.role === 'text-panel') {
-      bakeTextPanelScaleToLayout(transformCtrl.object.userData.objectId, transformCtrl.object);
     }
   }
 });
@@ -6346,17 +6346,7 @@ function findTextPanelRoot(object) {
   return null;
 }
 
-function broadcastObjectUpdate(objectId, patch) {
-  const payload = {
-    kind: 'scene-delta',
-    objectId,
-    ...patch,
-  };
-  broadcast(payload);
-}
-
-function rerenderTextPanel(objectId, asset) {
-  const object = managedObjects.get(objectId);
+function rerenderTextPanelObject(object, asset) {
   if (!object) return;
 
   const resolvedText = object.userData?.resolvedText || asset.text || '';
@@ -6385,8 +6375,11 @@ function rerenderTextPanel(objectId, asset) {
   oldTexture?.dispose();
 }
 
-function bakeTextPanelScaleToLayout(objectId, object) {
-  const asset = object?.userData?.asset;
+function bakeTextPanelScaleToLayout(object) {
+  if (!object) return false;
+  if (object.userData?.role !== 'text-panel') return false;
+
+  const asset = object.userData?.asset;
   if (!asset || asset.type !== 'text') return false;
 
   const sx = object.scale.x || 1;
@@ -6412,15 +6405,10 @@ function bakeTextPanelScaleToLayout(objectId, object) {
     layout: nextLayout,
   };
 
-  object.scale.set(1, 1, 1);
   object.userData.asset = nextAsset;
+  object.scale.set(1, 1, 1);
 
-  rerenderTextPanel(objectId, nextAsset);
-
-  broadcastObjectUpdate(objectId, {
-    asset: nextAsset,
-    scale: [1, 1, 1],
-  });
+  rerenderTextPanelObject(object, nextAsset);
 
   return true;
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -990,6 +990,11 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
       }
       dragStartState = null;
     }
+
+    // Text Panel scale bake
+    if (transformCtrl.object && transformCtrl.object.userData?.role === 'text-panel') {
+      bakeTextPanelScaleToLayout(transformCtrl.object.userData.objectId, transformCtrl.object);
+    }
   }
 });
 
@@ -6339,6 +6344,85 @@ function findTextPanelRoot(object) {
     current = current.parent;
   }
   return null;
+}
+
+function broadcastObjectUpdate(objectId, patch) {
+  const payload = {
+    kind: 'scene-delta',
+    objectId,
+    ...patch,
+  };
+  broadcast(payload);
+}
+
+function rerenderTextPanel(objectId, asset) {
+  const object = managedObjects.get(objectId);
+  if (!object) return;
+
+  const resolvedText = object.userData?.resolvedText || asset.text || '';
+
+  const renderAsset = {
+    ...asset,
+    text: resolvedText,
+  };
+
+  const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });
+  const canvas = result.canvas;
+
+  const mesh = object.children.find((child) => child.isMesh);
+  if (!mesh) return;
+
+  const oldTexture = mesh.material.map;
+  const newTexture = new THREE.CanvasTexture(canvas);
+  newTexture.colorSpace = THREE.SRGBColorSpace;
+  newTexture.magFilter = THREE.LinearFilter;
+  newTexture.minFilter = THREE.LinearFilter;
+
+  mesh.material.map = newTexture;
+  mesh.material.needsUpdate = true;
+
+  object.userData.textPanelMetrics = result.metrics;
+  oldTexture?.dispose();
+}
+
+function bakeTextPanelScaleToLayout(objectId, object) {
+  const asset = object?.userData?.asset;
+  if (!asset || asset.type !== 'text') return false;
+
+  const sx = object.scale.x || 1;
+  const sy = object.scale.y || 1;
+
+  if (Math.abs(sx - 1) < 0.001 && Math.abs(sy - 1) < 0.001) {
+    return false;
+  }
+
+  const layout = {
+    ...DEFAULT_TEXT_LAYOUT,
+    ...(asset.layout || {}),
+  };
+
+  const nextLayout = {
+    ...layout,
+    width: Math.max(0.4, layout.width * Math.abs(sx)),
+    height: Math.max(0.3, layout.height * Math.abs(sy)),
+  };
+
+  const nextAsset = {
+    ...asset,
+    layout: nextLayout,
+  };
+
+  object.scale.set(1, 1, 1);
+  object.userData.asset = nextAsset;
+
+  rerenderTextPanel(objectId, nextAsset);
+
+  broadcastObjectUpdate(objectId, {
+    asset: nextAsset,
+    scale: [1, 1, 1],
+  });
+
+  return true;
 }
 
 function loadTextObject(objectId, info, asset, existing) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1013,13 +1013,20 @@ function sendSelectedDelta() {
 
   if (!isFinite(pos[0]) || !isFinite(pos[1]) || !isFinite(pos[2])) return;
 
-  broadcast({
+  const payload = {
     kind: 'scene-delta',
     objectId: obj.userData.objectId,
     position: pos,
     rotation: rot,
     scale: scl,
-  });
+  };
+
+  // Text Panel scale bake では asset.layout が本体なので、asset を含める
+  if (obj.userData?.asset?.type === 'text') {
+    payload.asset = structuredClone(obj.userData.asset);
+  }
+
+  broadcast(payload);
   notifySceneStateChanged('selected-transform-sent');
 }
 
@@ -6362,17 +6369,33 @@ function rerenderTextPanelObject(object, asset) {
   const mesh = object.children.find((child) => child.isMesh);
   if (!mesh) return;
 
+  const layout = {
+    ...DEFAULT_TEXT_LAYOUT,
+    ...(asset.layout || {}),
+  };
+
+  const panelWidth = layout.width;
+  const panelHeight = layout.height;
+
   const oldTexture = mesh.material.map;
+  const oldGeometry = mesh.geometry;
+
   const newTexture = new THREE.CanvasTexture(canvas);
   newTexture.colorSpace = THREE.SRGBColorSpace;
   newTexture.magFilter = THREE.LinearFilter;
   newTexture.minFilter = THREE.LinearFilter;
 
+  const newGeometry = new THREE.PlaneGeometry(panelWidth, panelHeight);
+
+  mesh.geometry = newGeometry;
   mesh.material.map = newTexture;
   mesh.material.needsUpdate = true;
+  mesh.position.y = panelHeight / 2;
 
   object.userData.textPanelMetrics = result.metrics;
+
   oldTexture?.dispose();
+  oldGeometry?.dispose();
 }
 
 function bakeTextPanelScaleToLayout(object) {


### PR DESCRIPTION
## 概要
Text Panel v2 で scale 変更を layout.width/height に bake し、表示枠サイズ変更として機能させる

## 依存
- PR #303 (text-panel-v2-remove-scroll) をマージ後に base する

## 新規関数
- broadcastObjectUpdate(): scene-delta を broadcast する helper
- rerenderTextPanel(): asset 更新後に canvas texture を再レンダリング
- bakeTextPanelScaleToLayout(): scale を layout に bake する実装

## TransformControls 統合
- dragging-changed イベント (e.value === false) でドラッグ終了時に実行
- text-panel role の object のみ対象
- scale [1,1,1] との差が十分大きい場合のみ実行
- bake後: layout 変更 + scale reset + rerender + broadcast

## 仕様
変更前:
```
layout.width = 2.4, layout.height = 1.6
scale = [1.5, 1.2, 1]
```

変更後:
```
layout.width = 3.6, layout.height = 1.92
scale = [1, 1, 1]
fontSize = 32 (変更なし)
```

## 互換性
- replacement 時は既存 layout を維持（replaceObjectContent() で実装済み）
- 既存 text object が scale を持つ場合、次回 scale 操作時に bake
- Phase1 では読み込み時に勝手に migration しない

## テスト
- Text Panel を scale (xまたはy) すると layout が変更される
- scale後 fontSize は変わらない
- scale後 object.scale は [1,1,1] に戻る
- 他クライアントにも layout 変更が同期される
- replacement後も layout が維持される

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhfZsVAdArpcAM1ePQE1X)_