### PR TITLE
Add text asset editing support to scene inspector

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -9018,8 +9018,21 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       const editedAssetIsText = editedAsset?.type === 'text';
 
       if (baseAssetIsText && editedAssetIsText) {
-        const assetPatch = { type: 'text' };
+        const assetPatch = cloneInspectorValue(baseAsset);
         const changedAssetFields = [];
+
+        const editableTextAssetKeys = new Set([
+          ...EDITABLE_TEXT_ASSET_FIELDS,
+          'layout',
+        ]);
+
+        const readOnlyTextAssetKeys = new Set([
+          'type',
+          'source',
+          'text',
+          'url',
+          'format',
+        ]);
 
         // Handle text asset display properties
         for (const key of EDITABLE_TEXT_ASSET_FIELDS) {
@@ -9064,17 +9077,14 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
           ...Object.keys(baseAsset || {}),
           ...Object.keys(editedAsset || {}),
         ]);
-        const editableKeys = new Set([
-          'type',
-          ...EDITABLE_TEXT_ASSET_FIELDS,
-          'layout',
-          'source',
-          'text',
-          'url',
-          'format', // these are read-only
-        ]);
         for (const key of assetKeys) {
-          if (!editableKeys.has(key) && !valuesEqual(baseAsset?.[key], editedAsset?.[key])) {
+          if (readOnlyTextAssetKeys.has(key) && !valuesEqual(baseAsset?.[key], editedAsset?.[key])) {
+            addIgnoredSceneInspectorEntry(
+              ignoredEntries,
+              `objects.${objectId}.asset.${key}`,
+              'text asset content/source fields are read-only; use replacement to change content'
+            );
+          } else if (!editableTextAssetKeys.has(key) && !readOnlyTextAssetKeys.has(key) && !valuesEqual(baseAsset?.[key], editedAsset?.[key])) {
             addIgnoredSceneInspectorEntry(
               ignoredEntries,
               `objects.${objectId}.asset.${key}`,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8777,6 +8777,21 @@ const EDITABLE_SCENE_OBJECT_FIELDS = new Set([
   'asset',
 ]);
 
+const EDITABLE_TEXT_ASSET_FIELDS = new Set([
+  'fontSize',
+  'fontFamily',
+  'fontWeight',
+  'fontStyle',
+  'color',
+  'backgroundColor',
+  'align',
+]);
+
+const EDITABLE_TEXT_LAYOUT_FIELDS = new Set([
+  'width',
+  'height',
+]);
+
 function cloneInspectorValue(value) {
   if (value === undefined) return undefined;
   if (value === null || typeof value !== 'object') return value;
@@ -8811,6 +8826,55 @@ function validateColorValue(value, path, errors) {
     errors.push(`${path} must be a string or number color value.`);
   }
   return valid;
+}
+
+function validateFontSize(value, path, errors) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    errors.push(`${path} must be a finite number.`);
+    return false;
+  }
+  if (value < 8 || value > 256) {
+    errors.push(`${path} must be between 8 and 256.`);
+    return false;
+  }
+  return true;
+}
+
+function validateTextLayoutValue(value, path, errors) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    errors.push(`${path} must be a finite number.`);
+    return false;
+  }
+  if (path.includes('width') && (value < 0.4 || value > 100)) {
+    errors.push(`${path} must be between 0.4 and 100.`);
+    return false;
+  }
+  if (path.includes('height') && (value < 0.3 || value > 100)) {
+    errors.push(`${path} must be between 0.3 and 100.`);
+    return false;
+  }
+  return true;
+}
+
+function validateTextAssetField(key, value, objectId, errors) {
+  if (key === 'fontSize') {
+    return validateFontSize(value, `objects.${objectId}.asset.fontSize`, errors);
+  }
+  if (key === 'color' || key === 'backgroundColor') {
+    return validateColorValue(value, `objects.${objectId}.asset.${key}`, errors);
+  }
+  if (key === 'fontFamily' || key === 'fontWeight' || key === 'fontStyle' || key === 'align') {
+    if (typeof value !== 'string') {
+      errors.push(`objects.${objectId}.asset.${key} must be a string.`);
+      return false;
+    }
+    if (key === 'align' && !['left', 'center', 'right'].includes(value)) {
+      errors.push(`objects.${objectId}.asset.align must be 'left', 'center', or 'right'.`);
+      return false;
+    }
+    return true;
+  }
+  return true;
 }
 
 function addIgnoredSceneInspectorEntry(entries, path, reason) {
@@ -8950,40 +9014,116 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       const baseAsset = baseObject.asset;
       const editedAsset = editedObject.asset;
       const baseAssetIsPrimitive = baseAsset?.type === 'primitive';
-      const assetKeys = new Set([
-        ...Object.keys(baseAsset || {}),
-        ...Object.keys(editedAsset || {}),
-      ]);
-      const changedAssetKeys = Array.from(assetKeys)
-        .filter((key) => !valuesEqual(baseAsset?.[key], editedAsset?.[key]));
+      const baseAssetIsText = baseAsset?.type === 'text';
+      const editedAssetIsText = editedAsset?.type === 'text';
 
-      const unsupportedAssetKeys = changedAssetKeys.filter((key) => key !== 'color');
-      if (unsupportedAssetKeys.length > 0) {
-        for (const key of unsupportedAssetKeys) {
-          addIgnoredSceneInspectorEntry(
-            ignoredEntries,
-            `objects.${objectId}.asset.${key}`,
-            'only asset.color is editable in this prototype'
-          );
+      if (baseAssetIsText && editedAssetIsText) {
+        const assetPatch = { type: 'text' };
+        const changedAssetFields = [];
+
+        // Handle text asset display properties
+        for (const key of EDITABLE_TEXT_ASSET_FIELDS) {
+          if (!valuesEqual(baseAsset?.[key], editedAsset?.[key])) {
+            const isValid = validateTextAssetField(key, editedAsset?.[key], objectId, errors);
+            if (isValid) {
+              assetPatch[key] = cloneInspectorValue(editedAsset[key]);
+              changedAssetFields.push(`asset.${key}`);
+            }
+          }
         }
-      }
 
-      if (changedAssetKeys.includes('color')) {
-        if (!editedAsset || typeof editedAsset !== 'object' || Array.isArray(editedAsset)) {
-          addIgnoredSceneInspectorEntry(
-            ignoredEntries,
-            `objects.${objectId}.asset.color`,
-            'color edits require an asset object'
-          );
-        } else if (!baseAssetIsPrimitive) {
-          addIgnoredSceneInspectorEntry(
-            ignoredEntries,
-            `objects.${objectId}.asset.color`,
-            'color edits are limited to primitive objects'
-          );
-        } else if (validateColorValue(editedAsset?.color, `objects.${objectId}.asset.color`, errors)) {
-          objectDelta.asset = { color: editedAsset.color };
-          changedFields.push('asset.color');
+        // Handle layout object
+        if (!valuesEqual(baseAsset?.layout, editedAsset?.layout)) {
+          const layoutPatch = {
+            ...(baseAsset?.layout || {}),
+          };
+          let layoutChanged = false;
+
+          for (const key of EDITABLE_TEXT_LAYOUT_FIELDS) {
+            if (!valuesEqual(baseAsset?.layout?.[key], editedAsset?.layout?.[key])) {
+              const isValid = validateTextLayoutValue(
+                editedAsset?.layout?.[key],
+                `objects.${objectId}.asset.layout.${key}`,
+                errors
+              );
+              if (isValid) {
+                layoutPatch[key] = editedAsset.layout[key];
+                changedAssetFields.push(`asset.layout.${key}`);
+                layoutChanged = true;
+              }
+            }
+          }
+
+          if (layoutChanged) {
+            assetPatch.layout = layoutPatch;
+          }
+        }
+
+        // Collect ignored fields for text asset
+        const assetKeys = new Set([
+          ...Object.keys(baseAsset || {}),
+          ...Object.keys(editedAsset || {}),
+        ]);
+        const editableKeys = new Set([
+          'type',
+          ...EDITABLE_TEXT_ASSET_FIELDS,
+          'layout',
+          'source',
+          'text',
+          'url',
+          'format', // these are read-only
+        ]);
+        for (const key of assetKeys) {
+          if (!editableKeys.has(key) && !valuesEqual(baseAsset?.[key], editedAsset?.[key])) {
+            addIgnoredSceneInspectorEntry(
+              ignoredEntries,
+              `objects.${objectId}.asset.${key}`,
+              'asset field is not editable for this asset type'
+            );
+          }
+        }
+
+        if (changedAssetFields.length > 0) {
+          objectDelta.asset = assetPatch;
+          changedFields.push(...changedAssetFields);
+        }
+      } else {
+        // Primitive and other asset type handling
+        const assetKeys = new Set([
+          ...Object.keys(baseAsset || {}),
+          ...Object.keys(editedAsset || {}),
+        ]);
+        const changedAssetKeys = Array.from(assetKeys)
+          .filter((key) => !valuesEqual(baseAsset?.[key], editedAsset?.[key]));
+
+        const unsupportedAssetKeys = changedAssetKeys.filter((key) => key !== 'color');
+        if (unsupportedAssetKeys.length > 0) {
+          for (const key of unsupportedAssetKeys) {
+            addIgnoredSceneInspectorEntry(
+              ignoredEntries,
+              `objects.${objectId}.asset.${key}`,
+              'asset field is not editable for this asset type'
+            );
+          }
+        }
+
+        if (changedAssetKeys.includes('color')) {
+          if (!editedAsset || typeof editedAsset !== 'object' || Array.isArray(editedAsset)) {
+            addIgnoredSceneInspectorEntry(
+              ignoredEntries,
+              `objects.${objectId}.asset.color`,
+              'color edits require an asset object'
+            );
+          } else if (!baseAssetIsPrimitive) {
+            addIgnoredSceneInspectorEntry(
+              ignoredEntries,
+              `objects.${objectId}.asset.color`,
+              'color edits are limited to primitive objects'
+            );
+          } else if (validateColorValue(editedAsset?.color, `objects.${objectId}.asset.color`, errors)) {
+            objectDelta.asset = { color: editedAsset.color };
+            changedFields.push('asset.color');
+          }
         }
       }
     }


### PR DESCRIPTION
## 概要

Text asset の編集機能を Scene Inspector に追加します。フォントサイズ、フォントファミリー、フォントウェイト、フォントスタイル、色、背景色、テキスト配置、およびレイアウト（幅・高さ）の編集に対応しました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **編集可能フィールドの定義**
   - `EDITABLE_TEXT_ASSET_FIELDS`: テキストアセットの表示プロパティ（fontSize, fontFamily, fontWeight, fontStyle, color, backgroundColor, align）
   - `EDITABLE_TEXT_LAYOUT_FIELDS`: レイアウトプロパティ（width, height）

2. **バリデーション関数の追加**
   - `validateFontSize()`: フォントサイズを 8～256 の範囲で検証
   - `validateTextLayoutValue()`: レイアウト値を検証（width: 0.4～100, height: 0.3～100）
   - `validateTextAssetField()`: テキストアセットフィールドの包括的な検証

3. **シーンインスペクタの差分生成ロジック**
   - Text asset 専用の処理パスを追加
   - Primitive asset の既存ロジックを別パスに分離
   - Text asset の変更フィールドを個別に追跡し、検証後に `assetPatch` に追加
   - レイアウト変更時は既存値をマージして部分更新に対応

### staging で見てほしい点

- Text asset の各プロパティ編集が正常に動作すること
- バリデーションエラーが適切に報告されること
- Primitive asset の既存機能（color 編集）が引き続き動作すること
- 無効な編集は `ignoredEntries` に記録されること

## 変更していないこと

- Primitive asset の color 編集機能（既存ロジック維持）
- その他の asset type の処理
- Scene sync の REST API 仕様

## staging確認

未確認

## テスト/チェック

- 既存の scene inspector ロジックが Primitive asset に対して引き続き動作することを確認
- Text asset の各フィールドに対するバリデーションロジックが正しく機能することを確認

## リスク

- Text asset 編集時に無効な値が送信された場合、バリデーションエラーが適切に記録される設計のため、ユーザーへのエラー表示が必要
- レイアウト値の部分更新時に既存値のマージが正しく動作することを確認が必要

## follow-up tasks

- Text asset 編集時のエラーメッセージ表示 UI の実装
- Text asset の他のプロパティ（source, text, url, format）の編集対応検討
- バリデーション範囲の調整（ユーザーフィードバック基づく）

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_012QYpbqECBfjT4GxMExqnY1