### PR TITLE
Bind Unity Loomlet behavior graphs

### DIFF
--- a/docs/scene-sync-loom-protocol.md
+++ b/docs/scene-sync-loom-protocol.md
@@ -168,6 +168,18 @@ Scene Sync 側の方針:
 
 ---
 
+## Unity runtime binding
+
+Unity package は `com.afjk.loomlet-runtime` を使って compile 済み Graph JSON を評価する。
+
+- `scene-graph-set` / `scene-graph-clear` を受信し、object scope graph は対象 GameObject の `SceneSyncLoomletBehaviour` に bind する。
+- `scene-state.loomGraphs.scene` と `scene-state.loomGraphs.objects[objectId]` を late join 時に復元する。
+- object metadata の `loomGraph` または `behaviorGraph` に Graph JSON が含まれる場合も object graph として bind する。
+- Unity package は Loomlet DSL parser / compiler を持たない。
+- Scene clock は host が read-only input として渡し、graph から pause / seek / reset などの host control は行わない。
+
+---
+
 ## Related docs
 
 - [Scene Sync Spec Index](./scene-sync-spec.md)

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -914,7 +914,7 @@ namespace Afjk.SceneSync.Editor
 
         private void OnHandoff(string raw)
         {
-            if (!raw.Contains("\"kind\"")) return;
+            if (!raw.Contains("\"kind\"") && !raw.Contains("\"type\":\"scene-graph-")) return;
 
             // from.id を抽出（handoff メッセージに含まれる）
             string fromId = null;
@@ -930,7 +930,15 @@ namespace Afjk.SceneSync.Editor
         {
             if (string.IsNullOrEmpty(raw)) return;
 
-            if (raw.Contains("\"kind\":\"scene-request\""))
+            if (raw.Contains("\"type\":\"scene-graph-set\""))
+            {
+                HandleSceneGraphSet(raw);
+            }
+            else if (raw.Contains("\"type\":\"scene-graph-clear\""))
+            {
+                HandleSceneGraphClear(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-request\""))
             {
                 if (fromId != null)
                     _ = HandleSceneRequest(fromId);
@@ -1096,6 +1104,117 @@ namespace Afjk.SceneSync.Editor
                 Debug.Log("[SceneSync] Restore scene-state object as scene-add: " + fakeJson);
                 HandleSceneAdd(fakeJson);
             }
+
+            RestoreLoomGraphsFromSceneState(raw);
+        }
+
+        private void HandleSceneGraphSet(string raw)
+        {
+            var graphJson = SceneSyncWireJson.ExtractRawObject(raw, "graph");
+            if (string.IsNullOrWhiteSpace(graphJson)) return;
+
+            if (TryExtractGraphObjectScope(raw, out var objectId))
+            {
+                var go = FindManagedObject(objectId);
+                if (go == null)
+                {
+                    Debug.LogWarning("[SceneSync] scene-graph-set target not found: objectId=" + objectId);
+                    return;
+                }
+
+                SceneSyncLoomletBehaviour.SetObjectGraph(go, FindSceneSyncManager(), objectId, graphJson);
+                EditorUtility.SetDirty(go);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+                Debug.Log("[SceneSync] Bound Loomlet object graph: objectId=" + objectId);
+                return;
+            }
+
+            var manager = FindSceneSyncManager();
+            if (manager == null)
+            {
+                Debug.LogWarning("[SceneSync] scene-graph-set scene scope ignored because SceneSyncManager is missing");
+                return;
+            }
+
+            SceneSyncLoomletBehaviour.SetSceneGraph(manager, graphJson);
+            EditorUtility.SetDirty(manager);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+            Debug.Log("[SceneSync] Bound Loomlet scene graph");
+        }
+
+        private void HandleSceneGraphClear(string raw)
+        {
+            if (TryExtractGraphObjectScope(raw, out var objectId))
+            {
+                var go = FindManagedObject(objectId);
+                SceneSyncLoomletBehaviour.ClearObjectGraph(go);
+                if (go != null) EditorUtility.SetDirty(go);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+                Debug.Log("[SceneSync] Cleared Loomlet object graph: objectId=" + objectId);
+                return;
+            }
+
+            var manager = FindSceneSyncManager();
+            SceneSyncLoomletBehaviour.ClearSceneGraph(manager);
+            if (manager != null) EditorUtility.SetDirty(manager);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+            Debug.Log("[SceneSync] Cleared Loomlet scene graph");
+        }
+
+        private bool TryExtractGraphObjectScope(string raw, out string objectId)
+        {
+            var scopeJson = SceneSyncWireJson.ExtractRawObject(raw, "scope");
+            objectId = SceneSyncWireJson.ExtractString(scopeJson, "object");
+            if (!string.IsNullOrWhiteSpace(objectId)) return true;
+
+            var scope = SceneSyncWireJson.ExtractString(raw, "scope");
+            if (scope == "object")
+            {
+                objectId = SceneSyncWireJson.ExtractString(raw, "objectId");
+                return !string.IsNullOrWhiteSpace(objectId);
+            }
+
+            objectId = null;
+            return !string.IsNullOrWhiteSpace(objectId);
+        }
+
+        private void RestoreLoomGraphsFromSceneState(string raw)
+        {
+            var loomGraphsJson = SceneSyncWireJson.ExtractRawObject(raw, "loomGraphs");
+            if (string.IsNullOrWhiteSpace(loomGraphsJson)) return;
+
+            var manager = FindSceneSyncManager();
+            var sceneGraphJson = SceneSyncWireJson.ExtractRawObject(loomGraphsJson, "scene");
+            if (manager != null && !string.IsNullOrWhiteSpace(sceneGraphJson))
+                SceneSyncLoomletBehaviour.SetSceneGraph(manager, sceneGraphJson);
+
+            foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(loomGraphsJson, "objects"))
+            {
+                var go = FindManagedObject(entry.Key);
+                if (go == null)
+                {
+                    Debug.LogWarning("[SceneSync] scene-state Loomlet graph target not found: objectId=" + entry.Key);
+                    continue;
+                }
+                SceneSyncLoomletBehaviour.SetObjectGraph(go, manager, entry.Key, entry.Value);
+                EditorUtility.SetDirty(go);
+            }
+
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+        }
+
+        private void ApplyMetadataBehaviorGraph(GameObject go, string objectId, string metadataJson)
+        {
+            if (go == null || string.IsNullOrWhiteSpace(objectId) || string.IsNullOrWhiteSpace(metadataJson)) return;
+
+            var graphJson = SceneSyncWireJson.ExtractRawObject(metadataJson, "loomGraph");
+            if (string.IsNullOrWhiteSpace(graphJson))
+                graphJson = SceneSyncWireJson.ExtractRawObject(metadataJson, "behaviorGraph");
+            if (string.IsNullOrWhiteSpace(graphJson)) return;
+
+            SceneSyncLoomletBehaviour.SetObjectGraph(go, FindSceneSyncManager(), objectId, graphJson);
+            EditorUtility.SetDirty(go);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
         }
 
         private void HandleSceneEnv(string raw)
