### PR TITLE
[codex] Support Unity visual scene deltas

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1113,6 +1113,8 @@ namespace Afjk.SceneSync.Editor
             if (!objectIdMatch.Success) return;
             var objectId = objectIdMatch.Groups[1].Value;
 
+            var name = SceneSyncWireJson.ExtractString(raw, "name");
+            var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
             float[] position = ExtractArray(raw, "\"position\":");
             float[] rotation = ExtractArray(raw, "\"rotation\":");
             float[] scale = ExtractArray(raw, "\"scale\":");
@@ -1122,9 +1124,16 @@ namespace Afjk.SceneSync.Editor
             var go = FindManagedObject(objectId);
             if (go == null) return;
 
+            if (!string.IsNullOrWhiteSpace(name))
+                go.name = name;
+
+            if (visible.HasValue)
+                go.SetActive(visible.Value);
+
             if (!string.IsNullOrWhiteSpace(assetJson) || !string.IsNullOrWhiteSpace(metadataJson))
             {
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+                SceneSyncPanelFactory.ApplyAssetVisualDelta(go, assetJson);
 
                 if (!string.IsNullOrWhiteSpace(assetJson))
                 {
@@ -1684,6 +1693,7 @@ namespace Afjk.SceneSync.Editor
             var nameMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"name\":\"([^\"]+)\"");
             var name = nameMatch.Success ? nameMatch.Groups[1].Value : objectId;
+            var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
             float[] rotation = ExtractArray(raw, "\"rotation\":");
@@ -1738,12 +1748,13 @@ namespace Afjk.SceneSync.Editor
             // メッシュがある場合は glB をダウンロードしてインポート
             if (hasMeshAsset)
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible);
             }
             else
             {
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                 ApplyTransform(go, position, rotation, scale);
                 _managedObjects[objectId] = go;
@@ -2081,6 +2092,7 @@ namespace Afjk.SceneSync.Editor
                     ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
                     ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
                     ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
+                    ",\"visible\":" + (go.activeSelf ? "true" : "false") +
                     meshPathJson + assetIdJson + assetJson + metadataJson + "}");
             }
 
@@ -2110,7 +2122,7 @@ namespace Afjk.SceneSync.Editor
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
             float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
