### PR TITLE
[codex] Add Unity Scene Sync metadata round-trip support

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -74,6 +74,7 @@ namespace Afjk.SceneSync.Editor
         private bool _showManagedUnityObjects = true;
         private Vector2 _scrollPosition;
         private bool _isSceneSwitching = false;
+        private string _envId = null;
 
         private void OnEnable()
         {
@@ -940,6 +941,10 @@ namespace Afjk.SceneSync.Editor
             {
                 HandleSceneState(raw);
             }
+            else if (raw.Contains("\"kind\":\"scene-env\""))
+            {
+                HandleSceneEnv(raw);
+            }
             else if (raw.Contains("\"kind\":\"scene-batch\""))
             {
                 HandleSceneBatch(raw, fromId);
@@ -1081,28 +1086,24 @@ namespace Afjk.SceneSync.Editor
             _sceneReceived = true;
             Debug.Log("[SceneSync] Received scene-state");
 
-            // "objects":{...} の中身を簡易パース
-            var objectsMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"objects\"\\s*:\\s*\\{(.+)\\}\\s*\\}\\s*$");
-            if (!objectsMatch.Success) return;
+            var envId = SceneSyncWireJson.ExtractString(raw, "envId");
+            if (!string.IsNullOrWhiteSpace(envId))
+                _envId = envId;
 
-            var objectsBody = objectsMatch.Groups[1].Value;
-
-            // 各 "objectId":{...} を抽出（asset など1段ネストの {} を含む場合も対応）
-            var entryPattern = new System.Text.RegularExpressions.Regex(
-                "\"([^\"]+)\"\\s*:\\s*\\{((?:[^{}]|\\{[^{}]*\\})*)\\}");
-            var matches = entryPattern.Matches(objectsBody);
-
-            foreach (System.Text.RegularExpressions.Match m in matches)
+            foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(raw, "objects"))
             {
-                var objectId = m.Groups[1].Value;
-                var body = m.Groups[2].Value;
-
-                // scene-add 相当の JSON を構築して処理
-                var fakeJson = "{\"kind\":\"scene-add\",\"objectId\":\"" + objectId + "\"," + body + "}";
+                var fakeJson = "{\"kind\":\"scene-add\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(entry.Key) + "\"," + entry.Value.Trim().TrimStart('{');
                 Debug.Log("[SceneSync] Restore scene-state object as scene-add: " + fakeJson);
                 HandleSceneAdd(fakeJson);
             }
+        }
+
+        private void HandleSceneEnv(string raw)
+        {
+            var envId = SceneSyncWireJson.ExtractString(raw, "envId");
+            if (string.IsNullOrWhiteSpace(envId)) return;
+            _envId = envId;
+            Debug.Log("[SceneSync] scene-env received: envId=" + envId);
         }
 
         private void HandleSceneDelta(string raw)
@@ -1507,6 +1508,7 @@ namespace Afjk.SceneSync.Editor
 
             var objectId = identity.ObjectId;
             var path = PresenceClient.GenerateRandomPath();
+            var assetId = PresenceClientRuntime.ComputeAssetId(glb);
 
             var uploaded = await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
             if (!uploaded)
@@ -1524,6 +1526,7 @@ namespace Afjk.SceneSync.Editor
 
             _meshPaths[objectId] = path;
             identity.MeshPath = path;
+            identity.AssetId = assetId;
             identity.State = SceneSyncState.Synced;
             EditorUtility.SetDirty(identity);
             EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
@@ -1536,7 +1539,8 @@ namespace Afjk.SceneSync.Editor
                 ",\"rotation\":[" + FormatFloat(rot.x) + "," + FormatFloat(rot.y) + "," + FormatFloat(-rot.z) + "," + FormatFloat(-rot.w) + "]" +
                 ",\"scale\":[" + FormatFloat(scl.x) + "," + FormatFloat(scl.y) + "," + FormatFloat(scl.z) + "]" +
                 ",\"meshPath\":\"" + JsonEscape(path) + "\"" +
-                ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}}";
+                (!string.IsNullOrEmpty(assetId) ? ",\"assetId\":\"" + JsonEscape(assetId) + "\"" : "") +
+                ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") + "}";
             await _client.Broadcast(payload);
 
             _managedObjects[objectId] = go;
@@ -1680,6 +1684,13 @@ namespace Afjk.SceneSync.Editor
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
+            var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            if (string.IsNullOrEmpty(meshPath) && !string.IsNullOrEmpty(assetJson))
+                meshPath = SceneSyncWireJson.ExtractString(assetJson, "meshPath");
+            if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
+                assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
+
             // Extract visualBasis from asset JSON
             var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"visualBasis\":\"([^\"]+)\"");
@@ -1691,16 +1702,20 @@ namespace Afjk.SceneSync.Editor
                 _meshPaths[objectId] = meshPath;
             }
 
+            var assetType = SceneSyncWireJson.GetAssetType(assetJson);
+            var hasMeshAsset = !string.IsNullOrEmpty(meshPath)
+                || (assetType == "mesh"
+                    && SceneSyncWireJson.GetAssetSource(assetJson) == "url"
+                    && !string.IsNullOrEmpty(SceneSyncWireJson.GetAssetUrl(assetJson)));
+
             // メッシュがある場合は glB をダウンロードしてインポート
-            if (!string.IsNullOrEmpty(meshPath))
+            if (hasMeshAsset)
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson);
             }
             else
             {
-                // メッシュなしの場合はプレースホルダーの Cube を作成
-                var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                go.name = name;
+                var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                 ApplyTransform(go, position, rotation, scale);
@@ -1766,6 +1781,11 @@ namespace Afjk.SceneSync.Editor
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
+            var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
+                assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
+
             // Extract visualBasis from asset JSON
             var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"visualBasis\":\"([^\"]+)\"");
