### PR TITLE
[codex] Harden Unity scene-state asset roundtrip

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1690,9 +1690,7 @@ namespace Afjk.SceneSync.Editor
 
             Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
-            var nameMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"name\":\"([^\"]+)\"");
-            var name = nameMatch.Success ? nameMatch.Groups[1].Value : objectId;
+            var name = SceneSyncWireJson.ExtractString(raw, "name") ?? objectId;
             var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
@@ -1728,10 +1726,7 @@ namespace Afjk.SceneSync.Editor
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
-            // Extract visualBasis from asset JSON
-            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"visualBasis\":\"([^\"]+)\"");
-            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+            var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
 
             // meshPath を保存
             if (!string.IsNullOrEmpty(meshPath))
@@ -1824,10 +1819,7 @@ namespace Afjk.SceneSync.Editor
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
-            // Extract visualBasis from asset JSON
-            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"visualBasis\":\"([^\"]+)\"");
-            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+            var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
@@ -1963,7 +1955,15 @@ namespace Afjk.SceneSync.Editor
                     || go.GetComponentInChildren<SkinnedMeshRenderer>() != null)
                 {
                     var glb = await PresenceClient.ExportGameObjectAsGlb(go);
-                    if (glb != null)
+                    if (glb == null)
+                    {
+                        Debug.LogWarning(
+                            $"[SceneSync] scene-state skipped because GLB export failed: " +
+                            $"objectId={objectId}, name={go.name}"
+                        );
+                        continue;
+                    }
+                    else
                     {
                         if (!IsGlbWithinUploadLimit(glb))
                         {
@@ -1980,11 +1980,6 @@ namespace Afjk.SceneSync.Editor
                         path = PresenceClient.GenerateRandomPath();
                         var assetId = PresenceClientRuntime.ComputeAssetId(glb);
                         pendingUploads.Add((objectId, glb, path, assetId));
-                        if (identity != null)
-                        {
-                            identity.AssetId = assetId;
-                            EditorUtility.SetDirty(identity);
-                        }
                     }
                 }
 
@@ -2064,9 +2059,7 @@ namespace Afjk.SceneSync.Editor
 
                 var identity = go.GetComponent<SceneSyncIdentity>();
                 var isUnityVisualBasis = identity == null || identity.Origin == SceneSyncOrigin.Unity;
-                var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
                 var assetId = identity != null ? identity.AssetId : null;
-                var assetIdJson = !string.IsNullOrEmpty(assetId) ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
                 var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
                 var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
                 var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
@@ -2077,23 +2070,21 @@ namespace Afjk.SceneSync.Editor
                         assetId,
                         isUnityVisualBasis ? "unity" : null);
                 }
-                var assetJson = !string.IsNullOrWhiteSpace(rawAssetJson)
-                    ? ",\"asset\":" + rawAssetJson
-                    : "";
-                var metadataJson = !string.IsNullOrWhiteSpace(rawMetadataJson)
-                    ? ",\"metadata\":" + rawMetadataJson
-                    : "";
-
                 var pos = transform.position;
                 var rot = transform.rotation;
                 var scl = transform.localScale;
 
-                objectsJson.Append("\"" + objectId + "\":{\"name\":\"" + go.name + "\"" +
-                    ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
-                    ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
-                    ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
-                    ",\"visible\":" + (go.activeSelf ? "true" : "false") +
-                    meshPathJson + assetIdJson + assetJson + metadataJson + "}");
+                objectsJson.Append(SceneSyncWireJson.BuildObjectJson(
+                    objectId,
+                    go.name,
+                    pos,
+                    rot,
+                    scl,
+                    go.activeSelf,
+                    path,
+                    assetId,
+                    rawAssetJson,
+                    rawMetadataJson));
             }
 
             objectsJson.Append("}");

--- a/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
+++ b/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
@@ -218,12 +218,12 @@ namespace Afjk.SceneSync
             return await GlbExporter.ExportGameObjectAsGlb(go, SceneSyncGlbExportBackend.GltfFast);
         }
 