@@ -1134,6 +1253,7 @@ namespace Afjk.SceneSync.Editor
             {
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
                 SceneSyncPanelFactory.ApplyAssetVisualDelta(go, assetJson);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
 
                 if (!string.IsNullOrWhiteSpace(assetJson))
                 {
@@ -1305,6 +1425,7 @@ namespace Afjk.SceneSync.Editor
             if (!string.IsNullOrEmpty(meshPath))
                 _meshPaths[objectId] = meshPath;
             SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
             if (visible.HasValue) go.SetActive(visible.Value);
             ApplyTransform(go, position, rotation, scale);
 
@@ -1887,6 +2008,7 @@ namespace Afjk.SceneSync.Editor
             {
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                 ApplyTransform(go, position, rotation, scale);
@@ -1996,6 +2118,7 @@ namespace Afjk.SceneSync.Editor
                     EditorUtility.SetDirty(identity);
                 }
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 Debug.Log("[SceneSync] Received scene-mesh for Unity-authored object; keeping local GameObject: " + objectId);
                 return;
             }
@@ -2249,8 +2372,43 @@ namespace Afjk.SceneSync.Editor
             var envJson = !string.IsNullOrWhiteSpace(_envId)
                 ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
                 : "";
-            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson + "}";
+            var loomGraphsJson = BuildLoomGraphsStateJson();
+            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson
+                + (!string.IsNullOrWhiteSpace(loomGraphsJson) ? ",\"loomGraphs\":" + loomGraphsJson : "")
+                + "}";
             await _client.SendHandoff(fromId, payload);
+        }
+
+        private string BuildLoomGraphsStateJson()
+        {
+            var manager = FindSceneSyncManager();
+            var sceneGraph = manager != null ? manager.GetComponent<SceneSyncLoomletBehaviour>() : null;
+            var hasSceneGraph = sceneGraph != null
+                && sceneGraph.SceneScope
+                && !string.IsNullOrWhiteSpace(sceneGraph.GraphJson);
+
+            var objects = new System.Text.StringBuilder();
+            objects.Append("{");
+            var hasObjectGraphs = false;
+            foreach (var kvp in _managedObjects)
+            {
+                var go = kvp.Value;
+                if (go == null) continue;
+                var runner = go.GetComponent<SceneSyncLoomletBehaviour>();
+                if (runner == null || runner.SceneScope || string.IsNullOrWhiteSpace(runner.GraphJson)) continue;
+                if (hasObjectGraphs) objects.Append(",");
+                hasObjectGraphs = true;
+                objects.Append("\"").Append(SceneSyncWireJson.JsonEscape(kvp.Key)).Append("\":").Append(runner.GraphJson);
+            }
+            objects.Append("}");
+
+            if (!hasSceneGraph && !hasObjectGraphs) return null;
+
+            var builder = new System.Text.StringBuilder();
+            builder.Append("{\"scene\":");
+            builder.Append(hasSceneGraph ? sceneGraph.GraphJson : "null");
+            builder.Append(",\"objects\":").Append(objects).Append("}");
+            return builder.ToString();
         }
 
         private void ApplyTransform(GameObject go, float[] position, float[] rotation, float[] scale)
