### PR TITLE
[codex] Resolve Unity-origin objects from hierarchy

### DIFF
--- a/docs/scene-sync-api-protocol.md
+++ b/docs/scene-sync-api-protocol.md
@@ -123,6 +123,8 @@ OpenAPI 定義:
   "objects": {
     "obj-001": {
       "name": "Cube",
+      "origin": "unity",
+      "unityHierarchyPath": "SceneRoot/Cube",
       "position": [0, 0.5, 0],
       "rotation": [0, 0, 0, 1],
       "scale": [1, 1, 1],
@@ -139,6 +141,8 @@ OpenAPI 定義:
 `scene-state` は、単なる transform だけでなく、復元に必要な asset metadata も保持する。
 特に Unity 由来 GLB では `asset.visualBasis` を落としてはいけない。詳細は [座標系と visualBasis](./scene-sync-coordinate-system.md) を参照。
 
+Unity が publish した `origin: "unity"` object は Unity Hierarchy 上の既存 `GameObject` が実体を管理する。Unity client は受信時に `objectId`、`unityHierarchyPath`、最後に一意な `name` の順で既存 object を解決し、見つかった場合は新規 object を生成せずその object に transform / metadata を反映する。
+
 ### `scene-add`
 
 ```json
@@ -146,6 +150,8 @@ OpenAPI 定義:
   "kind": "scene-add",
   "objectId": "obj-002",
   "name": "Sphere",
+  "origin": "unity",
+  "unityHierarchyPath": "SceneRoot/Sphere",
   "position": [0, 0, 0],
   "rotation": [0, 0, 0, 1],
   "scale": [1, 1, 1],

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1965,7 +1965,7 @@ namespace Afjk.SceneSync.Editor
             _meshPaths[objectId] = meshPath;
 
             var go = FindManagedObject(objectId);
-            var name = go != null ? go.name : objectId;
+            var name = SceneSyncWireJson.ExtractString(raw, "name") ?? (go != null ? go.name : objectId);
 
             if (go == null && origin == "unity")
             {

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1208,6 +1208,116 @@ namespace Afjk.SceneSync.Editor
             return null;
         }
 
+        private static IEnumerable<GameObject> EnumerateSceneGameObjects()
+        {
+            var rootObjects = UnityEngine.SceneManagement.SceneManager
+                .GetActiveScene().GetRootGameObjects();
+
+            foreach (var root in rootObjects)
+            {
+                if (root == null) continue;
+                foreach (var transform in root.GetComponentsInChildren<Transform>(true))
+                {
+                    if (transform != null) yield return transform.gameObject;
+                }
+            }
+        }
+
+        private GameObject ResolveUnityOriginObject(string objectId, string name, string unityHierarchyPath)
+        {
+            var candidates = EnumerateSceneGameObjects();
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate == null) continue;
+                var identity = candidate.GetComponent<SceneSyncIdentity>();
+                if (identity == null) continue;
+                if (identity.Origin != SceneSyncOrigin.Unity) continue;
+                if (identity.Temporary) continue;
+                if (identity.ObjectId == objectId) return candidate;
+            }
+
+            if (int.TryParse(objectId, out var instanceId))
+            {
+                foreach (var candidate in EnumerateSceneGameObjects())
+                {
+                    if (candidate != null && candidate.GetInstanceID() == instanceId)
+                        return candidate;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(unityHierarchyPath))
+            {
+                GameObject match = null;
+                foreach (var candidate in EnumerateSceneGameObjects())
+                {
+                    if (candidate == null) continue;
+                    var identity = candidate.GetComponent<SceneSyncIdentity>();
+                    if (identity != null && identity.Temporary) continue;
+                    if (SceneSyncWireJson.GetUnityHierarchyPath(candidate) != unityHierarchyPath) continue;
+                    if (match != null) return null;
+                    match = candidate;
+                }
+                if (match != null) return match;
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                GameObject match = null;
+                foreach (var candidate in EnumerateSceneGameObjects())
+                {
+                    if (candidate == null) continue;
+                    var identity = candidate.GetComponent<SceneSyncIdentity>();
+                    if (identity != null && identity.Temporary) continue;
+                    if (candidate.name != name) continue;
+                    if (match != null) return null;
+                    match = candidate;
+                }
+                return match;
+            }
+
+            return null;
+        }
+
+        private void BindUnityOriginObject(
+            GameObject go,
+            string objectId,
+            string meshPath,
+            string assetId,
+            string assetJson,
+            string metadataJson,
+            bool? visible,
+            float[] position,
+            float[] rotation,
+            float[] scale)
+        {
+            if (go == null) return;
+
+            var identity = EnsureSceneSyncIdentity(go);
+            identity.ObjectId = objectId;
+            identity.Origin = SceneSyncOrigin.Unity;
+            identity.Temporary = false;
+            identity.State = SceneSyncState.Synced;
+            identity.MeshPath = meshPath;
+            identity.AssetId = assetId;
+            identity.LockOwner = null;
+
+            if (!string.IsNullOrEmpty(meshPath))
+                _meshPaths[objectId] = meshPath;
+            SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            if (visible.HasValue) go.SetActive(visible.Value);
+            ApplyTransform(go, position, rotation, scale);
+
+            _managedObjects[objectId] = go;
+            _knownObjectIds.Add(objectId);
+            _instanceToObjectId[go.GetInstanceID()] = objectId;
+            _lastSnapshots[objectId] = new TransformSnapshot(go.transform);
+
+            EditorUtility.SetDirty(identity);
+            EditorUtility.SetDirty(go);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+        }
+
         private float[] ExtractArray(string json, string key)
         {
             var pattern = System.Text.RegularExpressions.Regex.Escape(key) + @"\s*\[\s*([^\]]+)\s*\]";
@@ -1571,6 +1681,8 @@ namespace Afjk.SceneSync.Editor
             var rot = go.transform.rotation;
             var scl = go.transform.localScale;
             var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + JsonEscape(objectId) + "\",\"name\":\"" + JsonEscape(go.name) + "\"" +
+                ",\"origin\":\"unity\"" +
+                ",\"unityHierarchyPath\":\"" + JsonEscape(SceneSyncWireJson.GetUnityHierarchyPath(go)) + "\"" +
                 ",\"position\":[" + FormatFloat(pos.x) + "," + FormatFloat(pos.y) + "," + FormatFloat(-pos.z) + "]" +
                 ",\"rotation\":[" + FormatFloat(rot.x) + "," + FormatFloat(rot.y) + "," + FormatFloat(-rot.z) + "," + FormatFloat(-rot.w) + "]" +
                 ",\"scale\":[" + FormatFloat(scl.x) + "," + FormatFloat(scl.y) + "," + FormatFloat(scl.z) + "]" +
@@ -1691,6 +1803,8 @@ namespace Afjk.SceneSync.Editor
             Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
             var name = SceneSyncWireJson.ExtractString(raw, "name") ?? objectId;
+            var origin = SceneSyncWireJson.ExtractString(raw, "origin");
+            var unityHierarchyPath = SceneSyncWireJson.ExtractString(raw, "unityHierarchyPath");
             var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
@@ -1732,6 +1846,30 @@ namespace Afjk.SceneSync.Editor
             if (!string.IsNullOrEmpty(meshPath))
             {
                 _meshPaths[objectId] = meshPath;
+            }
+
+            if (origin == "unity")
+            {
+                var unityObject = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
+                if (unityObject != null)
+                {
+                    BindUnityOriginObject(
+                        unityObject,
+                        objectId,
+                        meshPath,
+                        assetId,
+                        assetJson,
+                        metadataJson,
+                        visible,
+                        position,
+                        rotation,
+                        scale);
+                    Debug.Log("[SceneSync] scene-add resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + unityObject.name);
+                    return;
+                }
+
+                Debug.LogWarning("[SceneSync] origin=unity object not found in Hierarchy; ignoring remote creation: objectId=" + objectId + ", name=" + name + ", hierarchyPath=" + unityHierarchyPath);
+                return;
             }
 
             var assetType = SceneSyncWireJson.GetAssetType(assetJson);
@@ -1820,12 +1958,28 @@ namespace Afjk.SceneSync.Editor
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
             var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
+            var origin = SceneSyncWireJson.ExtractString(raw, "origin");
+            var unityHierarchyPath = SceneSyncWireJson.ExtractString(raw, "unityHierarchyPath");
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
 
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
+
+            if (go == null && origin == "unity")
+            {
+                go = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
+                if (go != null)
+                {
+                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null);
+                    Debug.Log("[SceneSync] scene-mesh resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + go.name);
+                    return;
+                }
+
+                Debug.LogWarning("[SceneSync] origin=unity scene-mesh target not found in Hierarchy; ignoring remote creation: objectId=" + objectId + ", hierarchyPath=" + unityHierarchyPath);
+                return;
+            }
 
             Debug.Log(
                 "[SceneSync] scene-mesh received: objectId=" + objectId
@@ -2084,7 +2238,9 @@ namespace Afjk.SceneSync.Editor
                     path,
                     assetId,
                     rawAssetJson,
-                    rawMetadataJson));
+                    rawMetadataJson,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
             }
 
             objectsJson.Append("}");

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -402,7 +402,7 @@ namespace Afjk.SceneSync
                     _meshPathCache[path] = glb;
 
                 var assetIdJson = assetId != null ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
-                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" +
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"name\":\"" + SceneSyncWireJson.JsonEscape(go.name) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" +
                     ",\"origin\":\"unity\"" +
                     ",\"unityHierarchyPath\":\"" + SceneSyncWireJson.JsonEscape(SceneSyncWireJson.GetUnityHierarchyPath(go)) + "\"" +
                     assetIdJson +
@@ -1611,7 +1611,7 @@ namespace Afjk.SceneSync
             _meshPaths[objectId] = meshPath;
 
             var go = FindManagedObject(objectId);
-            var name = go != null ? go.name : objectId;
+            var name = SceneSyncWireJson.ExtractString(raw, "name") ?? (go != null ? go.name : objectId);
 
             if (go == null && origin == "unity")
             {

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -402,7 +402,10 @@ namespace Afjk.SceneSync
                     _meshPathCache[path] = glb;
 
                 var assetIdJson = assetId != null ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
-                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" + assetIdJson +
+                var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" +
+                    ",\"origin\":\"unity\"" +
+                    ",\"unityHierarchyPath\":\"" + SceneSyncWireJson.JsonEscape(SceneSyncWireJson.GetUnityHierarchyPath(go)) + "\"" +
+                    assetIdJson +
                     ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") + "}";
                 await _client.Broadcast(payload);
             }
@@ -782,6 +785,8 @@ namespace Afjk.SceneSync
                 ? ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity")
                 : "";
             var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(go.GetInstanceID().ToString()) + "\",\"name\":\"" + SceneSyncWireJson.JsonEscape(go.name) + "\"" +
+                ",\"origin\":\"unity\"" +
+                ",\"unityHierarchyPath\":\"" + SceneSyncWireJson.JsonEscape(SceneSyncWireJson.GetUnityHierarchyPath(go)) + "\"" +
                 ",\"position\":[" + SceneSyncWireJson.FormatFloat(pos.x) + "," + SceneSyncWireJson.FormatFloat(pos.y) + "," + SceneSyncWireJson.FormatFloat(-pos.z) + "]" +
                 ",\"rotation\":[" + SceneSyncWireJson.FormatFloat(rot.x) + "," + SceneSyncWireJson.FormatFloat(rot.y) + "," + SceneSyncWireJson.FormatFloat(-rot.z) + "," + SceneSyncWireJson.FormatFloat(-rot.w) + "]" +
                 ",\"scale\":[" + SceneSyncWireJson.FormatFloat(scl.x) + "," + SceneSyncWireJson.FormatFloat(scl.y) + "," + SceneSyncWireJson.FormatFloat(scl.z) + "]" +
@@ -1243,6 +1248,94 @@ namespace Afjk.SceneSync
             return null;
         }
 
+        private GameObject ResolveUnityOriginObject(string objectId, string name, string unityHierarchyPath)
+        {
+            var candidates = GetAllSyncTargets();
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate == null || IsTemporaryObject(candidate)) continue;
+                var identity = candidate.GetComponent<SceneSyncIdentity>();
+                if (identity == null) continue;
+                if (identity.Origin != SceneSyncOrigin.Unity) continue;
+                if (identity.Temporary) continue;
+                if (identity.ObjectId == objectId) return candidate;
+            }
+
+            if (int.TryParse(objectId, out var instanceId))
+            {
+                foreach (var candidate in candidates)
+                {
+                    if (candidate != null && candidate.GetInstanceID() == instanceId && !IsTemporaryObject(candidate))
+                        return candidate;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(unityHierarchyPath))
+            {
+                GameObject match = null;
+                foreach (var candidate in candidates)
+                {
+                    if (candidate == null || IsTemporaryObject(candidate)) continue;
+                    if (SceneSyncWireJson.GetUnityHierarchyPath(candidate) != unityHierarchyPath) continue;
+                    if (match != null) return null;
+                    match = candidate;
+                }
+                if (match != null) return match;
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                GameObject match = null;
+                foreach (var candidate in candidates)
+                {
+                    if (candidate == null || IsTemporaryObject(candidate)) continue;
+                    if (candidate.name != name) continue;
+                    if (match != null) return null;
+                    match = candidate;
+                }
+                return match;
+            }
+
+            return null;
+        }
+
+        private void BindUnityOriginObject(
+            GameObject go,
+            string objectId,
+            string meshPath,
+            string assetId,
+            string assetJson,
+            string metadataJson,
+            bool? visible,
+            float[] position,
+            float[] rotation,
+            float[] scale)
+        {
+            if (go == null) return;
+
+            var identity = EnsureSceneSyncIdentity(go);
+            identity.ObjectId = objectId;
+            identity.Origin = SceneSyncOrigin.Unity;
+            identity.Temporary = false;
+            identity.State = SceneSyncState.Synced;
+            identity.MeshPath = meshPath;
+            identity.AssetId = assetId;
+            identity.LockOwner = null;
+
+            if (!string.IsNullOrEmpty(meshPath))
+                _meshPaths[objectId] = meshPath;
+            SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            if (visible.HasValue) go.SetActive(visible.Value);
+            ApplyTransform(go, position, rotation, scale);
+
+            _managedObjects[objectId] = go;
+            _knownObjectIds.Add(objectId);
+            _instanceToObjectId[go.GetInstanceID()] = objectId;
+            _remoteRemovedUnityObjectIds.Remove(objectId);
+            OnObjectAdded?.Invoke(objectId, go);
+        }
+
         private float[] ExtractArray(string json, string key)
         {
             var pattern = System.Text.RegularExpressions.Regex.Escape(key) + @"\s*\[\s*([^\]]+)\s*\]";
@@ -1286,6 +1379,8 @@ namespace Afjk.SceneSync
             Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → not yet managed");
 
             var name = SceneSyncWireJson.ExtractString(raw, "name") ?? objectId;
+            var origin = SceneSyncWireJson.ExtractString(raw, "origin");
+            var unityHierarchyPath = SceneSyncWireJson.ExtractString(raw, "unityHierarchyPath");
             var visible = SceneSyncWireJson.ExtractBoolean(raw, "visible");
 
             float[] position = ExtractArray(raw, "\"position\":");
@@ -1328,6 +1423,30 @@ namespace Afjk.SceneSync
             if (!string.IsNullOrEmpty(meshPath))
             {
                 _meshPaths[objectId] = meshPath;
+            }
+
+            if (origin == "unity")
+            {
+                var unityObject = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
+                if (unityObject != null)
+                {
+                    BindUnityOriginObject(
+                        unityObject,
+                        objectId,
+                        meshPath,
+                        assetId,
+                        assetJson,
+                        metadataJson,
+                        visible,
+                        position,
+                        rotation,
+                        scale);
+                    Debug.Log("[SceneSync] scene-add resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + unityObject.name);
+                    return;
+                }
+
+                Debug.LogWarning("[SceneSync] origin=unity object not found in Hierarchy; ignoring remote creation: objectId=" + objectId + ", name=" + name + ", hierarchyPath=" + unityHierarchyPath);
+                return;
             }
 
             // Unity 由来の objectId は整数（InstanceID）。
@@ -1485,12 +1604,28 @@ namespace Afjk.SceneSync
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
             var visualBasis = SceneSyncWireJson.ExtractString(assetJson, "visualBasis");
+            var origin = SceneSyncWireJson.ExtractString(raw, "origin");
+            var unityHierarchyPath = SceneSyncWireJson.ExtractString(raw, "unityHierarchyPath");
 
             // meshPath を保存
             _meshPaths[objectId] = meshPath;
 
             var go = FindManagedObject(objectId);
             var name = go != null ? go.name : objectId;
+
+            if (go == null && origin == "unity")
+            {
+                go = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
+                if (go != null)
+                {
+                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null);
+                    Debug.Log("[SceneSync] scene-mesh resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + go.name);
+                    return;
+                }
+
+                Debug.LogWarning("[SceneSync] origin=unity scene-mesh target not found in Hierarchy; ignoring remote creation: objectId=" + objectId + ", hierarchyPath=" + unityHierarchyPath);
+                return;
+            }
 
             Debug.Log(
                 "[SceneSync] scene-mesh received: objectId=" + objectId
@@ -1687,7 +1822,9 @@ namespace Afjk.SceneSync
                     path,
                     assetId,
                     rawAssetJson,
-                    rawMetadataJson));
+                    rawMetadataJson,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
                 sceneStateObjectCount++;
             }
 
@@ -1747,7 +1884,9 @@ namespace Afjk.SceneSync
                     path,
                     assetId,
                     rawAssetJson,
-                    rawMetadataJson));
+                    rawMetadataJson,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
                 sceneStateObjectCount++;
             }
 

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
@@ -193,11 +193,17 @@ namespace Afjk.SceneSync
             string meshPath,
             string assetId,
             string assetJson,
-            string metadataJson)
+            string metadataJson,
+            string origin = null,
+            string unityHierarchyPath = null)
         {
             var builder = new StringBuilder();
             builder.Append("\"").Append(JsonEscape(objectId)).Append("\":{");
             builder.Append("\"name\":\"").Append(JsonEscape(name)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(origin))
+                builder.Append(",\"origin\":\"").Append(JsonEscape(origin)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(unityHierarchyPath))
+                builder.Append(",\"unityHierarchyPath\":\"").Append(JsonEscape(unityHierarchyPath)).Append("\"");
             builder.Append(",\"position\":[")
                 .Append(FormatFloat(position.x)).Append(",")
                 .Append(FormatFloat(position.y)).Append(",")
@@ -222,6 +228,21 @@ namespace Afjk.SceneSync
                 builder.Append(",\"metadata\":").Append(metadataJson);
             builder.Append("}");
             return builder.ToString();
+        }
+
+        public static string GetUnityHierarchyPath(GameObject go)
+        {
+            if (go == null) return null;
+
+            var stack = new Stack<string>();
+            var current = go.transform;
+            while (current != null)
+            {
+                stack.Push(current.name);
+                current = current.parent;
+            }
+
+            return string.Join("/", stack);
         }
 
         public static string GetAssetType(string assetJson)


### PR DESCRIPTION
## Summary

- Emit `origin: "unity"` and `unityHierarchyPath` for Unity-authored scene payloads and scene-state entries.
- Add Unity Runtime and Editor resolvers that bind incoming `origin=unity` objects to existing Hierarchy GameObjects by object ID, hierarchy path, or unique name.
- When a Unity-origin target is resolved, apply transform and wire metadata to the existing GameObject instead of creating a remote temporary object or importing a replacement GLB.
- Document the Unity-origin resolution contract in the Scene Sync API protocol.

Closes #318.

## Validation

- `git diff --check`
- `npm test` in `packages/scene-sync-mcp`

Unity Editor / Runtime playback was not launched in this environment.