@@ -1791,6 +1811,7 @@ namespace Afjk.SceneSync.Editor
                     if (assetId != null) identity.AssetId = assetId;
                     EditorUtility.SetDirty(identity);
                 }
+                SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
                 Debug.Log("[SceneSync] Received scene-mesh for Unity-authored object; keeping local GameObject: " + objectId);
                 return;
             }
@@ -1808,11 +1829,11 @@ namespace Afjk.SceneSync.Editor
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId, visualBasis);
+                    assetId, visualBasis, assetJson, metadataJson);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson);
             }
         }
 
@@ -1853,10 +1874,6 @@ namespace Afjk.SceneSync.Editor
         {
             if (identity == null) return false;
 
-            // Do not re-export remote temporary objects received from Web.
-            if (identity.Origin == SceneSyncOrigin.Remote) return false;
-            if (identity.Temporary) return false;
-
             return true;
         }
 
@@ -1870,7 +1887,7 @@ namespace Afjk.SceneSync.Editor
             var objectsJson = new System.Text.StringBuilder();
             objectsJson.Append("{");
             bool first = true;
-            var pendingUploads = new List<(string objectId, byte[] glb, string path)>();
+            var pendingUploads = new List<(string objectId, byte[] glb, string path, string assetId)>();
             var objectData = new Dictionary<string, (GameObject go, string path, Transform transform)>();
             int sceneStateObjectCount = 0;
 
@@ -1878,15 +1895,16 @@ namespace Afjk.SceneSync.Editor
             {
                 if (!IsSyncTarget(go)) continue;
 
-                var objectId = go.GetInstanceID().ToString();
-
                 if (IsUnderSceneSyncInternalHierarchy(go))
                 {
-                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: objectId={objectId} name={go.name}");
+                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: name={go.name}");
                     continue;
                 }
 
                 var identity = go.GetComponent<SceneSyncIdentity>();
+                var objectId = identity != null && !string.IsNullOrWhiteSpace(identity.ObjectId)
+                    ? identity.ObjectId
+                    : go.GetInstanceID().ToString();
                 if (identity != null && !ShouldIncludeInUnitySceneState(identity))
                 {
                     Debug.Log($"[SceneSync] scene-state skip: objectId={objectId} origin={identity.Origin} temporary={identity.Temporary}");
@@ -1922,7 +1940,13 @@ namespace Afjk.SceneSync.Editor
                         }
 
                         path = PresenceClient.GenerateRandomPath();
-                        pendingUploads.Add((objectId, glb, path));
+                        var assetId = PresenceClientRuntime.ComputeAssetId(glb);
+                        pendingUploads.Add((objectId, glb, path, assetId));
+                        if (identity != null)
+                        {
+                            identity.AssetId = assetId;
+                            EditorUtility.SetDirty(identity);
+                        }
                     }
                 }
 
@@ -1957,12 +1981,22 @@ namespace Afjk.SceneSync.Editor
 
             // アップロードを先に完了させる
             var failedObjectIds = new HashSet<string>();
-            foreach (var (objectId, glb, path) in pendingUploads)
+            foreach (var (objectId, glb, path, assetId) in pendingUploads)
             {
                 var uploaded = await PresenceClient.UploadGlb(glb, GetBlobUrl(), path);
                 if (uploaded)
                 {
                     _meshPaths[objectId] = path;
+                    if (objectData.TryGetValue(objectId, out var data))
+                    {
+                        var identity = data.go.GetComponent<SceneSyncIdentity>();
+                        if (identity != null)
+                        {
+                            identity.MeshPath = path;
+                            identity.AssetId = assetId;
+                            EditorUtility.SetDirty(identity);
+                        }
+                    }
                 }
                 else
                 {
@@ -1990,11 +2024,26 @@ namespace Afjk.SceneSync.Editor
                 if (!first) objectsJson.Append(",");
                 first = false;
 
-                var isUnityVisualBasis = go.GetComponent<SceneSyncIdentity>() == null
-                    || go.GetComponent<SceneSyncIdentity>().Origin == SceneSyncOrigin.Unity;
+                var identity = go.GetComponent<SceneSyncIdentity>();
+                var isUnityVisualBasis = identity == null || identity.Origin == SceneSyncOrigin.Unity;
                 var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
-                var assetJson = path != null && isUnityVisualBasis
-                    ? ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}"
+                var assetId = identity != null ? identity.AssetId : null;
+                var assetIdJson = !string.IsNullOrEmpty(assetId) ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
+                var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
+                var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
+                var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
+                {
+                    rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
+                        path,
+                        assetId,
+                        isUnityVisualBasis ? "unity" : null);
+                }
+                var assetJson = !string.IsNullOrWhiteSpace(rawAssetJson)
+                    ? ",\"asset\":" + rawAssetJson
+                    : "";
+                var metadataJson = !string.IsNullOrWhiteSpace(rawMetadataJson)
+                    ? ",\"metadata\":" + rawMetadataJson
                     : "";
 
                 var pos = transform.position;
@@ -2005,13 +2054,16 @@ namespace Afjk.SceneSync.Editor
                     ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
                     ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
                     ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                    meshPathJson + assetJson + "}");
+                    meshPathJson + assetIdJson + assetJson + metadataJson + "}");
             }
 
             objectsJson.Append("}");
 
             // handoff で 1対1 返信（broadcast ではない）
-            var payload = "{\"kind\":\"scene-state\",\"objects\":" + objectsJson + "}";
+            var envJson = !string.IsNullOrWhiteSpace(_envId)
+                ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
+                : "";
+            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson + "}";
             await _client.SendHandoff(fromId, payload);
         }
 