-            string assetJson = null, string metadataJson = null)
+            string assetJson = null, string metadataJson = null, bool? visible = null)
         {
             try
             {
@@ -2135,6 +2147,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] Download failed: " + response.StatusCode);
                     var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                    if (visible.HasValue) fallback.SetActive(visible.Value);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;
@@ -2165,6 +2178,7 @@ namespace Afjk.SceneSync.Editor
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -2196,6 +2210,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
                     var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                    if (visible.HasValue) fallback.SetActive(visible.Value);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
                     _managedObjects[objectId] = fallback;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1143,6 +1143,8 @@ namespace Afjk.SceneSync
             if (!objectIdMatch.Success) return;
             var objectId = objectIdMatch.Groups[1].Value;
 
+            var name = SceneSyncWireJson.ExtractString(raw, "name");
+            var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
             float[] position = ExtractArray(raw, "\"position\":");
             float[] rotation = ExtractArray(raw, "\"rotation\":");
             float[] scale = ExtractArray(raw, "\"scale\":");
@@ -1152,9 +1154,16 @@ namespace Afjk.SceneSync
             var go = FindManagedObject(objectId);
             if (go == null) return;
 
+            if (!string.IsNullOrWhiteSpace(name))
+                go.name = name;
+
+            if (visible.HasValue)
+                go.SetActive(visible.Value);
+
             if (!string.IsNullOrWhiteSpace(assetJson) || !string.IsNullOrWhiteSpace(metadataJson))
             {
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+                SceneSyncPanelFactory.ApplyAssetVisualDelta(go, assetJson);
 
                 if (!string.IsNullOrWhiteSpace(assetJson))
                 {
@@ -1259,6 +1268,7 @@ namespace Afjk.SceneSync
             var nameMatch = System.Text.RegularExpressions.Regex.Match(
                 raw, "\"name\":\"([^\"]+)\"");
             var name = nameMatch.Success ? nameMatch.Groups[1].Value : objectId;
+            var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
             float[] rotation = ExtractArray(raw, "\"rotation\":");
@@ -1337,6 +1347,7 @@ namespace Afjk.SceneSync
                 placeholder.hideFlags = HideFlags.NotEditable;
                 ConfigureRemoteTemporaryIdentity(placeholder, objectId, meshPath, assetId);
                 SceneSyncPanelFactory.ConfigureWireMetadata(placeholder, assetJson, metadataJson);
+                if (visible.HasValue) placeholder.SetActive(visible.Value);
                 placeholder.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                 _managedObjects[objectId] = placeholder;
@@ -1344,7 +1355,7 @@ namespace Afjk.SceneSync
                 _instanceToObjectId[placeholder.GetInstanceID()] = objectId;
 
                 // 非同期でダウンロード・インポート開始
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible);
             }
             else
             {
@@ -1352,6 +1363,7 @@ namespace Afjk.SceneSync
 
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
                 _managedObjects[objectId] = go;
@@ -1645,6 +1657,7 @@ namespace Afjk.SceneSync
                     pos,
                     rot,
                     scl,
+                    go.activeSelf,
                     path,
                     assetId,
                     rawAssetJson,
@@ -1704,6 +1717,7 @@ namespace Afjk.SceneSync
                     pos,
                     rot,
                     scl,
+                    go.activeSelf,
                     path,
                     assetId,
                     rawAssetJson,
@@ -1876,13 +1890,15 @@ namespace Afjk.SceneSync
             float[] scale,
             string assetId = null,
             string assetJson = null,
-            string metadataJson = null)
+            string metadataJson = null,
+            bool? visible = null)
         {
             var placeholder = _managedObjects[objectId];
             var placeholderInstanceId = placeholder.GetInstanceID();
 
             var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
             ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+            if (visible.HasValue) fallback.SetActive(visible.Value);
             fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
             var fallbackMaterial = GetFallbackImportMaterial();
@@ -1903,7 +1919,7 @@ namespace Afjk.SceneSync
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
             float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
-            string assetJson = null, string metadataJson = null)
+            string assetJson = null, string metadataJson = null, bool? visible = null)
         {
             _knownObjectIds.Add(objectId);
 
@@ -1969,7 +1985,7 @@ namespace Afjk.SceneSync
                         _ = HandleMissingGlb(objectId, meshPath, null, assetId);
                     }
 
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -2031,6 +2047,7 @@ namespace Afjk.SceneSync
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
                     importedGlbRoot.transform.SetParent(go.transform, worldPositionStays: false);
@@ -2087,7 +2104,7 @@ namespace Afjk.SceneSync
                         + ", loadingError=" + gltf.LoadingError
                         + ", sceneCount=" + gltf.SceneCount
                         + ", defaultScene=" + (gltf.DefaultSceneIndex.HasValue ? gltf.DefaultSceneIndex.Value.ToString() : "null"));
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
                     OnObjectAdded?.Invoke(objectId, fallback);
                 }
 
@@ -2126,7 +2143,7 @@ namespace Afjk.SceneSync
 
                 if (_managedObjects.ContainsKey(objectId))
                 {
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
@@ -62,6 +62,34 @@ namespace Afjk.SceneSync
             return UnescapeJsonString(match.Groups[1].Value);
         }
 
