### PR TITLE
[codex] Expand Scene Sync MCP object placement tools

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5844,6 +5844,28 @@ async function handleAiCommand(from, payload) {
       case 'focusObject':
         result = focusCameraOnObject(payload.params?.objectId);
         break;
+      case 'selectObject': {
+        const objectId = typeof payload.params?.objectId === 'string' ? payload.params.objectId.trim() : '';
+        const obj = objectId ? managedObjects.get(objectId) : null;
+        if (!objectId) {
+          result = { ok: false, error: 'objectId is required' };
+          break;
+        }
+        if (!obj) {
+          result = { ok: false, error: `object not found: ${objectId}` };
+          break;
+        }
+
+        selectManagedObject(obj, { reason: 'ai-select-object' });
+        notifySelectionChanged('ai-select-object');
+        result = {
+          ok: true,
+          action: 'selectObject',
+          objectId,
+          selection: getCurrentSelectionPayload(),
+        };
+        break;
+      }
       case 'undo':
         if (!presenceState.historyManager.canUndo()) {
           result = { ok: false, error: 'nothing to undo' };

--- a/packages/scene-sync-mcp/README.md
+++ b/packages/scene-sync-mcp/README.md
@@ -6,6 +6,7 @@ Scene Sync is a real-time 3D scene synchronization system. This MCP server lets 
 - Redeem pairing codes to link to a user's Scene Sync room
 - Add and manipulate 3D objects (boxes, spheres, primitives, and image/video/text/GLB assets from URL)
 - Place objects precisely using world bounds, alignment, and size fitting helpers
+- Inspect one object at a time and select/focus targets for transparent AI edits
 - Replace existing media/text panels with new content (with Undo/Redo support)
 - Inspect camera pose
 - Access browser operation history (undo/redo)
@@ -14,6 +15,8 @@ Scene Sync is a real-time 3D scene synchronization system. This MCP server lets 
 - Take screenshots
 - Switch animation clips on animated GLB objects
 - Manage the link session
+
+The toolset follows the useful parts of Blender MCP-style workflows: inspect a target, select/focus it, place or resize it with measured bounds, then verify with a screenshot. It intentionally avoids arbitrary browser code execution and built-in asset search; Scene Sync MCP stays focused on safe observation and constrained scene edits.
 
 ## Installation
 
@@ -167,7 +170,7 @@ Input:
 ```
 
 ### scene_sync_status
-Check current link status and expiration time.
+Check current link status, expiration time, server URL, and supported capabilities.
 
 ### scene_sync_get_scene
 Get the current scene state (objects and environment). May take up to 5 seconds.
@@ -192,6 +195,28 @@ Returned objects may include world-space bounds:
 ```
 
 `bounds.world.size` is the actual size after scale is applied.
+
+### scene_sync_get_object
+Get details for one object without returning the full scene.
+
+Input:
+```json
+{
+  "objectId": "fox"
+}
+```
+
+The response includes transform, `bounds.world`, `asset`, `metadata`, and animation fields when available.
+
+### scene_sync_select_object
+Select an object in the linked browser so the user can see which target the AI is working on.
+
+Input:
+```json
+{
+  "objectId": "fox"
+}
+```
 
 ### scene_sync_add_box
 Add a box to the scene. High-level tool; use directly for requests like "add a red cube".
@@ -259,6 +284,60 @@ Input:
       "value": 0
     }
   }