@@ -2030,7 +2082,8 @@ namespace Afjk.SceneSync.Editor
 
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
-            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null)
+            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
+            string assetJson = null, string metadataJson = null)
         {
             try
             {
@@ -2039,7 +2092,12 @@ namespace Afjk.SceneSync.Editor
                     _meshPaths[objectId] = meshPath;
                 }
 
-                var url = GetBlobUrl() + "/" + meshPath;
+                var assetUrl = SceneSyncWireJson.GetAssetSource(assetJson) == "url"
+                    ? SceneSyncWireJson.GetAssetUrl(assetJson)
+                    : null;
+                var url = !string.IsNullOrWhiteSpace(assetUrl)
+                    ? assetUrl
+                    : GetBlobUrl() + "/" + meshPath;
                 Debug.Log("[SceneSync] Downloading mesh: " + url);
 
                 var http = new HttpClient();
@@ -2048,9 +2106,7 @@ namespace Afjk.SceneSync.Editor
                 if (!response.IsSuccessStatusCode)
                 {
                     Debug.LogWarning("[SceneSync] Download failed: " + response.StatusCode);
-                    // フォールバック: Cube を作成
-                    var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                    fallback.name = name;
+                    var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
@@ -2061,8 +2117,9 @@ namespace Afjk.SceneSync.Editor
                 }
 
                 var glbBytes = await response.Content.ReadAsByteArrayAsync();
+                var tempFileName = !string.IsNullOrEmpty(meshPath) ? meshPath : objectId;
                 var tempPath = System.IO.Path.Combine(
-                    Application.temporaryCachePath, meshPath + ".glb");
+                    Application.temporaryCachePath, tempFileName + ".glb");
                 System.IO.File.WriteAllBytes(tempPath, glbBytes);
 
                 // Editor モード: UninterruptedDeferAgent（DontDestroyOnLoad を使わない）
@@ -2080,6 +2137,7 @@ namespace Afjk.SceneSync.Editor
                 {
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                    SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -2109,8 +2167,7 @@ namespace Afjk.SceneSync.Editor
                 else
                 {
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
-                    var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                    fallback.name = name;
+                    var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -49,6 +49,7 @@ namespace Afjk.SceneSync
         private Dictionary<string, double> _responderCooldowns = new Dictionary<string, double>(); // cacheKey-peerId → timestamp
         private string _activeOutgoingTransferId = null;
         private readonly HashSet<string> _remoteRemovedUnityObjectIds = new HashSet<string>();
+        private string _envId = null;
 
         private const double RECOVERY_TIMEOUT_MS = 30000;
         private const double PEER_RETRY_INTERVAL_MS = 4000;
@@ -395,7 +396,8 @@ namespace Afjk.SceneSync
                 await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
 
                 var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
-                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + path + "\"" + assetIdJson + "}";
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + path + "\"" + assetIdJson +
+                    ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") + "}";
                 await _client.Broadcast(payload);
             }
         }
@@ -756,11 +758,14 @@ namespace Afjk.SceneSync
 
             var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
             var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
+            var assetJson = path != null
+                ? ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity")
+                : "";
             var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + go.GetInstanceID() + "\",\"name\":\"" + go.name + "\"" +
                 ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
                 ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
                 ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                meshPathJson + assetIdJson + "}";
+                meshPathJson + assetIdJson + assetJson + "}";
             await _client.Broadcast(payload);
 
             _knownObjectIds.Add(go.GetInstanceID().ToString());
@@ -808,6 +813,10 @@ namespace Afjk.SceneSync
             else if (raw.Contains("\"kind\":\"scene-state\""))
             {
                 HandleSceneState(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-env\""))
+            {
+                HandleSceneEnv(raw);
             }
             else if (raw.Contains("\"kind\":\"scene-batch\""))
             {
@@ -1107,28 +1116,24 @@ namespace Afjk.SceneSync
             _sceneReceived = true;
             Debug.Log("[SceneSync] Received scene-state");
 
-            // "objects":{...} の中身を簡易パース
-            var objectsMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"objects\"\\s*:\\s*\\{(.+)\\}\\s*\\}\\s*$");
-            if (!objectsMatch.Success) return;
+            var envId = SceneSyncWireJson.ExtractString(raw, "envId");
+            if (!string.IsNullOrWhiteSpace(envId))
+                _envId = envId;
 
-            var objectsBody = objectsMatch.Groups[1].Value;
-
-            // 各 "objectId":{...} を抽出（asset など1段ネストの {} を含む場合も対応）
-            var entryPattern = new System.Text.RegularExpressions.Regex(
-                "\"([^\"]+)\"\\s*:\\s*\\{((?:[^{}]|\\{[^{}]*\\})*)\\}");
-            var matches = entryPattern.Matches(objectsBody);
-
-            foreach (System.Text.RegularExpressions.Match m in matches)
+            foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(raw, "objects"))
             {
-                var objectId = m.Groups[1].Value;
-                var body = m.Groups[2].Value;
-
-                // scene-add 相当の JSON を構築して処理
-                var fakeJson = "{\"kind\":\"scene-add\",\"objectId\":\"" + objectId + "\"," + body + "}";
+                var fakeJson = "{\"kind\":\"scene-add\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(entry.Key) + "\"," + entry.Value.Trim().TrimStart('{');
                 Debug.Log("[SceneSync] Restore scene-state object as scene-add: " + fakeJson);
                 HandleSceneAdd(fakeJson);
             }
+        }
+
+        private void HandleSceneEnv(string raw)
+        {
+            var envId = SceneSyncWireJson.ExtractString(raw, "envId");
+            if (string.IsNullOrWhiteSpace(envId)) return;
+            _envId = envId;
+            Debug.Log("[SceneSync] scene-env received: envId=" + envId);
         }
 
         private void HandleSceneDelta(string raw)
