### PR TITLE
[codex] Depend Scene Sync on Loomlet runtime

### DIFF
--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -6,51 +6,6 @@ afjk.jp/pipe の presence-server と blob store を利用して通信する。
 
 ## インストール
 
-`Packages/manifest.json` に以下を追加:
-
-```json
-{
-  "scopedRegistries": [
-    {
-      "name": "afjk",
-      "url": "https://upm.afjk.jp",
-      "scopes": ["com.afjk"]
-    }
-  ],
-  "dependencies": {
-    "com.afjk.scene-sync": "0.1.0"
-  }
-}
-```
-
-### Git URL
-
-Unity Editor の **Window > Package Manager > + > Add package from git URL** に以下を入力:
-
-```
-https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync
-```
-
-特定バージョンを指定する場合:
-
-```
-https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
-```
-
-`Packages/manifest.json` に直接記述する場合:
-
-```json
-{
-  "dependencies": {
-    "com.afjk.scene-sync": "https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync"
-  }
-}
-```
-
-依存パッケージ（`com.unity.cloud.gltfast@6.0.0`）は自動インストールされない場合があるため、別途追加してください。
-
-## インストール
-
 ### UPM スコープドレジストリ（推奨）
 
 `Packages/manifest.json` に以下を追加:
@@ -59,7 +14,7 @@ https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
 {
   "scopedRegistries": [
     {
-      "name": "afjk",
+      "name": "afjk UPM Registry",
       "url": "https://upm.afjk.jp",
       "scopes": ["com.afjk"]
     }
@@ -69,6 +24,10 @@ https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
   }
 }
 ```
+
+Scene Sync は `com.afjk.loomlet-runtime@0.3.0` に依存しています。`upm.afjk.jp` の scoped registry が設定されていれば、Scene Sync のインストール時に Loomlet Runtime も自動で解決されます。
+
+`com.afjk.loomlet-runtime@0.3.0` が `upm.afjk.jp` に publish 済みである必要があります。Scene Sync 側の依存 version は package release ごとに固定します。
 
 ### Git URL
 
@@ -94,7 +53,7 @@ https://github.com/afjk/afjk.jp.git?path=unity/com.afjk.scene-sync#v0.1.0
 }
 ```
 
-依存パッケージ（`com.unity.cloud.gltfast@6.0.0`）は自動インストールされない場合があるため、別途追加してください。
+Git URL でインストールする場合も、`com.afjk.loomlet-runtime@0.3.0` と `com.unity.cloud.gltfast@6.0.0` は package dependency として解決されます。解決されない場合は、`upm.afjk.jp` scoped registry と Unity package registry の設定を確認してください。
 
 ---
 

--- a/unity/com.afjk.scene-sync/package.json
+++ b/unity/com.afjk.scene-sync/package.json
@@ -9,6 +9,7 @@
   },
   "keywords": ["scene", "sync", "collaboration", "websocket"],
   "dependencies": {
+    "com.afjk.loomlet-runtime": "0.3.0",
     "com.unity.cloud.gltfast": "6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add `com.afjk.loomlet-runtime@0.3.0` as a Unity package dependency of `com.afjk.scene-sync`.
- Document the required `upm.afjk.jp` scoped registry and automatic Loomlet Runtime dependency resolution.
- Clarify that the Scene Sync dependency version is fixed per package release and requires the Loomlet Runtime version to already be published.

Closes #317.

## Validation

- `node -e "JSON.parse(require('node:fs').readFileSync('unity/com.afjk.scene-sync/package.json','utf8')); console.log('package.json ok')"`
- `npm_config_cache=/private/tmp/npm-cache npm view com.afjk.loomlet-runtime@0.3.0 version --registry https://upm.afjk.jp`
- `npm_config_cache=/private/tmp/npm-cache npm pack --dry-run` in `unity/com.afjk.scene-sync`

Note: an unrelated untracked file, `unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs.meta`, exists locally and is not included in this PR.