+}
+```
+
+### scene_sync_verify_bounds_alignment
+Check whether bounds anchors are aligned within tolerance.
+
+Input:
+```json
+{
+  "sourceObjectId": "image-panel",
+  "targetObjectId": "wall",
+  "axes": {
+    "x": { "source": "center", "target": "center", "tolerance": 0.01 },
+    "y": { "source": "center", "target": "center", "tolerance": 0.01 },
+    "z": { "source": "min", "target": "max", "offset": 0.02, "tolerance": 0.01 }
+  }
+}
+```
+
+### scene_sync_place_on_floor
+Move an object so its bounds bottom rests on a floor Y value.
+
+Input:
+```json
+{
+  "objectId": "fox",
+  "y": 0,
+  "offset": 0
+}
+```
+
+### scene_sync_center_on_object
+Center a source object on a target object using bounds centers.
+
+Input:
+```json
+{
+  "sourceObjectId": "image-panel",
+  "targetObjectId": "wall",
+  "axes": ["x", "y"]
+}
+```
+
+### scene_sync_place_in_front_of
+Place a source object just in front of a target object's world Z max.
+
+Input:
+```json
+{
+  "sourceObjectId": "image-panel",
+  "targetObjectId": "wall",
+  "offset": 0.02,
+  "centerX": true,
+  "centerY": true
 }
 ```
 
@@ -529,6 +608,10 @@ Use these tools for production-like placement tasks:
 
 - `scene_sync_set_transform`: update position, rotation, and scale together
 - `scene_sync_align_bounds`: align object bounds to another object or to a world coordinate
+- `scene_sync_verify_bounds_alignment`: verify placement numerically after an operation
+- `scene_sync_place_on_floor`: common floor placement wrapper
+- `scene_sync_center_on_object`: common bounds-center wrapper
+- `scene_sync_place_in_front_of`: common front-of-target wrapper
 - `scene_sync_fit_bounds_size`: scale an object to a target world-space size
 
 Place an object on the floor at world Y=0:
@@ -575,6 +658,19 @@ Make a GLB model 1 meter tall:
 }
 ```
 
+Import a model and immediately normalize its largest bounds axis to 1.5 meters:
+
+```json
+{
+  "tool": "scene_sync_add_glb_from_url",
+  "arguments": {
+    "url": "https://example.com/model.glb",
+    "targetSize": 1.5,
+    "targetAxis": "max"
+  }
+}
+```
+
 ### scene_sync_undo
 Undo the last operation recorded in the Scene Sync history.
 
@@ -589,6 +685,21 @@ Note: Undo/Redo operates on the browser-side Scene Sync history. Some operations
 
 ### scene_sync_focus_object
 Focus the browser camera on an object (requires objectId).
+
+### scene_sync_focus_and_screenshot
+
+Focus the browser camera on an object and immediately take a screenshot.
+
+Input:
+
+```json
+{
+  "objectId": "fox",
+  "mode": "image",
+  "maxWidth": 768,
+  "quality": 0.7
+}
+```
 
 ### scene_sync_screenshot
 
@@ -716,6 +827,7 @@ Browser AI commands in `html/assets/js/scenesync/scene.js` should stay in sync w
 |---|---|---|
 | `getCameraPose` | `scene_sync_get_camera_pose` | supported |
 | `focusObject` | `scene_sync_focus_object` | supported |
+| `selectObject` | `scene_sync_select_object` | supported |
 | `screenshot` | `scene_sync_screenshot` | supported |
 | `uploadGlbFromUrl` | `scene_sync_add_glb_from_url` | supported |
 | `addImageFromUrl` | `scene_sync_add_image_from_url` | supported |

--- a/packages/scene-sync-mcp/src/server.mjs
+++ b/packages/scene-sync-mcp/src/server.mjs
@@ -19,6 +19,7 @@ import {
   makeObjectId,
   assertBoundsWorld,
   computeAlignedPosition,
+  computeBoundsAlignmentErrors,
   computeFitScale
 } from './validators.mjs'
 import { jsonResult, errorResult, successResult, imageResult } from './tool-results.mjs'
@@ -29,6 +30,22 @@ const server = new McpServer({
   name: 'scene-sync-mcp',
   version: '0.1.0'
 })