@@ -1259,6 +1264,13 @@ namespace Afjk.SceneSync
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
+            var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            if (string.IsNullOrEmpty(meshPath) && !string.IsNullOrEmpty(assetJson))
+                meshPath = SceneSyncWireJson.ExtractString(assetJson, "meshPath");
+            if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
+                assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
+
             // Extract visualBasis from asset JSON
             var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"visualBasis\":\"([^\"]+)\"");
@@ -1287,14 +1299,21 @@ namespace Afjk.SceneSync
                 }
             }
 
+            var assetType = SceneSyncWireJson.GetAssetType(assetJson);
+            var hasMeshAsset = !string.IsNullOrEmpty(meshPath)
+                || (assetType == "mesh"
+                    && SceneSyncWireJson.GetAssetSource(assetJson) == "url"
+                    && !string.IsNullOrEmpty(SceneSyncWireJson.GetAssetUrl(assetJson)));
+
             // メッシュがある場合は glB をダウンロードしてインポート
-            if (!string.IsNullOrEmpty(meshPath))
+            if (hasMeshAsset)
             {
                 Debug.Log("[SceneSync] scene-add: creating remote temporary for objectId=" + objectId + ", meshPath=" + meshPath);
                 // プレースホルダーを先行登録（同期フェーズで登録を確実にする）
                 var placeholder = new GameObject(objectId);
                 placeholder.hideFlags = HideFlags.NotEditable;
                 ConfigureRemoteTemporaryIdentity(placeholder, objectId, meshPath, assetId);
+                SceneSyncPanelFactory.ConfigureWireMetadata(placeholder, assetJson, metadataJson);
                 placeholder.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                 _managedObjects[objectId] = placeholder;
@@ -1302,20 +1321,13 @@ namespace Afjk.SceneSync
                 _instanceToObjectId[placeholder.GetInstanceID()] = objectId;
 
                 // 非同期でダウンロード・インポート開始
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson);
             }
             else
             {
-                // Extract asset type for diagnostic logging
-                var assetTypeMatch = System.Text.RegularExpressions.Regex.Match(
-                    raw, "\"asset\"\\s*:\\s*\\{[^}]*\"type\"\\s*:\\s*\"([^\"]+)\"");
-                var assetType = assetTypeMatch.Success ? assetTypeMatch.Groups[1].Value : "unknown";
+                Debug.Log("[SceneSync] scene-add: assetType=" + assetType + " (no meshPath) → panel/primitive object for objectId=" + objectId);
 
-                // image / video / text are browser-only assets; Unity shows a Cube placeholder
-                Debug.Log("[SceneSync] scene-add: assetType=" + assetType + " (no meshPath) → Cube placeholder for objectId=" + objectId);
-
-                var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                go.name = name;
+                var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
@@ -1417,6 +1429,11 @@ namespace Afjk.SceneSync
                 raw, "\"assetId\":\"([^\"]+)\"");
             var assetId = assetIdMatch.Success ? assetIdMatch.Groups[1].Value : null;
 
+            var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
+            var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
+                assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
+
             // Extract visualBasis from asset JSON
             var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"visualBasis\":\"([^\"]+)\"");
@@ -1447,6 +1464,7 @@ namespace Afjk.SceneSync
                     identity.MeshPath = meshPath;
                     identity.AssetId = assetId;
                 }
+                SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
 
                 _managedObjects[objectId] = go;
                 _knownObjectIds.Add(objectId);
@@ -1469,11 +1487,11 @@ namespace Afjk.SceneSync
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId, visualBasis);
+                    assetId, visualBasis, assetJson, metadataJson);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson);
             }
         }
 
@@ -1514,10 +1532,6 @@ namespace Afjk.SceneSync
         {
             if (identity == null) return false;
 
-            // Do not re-export remote temporary objects received from Web.
-            if (identity.Origin == SceneSyncOrigin.Remote) return false;
-            if (identity.Temporary) return false;
-
             return true;
         }
 
@@ -1537,15 +1551,16 @@ namespace Afjk.SceneSync
             {
                 if (!IsSyncTarget(go)) continue;
 
-                var objectId = go.GetInstanceID().ToString();
-
                 if (IsUnderSceneSyncInternalHierarchy(go))
                 {
-                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: objectId={objectId} name={go.name}");
+                    Debug.Log($"[SceneSync] scene-state skip: internal hierarchy: name={go.name}");
                     continue;
                 }
 
                 var identity = go.GetComponent<SceneSyncIdentity>();
+                var objectId = identity != null && !string.IsNullOrWhiteSpace(identity.ObjectId)
+                    ? identity.ObjectId
+                    : go.GetInstanceID().ToString();
                 if (identity != null && !ShouldIncludeInUnitySceneState(identity))
                 {
                     Debug.Log($"[SceneSync] scene-state skip: objectId={objectId} origin={identity.Origin} temporary={identity.Temporary}");
@@ -1591,16 +1606,26 @@ namespace Afjk.SceneSync
 
                 if (!first) objectsJson.Append(",");
                 first = false;
-                var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
-                var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
-                var assetJson = path != null && isUnityVisualBasis
-                    ? ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}"
-                    : "";
-                objectsJson.Append("\"" + objectId + "\":{\"name\":\"" + go.name + "\"" +
-                    ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
-                    ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
-                    ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                    meshPathJson + assetIdJson + assetJson + "}");
+                var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
+                var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
+                var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
+                {
+                    rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
+                        path,
+                        assetId,
+                        isUnityVisualBasis ? "unity" : null);
+                }
+                objectsJson.Append(SceneSyncWireJson.BuildObjectJson(
+                    objectId,
+                    go.name,
+                    pos,
+                    rot,
+                    scl,
+                    path,
+                    assetId,
+                    rawAssetJson,
+                    rawMetadataJson));
                 sceneStateObjectCount++;
             }
 