@@ -2294,6 +2452,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] Download failed: " + response.StatusCode);
                     var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                    ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
                     if (visible.HasValue) fallback.SetActive(visible.Value);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
@@ -2325,6 +2484,7 @@ namespace Afjk.SceneSync.Editor
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                     if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
@@ -2357,6 +2517,7 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
                     var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                    ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
                     if (visible.HasValue) fallback.SetActive(visible.Value);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     ApplyTransform(fallback, position, rotation, scale);
@@ -2458,6 +2619,7 @@ namespace Afjk.SceneSync.Editor
             _locks.Remove(objectId);
             _lastSnapshots.Remove(objectId);
             _knownObjectIds.Remove(objectId);
+            SceneSyncLoomletBehaviour.ClearObjectGraph(go);
 
             if (go != null)
             {

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -29,6 +29,8 @@ Scene Sync は `com.afjk.loomlet-runtime@0.3.0` に依存しています。`upm.
 
 `com.afjk.loomlet-runtime@0.3.0` が `upm.afjk.jp` に publish 済みである必要があります。Scene Sync 側の依存 version は package release ごとに固定します。
 
+Unity 受信側は `scene-graph-set` / `scene-graph-clear` と `scene-state.loomGraphs` を受け取り、対象 GameObject に `SceneSyncLoomletBehaviour` を bind します。Object scope の graph は同じ object への再送で置き換わり、clear または replace 時に `sceneOffsetPosition` の base position を復元します。Unity 側は Loomlet DSL を parse せず、compile 済み Graph JSON だけを評価します。
+
 ### Git URL
 
 Unity Editor の **Window > Package Manager > + > Add package from git URL** に以下を入力:

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
@@ -88,10 +88,18 @@ namespace Afjk.SceneSync
             _startedAt = Time.realtimeSinceStartup;
             _lastTime = _startedAt;
 
-            var graph = LoomletGraph.FromJson(graphJson);
-            if (!sceneScope)
-                InjectObjectScopeTarget(graph, targetObjectId);
-            _evaluator = new LoomletEvaluator(graph, CreateSceneSyncRegistry());
+            try
+            {
+                var graph = LoomletGraph.FromJson(graphJson);
+                if (!sceneScope)
+                    InjectObjectScopeTarget(graph, targetObjectId);
+                _evaluator = new LoomletEvaluator(graph, CreateSceneSyncRegistry());
+            }
+            catch (Exception error)
+            {
+                Debug.LogWarning("[SceneSync] Failed to bind Loomlet graph: " + error.Message);
+                ClearGraph(restoreBases: false);
+            }
         }
 
         public void ClearGraph(bool restoreBases)
@@ -113,7 +121,7 @@ namespace Afjk.SceneSync
 
             try
             {
-                _context.WithSceneClock(elapsed, delta, false, "server", 1.0);
+                _context.WithSceneClock(elapsed, delta, false, "local", 1.0);
                 _evaluator.Evaluate(_context);
             }
             catch (Exception error)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using Loomlet.Runtime;
+using UnityEngine;
+
+namespace Afjk.SceneSync
+{
+    [ExecuteAlways]
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncLoomletBehaviour : MonoBehaviour
+    {
+        private static readonly HashSet<string> SceneNodeTypes = new HashSet<string>
+        {
+            "sceneSetPosition",
+            "sceneOffsetPosition",
+            "sceneSetRotation",
+            "sceneSetScale",
+            "sceneSetColor",
+            "sceneSetVisible",
+            "scene.setPosition",
+            "scene.offsetPosition",
+            "scene.setRotation",
+            "scene.setScale",
+            "scene.setColor",
+            "scene.setVisible"
+        };
+
+        [SerializeField] private string objectId;
+        [SerializeField] private bool sceneScope;
+        [SerializeField] private string graphJson;
+        [SerializeField] private SceneSyncManager manager;
+
+        private LoomletEvaluator _evaluator;
+        private LoomletEvaluationContext _context;
+        private double _lastTime;
+        private double _startedAt;
+        private readonly Dictionary<string, Vector3> _offsetBasePositions = new Dictionary<string, Vector3>();
+
+        public string ObjectId => objectId;
+        public bool SceneScope => sceneScope;
+        public string GraphJson => graphJson;
+
+        public static SceneSyncLoomletBehaviour SetObjectGraph(GameObject go, SceneSyncManager owner, string targetObjectId, string rawGraphJson)
+        {
+            if (go == null || string.IsNullOrWhiteSpace(rawGraphJson)) return null;
+
+            var runner = go.GetComponent<SceneSyncLoomletBehaviour>();
+            if (runner == null) runner = go.AddComponent<SceneSyncLoomletBehaviour>();
+            runner.Configure(owner, targetObjectId, rawGraphJson, isSceneScope: false);
+            return runner;
+        }
+
+        public static void ClearObjectGraph(GameObject go)
+        {
+            var runner = go != null ? go.GetComponent<SceneSyncLoomletBehaviour>() : null;
+            if (runner == null) return;
+            runner.ClearGraph(restoreBases: true);
+            DestroyRunner(runner);
+        }
+
+        public static SceneSyncLoomletBehaviour SetSceneGraph(SceneSyncManager owner, string rawGraphJson)
+        {
+            if (owner == null || string.IsNullOrWhiteSpace(rawGraphJson)) return null;
+
+            var runner = owner.GetComponent<SceneSyncLoomletBehaviour>();
+            if (runner == null) runner = owner.gameObject.AddComponent<SceneSyncLoomletBehaviour>();
+            runner.Configure(owner, null, rawGraphJson, isSceneScope: true);
+            return runner;
+        }
+
+        public static void ClearSceneGraph(SceneSyncManager owner)
+        {
+            var runner = owner != null ? owner.GetComponent<SceneSyncLoomletBehaviour>() : null;
+            if (runner == null || !runner.sceneScope) return;
+            runner.ClearGraph(restoreBases: true);
+            DestroyRunner(runner);
+        }
+
+        public void Configure(SceneSyncManager owner, string targetObjectId, string rawGraphJson, bool isSceneScope)
+        {
+            ClearGraph(restoreBases: true);
+
+            manager = owner;
+            objectId = targetObjectId;
+            sceneScope = isSceneScope;
+            graphJson = rawGraphJson;
+            _context = new LoomletEvaluationContext();
+            _startedAt = Time.realtimeSinceStartup;
+            _lastTime = _startedAt;
+
+            var graph = LoomletGraph.FromJson(graphJson);
+            if (!sceneScope)
+                InjectObjectScopeTarget(graph, targetObjectId);
+            _evaluator = new LoomletEvaluator(graph, CreateSceneSyncRegistry());
+        }
+
+        public void ClearGraph(bool restoreBases)
+        {
+            if (restoreBases) RestoreOffsetBases();
+            _evaluator = null;
+            _context = null;
+            graphJson = null;
+        }
+
+        private void Update()
+        {
+            if (_evaluator == null) return;
+
+            var now = (double)Time.realtimeSinceStartup;
+            var elapsed = now - _startedAt;
+            var delta = Math.Max(0, now - _lastTime);
+            _lastTime = now;
+
+            try
+            {
+                _context.WithSceneClock(elapsed, delta, false, "server", 1.0);
+                _evaluator.Evaluate(_context);
+            }
+            catch (Exception error)
+            {
+                Debug.LogWarning("[SceneSync] Loomlet graph evaluation failed: " + error.Message);
+                _evaluator = null;
+            }
+        }
+
+        private LoomletFunctionRegistry CreateSceneSyncRegistry()
+        {
+            var registry = LoomletFunctionRegistry.CreateDefault();
+
+            registry.Register("constant", new[] { "value" }, (inputs, context) => Out(Number(inputs, "value")));
+            registry.Register("serverClock", new string[0], (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
+            registry.Register("sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
+                Math.Sin(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
+                Number(inputs, "amplitude", 1) + Number(inputs, "offset")));
+            registry.Register("cosine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
+                Math.Cos(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
+                Number(inputs, "amplitude", 1) + Number(inputs, "offset")));
+            registry.Register("add", new[] { "a", "b" }, (inputs, context) => Out(Number(inputs, "a") + Number(inputs, "b")));
+            registry.Register("multiply", new[] { "a", "b" }, (inputs, context) => Out(Number(inputs, "a", 1) * Number(inputs, "b", 1)));
+
+            RegisterSceneNode(registry, "sceneSetPosition", ApplySetPosition);
+            RegisterSceneNode(registry, "scene.setPosition", ApplySetPosition);
+            RegisterSceneNode(registry, "sceneOffsetPosition", ApplyOffsetPosition);
+            RegisterSceneNode(registry, "scene.offsetPosition", ApplyOffsetPosition);
+            RegisterSceneNode(registry, "sceneSetRotation", ApplySetRotation);
+            RegisterSceneNode(registry, "scene.setRotation", ApplySetRotation);
+            RegisterSceneNode(registry, "sceneSetScale", ApplySetScale);
+            RegisterSceneNode(registry, "scene.setScale", ApplySetScale);
+            RegisterSceneNode(registry, "sceneSetColor", ApplySetColor);
+            RegisterSceneNode(registry, "scene.setColor", ApplySetColor);
+            RegisterSceneNode(registry, "sceneSetVisible", ApplySetVisible);
+            RegisterSceneNode(registry, "scene.setVisible", ApplySetVisible);
+
+            return registry;
+        }
+
+        private static void RegisterSceneNode(
+            LoomletFunctionRegistry registry,
+            string type,
+            Func<Dictionary<string, object>, Dictionary<string, object>> evaluate)
+        {
+            registry.Register(
+                type,
+                new[] { "objectId", "target", "x", "y", "z", "w", "r", "g", "b", "visible" },
+                (inputs, context) => evaluate(inputs));
+        }
+
+        private Dictionary<string, object> ApplySetPosition(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+                target.transform.position = new Vector3(
+                    (float)Number(inputs, "x"),
+                    (float)Number(inputs, "y"),
+                    (float)-Number(inputs, "z"));
+            return Empty();
+        }
+
+        private Dictionary<string, object> ApplyOffsetPosition(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            var targetId = ResolveGraphTargetId(inputs) ?? target?.GetInstanceID().ToString();
+            if (target != null && !string.IsNullOrWhiteSpace(targetId))
+            {
+                if (!_offsetBasePositions.ContainsKey(targetId))
+                    _offsetBasePositions[targetId] = target.transform.position;
+                var basePosition = _offsetBasePositions[targetId];
+                target.transform.position = basePosition + new Vector3(
+                    (float)Number(inputs, "x"),
+                    (float)Number(inputs, "y"),
+                    (float)-Number(inputs, "z"));
+            }
+            return Empty();
+        }
+
+        private Dictionary<string, object> ApplySetRotation(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+            {
+                var x = (float)(Number(inputs, "x") * Mathf.Rad2Deg);
+                var y = (float)(Number(inputs, "y") * Mathf.Rad2Deg);
+                var z = (float)(-Number(inputs, "z") * Mathf.Rad2Deg);
+                target.transform.localEulerAngles = new Vector3(x, y, z);
+            }
+            return Empty();
+        }
+
+        private Dictionary<string, object> ApplySetScale(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+                target.transform.localScale = new Vector3(
+                    (float)Number(inputs, "x", 1),
+                    (float)Number(inputs, "y", 1),
+                    (float)Number(inputs, "z", 1));
+            return Empty();
+        }
+
+        private Dictionary<string, object> ApplySetColor(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target == null) return Empty();
+
+            var color = new Color(
+                (float)Number(inputs, "r", 1),
+                (float)Number(inputs, "g", 1),
+                (float)Number(inputs, "b", 1));
+            foreach (var renderer in target.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer == null || renderer.material == null) continue;
+                var next = color;
+                next.a = renderer.material.color.a;
+                renderer.material.color = next;
+            }
+            return Empty();
+        }
+
+        private Dictionary<string, object> ApplySetVisible(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+                target.SetActive(Bool(inputs, "visible", true));
+            return Empty();
+        }
+
+        private GameObject ResolveGraphTarget(Dictionary<string, object> inputs)
+        {
+            var targetId = ResolveGraphTargetId(inputs);
+            if (string.IsNullOrWhiteSpace(targetId)) return gameObject;
+            if (!sceneScope && targetId == objectId) return gameObject;
+            return manager != null ? manager.FindSceneSyncObject(targetId) : null;
+        }
+
+        private string ResolveGraphTargetId(Dictionary<string, object> inputs)
+        {
+            var explicitObjectId = Text(inputs, "objectId");
+            if (!string.IsNullOrWhiteSpace(explicitObjectId)) return explicitObjectId;
+
+            var target = Text(inputs, "target");
+            if (!string.IsNullOrWhiteSpace(target)) return target;
+
+            return sceneScope ? null : objectId;
+        }
+
+        private void RestoreOffsetBases()
+        {
+            foreach (var pair in _offsetBasePositions)
+            {
+                var target = pair.Key == objectId ? gameObject : manager != null ? manager.FindSceneSyncObject(pair.Key) : null;
+                if (target != null) target.transform.position = pair.Value;
+            }
+            _offsetBasePositions.Clear();
+        }
+
+        private static void InjectObjectScopeTarget(LoomletGraph graph, string targetObjectId)
+        {
+            if (graph == null || string.IsNullOrWhiteSpace(targetObjectId)) return;
+
+            foreach (var node in graph.Nodes)
+            {
+                if (node == null || !SceneNodeTypes.Contains(node.Type)) continue;
+                if (node.Params == null) node.Params = new Dictionary<string, object>();
+                if (!node.Params.ContainsKey("target") && !node.Params.ContainsKey("objectId"))
+                    node.Params["target"] = targetObjectId;
+            }
+        }
+
+        private static Dictionary<string, object> Out(object value) => new Dictionary<string, object> { ["out"] = value };
+        private static Dictionary<string, object> Empty() => new Dictionary<string, object>();
+
+        private static double Number(Dictionary<string, object> inputs, string key, double fallback = 0)
+        {
+            if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null) return fallback;
+            try { return Convert.ToDouble(value); }
+            catch { return fallback; }
+        }
+
+        private static bool Bool(Dictionary<string, object> inputs, string key, bool fallback)
+        {
+            if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null) return fallback;
+            if (value is bool b) return b;
+            if (bool.TryParse(value.ToString(), out var parsed)) return parsed;
+            return fallback;
+        }
+
+        private static string Text(Dictionary<string, object> inputs, string key)
+        {
+            if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null) return null;
+            return value.ToString();
+        }
+
+        private static void DestroyRunner(SceneSyncLoomletBehaviour runner)
+        {
+            if (runner == null) return;
+            if (Application.isPlaying) Destroy(runner);
+            else DestroyImmediate(runner);
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56d81a64626e46bc9f44b756bcbccf9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -338,6 +338,11 @@ namespace Afjk.SceneSync
             return ResolveSceneSyncRoot(go);
         }
 
+        public GameObject FindSceneSyncObject(string objectId)
+        {
+            return FindManagedObject(objectId);
+        }
+
         public bool ValidateManagedObjects()
         {
             EnsureManagedObjectsList();
@@ -808,7 +813,7 @@ namespace Afjk.SceneSync
 
         private void OnHandoff(string raw)
         {
-            if (!raw.Contains("\"kind\"")) return;
+            if (!raw.Contains("\"kind\"") && !raw.Contains("\"type\":\"scene-graph-")) return;
 
             // from.id を抽出（handoff メッセージに含まれる）
             string fromId = null;
@@ -824,7 +829,15 @@ namespace Afjk.SceneSync
         {
             if (string.IsNullOrEmpty(raw)) return;
 
-            if (raw.Contains("\"kind\":\"scene-request\""))
+            if (raw.Contains("\"type\":\"scene-graph-set\""))
+            {
+                HandleSceneGraphSet(raw);
+            }
+            else if (raw.Contains("\"type\":\"scene-graph-clear\""))
+            {
+                HandleSceneGraphClear(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-request\""))
             {
                 if (fromId != null)
                     _ = HandleSceneRequest(fromId);
@@ -1151,6 +1164,95 @@ namespace Afjk.SceneSync
                 Debug.Log("[SceneSync] Restore scene-state object as scene-add: " + fakeJson);
                 HandleSceneAdd(fakeJson);
             }
+
+            RestoreLoomGraphsFromSceneState(raw);
+        }
+
+        private void HandleSceneGraphSet(string raw)
+        {
+            var graphJson = SceneSyncWireJson.ExtractRawObject(raw, "graph");
+            if (string.IsNullOrWhiteSpace(graphJson)) return;
+
+            if (TryExtractGraphObjectScope(raw, out var objectId))
+            {
+                var go = FindManagedObject(objectId);
+                if (go == null)
+                {
+                    Debug.LogWarning("[SceneSync] scene-graph-set target not found: objectId=" + objectId);
+                    return;
+                }
+
+                SceneSyncLoomletBehaviour.SetObjectGraph(go, this, objectId, graphJson);
+                Debug.Log("[SceneSync] Bound Loomlet object graph: objectId=" + objectId);
+                return;
+            }
+
+            SceneSyncLoomletBehaviour.SetSceneGraph(this, graphJson);
+            Debug.Log("[SceneSync] Bound Loomlet scene graph");
+        }
+
+        private void HandleSceneGraphClear(string raw)
+        {
+            if (TryExtractGraphObjectScope(raw, out var objectId))
+            {
+                var go = FindManagedObject(objectId);
+                SceneSyncLoomletBehaviour.ClearObjectGraph(go);
+                Debug.Log("[SceneSync] Cleared Loomlet object graph: objectId=" + objectId);
+                return;
+            }
+
+            SceneSyncLoomletBehaviour.ClearSceneGraph(this);
+            Debug.Log("[SceneSync] Cleared Loomlet scene graph");
+        }
+
+        private bool TryExtractGraphObjectScope(string raw, out string objectId)
+        {
+            var scopeJson = SceneSyncWireJson.ExtractRawObject(raw, "scope");
+            objectId = SceneSyncWireJson.ExtractString(scopeJson, "object");
+            if (!string.IsNullOrWhiteSpace(objectId)) return true;
+
+            var scope = SceneSyncWireJson.ExtractString(raw, "scope");
+            if (scope == "object")
+            {
+                objectId = SceneSyncWireJson.ExtractString(raw, "objectId");
+                return !string.IsNullOrWhiteSpace(objectId);
+            }
+
+            objectId = null;
+            return !string.IsNullOrWhiteSpace(objectId);
+        }
+
+        private void RestoreLoomGraphsFromSceneState(string raw)
+        {
+            var loomGraphsJson = SceneSyncWireJson.ExtractRawObject(raw, "loomGraphs");
+            if (string.IsNullOrWhiteSpace(loomGraphsJson)) return;
+
+            var sceneGraphJson = SceneSyncWireJson.ExtractRawObject(loomGraphsJson, "scene");
+            if (!string.IsNullOrWhiteSpace(sceneGraphJson))
+                SceneSyncLoomletBehaviour.SetSceneGraph(this, sceneGraphJson);
+
+            foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(loomGraphsJson, "objects"))
+            {
+                var go = FindManagedObject(entry.Key);
+                if (go == null)
+                {
+                    Debug.LogWarning("[SceneSync] scene-state Loomlet graph target not found: objectId=" + entry.Key);
+                    continue;
+                }
+                SceneSyncLoomletBehaviour.SetObjectGraph(go, this, entry.Key, entry.Value);
+            }
+        }
+
+        private void ApplyMetadataBehaviorGraph(GameObject go, string objectId, string metadataJson)
+        {
+            if (go == null || string.IsNullOrWhiteSpace(objectId) || string.IsNullOrWhiteSpace(metadataJson)) return;
+
+            var graphJson = SceneSyncWireJson.ExtractRawObject(metadataJson, "loomGraph");
+            if (string.IsNullOrWhiteSpace(graphJson))
+                graphJson = SceneSyncWireJson.ExtractRawObject(metadataJson, "behaviorGraph");
+            if (string.IsNullOrWhiteSpace(graphJson)) return;
+
+            SceneSyncLoomletBehaviour.SetObjectGraph(go, this, objectId, graphJson);
         }
 
         private void HandleSceneEnv(string raw)
@@ -1189,6 +1291,7 @@ namespace Afjk.SceneSync
             {
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
                 SceneSyncPanelFactory.ApplyAssetVisualDelta(go, assetJson);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
 
                 if (!string.IsNullOrWhiteSpace(assetJson))
                 {
@@ -1326,6 +1429,7 @@ namespace Afjk.SceneSync
             if (!string.IsNullOrEmpty(meshPath))
                 _meshPaths[objectId] = meshPath;
             SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
             if (visible.HasValue) go.SetActive(visible.Value);
             ApplyTransform(go, position, rotation, scale);
 
@@ -1481,6 +1585,7 @@ namespace Afjk.SceneSync
                 placeholder.hideFlags = HideFlags.NotEditable;
                 ConfigureRemoteTemporaryIdentity(placeholder, objectId, meshPath, assetId);
                 SceneSyncPanelFactory.ConfigureWireMetadata(placeholder, assetJson, metadataJson);
+                ApplyMetadataBehaviorGraph(placeholder, objectId, metadataJson);
                 if (visible.HasValue) placeholder.SetActive(visible.Value);
                 placeholder.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
@@ -1497,6 +1602,7 @@ namespace Afjk.SceneSync
 
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
@@ -1647,6 +1753,7 @@ namespace Afjk.SceneSync
                     identity.AssetId = assetId;
                 }
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
 
                 _managedObjects[objectId] = go;
                 _knownObjectIds.Add(objectId);
@@ -1898,8 +2005,42 @@ namespace Afjk.SceneSync
             var envJson = !string.IsNullOrWhiteSpace(_envId)
                 ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
                 : "";
-            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson + "}";
+            var loomGraphsJson = BuildLoomGraphsStateJson();
+            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson
+                + (!string.IsNullOrWhiteSpace(loomGraphsJson) ? ",\"loomGraphs\":" + loomGraphsJson : "")
+                + "}";
             await _client.SendHandoff(fromId, payload);
+        }
+
+        private string BuildLoomGraphsStateJson()
+        {
+            var sceneGraph = GetComponent<SceneSyncLoomletBehaviour>();
+            var hasSceneGraph = sceneGraph != null
+                && sceneGraph.SceneScope
+                && !string.IsNullOrWhiteSpace(sceneGraph.GraphJson);
+
+            var objects = new System.Text.StringBuilder();
+            objects.Append("{");
+            var hasObjectGraphs = false;
+            foreach (var kvp in _managedObjects)
+            {
+                var go = kvp.Value;
+                if (go == null) continue;
+                var runner = go.GetComponent<SceneSyncLoomletBehaviour>();
+                if (runner == null || runner.SceneScope || string.IsNullOrWhiteSpace(runner.GraphJson)) continue;
+                if (hasObjectGraphs) objects.Append(",");
+                hasObjectGraphs = true;
+                objects.Append("\"").Append(SceneSyncWireJson.JsonEscape(kvp.Key)).Append("\":").Append(runner.GraphJson);
+            }
+            objects.Append("}");
+
+            if (!hasSceneGraph && !hasObjectGraphs) return null;
+
+            var builder = new System.Text.StringBuilder();
+            builder.Append("{\"scene\":");
+            builder.Append(hasSceneGraph ? sceneGraph.GraphJson : "null");
+            builder.Append(",\"objects\":").Append(objects).Append("}");
+            return builder.ToString();
         }
 
         private void ApplyTransform(GameObject go, float[] position, float[] rotation, float[] scale)
@@ -2059,6 +2200,7 @@ namespace Afjk.SceneSync
 
             var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
             ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+            ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
             if (visible.HasValue) fallback.SetActive(visible.Value);
             fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
 
@@ -2208,6 +2350,7 @@ namespace Afjk.SceneSync
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                     if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
                     var importedGlbRoot = new GameObject("ImportedGlbRoot");
@@ -2758,6 +2901,7 @@ namespace Afjk.SceneSync
             _lastSnapshots.Remove(objectId);
             _meshPaths.Remove(objectId);
             _locks.Remove(objectId);
+            SceneSyncLoomletBehaviour.ClearObjectGraph(go);
 
             if (go != null)
             {

--- a/unity/com.afjk.scene-sync/Runtime/com.afjk.scene-sync.Runtime.asmdef
+++ b/unity/com.afjk.scene-sync/Runtime/com.afjk.scene-sync.Runtime.asmdef
@@ -3,7 +3,8 @@
   "rootNamespace": "Afjk.SceneSync",
   "references": [
     "glTFast",
-    "glTFast.Export"
+    "glTFast.Export",
+    "Loomlet.Runtime"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- add a Unity `SceneSyncLoomletBehaviour` bridge that evaluates received Graph JSON through `com.afjk.loomlet-runtime`
- handle `scene-graph-set` / `scene-graph-clear`, `scene-state.loomGraphs`, and metadata `loomGraph` / `behaviorGraph` in Runtime and Editor paths
- export bound graph state in Unity `scene-state` replies and document the Unity binding behavior

Closes #316

## Validation
- `git diff --check`
- `npm test` in `packages/scene-sync-mcp`

Unity Editor / Runtime playback was not launched in this environment.