+
+const CAPABILITIES = {
+  screenshotImage: true,
+  screenshotUrl: true,
+  boundsWorld: true,
+  selection: true,
+  selectObject: true,
+  cameraPose: true,
+  focusObject: true,
+  focusAndScreenshot: true,
+  boundsPlacement: true,
+  boundsAlignmentVerification: true,
+  objectInfo: true,
+  mediaReplacement: true,
+  textReplacement: true
+}
 
 // Helper to get current session or throw error
 function getSession() {
@@ -149,6 +166,25 @@ function findSceneObject(scene, objectId) {
   return listSceneObjects(scene).find((obj) => obj.objectId === objectId) || null
 }
 
+function summarizeObject(object) {
+  if (!object) return null
+
+  return {
+    objectId: object.objectId,
+    name: object.name,
+    position: object.position,
+    rotation: object.rotation,
+    scale: object.scale,
+    visible: object.visible,
+    bounds: object.bounds,
+    asset: object.asset,
+    metadata: object.metadata,
+    meshPath: object.meshPath,
+    animation: object.animation,
+    animationClips: object.animationClips
+  }
+}
+
 function getWorldBounds(object) {
   const bounds = object?.bounds?.world
   if (!bounds) {
@@ -169,6 +205,68 @@ function getObjectPosition(object) {
 
 function getObjectScale(object) {
   return normalizeScale(object?.scale, [1, 1, 1])
+}
+
+async function requestScreenshot({ mode = 'image', maxWidth = 768, quality } = {}) {
+  const session = getSession()
+
+  const response = await client.aiCommand(
+    session.roomId,
+    session.sessionId,
+    'screenshot',
+    {
+      mode,
+      maxWidth,
+      quality: quality ?? (mode === 'image' ? 0.7 : 0.92)
+    },
+    { timeout: 15000 }
+  )
+
+  assertAiCommandOk(response)
+
+  return {
+    session,
+    response,
+    result: response?.result || response
+  }
+}
+
+function screenshotToolResult({ mode, session, response, result, metadata = {} }) {
+  if (mode === 'image') {
+    const base64 = result?.base64 || result?.data || null
+    const mimeType = result?.mimeType || 'image/jpeg'
+
+    if (!base64 || typeof base64 !== 'string') {
+      return errorResult(new Error('screenshot did not return base64 image data'))
+    }
+
+    return imageResult({
+      data: base64,
+      mimeType,
+      metadata: {
+        ok: true,
+        action: 'screenshot',
+        mode: 'image',
+        mimeType,
+        width: result.width ?? null,
+        height: result.height ?? null,
+        room: response.room || session.roomId,
+        userPresent: response.userPresent !== false,
+        targetPeerId: response.targetPeerId || null,
+        ...metadata
+      }
+    })
+  }
+
+  const sanitized = sanitizeScreenshotResult(response)
+
+  return jsonResult({
+    ...sanitized,
+    ok: true,
+    action: 'screenshot',
+    mode: 'url',
+    ...metadata
+  })
 }
 
 // Helper to add primitive objects
@@ -226,7 +324,9 @@ const urlTransformInputSchema = z.object({
   name: z.string().optional().describe('Display name. If omitted, browser may infer from URL filename.'),
   position: z.array(z.number()).length(3).optional().describe('[x, y, z] position in meters'),
   rotation: z.array(z.number()).length(4).optional().describe('[x, y, z, w] quaternion'),
-  scale: z.array(z.number()).length(3).optional().describe('[x, y, z] scale')
+  scale: z.array(z.number()).length(3).optional().describe('[x, y, z] scale'),
+  targetSize: z.number().positive().optional().describe('Optional target world-bounds size in meters after import.'),
+  targetAxis: z.enum(['x', 'y', 'z', 'max']).optional().describe('Bounds axis used with targetSize. Defaults to max.')
 })
 
 function makeUrlAssetToolHandler(action, options = {}) {
@@ -236,8 +336,9 @@ function makeUrlAssetToolHandler(action, options = {}) {
     timeout = 60000
   } = options
 
-  return async ({ url, objectId, name, position, rotation, scale }) => {
+  return async ({ url, objectId, name, position, rotation, scale, targetSize, targetAxis = 'max' }) => {
     try {
+      const session = getSession()
       const finalObjectId = objectId || makeObjectId(objectIdPrefix)
       assertObjectId(finalObjectId)
 
@@ -254,12 +355,52 @@ function makeUrlAssetToolHandler(action, options = {}) {
       }
 
       const response = await runAiCommand(action, params, { timeout })
+      let fitted = null
+
+      if (targetSize !== undefined) {
+        const scene = await client.getScene(session.roomId, session.sessionId)
+        const object = findSceneObject(scene, finalObjectId)
+        if (!object) {
+          throw new ValidationError(`Imported object not found for targetSize fit: ${finalObjectId}`)
+        }
+
+        const bounds = getWorldBounds(object)
+        const currentBoundsSize = normalizeVec3(bounds.size, [
+          bounds.max[0] - bounds.min[0],
+          bounds.max[1] - bounds.min[1],
+          bounds.max[2] - bounds.min[2]
+        ])
+        const axis = targetAxis === 'max'
+          ? ['x', 'y', 'z'][currentBoundsSize.indexOf(Math.max(...currentBoundsSize))]
+          : targetAxis
+        const nextScale = computeFitScale({
+          currentScale: getObjectScale(object),
+          currentBoundsSize,
+          targetSize: { [axis]: targetSize },
+          preserveAspect: true
+        })
+
+        await client.broadcast(session.roomId, session.sessionId, {
+          kind: 'scene-delta',
+          objectId: finalObjectId,
+          scale: nextScale
+        })
+
+        fitted = {
+          axis,
+          targetAxis,
+          targetSize,
+          scale: nextScale,
+          previousBoundsSize: currentBoundsSize
+        }
+      }
 
       return jsonResult({
         ...response,
         ok: true,
         objectId: finalObjectId,
-        action
+        action,
+        ...(fitted ? { fitted } : {})
       })
     } catch (e) {
       if (e instanceof ValidationError) {
@@ -322,6 +463,10 @@ server.registerTool(
       if (!session.sessionId || !session.roomId) {
         return jsonResult({
           linked: false,
+          capabilities: CAPABILITIES,
+          server: {
+            baseUrl: client.baseUrl
+          },
           message: 'Not linked. Ask the user to press AIにリンク in Scene Sync and provide the 6-digit code.'
         })
       }
@@ -329,6 +474,11 @@ server.registerTool(
       if (session.expiresAt && session.expiresAt <= Date.now()) {
         return jsonResult({
           linked: false,
+          roomId: session.roomId,
+          capabilities: CAPABILITIES,
+          server: {
+            baseUrl: client.baseUrl
+          },
           message: 'Link expired. Ask the user to redeem a new code.'
         })
       }
@@ -338,7 +488,11 @@ server.registerTool(
         linked: true,
         roomId: session.roomId,
         expiresAt: session.expiresAt,
-        expiresInSec
+        expiresInSec,
+        capabilities: CAPABILITIES,
+        server: {
+          baseUrl: client.baseUrl
+        }
       })
     } catch (e) {
       return errorResult(e)
@@ -416,6 +570,89 @@ server.registerTool(
         action: 'getSelection'
       })
     } catch (e) {
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_get_object
+server.registerTool(
+  'scene_sync_get_object',
+  {
+    title: 'Get Scene Sync object details',
+    description: 'Get one object from the current Scene Sync scene, including transform, bounds, asset, metadata, and animation information when available.',
+    inputSchema: z.object({
+      objectId: z.string().describe('Target object ID')
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async ({ objectId }) => {
+    try {
+      const session = getSession()
+      assertObjectId(objectId)
+
+      const scene = await client.getScene(session.roomId, session.sessionId)
+      const object = findSceneObject(scene, objectId)
+      if (!object) {
+        throw new ValidationError(`Object not found: ${objectId}`)
+      }
+
+      return jsonResult({
+        ok: true,
+        roomId: scene?.roomId || session.roomId,
+        userPresent: scene?.userPresent !== false,
+        object: summarizeObject(object)
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_select_object
+server.registerTool(
+  'scene_sync_select_object',
+  {
+    title: 'Select Scene Sync object',
+    description: 'Select an object in the linked browser so the user can see which target the AI is working on.',
+    inputSchema: z.object({
+      objectId: z.string().describe('Target object ID')
+    }),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async ({ objectId }) => {
+    try {
+      assertObjectId(objectId)
+
+      const response = await runAiCommand(
+        'selectObject',
+        { objectId },
+        { timeout: 10000 }
+      )
+
+      return jsonResult({
+        ...response,
+        ok: true,
+        objectId,
+        action: 'selectObject'
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
       return errorResult(e)
     }
   }
@@ -794,6 +1031,10 @@ const alignAxisRuleSchema = z.object({
   offset: z.number().optional().describe('Optional offset in meters after alignment')
 })
 
+const verifyAxisRuleSchema = alignAxisRuleSchema.extend({
+  tolerance: z.number().min(0).optional().describe('Allowed absolute error in meters. Defaults to 0.01.')
+})
+
 // scene_sync_set_transform
 server.registerTool(
   'scene_sync_set_transform',
@@ -909,6 +1150,249 @@ server.registerTool(
         sourceBounds,
         targetObjectId: targetObjectId || null,
         targetBounds
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_verify_bounds_alignment
+server.registerTool(
+  'scene_sync_verify_bounds_alignment',
+  {
+    title: 'Verify bounds alignment',
+    description: 'Measure whether source object world-bounds anchors are aligned to target object bounds or explicit world coordinates within tolerance.',
+    inputSchema: z.object({
+      sourceObjectId: z.string().describe('Object to check'),
+      targetObjectId: z.string().optional().describe('Object to check against. If omitted, use explicit axis values.'),
+      axes: z.object({
+        x: verifyAxisRuleSchema.optional(),
+        y: verifyAxisRuleSchema.optional(),
+        z: verifyAxisRuleSchema.optional()
+      }).describe('Per-axis verification rules. Each axis uses either targetObjectId+target or explicit value.')
+    }),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  },
+  async ({ sourceObjectId, targetObjectId, axes }) => {
+    try {
+      const session = getSession()
+      assertObjectId(sourceObjectId)
+      if (targetObjectId !== undefined) {
+        assertObjectId(targetObjectId)
+      }
+
+      const scene = await client.getScene(session.roomId, session.sessionId)
+      const sourceObject = findSceneObject(scene, sourceObjectId)
+      if (!sourceObject) {
+        throw new ValidationError(`Source object not found: ${sourceObjectId}`)
+      }
+
+      const targetObject = targetObjectId ? findSceneObject(scene, targetObjectId) : null
+      if (targetObjectId && !targetObject) {
+        throw new ValidationError(`Target object not found: ${targetObjectId}`)
+      }
+
+      const sourceBounds = getWorldBounds(sourceObject)
+      const targetBounds = targetObject ? getWorldBounds(targetObject) : null
+      const verification = computeBoundsAlignmentErrors({
+        sourceBounds,
+        targetBounds,
+        axes
+      })
+
+      return successResult({
+        passed: verification.ok,
+        errors: verification.errors,
+        axisPassed: verification.passed,
+        sourceObjectId,
+        targetObjectId: targetObjectId || null,
+        axes,
+        sourceBounds,
+        targetBounds
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+async function alignBoundsTool({ sourceObjectId, targetObjectId, axes }) {
+  const session = getSession()
+  assertObjectId(sourceObjectId)
+  if (targetObjectId !== undefined) {
+    assertObjectId(targetObjectId)
+  }
+
+  const scene = await client.getScene(session.roomId, session.sessionId)
+  const sourceObject = findSceneObject(scene, sourceObjectId)
+  if (!sourceObject) {
+    throw new ValidationError(`Source object not found: ${sourceObjectId}`)
+  }
+
+  const targetObject = targetObjectId ? findSceneObject(scene, targetObjectId) : null
+  if (targetObjectId && !targetObject) {
+    throw new ValidationError(`Target object not found: ${targetObjectId}`)
+  }
+
+  const sourcePosition = getObjectPosition(sourceObject)
+  const sourceBounds = getWorldBounds(sourceObject)
+  const targetBounds = targetObject ? getWorldBounds(targetObject) : null
+
+  const nextPosition = computeAlignedPosition({
+    sourcePosition,
+    sourceBounds,
+    targetBounds,
+    axes
+  })
+
+  await client.broadcast(session.roomId, session.sessionId, {
+    kind: 'scene-delta',
+    objectId: sourceObjectId,
+    position: nextPosition
+  })
+
+  return {
+    objectId: sourceObjectId,
+    position: nextPosition,
+    aligned: axes,
+    sourceBounds,
+    targetObjectId: targetObjectId || null,
+    targetBounds
+  }
+}
+
+// scene_sync_place_on_floor
+server.registerTool(
+  'scene_sync_place_on_floor',
+  {
+    title: 'Place object on floor',
+    description: 'Move an object so its world bounds bottom rests on a floor Y value. Defaults to Y=0.',
+    inputSchema: z.object({
+      objectId: z.string().describe('Object to move'),
+      y: z.number().optional().describe('Floor world Y value. Defaults to 0.'),
+      offset: z.number().optional().describe('Additional Y offset in meters. Defaults to 0.')
+    })
+  },
+  async ({ objectId, y = 0, offset = 0 }) => {
+    try {
+      const result = await alignBoundsTool({
+        sourceObjectId: objectId,
+        axes: {
+          y: {
+            source: 'min',
+            value: y,
+            offset
+          }
+        }
+      })
+
+      return successResult({
+        ...result,
+        action: 'placeOnFloor',
+        floorY: y,
+        offset
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_center_on_object
+server.registerTool(
+  'scene_sync_center_on_object',
+  {
+    title: 'Center object on another object',
+    description: 'Move a source object so selected world-bounds center axes match a target object center.',
+    inputSchema: z.object({
+      sourceObjectId: z.string().describe('Object to move'),
+      targetObjectId: z.string().describe('Object to center on'),
+      axes: z.array(z.enum(['x', 'y', 'z'])).optional().describe('Axes to center. Defaults to x, y, and z.')
+    })
+  },
+  async ({ sourceObjectId, targetObjectId, axes = ['x', 'y', 'z'] }) => {
+    try {
+      const axisRules = {}
+      for (const axis of axes) {
+        axisRules[axis] = {
+          source: 'center',
+          target: 'center'
+        }
+      }
+
+      const result = await alignBoundsTool({
+        sourceObjectId,
+        targetObjectId,
+        axes: axisRules
+      })
+
+      return successResult({
+        ...result,
+        action: 'centerOnObject'
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
+// scene_sync_place_in_front_of
+server.registerTool(
+  'scene_sync_place_in_front_of',
+  {
+    title: 'Place object in front of target bounds',
+    description: 'Move a source object in front of a target object using world Z bounds, optionally centering X and Y.',
+    inputSchema: z.object({
+      sourceObjectId: z.string().describe('Object to move'),
+      targetObjectId: z.string().describe('Object to place in front of'),
+      offset: z.number().optional().describe('Gap in meters between target max Z and source min Z. Defaults to 0.1.'),
+      centerX: z.boolean().optional().describe('Center X on the target. Defaults to true.'),
+      centerY: z.boolean().optional().describe('Center Y on the target. Defaults to true.')
+    })
+  },
+  async ({ sourceObjectId, targetObjectId, offset = 0.1, centerX = true, centerY = true }) => {
+    try {
+      const axes = {
+        z: {
+          source: 'min',
+          target: 'max',
+          offset
+        }
+      }
+
+      if (centerX) axes.x = { source: 'center', target: 'center' }
+      if (centerY) axes.y = { source: 'center', target: 'center' }
+
+      const result = await alignBoundsTool({
+        sourceObjectId,
+        targetObjectId,
+        axes
+      })
+
+      return successResult({
+        ...result,
+        action: 'placeInFrontOf',
+        offset,
+        centerX,
+        centerY
       })
     } catch (e) {
       if (e instanceof ValidationError) {
@@ -1070,6 +1554,47 @@ server.registerTool(
   }
 )
 
+// scene_sync_focus_and_screenshot
+server.registerTool(
+  'scene_sync_focus_and_screenshot',
+  {
+    title: 'Focus object and take screenshot',
+    description: 'Select/focus an object in the linked browser, then return a screenshot for visual verification.',
+    inputSchema: z.object({
+      objectId: z.string().describe('Target object ID'),
+      mode: z.enum(['image', 'url']).optional().describe('Return mode. image returns MCP image content. url returns URL metadata. Defaults to image.'),
+      maxWidth: z.number().int().min(128).max(2048).optional().describe('Maximum screenshot width in pixels. Defaults to 768.'),
+      quality: z.number().min(0.1).max(1).optional().describe('JPEG quality. Default 0.7 for image mode.')
+    })
+  },
+  async ({ objectId, mode = 'image', maxWidth = 768, quality } = {}) => {
+    try {
+      assertObjectId(objectId)
+
+      const focusResponse = await runAiCommand(
+        'focusObject',
+        { objectId },
+        { timeout: 10000 }
+      )
+
+      return screenshotToolResult({
+        mode,
+        ...await requestScreenshot({ mode, maxWidth, quality }),
+        metadata: {
+          action: 'focusAndScreenshot',
+          objectId,
+          focused: focusResponse?.ok !== false
+        }
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return errorResult(e)
+      }
+      return errorResult(e)
+    }
+  }
+)
+
 // scene_sync_screenshot
 server.registerTool(
   'scene_sync_screenshot',
@@ -1084,56 +1609,9 @@ server.registerTool(
   },
   async ({ mode = 'image', maxWidth = 768, quality } = {}) => {
     try {
-      const session = getSession()
-
-      const response = await client.aiCommand(
-        session.roomId,
-        session.sessionId,
-        'screenshot',
-        {
-          mode,
-          maxWidth,
-          quality: quality ?? (mode === 'image' ? 0.7 : 0.92)
-        },
-        { timeout: 15000 }
-      )
-
-      assertAiCommandOk(response)
-
-      const result = response?.result || response
-
-      if (mode === 'image') {
-        const base64 = result?.base64 || result?.data || null
-        const mimeType = result?.mimeType || 'image/jpeg'
-
-        if (!base64 || typeof base64 !== 'string') {
-          return errorResult(new Error('screenshot did not return base64 image data'))
-        }
-
-        return imageResult({
-          data: base64,
-          mimeType,
-          metadata: {
-            ok: true,
-            action: 'screenshot',
-            mode: 'image',
-            mimeType,
-            width: result.width ?? null,
-            height: result.height ?? null,
-            room: response.room || session.roomId,
-            userPresent: response.userPresent !== false,
-            targetPeerId: response.targetPeerId || null
-          }
-        })
-      }
-
-      const sanitized = sanitizeScreenshotResult(response)
-
-      return jsonResult({
-        ...sanitized,
-        ok: true,
-        action: 'screenshot',
-        mode: 'url'
+      return screenshotToolResult({
+        mode,
+        ...await requestScreenshot({ mode, maxWidth, quality })
       })
     } catch (e) {
       if (e instanceof ValidationError) {

--- a/packages/scene-sync-mcp/src/validators.mjs
+++ b/packages/scene-sync-mcp/src/validators.mjs
@@ -252,3 +252,64 @@ export function computeFitScale({ currentScale, currentBoundsSize, targetSize, p
 
   return nextScale
 }
+
+export function computeBoundsAlignmentErrors({ sourceBounds, targetBounds = null, axes }) {
+  assertBoundsWorld(sourceBounds, 'sourceBounds')
+
+  if (!axes || typeof axes !== 'object') {
+    throw new ValidationError('axes must be an object.')
+  }
+
+  const errors = {}
+  const passed = {}
+  let checked = 0
+
+  for (const axis of ['x', 'y', 'z']) {
+    const rule = axes[axis]
+    if (!rule) continue
+
+    checked += 1
+
+    const sourceValue = getBoundsAnchor(sourceBounds, axis, rule.source)
+    let targetValue = null
+
+    if (typeof rule.value === 'number') {
+      if (!Number.isFinite(rule.value)) {
+        throw new ValidationError(`axes.${axis}.value must be a finite number.`)
+      }
+      targetValue = rule.value
+    } else {
+      if (!targetBounds) {
+        throw new ValidationError(`axes.${axis}.value or targetBounds is required.`)
+      }
+      if (!rule.target) {
+        throw new ValidationError(`axes.${axis}.target is required when verifying target bounds.`)
+      }
+      targetValue = getBoundsAnchor(targetBounds, axis, rule.target)
+    }
+
+    const offset = rule.offset === undefined ? 0 : rule.offset
+    if (typeof offset !== 'number' || !Number.isFinite(offset)) {
+      throw new ValidationError(`axes.${axis}.offset must be a finite number.`)
+    }
+
+    const tolerance = rule.tolerance === undefined ? 0.01 : rule.tolerance
+    if (typeof tolerance !== 'number' || !Number.isFinite(tolerance) || tolerance < 0) {
+      throw new ValidationError(`axes.${axis}.tolerance must be a finite non-negative number.`)
+    }
+
+    const error = sourceValue - (targetValue + offset)
+    errors[axis] = error
+    passed[axis] = Math.abs(error) <= tolerance
+  }
+
+  if (checked === 0) {
+    throw new ValidationError('At least one axis rule is required.')
+  }
+
+  return {
+    ok: Object.values(passed).every(Boolean),
+    errors,
+    passed
+  }
+}

--- a/packages/scene-sync-mcp/src/validators.test.mjs
+++ b/packages/scene-sync-mcp/src/validators.test.mjs
@@ -1,6 +1,13 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { assertQuat, assertVec3, computeAlignedPosition, computeFitScale, ValidationError } from './validators.mjs'
+import {
+  assertQuat,
+  assertVec3,
+  computeAlignedPosition,
+  computeBoundsAlignmentErrors,
+  computeFitScale,
+  ValidationError
+} from './validators.mjs'
 
 test('computeAlignedPosition aligns source minY to world Y=0', () => {
   const nextPosition = computeAlignedPosition({
@@ -84,6 +91,39 @@ test('computeFitScale rejects zero-sized current bounds on a fitted axis', () =>
       preserveAspect: true
     })
   }, ValidationError)
+})
+
+test('computeBoundsAlignmentErrors reports per-axis signed errors and pass state', () => {
+  const result = computeBoundsAlignmentErrors({
+    sourceBounds: {
+      min: [0, 0, 0],
+      center: [1, 1, 1],
+      max: [2, 2, 2]
+    },
+    targetBounds: {
+      min: [10, 10, 10],
+      center: [11, 11, 11],
+      max: [12, 12, 12]
+    },
+    axes: {
+      x: {
+        source: 'center',
+        target: 'center',
+        tolerance: 0.01
+      },
+      y: {
+        source: 'max',
+        value: 2.005,
+        tolerance: 0.01
+      }
+    }
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.errors.x, -10)
+  assert.equal(result.passed.x, false)
+  assert.ok(Math.abs(result.errors.y + 0.005) < 1e-9)
+  assert.equal(result.passed.y, true)
 })
 
 test('assertVec3 rejects NaN and Infinity', () => {


### PR DESCRIPTION
## Summary

- Add Scene Sync MCP object inspection and browser selection tools for safer scoped edits.
- Add focus-and-screenshot, status capabilities, bounds alignment verification, common placement wrappers, and import-time target size normalization.
- Add browser-side `selectObject` AI command support and README coverage for the new workflow.

Closes #310.

## Validation

- `npm test` in `packages/scene-sync-mcp`
- `node --check packages/scene-sync-mcp/src/server.mjs`
- `node --check html/assets/js/scenesync/scene.js`
- `git diff --check`