@@ -1640,16 +1665,26 @@ namespace Afjk.SceneSync
 
                 if (!first) objectsJson.Append(",");
                 first = false;
-                var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
-                var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
-                var assetJson = path != null && isUnityVisualBasis
-                    ? ",\"asset\":{\"type\":\"mesh\",\"visualBasis\":\"unity\"}"
-                    : "";
-                objectsJson.Append("\"" + kvp.Key + "\":{\"name\":\"" + go.name + "\"" +
-                    ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
-                    ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
-                    ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                    meshPathJson + assetIdJson + assetJson + "}");
+                var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
+                var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
+                var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
+                {
+                    rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
+                        path,
+                        assetId,
+                        isUnityVisualBasis ? "unity" : null);
+                }
+                objectsJson.Append(SceneSyncWireJson.BuildObjectJson(
+                    kvp.Key,
+                    go.name,
+                    pos,
+                    rot,
+                    scl,
+                    path,
+                    assetId,
+                    rawAssetJson,
+                    rawMetadataJson));
                 sceneStateObjectCount++;
             }
 
@@ -1662,7 +1697,10 @@ namespace Afjk.SceneSync
                 await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
 
             // handoff で 1対1 返信（broadcast ではない）
-            var payload = "{\"kind\":\"scene-state\",\"objects\":" + objectsJson + "}";
+            var envJson = !string.IsNullOrWhiteSpace(_envId)
+                ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
+                : "";
+            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson + "}";
             await _client.SendHandoff(fromId, payload);
         }
 
@@ -1813,13 +1851,14 @@ namespace Afjk.SceneSync
             float[] position,
             float[] rotation,
             float[] scale,
-            string assetId = null)
+            string assetId = null,
+            string assetJson = null,
+            string metadataJson = null)
         {
             var placeholder = _managedObjects[objectId];
             var placeholderInstanceId = placeholder.GetInstanceID();
 
-            var fallback = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            fallback.name = name;
+            var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
             ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
             fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
@@ -1840,7 +1879,8 @@ namespace Afjk.SceneSync
 
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
-            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null)
+            float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
+            string assetJson = null, string metadataJson = null)
         {
             _knownObjectIds.Add(objectId);
 
@@ -1866,7 +1906,12 @@ namespace Afjk.SceneSync
             // Download if not in cache
             if (glbBytes == null)
             {
-                var url = GetBlobUrl() + "/" + meshPath;
+                var assetUrl = SceneSyncWireJson.GetAssetSource(assetJson) == "url"
+                    ? SceneSyncWireJson.GetAssetUrl(assetJson)
+                    : null;
+                var url = !string.IsNullOrWhiteSpace(assetUrl)
+                    ? assetUrl
+                    : GetBlobUrl() + "/" + meshPath;
                 Debug.Log(
                     "[SceneSync] Downloading mesh: url=" + url
                     + ", objectId=" + objectId
@@ -1901,7 +1946,7 @@ namespace Afjk.SceneSync
                         _ = HandleMissingGlb(objectId, meshPath, null, assetId);
                     }
 
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -1917,8 +1962,9 @@ namespace Afjk.SceneSync
 
             try
             {
+                var tempFileName = !string.IsNullOrEmpty(meshPath) ? meshPath : objectId;
                 var tempPath = System.IO.Path.Combine(
-                    Application.temporaryCachePath, meshPath + ".glb");
+                    Application.temporaryCachePath, tempFileName + ".glb");
                 System.IO.File.WriteAllBytes(tempPath, glbBytes);
 
                 Debug.Log(
@@ -1930,7 +1976,7 @@ namespace Afjk.SceneSync
                 var deferAgent = gameObject.AddComponent<TimeBudgetPerFrameDeferAgent>();
                 var importSettings = new ImportSettings
                 {
-                    AnimationMethod = AnimationMethod.None,
+                    AnimationMethod = AnimationMethod.Mecanim,
                 };
                 var gltf = new GltfImport(
                     downloadProvider: null,
@@ -1961,6 +2007,7 @@ namespace Afjk.SceneSync
 
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                    SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -1992,6 +2039,7 @@ namespace Afjk.SceneSync
                         + ", placeholder=" + DescribeGameObject(placeholder));
                     await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);
                     ApplyFallbackMaterialToRenderers(go, replaceAll: false, reason: "post-import broken materials");
+                    PlayImportedAnimations(go);
 
                     // 位置・回転・スケールを設定
                     ApplyTransform(go, position, rotation, scale);
@@ -2016,7 +2064,7 @@ namespace Afjk.SceneSync
                         + ", loadingError=" + gltf.LoadingError
                         + ", sceneCount=" + gltf.SceneCount
                         + ", defaultScene=" + (gltf.DefaultSceneIndex.HasValue ? gltf.DefaultSceneIndex.Value.ToString() : "null"));
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                 }
 