-        public static async Task UploadGlb(byte[] glb, string blobBaseUrl, string path)
+        public static async Task<bool> UploadGlb(byte[] glb, string blobBaseUrl, string path)
         {
             if (glb == null || glb.Length == 0)
             {
                 Debug.LogWarning("[SceneSync] Upload skipped: glb is null or empty, path=" + path);
-                return;
+                return false;
             }
 
             try
@@ -238,17 +238,20 @@ namespace Afjk.SceneSync
                     Debug.LogWarning(
                         "[SceneSync] Upload failed: status=" + (int)response.StatusCode + " " + response.StatusCode
                         + ", url=" + url);
+                    return false;
                 }
                 else
                 {
                     Debug.Log(
                         "[SceneSync] Upload success: status=" + (int)response.StatusCode + " " + response.StatusCode
                         + ", url=" + url);
+                    return true;
                 }
             }
             catch (Exception ex)
             {
                 Debug.LogWarning("[SceneSync] Upload failed: path=" + path + ", blobBaseUrl=" + blobBaseUrl + "\n" + ex);
+                return false;
             }
         }
 

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -388,15 +388,21 @@ namespace Afjk.SceneSync
                 // blob store に POST（全クライアント共有）
                 var path = PresenceClientRuntime.GenerateRandomPath();
                 var assetId = PresenceClientRuntime.ComputeAssetId(glb);
+                var uploaded = await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+                if (!uploaded)
+                {
+                    Debug.LogWarning("[SceneSync] Skipping scene-mesh broadcast because GLB upload failed: objectId=" + objectId);
+                    continue;
+                }
+
                 _meshPaths[objectId] = path;
                 if (assetId != null)
                     _assetIdCache[assetId] = glb;
                 if (path != null)
                     _meshPathCache[path] = glb;
-                await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
 
-                var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
-                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + objectId + "\",\"meshPath\":\"" + path + "\"" + assetIdJson +
+                var assetIdJson = assetId != null ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" + assetIdJson +
                     ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") + "}";
                 await _client.Broadcast(payload);
             }
@@ -731,11 +737,17 @@ namespace Afjk.SceneSync
             byte[] glb = null;
             string path = null;
             string assetId = null;
-            if (go.GetComponentInChildren<MeshFilter>() != null
-                || go.GetComponentInChildren<SkinnedMeshRenderer>() != null)
+            var hasMeshVisual = go.GetComponentInChildren<MeshFilter>() != null
+                || go.GetComponentInChildren<SkinnedMeshRenderer>() != null;
+            if (hasMeshVisual)
             {
                 glb = await PresenceClientRuntime.ExportGameObjectAsGlb(go);
-                if (glb != null)
+                if (glb == null)
+                {
+                    Debug.LogWarning("[SceneSync] Skipping scene-add because GLB export failed: objectId=" + sendObjectId);
+                    return;
+                }
+                else
                 {
                     path = PresenceClientRuntime.GenerateRandomPath();
                     assetId = PresenceClientRuntime.ComputeAssetId(glb);
@@ -746,25 +758,33 @@ namespace Afjk.SceneSync
             if (glb != null && path != null)
             {
                 var objectIdStr = go.GetInstanceID().ToString();
-                _meshPaths[objectIdStr] = path;
-                if (assetId != null)
-                    _assetIdCache[assetId] = glb;
-                if (path != null)
-                    _meshPathCache[path] = glb;
-                await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+                var uploaded = await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+                if (!uploaded)
+                {
+                    Debug.LogWarning("[SceneSync] Skipping scene-add because GLB upload failed: objectId=" + objectIdStr);
+                    return;
+                }
+                else
+                {
+                    _meshPaths[objectIdStr] = path;
+                    if (assetId != null)
+                        _assetIdCache[assetId] = glb;
+                    if (path != null)
+                        _meshPathCache[path] = glb;
+                }
             }
 
             if (_isShuttingDown || !_connected) return;
 
-            var meshPathJson = path != null ? ",\"meshPath\":\"" + path + "\"" : "";
-            var assetIdJson = assetId != null ? ",\"assetId\":\"" + assetId + "\"" : "";
+            var meshPathJson = path != null ? ",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" : "";
+            var assetIdJson = assetId != null ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
             var assetJson = path != null
                 ? ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity")
                 : "";
-            var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + go.GetInstanceID() + "\",\"name\":\"" + go.name + "\"" +
-                ",\"position\":[" + pos.x + "," + pos.y + "," + (-pos.z) + "]" +
-                ",\"rotation\":[" + rot.x + "," + rot.y + "," + (-rot.z) + "," + (-rot.w) + "]" +
-                ",\"scale\":[" + scl.x + "," + scl.y + "," + scl.z + "]" +
+            var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(go.GetInstanceID().ToString()) + "\",\"name\":\"" + SceneSyncWireJson.JsonEscape(go.name) + "\"" +
+                ",\"position\":[" + SceneSyncWireJson.FormatFloat(pos.x) + "," + SceneSyncWireJson.FormatFloat(pos.y) + "," + SceneSyncWireJson.FormatFloat(-pos.z) + "]" +
+                ",\"rotation\":[" + SceneSyncWireJson.FormatFloat(rot.x) + "," + SceneSyncWireJson.FormatFloat(rot.y) + "," + SceneSyncWireJson.FormatFloat(-rot.z) + "," + SceneSyncWireJson.FormatFloat(-rot.w) + "]" +
+                ",\"scale\":[" + SceneSyncWireJson.FormatFloat(scl.x) + "," + SceneSyncWireJson.FormatFloat(scl.y) + "," + SceneSyncWireJson.FormatFloat(scl.z) + "]" +
                 meshPathJson + assetIdJson + assetJson + "}";
             await _client.Broadcast(payload);
 
@@ -1265,9 +1285,7 @@ namespace Afjk.SceneSync
 
             Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
-            var nameMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"name\":\"([^\"]+)\"");
-            var name = nameMatch.Success ? nameMatch.Groups[1].Value : objectId;
+            var name = SceneSyncWireJson.ExtractString(raw, "name") ?? objectId;
             var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
@@ -1304,10 +1322,7 @@ namespace Afjk.SceneSync
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
-            // Extract visualBasis from asset JSON
-            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"visualBasis\":\"([^\"]+)\"");
-            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+            var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
 
             // meshPath を保存
             if (!string.IsNullOrEmpty(meshPath))
