### PR TITLE
Add local gaze input for Loomlet behaviors

### DIFF
--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -190,8 +190,16 @@ function createRuntimeManager({
 
     // Gaze state inputs (local-only, not broadcast)
     const gazeState = getObjectGazeState?.(objectId);
-    inputs['isGazed'] = gazeState?.isGazed || false;
-    inputs['gazeDwellTime'] = gazeState?.gazeDwellTime || 0;
+    const isGazed = gazeState?.isGazed || false;
+    const gazeDwellTime = gazeState?.gazeDwellTime || 0;
+    const gazeDistance = gazeState?.gazeDistance || 0;
+
+    inputs['isGazed'] = isGazed;
+    inputs['gazeDwellTime'] = gazeDwellTime;
+
+    inputs['target.isGazed'] = isGazed;
+    inputs['target.gazeDwellTime'] = gazeDwellTime;
+    inputs['target.gazeDistance'] = gazeDistance;
 
     return inputs;
   }

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -100,6 +100,8 @@ function createRuntimeManager({
   getViewerPosition,
   getViewerForward,
   getObjectHoverState,
+  getObjectGazeState,
+  getGazeHit,
   getLoomletHostEvents,
   clearLoomletHostEvents,
 }) {
@@ -126,6 +128,29 @@ function createRuntimeManager({
       if (viewerFwd) {
         inputs['viewer.forward'] = viewerFwd;
       }
+    }
+
+    // Viewer gaze inputs (local-only, not broadcast)
+    if (getViewerPosition) {
+      const gazeOrigin = getViewerPosition();
+      if (gazeOrigin) {
+        inputs['viewer.gaze.origin'] = gazeOrigin;
+      }
+    }
+    if (getViewerForward) {
+      const gazeDirection = getViewerForward();
+      if (gazeDirection) {
+        inputs['viewer.gaze.direction'] = gazeDirection;
+      }
+    }
+    const gazeHit = getGazeHit?.();
+    if (gazeHit) {
+      if (gazeHit.position) {
+        inputs['viewer.gaze.hitPosition'] = gazeHit.position;
+      }
+      inputs['viewer.gaze.hitDistance'] = gazeHit.distance;
+      inputs['viewer.gaze.hitObjectId'] = gazeHit.objectId;
+      inputs['viewer.gaze.source'] = gazeHit.source || 'camera';
     }
 
     // Object-scoped inputs
@@ -162,6 +187,11 @@ function createRuntimeManager({
     inputs['isSelected'] = hoverState?.isSelected || false;
     inputs['isHovered'] = hoverState?.isHovered || false;
     inputs['isBeingEdited'] = isObjectBeingEdited?.(objectId) || false;
+
+    // Gaze state inputs (local-only, not broadcast)
+    const gazeState = getObjectGazeState?.(objectId);
+    inputs['isGazed'] = gazeState?.isGazed || false;
+    inputs['gazeDwellTime'] = gazeState?.gazeDwellTime || 0;
 
     return inputs;
   }
@@ -378,6 +408,8 @@ export function createSceneSyncLoomIntegration({
   getViewerPosition,
   getViewerForward,
   getObjectHoverState,
+  getObjectGazeState,
+  getGazeHit,
   getLoomletHostEvents,
   clearLoomletHostEvents,
 }) {
@@ -389,6 +421,8 @@ export function createSceneSyncLoomIntegration({
     getViewerPosition,
     getViewerForward,
     getObjectHoverState,
+    getObjectGazeState,
+    getGazeHit,
     getLoomletHostEvents,
     clearLoomletHostEvents,
   });

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2608,14 +2608,17 @@ function getObjectGazeStateForLoomlet(objectId) {
 
   const isGazed = currentGazedObjectId === objectId;
   let gazeDwellTime = 0;
+  let gazeDistance = 0;
 
   if (isGazed && gazeEnterTime !== null) {
     gazeDwellTime = (performance.now() - gazeEnterTime) / 1000;
+    gazeDistance = currentGazeHit?.distance || 0;
   }
 
   return {
     isGazed,
     gazeDwellTime,
+    gazeDistance,
   };
 }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2571,6 +2571,15 @@ const loomletHostEvents = new Map(); // objectId -> Set<eventName>
 const tmpViewerPosition = new THREE.Vector3();
 const tmpViewerForward = new THREE.Vector3();
 
+// Gaze tracking state (local-only, not broadcast)
+let currentGazedObjectId = null;
+let gazeEnterTime = null;
+let lastGazeDwellEventAt = null;
+const gazeDwellThresholdSeconds = 1.0;
+const tmpGazeOrigin = new THREE.Vector3();
+const tmpGazeDirection = new THREE.Vector3();
+let currentGazeHit = null;
+
 function enqueueLoomletHostEvent(objectId, eventName) {
   if (!objectId || !eventName) return;
   if (!loomletHostEvents.has(objectId)) {
@@ -2594,6 +2603,35 @@ function getObjectHoverStateForLoomlet(objectId) {
   };
 }
 
+function getObjectGazeStateForLoomlet(objectId) {
+  if (!objectId) return null;
+
+  const isGazed = currentGazedObjectId === objectId;
+  let gazeDwellTime = 0;
+
+  if (isGazed && gazeEnterTime !== null) {
+    gazeDwellTime = (performance.now() - gazeEnterTime) / 1000;
+  }
+
+  return {
+    isGazed,
+    gazeDwellTime,
+  };
+}
+
+function getGazeHitForLoomlet() {
+  if (!currentGazeHit) return null;
+
+  return {
+    objectId: currentGazedObjectId,
+    position: currentGazeHit.point
+      ? [currentGazeHit.point.x, currentGazeHit.point.y, currentGazeHit.point.z]
+      : null,
+    distance: currentGazeHit.distance || 0,
+    source: 'camera',
+  };
+}
+
 function getViewerPositionForLoomlet() {
   if (!camera) return null;
   camera.getWorldPosition(tmpViewerPosition);
@@ -2604,6 +2642,62 @@ function getViewerForwardForLoomlet() {
   if (!camera) return null;
   camera.getWorldDirection(tmpViewerForward);
   return [tmpViewerForward.x, tmpViewerForward.y, tmpViewerForward.z];
+}
+
+function updateGazeStateFromCamera() {
+  if (!camera) return;
+
+  // Compute gaze ray from camera forward (local-only, not broadcast)
+  camera.getWorldPosition(tmpGazeOrigin);
+  camera.getWorldDirection(tmpGazeDirection);
+  raycaster.ray.origin.copy(tmpGazeOrigin);
+  raycaster.ray.direction.copy(tmpGazeDirection);
+
+  const targets = Array.from(managedObjects.values())
+    .filter(obj => !isSkySphereThreeObject(obj));
+  const hits = raycaster.intersectObjects(targets, true);
+
+  let newGazedObjectId = null;
+  let gazeHit = null;
+  if (hits.length > 0) {
+    let obj = hits[0].object;
+    while (obj.parent && !obj.userData.objectId) obj = obj.parent;
+    if (!obj.userData._isLockOverlay && obj.userData.objectId) {
+      newGazedObjectId = obj.userData.objectId;
+      gazeHit = hits[0];
+    }
+  }
+
+  // Handle gaze state changes
+  if (newGazedObjectId !== currentGazedObjectId) {
+    if (currentGazedObjectId) {
+      enqueueLoomletHostEvent(currentGazedObjectId, 'object.gaze.leave');
+    }
+    if (newGazedObjectId) {
+      const now = performance.now();
+      gazeEnterTime = now;
+      lastGazeDwellEventAt = now;
+      enqueueLoomletHostEvent(newGazedObjectId, 'object.gaze.enter');
+    } else {
+      gazeEnterTime = null;
+      lastGazeDwellEventAt = null;
+    }
+    currentGazedObjectId = newGazedObjectId;
+  }
+
+  currentGazeHit = gazeHit;
+}
+
+function updateGazeDwellState(now) {
+  if (!currentGazedObjectId || gazeEnterTime === null) return;
+
+  const gazeDwellMs = now - lastGazeDwellEventAt;
+  const gazeDwellSec = gazeDwellMs / 1000;
+
+  if (gazeDwellSec >= gazeDwellThresholdSeconds) {
+    enqueueLoomletHostEvent(currentGazedObjectId, 'object.gaze.dwell');
+    lastGazeDwellEventAt = now;
+  }
 }
 
 function getSelectedObjects() {
@@ -2896,6 +2990,14 @@ renderer.domElement.addEventListener('pointerup', (e) => {
 
 renderer.domElement.addEventListener('pointercancel', () => {
   pointerSelectionStart = null;
+});
+
+renderer.domElement.addEventListener('pointerleave', () => {
+  // Clear hover state when pointer leaves the canvas
+  if (currentHoveredObjectId) {
+    enqueueLoomletHostEvent(currentHoveredObjectId, 'object.hover.leave');
+    currentHoveredObjectId = null;
+  }
 });
 
 renderer.domElement.addEventListener('click', (event) => {
@@ -4015,6 +4117,8 @@ renderer.setAnimationLoop((time, frame) => {
 
   const now = performance.now();
   updateObjectGlbAnimations(now);
+  updateGazeStateFromCamera();
+  updateGazeDwellState(now);
   loomIntegration?.tickObjectGraphs?.(now);
 
   if (xrState.active) {
@@ -4269,6 +4373,8 @@ const loomIntegration = createSceneSyncLoomIntegration({
   getViewerPosition: getViewerPositionForLoomlet,
   getViewerForward: getViewerForwardForLoomlet,
   getObjectHoverState: getObjectHoverStateForLoomlet,
+  getObjectGazeState: getObjectGazeStateForLoomlet,
+  getGazeHit: getGazeHitForLoomlet,
   getLoomletHostEvents: getLoomletHostEventsForObject,
   clearLoomletHostEvents: clearLoomletHostEventsForObject,
 });


### PR DESCRIPTION
## Summary

Adds local-only gaze input for Loomlet behaviors in Scene Sync.

- Computes camera-forward gaze ray from viewer position/direction
- Adds gaze host inputs: `viewer.gaze.*` (origin, direction, hitPosition, hitDistance, hitObjectId, source) and `target.isGazed`/`gazeDwellTime`
- Adds local gaze events: `object.gaze.enter`, `object.gaze.leave`, `object.gaze.dwell`
- Ensures gaze events include `target` for object-scope Loomlet graphs
- Keeps raw gaze input local-only, not broadcast to room
- Adds pointer leave handler to clean up hover state

## Implementation Details

### Gaze Tracking

- Gaze ray is computed from camera forward direction each frame
- Raycast is performed against managed Scene Sync objects
- Gaze target changes trigger enter/leave events
- Dwell timer starts on enter and resets on leave
- Dwell event fires once per second while gazing at the same object

### Local-Only Behavior

- Raw gaze input is not broadcast to other clients
- Gaze events are not written to room history
- Shared activation from gaze dwell should be a separate explicit host decision

### Host Input Naming

Follows existing host input convention:
- Viewer-level: `viewer.gaze.origin`, `viewer.gaze.direction`, `viewer.gaze.hitPosition`, `viewer.gaze.hitDistance`, `viewer.gaze.hitObjectId`, `viewer.gaze.source`
- Object-level: `target.isGazed`, `target.gazeDwellTime`

## Manual Verification

### Setup

1. Create a test scene with at least two objects with Loomlet behavior graphs
2. In the first object's graph, add a behavior that:
   - Reads `target.isGazed` input
   - Changes color or scale when gazed (e.g., emit `scene.setColor`)
   - Resets when not gazed
3. In the second object, add a behavior that:
   - Listens for `object.gaze.dwell` event
   - Changes appearance or logs to console on dwell

### Test Steps

1. **Gaze Enter/Leave**
   - Look at the first object with camera forward direction
   - Confirm the object changes color/scale (indicates `target.isGazed` is true)
   - Look away
   - Confirm the object returns to normal state (indicates `target.isGazed` is false)

2. **Dwell Event**
   - Look at the second object and hold gaze for 1 second
   - Confirm the dwell event fires (visual change, console log, etc.)
   - Look away and look back again
   - Confirm dwell event fires again after 1 second

3. **Multiple Objects**
   - Quickly switch gaze between objects
   - Confirm enter/leave events fire correctly for each object

4. **Event Isolation**
   - Check browser console to verify no gaze events appear in room history
   - Open another browser tab connected to the same room
   - Confirm the other client does not see gaze events or changes from gaze input

5. **Pointer Leave Cleanup**
   - Move mouse outside the viewer canvas
   - Verify `object.hover.leave` event fires for the previously hovered object

## Testing Notes

- Gaze dwell threshold is 1 second (configurable in code)
- Dwell event repeats every 1 second while gazing at the same object
- Gaze input is computed from camera forward, works in and out of XR
- No eye-tracking hardware required for MVP

Closes #322

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf3qTgU9zjV6K1jKJSNkyW)_