+        public static bool? ExtractBoolean(string json, string fieldName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
+            var match = Regex.Match(
+                json,
+                "\"" + Regex.Escape(fieldName) + "\"\\s*:\\s*(true|false)");
+            if (!match.Success) return null;
+            return match.Groups[1].Value == "true";
+        }
+
+        public static float? ExtractFloat(string json, string fieldName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
+            var match = Regex.Match(
+                json,
+                "\"" + Regex.Escape(fieldName) + "\"\\s*:\\s*(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)");
+            if (!match.Success) return null;
+            if (float.TryParse(
+                match.Groups[1].Value,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var value))
+            {
+                return value;
+            }
+            return null;
+        }
+
         public static string ExtractRawObject(string json, string fieldName)
         {
             if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return null;
@@ -161,6 +189,7 @@ namespace Afjk.SceneSync
             Vector3 position,
             Quaternion rotation,
             Vector3 scale,
+            bool visible,
             string meshPath,
             string assetId,
             string assetJson,
@@ -182,6 +211,7 @@ namespace Afjk.SceneSync
                 .Append(FormatFloat(scale.x)).Append(",")
                 .Append(FormatFloat(scale.y)).Append(",")
                 .Append(FormatFloat(scale.z)).Append("]");
+            builder.Append(",\"visible\":").Append(visible ? "true" : "false");
             if (!string.IsNullOrEmpty(meshPath))
                 builder.Append(",\"meshPath\":\"").Append(JsonEscape(meshPath)).Append("\"");
             if (!string.IsNullOrEmpty(assetId))
@@ -365,7 +395,9 @@ namespace Afjk.SceneSync
             else if (assetType == "video")
                 ApplyVideoTexture(go, SceneSyncWireJson.GetAssetUrl(assetJson));
             else if (assetType == "text")
-                ApplyText(go, GetTextForAsset(assetJson));
+                ApplyTextPanelStyle(go, assetJson, updateText: true);
+            else if (SceneSyncWireJson.GetAssetColor(assetJson) != null)
+                ApplyColorToRenderers(go, SceneSyncWireJson.GetAssetColor(assetJson));
         }
 
         private static SceneSyncWireMetadata EnsureWireMetadata(GameObject go)
@@ -385,7 +417,7 @@ namespace Afjk.SceneSync
             else if (primitive == "capsule") type = PrimitiveType.Capsule;
 
             var go = GameObject.CreatePrimitive(type);
-            ApplyColor(go, SceneSyncWireJson.GetAssetColor(assetJson));
+            ApplyColorToRenderers(go, SceneSyncWireJson.GetAssetColor(assetJson));
             return go;
         }
 
@@ -432,6 +464,45 @@ namespace Afjk.SceneSync
             var textMesh = root.GetComponentInChildren<TextMesh>();
             if (textMesh == null) textMesh = AddTextMesh(root, text);
             else textMesh.text = LimitText(text);
+        }
+
+        private static void ApplyTextPanelStyle(GameObject root, string assetJson, bool updateText)
+        {
+            if (root == null) return;
+
+            var textMesh = root.GetComponentInChildren<TextMesh>();
+            if (textMesh == null) textMesh = AddTextMesh(root, GetTextForAsset(assetJson));
+            else if (updateText) textMesh.text = LimitText(GetTextForAsset(assetJson));
+
+            var textColor = SceneSyncWireJson.ExtractString(assetJson, "color");
+            if (!string.IsNullOrWhiteSpace(textColor) && TryParseCssColor(textColor, out var parsedTextColor))
+                textMesh.color = parsedTextColor;
+
+            var fontSize = SceneSyncWireJson.ExtractFloat(assetJson, "fontSize");
+            if (fontSize.HasValue)
+                textMesh.fontSize = Mathf.Max(1, Mathf.RoundToInt(fontSize.Value));
+
+            var backgroundColor = SceneSyncWireJson.ExtractString(assetJson, "backgroundColor");
+            if (!string.IsNullOrWhiteSpace(backgroundColor))
+            {
+                var renderer = FindTextBackgroundRenderer(root);
+                if (renderer != null) ApplyColor(renderer.gameObject, backgroundColor);
+            }
+        }
+
+        public static void ApplyAssetVisualDelta(GameObject go, string assetJson)
+        {
+            if (go == null || string.IsNullOrWhiteSpace(assetJson)) return;
+
+            if (SceneSyncWireJson.GetAssetType(assetJson) == "text")
+            {
+                ApplyTextPanelStyle(go, assetJson, updateText: false);
+                return;
+            }
+
+            var color = SceneSyncWireJson.GetAssetColor(assetJson);
+            if (!string.IsNullOrWhiteSpace(color))
+                ApplyColorToRenderers(go, color);
         }
 
         private static string GetTextForAsset(string assetJson)