@@ -2055,7 +2103,7 @@ namespace Afjk.SceneSync
 
                 if (_managedObjects.ContainsKey(objectId))
                 {
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -2080,6 +2128,25 @@ namespace Afjk.SceneSync
         {
             var identity = EnsureSceneSyncIdentity(go);
             identity.ConfigureRemoteTemporary(objectId, meshPath, assetId);
+        }
+
+        private static void PlayImportedAnimations(GameObject go)
+        {
+            if (go == null) return;
+
+            foreach (var animator in go.GetComponentsInChildren<Animator>(true))
+            {
+                animator.enabled = true;
+                if (animator.runtimeAnimatorController != null)
+                    animator.Play(0, 0, 0f);
+            }
+
+            foreach (var animation in go.GetComponentsInChildren<Animation>(true))
+            {
+                animation.enabled = true;
+                animation.playAutomatically = true;
+                animation.Play();
+            }
         }
 
         private void EnsureManagedObjectsList()
@@ -2426,7 +2493,7 @@ namespace Afjk.SceneSync
                 var deferAgent = gameObject.AddComponent<TimeBudgetPerFrameDeferAgent>();
                 var importSettings = new ImportSettings
                 {
-                    AnimationMethod = AnimationMethod.None,
+                    AnimationMethod = AnimationMethod.Mecanim,
                 };
                 var gltf = new GltfImport(downloadProvider: null, deferAgent: deferAgent);
                 var success = await gltf.Load("file://" + tempPath, importSettings);
@@ -2451,6 +2518,7 @@ namespace Afjk.SceneSync
 
                     await gltf.InstantiateMainSceneAsync(importedGlbRoot.transform);
                     ApplyFallbackMaterialToRenderers(newGo, replaceAll: false, reason: "post-recovery import");
+                    PlayImportedAnimations(newGo);
                     ApplyTransform(newGo, position, rotation, scale);
 
                     OnObjectAdded?.Invoke(objectId, newGo);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
@@ -1,0 +1,467 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Video;
+
+namespace Afjk.SceneSync
+{
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncWireMetadata : MonoBehaviour
+    {
+        [SerializeField] private string assetJson;
+        [SerializeField] private string metadataJson;
+
+        public string AssetJson
+        {
+            get => assetJson;
+            set => assetJson = value;
+        }
+
+        public string MetadataJson
+        {
+            get => metadataJson;
+            set => metadataJson = value;
+        }
+
+        public void Configure(string newAssetJson, string newMetadataJson)
+        {
+            assetJson = string.IsNullOrWhiteSpace(newAssetJson) ? null : newAssetJson;
+            metadataJson = string.IsNullOrWhiteSpace(newMetadataJson) ? null : newMetadataJson;
+        }
+    }
+
+    public static class SceneSyncWireJson
+    {
+        public static string JsonEscape(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return "";
+            return value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r");
+        }
+
+        public static string FormatFloat(float value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string ExtractString(string json, string fieldName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
+            var match = Regex.Match(
+                json,
+                "\"" + Regex.Escape(fieldName) + "\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"");
+            if (!match.Success) return null;
+            return UnescapeJsonString(match.Groups[1].Value);
+        }
+
+        public static string ExtractRawObject(string json, string fieldName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
+
+            var token = "\"" + fieldName + "\"";
+            var fieldIndex = json.IndexOf(token, StringComparison.Ordinal);
+            if (fieldIndex < 0) return null;
+
+            var colon = json.IndexOf(':', fieldIndex + token.Length);
+            if (colon < 0) return null;
+
+            var objectStart = json.IndexOf('{', colon + 1);
+            if (objectStart < 0) return null;
+
+            var objectEnd = FindMatching(json, objectStart, '{', '}');
+            if (objectEnd < 0) return null;
+            return json.Substring(objectStart, objectEnd - objectStart + 1);
+        }
+
+        public static List<KeyValuePair<string, string>> ExtractObjectMapEntries(string json, string fieldName)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+            var mapJson = ExtractRawObject(json, fieldName);
+            if (string.IsNullOrEmpty(mapJson)) return result;
+
+            var i = 1; // skip opening {
+            while (i < mapJson.Length - 1)
+            {
+                SkipWhitespaceAndComma(mapJson, ref i);
+                if (i >= mapJson.Length - 1 || mapJson[i] != '"') break;
+
+                var keyEnd = FindStringEnd(mapJson, i);
+                if (keyEnd < 0) break;
+                var key = UnescapeJsonString(mapJson.Substring(i + 1, keyEnd - i - 1));
+                i = keyEnd + 1;
+
+                SkipWhitespace(mapJson, ref i);
+                if (i >= mapJson.Length || mapJson[i] != ':') break;
+                i++;
+                SkipWhitespace(mapJson, ref i);
+                if (i >= mapJson.Length || mapJson[i] != '{') break;
+
+                var valueEnd = FindMatching(mapJson, i, '{', '}');
+                if (valueEnd < 0) break;
+                result.Add(new KeyValuePair<string, string>(key, mapJson.Substring(i, valueEnd - i + 1)));
+                i = valueEnd + 1;
+            }
+
+            return result;
+        }
+
+        public static float[] ExtractArray(string json, string fieldName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
+
+            var key = "\"" + fieldName + "\"";
+            var keyIndex = json.IndexOf(key, StringComparison.Ordinal);
+            if (keyIndex < 0) return null;
+            var start = json.IndexOf('[', keyIndex + key.Length);
+            if (start < 0) return null;
+            var end = json.IndexOf(']', start + 1);
+            if (end < 0) return null;
+
+            var nums = json.Substring(start + 1, end - start - 1).Split(',');
+            var result = new float[nums.Length];
+            for (var i = 0; i < nums.Length; i++)
+            {
+                if (float.TryParse(
+                    nums[i].Trim(),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var f))
+                {
+                    result[i] = f;
+                }
+            }
+            return result;
+        }
+
+        public static string BuildMeshAssetJson(string meshPath, string assetId, string visualBasis)
+        {
+            var builder = new StringBuilder();
+            builder.Append("{\"type\":\"mesh\",\"source\":\"carrier\"");
+            if (!string.IsNullOrEmpty(meshPath))
+                builder.Append(",\"meshPath\":\"").Append(JsonEscape(meshPath)).Append("\"");
+            if (!string.IsNullOrEmpty(assetId))
+                builder.Append(",\"assetId\":\"").Append(JsonEscape(assetId)).Append("\"");
+            if (!string.IsNullOrEmpty(visualBasis))
+                builder.Append(",\"visualBasis\":\"").Append(JsonEscape(visualBasis)).Append("\"");
+            builder.Append("}");
+            return builder.ToString();
+        }
+
+        public static string BuildObjectJson(
+            string objectId,
+            string name,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 scale,
+            string meshPath,
+            string assetId,
+            string assetJson,
+            string metadataJson)
+        {
+            var builder = new StringBuilder();
+            builder.Append("\"").Append(JsonEscape(objectId)).Append("\":{");
+            builder.Append("\"name\":\"").Append(JsonEscape(name)).Append("\"");
+            builder.Append(",\"position\":[")
+                .Append(FormatFloat(position.x)).Append(",")
+                .Append(FormatFloat(position.y)).Append(",")
+                .Append(FormatFloat(-position.z)).Append("]");
+            builder.Append(",\"rotation\":[")
+                .Append(FormatFloat(rotation.x)).Append(",")
+                .Append(FormatFloat(rotation.y)).Append(",")
+                .Append(FormatFloat(-rotation.z)).Append(",")
+                .Append(FormatFloat(-rotation.w)).Append("]");
+            builder.Append(",\"scale\":[")
+                .Append(FormatFloat(scale.x)).Append(",")
+                .Append(FormatFloat(scale.y)).Append(",")
+                .Append(FormatFloat(scale.z)).Append("]");
+            if (!string.IsNullOrEmpty(meshPath))
+                builder.Append(",\"meshPath\":\"").Append(JsonEscape(meshPath)).Append("\"");
+            if (!string.IsNullOrEmpty(assetId))
+                builder.Append(",\"assetId\":\"").Append(JsonEscape(assetId)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(assetJson))
+                builder.Append(",\"asset\":").Append(assetJson);
+            if (!string.IsNullOrWhiteSpace(metadataJson))
+                builder.Append(",\"metadata\":").Append(metadataJson);
+            builder.Append("}");
+            return builder.ToString();
+        }
+
+        public static string GetAssetType(string assetJson)
+        {
+            return ExtractString(assetJson, "type");
+        }
+
+        public static string GetAssetSource(string assetJson)
+        {
+            return ExtractString(assetJson, "source");
+        }
+
+        public static string GetAssetUrl(string assetJson)
+        {
+            return ExtractString(assetJson, "url");
+        }
+
+        public static string GetAssetPrimitive(string assetJson)
+        {
+            return ExtractString(assetJson, "primitive");
+        }
+
+        public static string GetAssetColor(string assetJson)
+        {
+            return ExtractString(assetJson, "color");
+        }
+
+        private static int FindMatching(string text, int start, char open, char close)
+        {
+            var depth = 0;
+            var inString = false;
+            var escape = false;
+
+            for (var i = start; i < text.Length; i++)
+            {
+                var ch = text[i];
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inString = !inString;
+                    continue;
+                }
+
+                if (inString) continue;
+
+                if (ch == open) depth++;
+                else if (ch == close)
+                {
+                    depth--;
+                    if (depth == 0) return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int FindStringEnd(string text, int startQuote)
+        {
+            var escape = false;
+            for (var i = startQuote + 1; i < text.Length; i++)
+            {
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+                if (text[i] == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+                if (text[i] == '"') return i;
+            }
+            return -1;
+        }
+
+        private static void SkipWhitespaceAndComma(string text, ref int index)
+        {
+            while (index < text.Length && (char.IsWhiteSpace(text[index]) || text[index] == ','))
+                index++;
+        }
+
+        private static void SkipWhitespace(string text, ref int index)
+        {
+            while (index < text.Length && char.IsWhiteSpace(text[index]))
+                index++;
+        }
+
+        private static string UnescapeJsonString(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            return value
+                .Replace("\\\"", "\"")
+                .Replace("\\\\", "\\")
+                .Replace("\\n", "\n")
+                .Replace("\\r", "\r")
+                .Replace("\\t", "\t");
+        }
+    }
+
+    public static class SceneSyncPanelFactory
+    {
+        private static readonly HttpClient Http = new HttpClient();
+
+        public static GameObject CreateObjectForAsset(string name, string assetJson, string metadataJson)
+        {
+            var assetType = SceneSyncWireJson.GetAssetType(assetJson);
+            GameObject go;
+
+            switch (assetType)
+            {
+                case "primitive":
+                    go = CreatePrimitive(assetJson);
+                    go.name = name;
+                    break;
+                case "image":
+                    go = CreatePanel(name, "ImagePanel");
+                    _ = ApplyImageTexture(go, SceneSyncWireJson.GetAssetUrl(assetJson));
+                    break;
+                case "video":
+                    go = CreatePanel(name, "VideoPanel");
+                    ApplyVideoTexture(go, SceneSyncWireJson.GetAssetUrl(assetJson));
+                    break;
+                case "text":
+                    go = CreateTextPanel(name, SceneSyncWireJson.ExtractString(assetJson, "text") ?? SceneSyncWireJson.GetAssetUrl(assetJson) ?? "Text");
+                    break;
+                default:
+                    go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                    go.name = name;
+                    break;
+            }
+
+            var wire = EnsureWireMetadata(go);
+            wire.Configure(assetJson, metadataJson);
+            return go;
+        }
+
+        public static void ConfigureWireMetadata(GameObject go, string assetJson, string metadataJson)
+        {
+            if (go == null) return;
+            EnsureWireMetadata(go).Configure(assetJson, metadataJson);
+        }
+
+        private static SceneSyncWireMetadata EnsureWireMetadata(GameObject go)
+        {
+            var metadata = go.GetComponent<SceneSyncWireMetadata>();
+            if (metadata == null) metadata = go.AddComponent<SceneSyncWireMetadata>();
+            return metadata;
+        }
+
+        private static GameObject CreatePrimitive(string assetJson)
+        {
+            var primitive = SceneSyncWireJson.GetAssetPrimitive(assetJson);
+            var type = PrimitiveType.Cube;
+            if (primitive == "sphere") type = PrimitiveType.Sphere;
+            else if (primitive == "cylinder") type = PrimitiveType.Cylinder;
+            else if (primitive == "plane") type = PrimitiveType.Plane;
+            else if (primitive == "capsule") type = PrimitiveType.Capsule;
+
+            var go = GameObject.CreatePrimitive(type);
+            ApplyColor(go, SceneSyncWireJson.GetAssetColor(assetJson));
+            return go;
+        }
+
+        private static GameObject CreatePanel(string name, string childName)
+        {
+            var go = new GameObject(name);
+            var panel = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            panel.name = childName;
+            panel.transform.SetParent(go.transform, worldPositionStays: false);
+            panel.transform.localPosition = Vector3.zero;
+            panel.transform.localRotation = Quaternion.identity;
+            panel.transform.localScale = Vector3.one;
+            return go;
+        }
+
+        private static GameObject CreateTextPanel(string name, string text)
+        {
+            var go = CreatePanel(name, "TextPanelBackground");
+            ApplyColor(go.transform.GetChild(0).gameObject, "#202020");
+
+            var textObject = new GameObject("Text");
+            textObject.transform.SetParent(go.transform, worldPositionStays: false);
+            textObject.transform.localPosition = new Vector3(-0.45f, 0.2f, -0.01f);
+            textObject.transform.localRotation = Quaternion.identity;
+            textObject.transform.localScale = Vector3.one * 0.08f;
+
+            var textMesh = textObject.AddComponent<TextMesh>();
+            textMesh.text = text.Length > 512 ? text.Substring(0, 512) : text;
+            textMesh.anchor = TextAnchor.UpperLeft;
+            textMesh.alignment = TextAlignment.Left;
+            textMesh.fontSize = 32;
+            textMesh.color = Color.white;
+            return go;
+        }
+
+        private static async Task ApplyImageTexture(GameObject root, string url)
+        {
+            if (root == null || string.IsNullOrWhiteSpace(url)) return;
+
+            try
+            {
+                var bytes = await Http.GetByteArrayAsync(url);
+                var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                if (!texture.LoadImage(bytes)) return;
+                texture.name = "SceneSyncImage";
+
+                var renderer = root.GetComponentInChildren<Renderer>();
+                if (renderer == null) return;
+                var material = new Material(Shader.Find("Unlit/Texture") ?? Shader.Find("Standard"));
+                material.mainTexture = texture;
+                renderer.sharedMaterial = material;
+
+                var aspect = texture.height > 0 ? (float)texture.width / texture.height : 1f;
+                var panel = renderer.transform;
+                panel.localScale = aspect >= 1f
+                    ? new Vector3(Mathf.Min(aspect, 3f), 1f, 1f)
+                    : new Vector3(1f, Mathf.Min(1f / aspect, 3f), 1f);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[SceneSync] Failed to load image panel texture: " + ex.Message);
+            }
+        }
+
+        private static void ApplyVideoTexture(GameObject root, string url)
+        {
+            if (root == null || string.IsNullOrWhiteSpace(url)) return;
+
+            var renderer = root.GetComponentInChildren<Renderer>();
+            if (renderer == null) return;
+
+            var texture = new RenderTexture(1024, 576, 0);
+            texture.name = "SceneSyncVideo";
+            var material = new Material(Shader.Find("Unlit/Texture") ?? Shader.Find("Standard"));
+            material.mainTexture = texture;
+            renderer.sharedMaterial = material;
+
+            var player = root.AddComponent<VideoPlayer>();
+            player.source = VideoSource.Url;
+            player.url = url;
+            player.isLooping = true;
+            player.playOnAwake = true;
+            player.renderMode = VideoRenderMode.RenderTexture;
+            player.targetTexture = texture;
+            player.audioOutputMode = VideoAudioOutputMode.None;
+            player.Prepare();
+            player.prepareCompleted += p => p.Play();
+        }
+
+        private static void ApplyColor(GameObject go, string htmlColor)
+        {
+            if (go == null || string.IsNullOrEmpty(htmlColor)) return;
+            if (!ColorUtility.TryParseHtmlString(htmlColor, out var color)) return;
+            var renderer = go.GetComponent<Renderer>();
+            if (renderer == null) return;
+            var material = new Material(Shader.Find("Standard"));
+            material.color = color;
+            renderer.sharedMaterial = material;
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cbbeae5e5f9498b9cc7696c3db51098
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Add a Runtime-side `SceneSyncWireMetadata` component and wire JSON helpers to preserve raw `asset` and `metadata` payloads.
- Update Unity Runtime and Editor scene-state handling to round-trip `asset`, `metadata`, `assetId`, `visualBasis`, and `envId` instead of dropping Web-authored panel metadata.
- Add initial handling for non-carrier assets and URL mesh metadata so Unity can keep scene restoration stable when it becomes the scene-state source.
- Keep Editor-side received GLB animation playback out of scope; Runtime imports received GLB animations with Mecanim.

## Why

Web Scene Sync now represents image/video/text as panel assets instead of always baking them into carrier GLB. Unity previously only tracked `meshPath` / `assetId` and would lose panel metadata when responding to `scene-state`, making Web scene restoration unstable after Unity joined the room.

## Validation

- Ran `dotnet build SceneSyncClient/SceneSyncClient.sln --no-restore` with the generated Unity csproj temporarily including the new Runtime source file. The build succeeded; existing warnings remain from unrelated Unity/dependency references.

## Notes

- `SceneSyncClient` generated csproj files are not part of this PR. Unity package import should pick up the new `.cs` file via the package source and `.meta`.
- Existing untracked `unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs.meta` was left out of this PR.