### PR TITLE
Auto-estimate text panel layout from content

### DIFF
--- a/html/assets/js/scenesync/components/text-panel-renderer.js
+++ b/html/assets/js/scenesync/components/text-panel-renderer.js
@@ -16,6 +16,64 @@ export const DEFAULT_TEXT_SCROLL = {
   y: 0,
 };
 
+export const AUTO_TEXT_LAYOUT_MIN_WIDTH = 0.6;
+export const AUTO_TEXT_LAYOUT_MIN_HEIGHT = 0.35;
+export const AUTO_TEXT_LAYOUT_MAX_WIDTH = DEFAULT_TEXT_LAYOUT.width;
+export const AUTO_TEXT_LAYOUT_MAX_HEIGHT = DEFAULT_TEXT_LAYOUT.height;
+
+export function estimateTextPanelLayout(text, options = {}) {
+  const fontSize = Number.isFinite(options.fontSize) ? options.fontSize : 32;
+  const format = options.format || 'plain';
+
+  const minWidth = AUTO_TEXT_LAYOUT_MIN_WIDTH;
+  const minHeight = AUTO_TEXT_LAYOUT_MIN_HEIGHT;
+  const maxWidth = AUTO_TEXT_LAYOUT_MAX_WIDTH;
+  const maxHeight = AUTO_TEXT_LAYOUT_MAX_HEIGHT;
+  const padding = DEFAULT_TEXT_LAYOUT.padding;
+  const lineHeight = DEFAULT_TEXT_LAYOUT.lineHeight;
+
+  const content = String(text || '').trim();
+  if (!content) {
+    return { ...DEFAULT_TEXT_LAYOUT, width: minWidth, height: minHeight };
+  }
+
+  const lines = content.split(/\r?\n/);
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+
+  const maxLineLength = Math.max(
+    1,
+    ...nonEmptyLines.map((line) => {
+      let normalized = line.trim();
+
+      if (format === 'markdown') {
+        normalized = normalized
+          .replace(/^#{1,6}\s+/, '')
+          .replace(/^[-*+]\s+/, '')
+          .replace(/^\d+\.\s+/, '')
+          .replace(/^>\s+/, '');
+      }
+
+      return Array.from(normalized).length;
+    })
+  );
+
+  const lineCount = Math.max(1, nonEmptyLines.length || lines.length);
+
+  const charWidthWorld = (fontSize / 512) * 0.62;
+
+  const estimatedTextWidth = maxLineLength * charWidthWorld;
+  const estimatedWidth = estimatedTextWidth + padding * 2;
+
+  const lineHeightWorld = (fontSize / 512) * lineHeight;
+  const estimatedHeight = lineCount * lineHeightWorld + padding * 2;
+
+  return {
+    ...DEFAULT_TEXT_LAYOUT,
+    width: Math.max(minWidth, Math.min(maxWidth, estimatedWidth)),
+    height: Math.max(minHeight, Math.min(maxHeight, estimatedHeight)),
+  };
+}
+
 export function normalizeTextAsset(asset, info = {}) {
   const source = asset && typeof asset === 'object' ? asset : {};
 

--- a/html/assets/js/scenesync/loaders/url-importers/text.js
+++ b/html/assets/js/scenesync/loaders/url-importers/text.js
@@ -60,7 +60,7 @@ export async function importTextUrl(url, ctx) {
         color: '#ffffff',
         backgroundColor: 'rgba(0,0,0,0.65)',
         align: 'left',
-        layout: { ...DEFAULT_TEXT_LAYOUT },
+        layout: { ...DEFAULT_TEXT_LAYOUT, autoFit: true },
         scroll: { ...DEFAULT_TEXT_SCROLL },
       },
       metadata: {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -20,7 +20,7 @@ import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
 import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
 import { resolveDroppedUrl } from './loaders/url-resolver.js';
-import { normalizeTextAsset, renderTextPanelCanvas, DEFAULT_TEXT_LAYOUT, DEFAULT_TEXT_SCROLL } from './components/text-panel-renderer.js';
+import { normalizeTextAsset, renderTextPanelCanvas, DEFAULT_TEXT_LAYOUT, DEFAULT_TEXT_SCROLL, estimateTextPanelLayout } from './components/text-panel-renderer.js';
 import { dispatchUrlImport } from './loaders/url-importers/index.js';
 import { getSceneSyncDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
@@ -6461,7 +6461,13 @@ function loadTextObject(objectId, info, asset, existing) {
     texture.magFilter = THREE.LinearFilter;
     texture.minFilter = THREE.LinearFilter;
 
-    const layout = normalizedAsset.layout || DEFAULT_TEXT_LAYOUT;
+    let layout = normalizedAsset.layout;
+    if (normalizedAsset.source === 'url') {
+      layout = estimateTextPanelLayout(resolvedText, {
+        format: normalizedAsset.format,
+        fontSize: normalizedAsset.fontSize,
+      });
+    }
     const panelWidth = layout.width;
     const panelHeight = layout.height;
 
@@ -8078,11 +8084,12 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     : readQuaternionArray(context.rotation, [0, 0, 0, 1]);
   const scale = readVector3Array(context.scale, [1, 1, 1]);
 
+  const format = /\.(md|markdown)$/i.test(filename) ? 'markdown' : 'plain';
   const newAsset = {
     type: 'text',
     source: 'inline',
     text,
-    format: /\.(md|markdown)$/i.test(filename) ? 'markdown' : 'plain',
+    format,
     fontFamily: 'system-sans',
     fontSize: 32,
     fontWeight: 'normal',
@@ -8090,7 +8097,10 @@ async function textImporterCallback(text, position, filename = 'text.md', contex
     color: '#ffffff',
     backgroundColor: 'rgba(0,0,0,0.65)',
     align: 'left',
-    layout: { ...DEFAULT_TEXT_LAYOUT },
+    layout: estimateTextPanelLayout(text, {
+      format,
+      fontSize: 32,
+    }),
     scroll: { ...DEFAULT_TEXT_SCROLL },
   };
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6447,9 +6447,25 @@ function loadTextObject(objectId, info, asset, existing) {
     : Promise.resolve(normalizedAsset.text || '');
 
   textPromise.then((resolvedText) => {
+    const shouldAutoFitLayout =
+      normalizedAsset.source === 'url' &&
+      normalizedAsset.layout?.autoFit === true;
+
+    let layout = normalizedAsset.layout;
+    if (shouldAutoFitLayout) {
+      layout = {
+        ...estimateTextPanelLayout(resolvedText, {
+          format: normalizedAsset.format,
+          fontSize: normalizedAsset.fontSize,
+        }),
+        autoFit: false,
+      };
+    }
+
     const renderAsset = {
       ...normalizedAsset,
       text: resolvedText,
+      layout,
     };
 
     const result = renderTextPanelCanvas(renderAsset, { pixelsPerUnit: 512 });
@@ -6461,13 +6477,6 @@ function loadTextObject(objectId, info, asset, existing) {
     texture.magFilter = THREE.LinearFilter;
     texture.minFilter = THREE.LinearFilter;
 
-    let layout = normalizedAsset.layout;
-    if (normalizedAsset.source === 'url') {
-      layout = estimateTextPanelLayout(resolvedText, {
-        format: normalizedAsset.format,
-        fontSize: normalizedAsset.fontSize,
-      });
-    }
     const panelWidth = layout.width;
     const panelHeight = layout.height;
 
@@ -6489,7 +6498,7 @@ function loadTextObject(objectId, info, asset, existing) {
     group.userData.name = info.name;
     group.userData.assetType = 'text';
     group.userData.role = 'text-panel';
-    group.userData.asset = structuredClone(normalizedAsset);
+    group.userData.asset = structuredClone(renderAsset);
     group.userData.textPanelMetrics = metrics;
     group.userData.resolvedText = resolvedText;
     group.userData.dropRaycastTarget = true;
@@ -6722,7 +6731,11 @@ async function replaceObjectContent(objectId, input, options = {}) {
       color: input.color || existingAsset.color || '#ffffff',
       backgroundColor: input.backgroundColor || existingAsset.backgroundColor || 'rgba(0,0,0,0.65)',
       align: input.align || existingAsset.align || 'left',
-      layout: existingAsset.layout || { ...DEFAULT_TEXT_LAYOUT },
+      layout: (() => {
+        const baseLayout = existingAsset.layout || { ...DEFAULT_TEXT_LAYOUT };
+        const { autoFit, ...cleanLayout } = baseLayout;
+        return { ...cleanLayout, autoFit: false };
+      })(),
       scroll: existingAsset.scroll || { ...DEFAULT_TEXT_SCROLL },
     };
     metaRole = existingMeta.role || 'text-panel';


### PR DESCRIPTION
## 概要

テキストパネルのレイアウト（幅・高さ）を、テキスト内容から自動推定する機能を追加しました。URL から読み込まれたテキストと、インポートされたテキストに対して、フォントサイズと行数に基づいて適切なパネルサイズを計算します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **`text-panel-renderer.js`** に `estimateTextPanelLayout()` 関数を追加
   - テキスト内容、フォントサイズ、フォーマット（plain/markdown）から パネルサイズを推定
   - 最大行長と行数をカウントして、世界座標系での幅・高さを計算
   - Markdown フォーマットの場合、見出し・リスト・引用記号を正規化して実際のテキスト幅を正確に推定
   - 最小値（0.6 × 0.35）と最大値（デフォルトレイアウト）の範囲内に収める

2. **`scene.js`** で自動推定を適用
   - URL から読み込まれたテキストオブジェクト（`source === 'url'`）に対して、`estimateTextPanelLayout()` を使用してレイアウトを決定
   - テキストインポート時（`textImporterCallback`）に、デフォルト固定値ではなく推定レイアウトを使用

### staging で見てほしい点

- URL からテキストを読み込んだ際に、テキスト内容に応じて自動的にパネルサイズが調整されることを確認
- Markdown ファイルをインポートした際に、見出しやリストが含まれていても正しくサイズが推定されることを確認
- 短いテキストと長いテキストで、それぞれ最小値・最大値の制約が正しく機能することを確認

## 変更していないこと

- 既存の `normalizeTextAsset()` や `renderTextPanelCanvas()` の動作
- ユーザーが明示的に指定したレイアウトの上書き（`normalizedAsset.layout` が既に存在する場合は使用）
- テキストレンダリングやキャンバス生成のロジック

## staging確認

未確認

## テスト/チェック

- 新規関数 `estimateTextPanelLayout()` の単体テストは未実施
- 既存の lint / build check は通過することを想定

## リスク

- 推定ロジックが不正確な場合、テキストがパネルからはみ出す可能性
- フォントサイズの計算係数（`fontSize / 512 * 0.62`）が環境によって異なる可能性

## follow-up tasks

- `estimateTextPanelLayout()` の単体テスト追加
- 複数言語（CJK 文字など）での文字幅推定の精度向上
- ユーザーが推定レイアウトを手動で調整できるUI の検討

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01UDGbVLw2hmMBn4VQ7DcGiy