@@ -522,12 +593,86 @@ namespace Afjk.SceneSync
         private static void ApplyColor(GameObject go, string htmlColor)
         {
             if (go == null || string.IsNullOrEmpty(htmlColor)) return;
-            if (!ColorUtility.TryParseHtmlString(htmlColor, out var color)) return;
+            if (!TryParseCssColor(htmlColor, out var color)) return;
             var renderer = go.GetComponent<Renderer>();
             if (renderer == null) return;
             var material = new Material(Shader.Find("Standard"));
+            ConfigureMaterialAlpha(material, color);
             material.color = color;
             renderer.sharedMaterial = material;
+        }
+
+        private static void ApplyColorToRenderers(GameObject root, string htmlColor)
+        {
+            if (root == null || string.IsNullOrEmpty(htmlColor)) return;
+            if (!TryParseCssColor(htmlColor, out var color)) return;
+
+            foreach (var renderer in root.GetComponentsInChildren<Renderer>(includeInactive: true))
+            {
+                var material = renderer.sharedMaterial != null
+                    ? new Material(renderer.sharedMaterial)
+                    : new Material(Shader.Find("Standard"));
+                ConfigureMaterialAlpha(material, color);
+                material.color = color;
+                renderer.sharedMaterial = material;
+            }
+        }
+
+        private static Renderer FindTextBackgroundRenderer(GameObject root)
+        {
+            if (root == null) return null;
+            foreach (var renderer in root.GetComponentsInChildren<Renderer>(includeInactive: true))
+            {
+                if (renderer.GetComponent<TextMesh>() == null) return renderer;
+            }
+            return null;
+        }
+
+        private static bool TryParseCssColor(string value, out Color color)
+        {
+            color = Color.white;
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            var trimmed = value.Trim();
+            if (ColorUtility.TryParseHtmlString(trimmed, out color)) return true;
+
+            var match = Regex.Match(
+                trimmed,
+                "^rgba?\\s*\\(\\s*([\\d.]+)\\s*,\\s*([\\d.]+)\\s*,\\s*([\\d.]+)(?:\\s*,\\s*([\\d.]+))?\\s*\\)$",
+                RegexOptions.IgnoreCase);
+            if (!match.Success) return false;
+
+            color = new Color(
+                ParseCssColorComponent(match.Groups[1].Value),
+                ParseCssColorComponent(match.Groups[2].Value),
+                ParseCssColorComponent(match.Groups[3].Value),
+                match.Groups[4].Success ? Mathf.Clamp01(ParseFloatInvariant(match.Groups[4].Value)) : 1f);
+            return true;
+        }
+
+        private static float ParseCssColorComponent(string value)
+        {
+            return Mathf.Clamp01(ParseFloatInvariant(value) / 255f);
+        }
+
+        private static float ParseFloatInvariant(string value)
+        {
+            if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+                return result;
+            return 0f;
+        }
+
+        private static void ConfigureMaterialAlpha(Material material, Color color)
+        {
+            if (material == null || color.a >= 0.999f) return;
+            material.SetFloat("_Mode", 3f);
+            material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            material.SetInt("_ZWrite", 0);
+            material.DisableKeyword("_ALPHATEST_ON");
+            material.EnableKeyword("_ALPHABLEND_ON");
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Apply `scene-delta.name` and `scene-delta.visible` in both Unity Runtime and Editor.
- Apply `asset.color` to Unity renderers, including primitive color updates.
- Apply text panel `color`, `backgroundColor`, and `fontSize` to Unity `TextMesh` panels.
- Preserve `visible` in Unity scene-state payloads and apply it during scene-add / scene-state restore.

## Validation
- `dotnet build SceneSyncClient/SceneSyncClient.sln --no-restore`

The build passes with existing Unity/project warnings only.