@@ -1469,10 +1484,7 @@ namespace Afjk.SceneSync
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
-            // Extract visualBasis from asset JSON
-            var visualBasisMatch = System.Text.RegularExpressions.Regex.Match(
-                raw, "\"visualBasis\":\"([^\"]+)\"");
-            var visualBasis = visualBasisMatch.Success ? visualBasisMatch.Groups[1].Value : null;
+            var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
@@ -1579,7 +1591,6 @@ namespace Afjk.SceneSync
             var objectsJson = new System.Text.StringBuilder();
             objectsJson.Append("{");
             bool first = true;
-            var pendingUploads = new List<(byte[] glb, string path, string assetId)>();
             int sceneStateObjectCount = 0;
 
             foreach (var go in rootObjects)
@@ -1628,13 +1639,28 @@ namespace Afjk.SceneSync
                     || go.GetComponentInChildren<SkinnedMeshRenderer>() != null)
                 {
                     var glb = await PresenceClientRuntime.ExportGameObjectAsGlb(go);
-                    if (glb != null)
+                    if (glb == null)
+                    {
+                        Debug.LogWarning(
+                            "[SceneSync] scene-state skipped because GLB export failed: objectId=" +
+                            objectId + ", name=" + go.name);
+                        continue;
+                    }
+                    else
                     {
                         path = PresenceClientRuntime.GenerateRandomPath();
                         assetId = PresenceClientRuntime.ComputeAssetId(glb);
-                        pendingUploads.Add((glb, path, assetId));
+                        var uploaded = await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
+                        if (!uploaded)
+                        {
+                            Debug.LogWarning(
+                                "[SceneSync] scene-state skipped because GLB upload failed: objectId=" +
+                                objectId + ", name=" + go.name);
+                            continue;
+                        }
                         _meshPaths[objectId] = path;
-                        _assetIdCache[assetId] = glb;
+                        if (assetId != null)
+                            _assetIdCache[assetId] = glb;
                         _meshPathCache[path] = glb;
                     }
                 }
@@ -1728,10 +1754,6 @@ namespace Afjk.SceneSync
             objectsJson.Append("}");
 
             Debug.Log($"[SceneSync] Building scene-state. count={sceneStateObjectCount}");
-
-            // アップロードを先に完了させる
-            foreach (var (glb, path, assetId) in pendingUploads)
-                await PresenceClientRuntime.UploadGlb(glb, GetBlobUrl(), path);
 
             // handoff で 1対1 返信（broadcast ではない）
             var envJson = !string.IsNullOrWhiteSpace(_envId)


### PR DESCRIPTION
## Summary

- Harden Unity Runtime GLB upload handling so scene-add, scene-mesh, and scene-state do not advertise missing or failed mesh uploads.
- Reuse shared Scene Sync wire JSON generation for Editor scene-state objects so names, IDs, mesh paths, asset IDs, asset metadata, and metadata are escaped and emitted consistently.
- Parse received object names and `asset.visualBasis` through the shared wire JSON helpers instead of ad hoc regex captures.

Closes #312.

## Validation

- `git diff --check`
- `npm test` in `packages/scene-sync-mcp`

Unity Editor / Runtime playback was not launched in this environment.