### PR TITLE
Add Scene Clock: host-controlled global time system for Loomlet

### DIFF
--- a/docs/scene-sync-runtime-time-model.md
+++ b/docs/scene-sync-runtime-time-model.md
@@ -179,8 +179,50 @@ Touch / click / grab / trigger などの event は、発生時刻を environment
 
 ---
 
+## Scene Clock: Host-Controlled Global Time
+
+従来のモデルに加えて、MVP では **Scene Clock** という Host 所有のグローバル時刻制御システムが導入されました。
+
+### 使い分け
+
+**Object Runtime Time** (このドキュメント):
+- Per-object の選択状態に基づく時刻
+- selected object: `t = 0`
+- normal object: 経過時間ベース
+- 用途: object ごとの animation / behavior
+
+**Scene Clock** (新規):
+- グローバルな Host 所有時刻
+- pause / seek / reset / rate control 可能
+- local-only: room history に記録しない
+- 用途: シーン全体の再生制御、デモ・オーサリング
+
+### Loomlet への時刻供給
+
+Loomlet object graph は、実際に評価される時刻として以下を受け取る：
+
+```text
+time.t = object runtime time (選択中は 0)
+time.delta = object runtime の delta
+time.isPaused = Scene Clock の pause 状態
+time.mode = Scene Clock のモード ('server-follow' | 'local')
+time.rate = Scene Clock の再生速度
+time.serverNow = 常に現在の server time
+```
+
+### 重要: 時刻の独立性
+
+- Object Runtime Time の `t = 0` 凍結はそのまま保持される
+- 選択中 object は Scene Clock が動いていても `t = 0` で評価される
+- Scene Clock の pause / seek は local-only で、他クライアントに影響しない
+
+詳細は [Scene Sync Scene Clock](./scene-sync-scene-clock.md) を参照。
+
+---
+
 ## 関連ドキュメント
 
 - [Scene Sync Spec Index](./scene-sync-spec.md)
 - [Animation](./scene-sync-animation.md)
 - [Loom graph protocol](./scene-sync-loom-protocol.md)
+- [Scene Sync Scene Clock](./scene-sync-scene-clock.md) - Host-controlled global time system

--- a/docs/scene-sync-scene-clock.md
+++ b/docs/scene-sync-scene-clock.md
@@ -1,0 +1,231 @@
+# Scene Sync Scene Clock
+
+Host-controlled global time system for Loomlet behaviors.
+
+## Overview
+
+**Scene Clock** is a host-owned, local-only time control system that complements the existing per-object selection-based time model.
+
+- **Host-owned**: only the local Scene Sync host can control time
+- **Local-only**: time control operations (pause, seek, reset) are never broadcast to the room
+- **Read-only for Loomlet**: behavior graphs can read time state but cannot modify it
+- **Independent**: operates separately from per-object selection-based `t=0` freezing
+
+## Time Models
+
+Scene Sync uses **two independent time coordinates**:
+
+### 1. Object Runtime Time (per-object, selection-aware)
+
+Each object has its own `runtime time` based on selection state:
+
+```text
+selected/edited object:
+  t = 0 (frozen for editing)
+
+normal object:
+  t = elapsed time since deselection (or Scene Clock time)
+```
+
+Controlled by: `getObjectRuntimeTime(objectId)` in scene.js
+
+Used for: GLB animations, per-object Loomlet behavior evaluation
+
+### 2. Scene Clock (global, host-controllable)
+
+A global time coordinate independent of selection state:
+
+```text
+mode = 'server-follow':
+  t = current server time (synchronized across clients)
+
+mode = 'local':
+  t = controllable local time (pause, seek, reset, rate)
+```
+
+Controlled by: Scene Clock API (reset, seek, pause, resume, follow server)
+
+Used for: global behavior control, demo/authoring animations
+
+## API Reference
+
+### Querying Time
+
+```js
+getSceneClockTime(now = performance.now())
+  → returns current scene time as number (seconds)
+
+getSceneClockDelta(now = performance.now())
+  → returns frame delta in seconds
+  → 0 when paused
+
+getSceneClockStateForLoomlet(now = performance.now())
+  → returns {
+      t: number,
+      delta: number,
+      isPaused: boolean,
+      mode: 'server-follow' | 'local',
+      rate: number,
+      serverNow: number (always current server time),
+    }
+```
+
+### Controlling Time
+
+```js
+resetSceneClock(now = performance.now())
+  → sets t = 0 in local mode
+
+seekSceneClock(t, now = performance.now())
+  → jumps to time t (seconds)
+  → switches to local mode if needed
+  → does NOT broadcast or rewrite history
+
+pauseSceneClock(now = performance.now())
+  → freezes time.t
+  → delta becomes 0
+  → local-only
+
+resumeSceneClock(now = performance.now())
+  → resumes from paused time
+
+setSceneClockMode(mode, now = performance.now())
+  → switches mode: 'server-follow' | 'local'
+
+followServerClock(now = performance.now())
+  → alias for setSceneClockMode('server-follow')
+```
+
+## Loomlet Host Inputs
+
+Behaviors can read time state via these read-only host inputs:
+
+```js
+inputs['time.t']         // object graph evaluation time
+                         // selected object: always 0
+                         // normal object: Scene Clock time
+inputs['time.delta']     // frame delta for object evaluation
+inputs['time.isPaused']  // whether Scene Clock is paused
+inputs['time.mode']      // 'server-follow' | 'local'
+inputs['time.rate']      // playback rate multiplier (1.0 = normal)
+inputs['time.serverNow'] // always current synchronized server time
+```
+
+Inputs are read-only. Behavior graphs cannot modify time controls.
+
+## Example Loomlet Behavior
+
+```json
+{
+  "nodes": [
+    {
+      "id": "time-input",
+      "type": "hostInput",
+      "params": { "key": "time.t" }
+    },
+    {
+      "id": "sine-wave",
+      "type": "math.sin",
+      "params": { "input": "time-input" }
+    },
+    {
+      "id": "scale-output",
+      "type": "math.multiply",
+      "params": { "a": "sine-wave", "b": 2 }
+    },
+    {
+      "id": "set-scale",
+      "type": "scene.setScale",
+      "params": {
+        "scale": ["scale-output", 1, 1],
+        "target": "my-object"
+      }
+    }
+  ]
+}
+```
+
+This graph animates `my-object` with a sine wave using `time.t`.
+
+When `my-object` is selected:
+- `time.t = 0` → animation freezes at origin
+- User can edit the object
+
+When `my-object` is deselected:
+- `time.t` advances with Scene Clock
+- Animation runs normally
+
+When user pauses Scene Clock:
+- `time.t` freezes for all objects
+- All time-dependent behaviors pause
+
+## Local-Only Guarantees
+
+The following operations **never broadcast** and **never rewrite history**:
+
+- `pauseSceneClock()`
+- `resumeSceneClock()`
+- `seekSceneClock(t)`
+- `resetSceneClock()`
+- `setSceneClockMode(mode)`
+
+Each client maintains its own local Scene Clock state. Pausing on one client does not affect other clients.
+
+**Future work** (out of scope for MVP):
+- Shared multiplayer time authority (consensus pause/seek)
+- Broadcasting time state changes
+- Time-based event sourcing and replay
+
+## Design Rationale
+
+### Why two time models?
+
+1. **Selection-based `t=0`** is essential for editing:
+   - User selects object → object "rewinds" to origin
+   - User can adjust initial pose without animation running
+   - Per-object behavior is intuitive for authors
+
+2. **Global Scene Clock** is essential for control and synchronization:
+   - Host needs to pause/rewind entire scene
+   - Demo playback and authoring flows benefit from global time control
+   - Future: distributed time authority for multi-client sync
+
+### Why local-only in MVP?
+
+- Simpler implementation
+- No room history conflicts
+- Supports demo/authoring use cases immediately
+- Clear migration path to future multiplayer time systems
+- Easier testing and debugging
+
+### Why read-only for Loomlet?
+
+- Time control belongs to Scene Sync host layer
+- Prevents conflicts between Loomlet graphs and host controls
+- Preserves deterministic behavior (given fixed host time, same graph produces same output)
+- Simplifies replay/undo later
+
+## Debug UI
+
+Scene Clock debug panel (`#scene-clock-panel`) provides manual time control:
+
+- **Time display**: current `t` in seconds
+- **Mode badge**: 'server-follow' | 'local'
+- **Status badge**: 'running' | 'paused'
+- **Reset**: jump to t=0
+- **Pause/Resume**: toggle pause
+- **Follow Server**: return to server-follow mode
+- **Seek input**: jump to arbitrary time
+- **Rate input**: playback speed multiplier
+
+To enable debug panel in developer console:
+
+```js
+document.getElementById('scene-clock-panel').removeAttribute('hidden')
+```
+
+## Related Docs
+
+- [Scene Sync Runtime Time Model](./scene-sync-runtime-time-model.md) - per-object time and selection behavior
+- [Scene Sync Spec](./scene-sync-spec.md) - overall Scene Sync architecture
+- [Loomlet Graph Protocol](./scene-sync-loom-protocol.md) - Loomlet behavior graph format

--- a/docs/scene-sync-scene-clock.md
+++ b/docs/scene-sync-scene-clock.md
@@ -105,6 +105,8 @@ inputs['time.t']         // object graph evaluation time
                          // selected object: always 0
                          // normal object: Scene Clock time
 inputs['time.delta']     // frame delta for object evaluation
+inputs['time.sceneT']    // Scene Clock global time (same as time.t for normal objects)
+inputs['time.sceneDelta'] // Scene Clock global delta
 inputs['time.isPaused']  // whether Scene Clock is paused
 inputs['time.mode']      // 'server-follow' | 'local'
 inputs['time.rate']      // playback rate multiplier (1.0 = normal)
@@ -112,6 +114,11 @@ inputs['time.serverNow'] // always current synchronized server time
 ```
 
 Inputs are read-only. Behavior graphs cannot modify time controls.
+
+### Note on Delta
+
+- **local mode**: delta = frame-to-frame time delta with rate applied
+- **server-follow mode**: delta = server time delta since last frame
 
 ## Example Loomlet Behavior
 

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -104,6 +104,7 @@ function createRuntimeManager({
   getGazeHit,
   getLoomletHostEvents,
   clearLoomletHostEvents,
+  getSceneClockStateForLoomlet,
 }) {
   const runtimes = new Map();
   const definitions = new Map();
@@ -113,7 +114,7 @@ function createRuntimeManager({
     return `${key}:${target}`;
   }
 
-  function buildHostInputsForObject(objectId) {
+  function buildHostInputsForObject(objectId, objectTime, clockState) {
     const inputs = {};
 
     // Viewer inputs
@@ -201,6 +202,18 @@ function createRuntimeManager({
     inputs['target.gazeDwellTime'] = gazeDwellTime;
     inputs['target.gazeDistance'] = gazeDistance;
 
+    // Scene Clock time inputs (local-only, not broadcast)
+    // time.t = object graph が実評価される runtime time
+    // (selected object の場合は t=0, normal object の場合は Scene Clock time)
+    if (clockState) {
+      inputs['time.t'] = objectTime ?? 0;
+      inputs['time.delta'] = clockState.delta ?? 0;
+      inputs['time.isPaused'] = clockState.isPaused;
+      inputs['time.mode'] = clockState.mode;
+      inputs['time.rate'] = clockState.rate;
+      inputs['time.serverNow'] = clockState.serverNow;
+    }
+
     return inputs;
   }
 
@@ -277,13 +290,16 @@ function createRuntimeManager({
     definitions.delete(key);
   }
 
-  function evaluateRuntime(key, entry, now = performance.now()) {
+  function evaluateRuntime(key, entry, clockState, now = performance.now()) {
+    // object graph の実評価時刻を決定
+    // - selected/edited object: t=0 (from getObjectRuntimeTime)
+    // - normal object: Scene Clock global time (from clockState)
     const time = entry.scopeObjectId && getObjectRuntimeTime
       ? getObjectRuntimeTime(entry.scopeObjectId, now)
-      : getServerTime();
+      : (clockState?.t ?? getServerTime());
 
     // Build host inputs for object-scoped evaluations
-    const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId) : {};
+    const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId, time, clockState) : {};
 
     // Gather host events for object-scoped evaluations
     let events = [];
@@ -328,9 +344,11 @@ function createRuntimeManager({
         throw new Error(`Unsupported Scene Sync graph message type: ${message.type}`);
       }
     },
-    tick(now = performance.now()) {
+    tick(clockState = null, now = performance.now()) {
+      // clockState: Scene Clock state from host
+      // If not provided, fall back to server time
       for (const [key, entry] of runtimes) {
-        evaluateRuntime(key, entry, now);
+        evaluateRuntime(key, entry, clockState, now);
       }
     },
     exportState() {
@@ -420,6 +438,7 @@ export function createSceneSyncLoomIntegration({
   getGazeHit,
   getLoomletHostEvents,
   clearLoomletHostEvents,
+  getSceneClockStateForLoomlet,
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
@@ -433,6 +452,7 @@ export function createSceneSyncLoomIntegration({
     getGazeHit,
     getLoomletHostEvents,
     clearLoomletHostEvents,
+    getSceneClockStateForLoomlet,
   });
 
   function isSceneGraphMessage(payload) {

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -208,6 +208,8 @@ function createRuntimeManager({
     if (clockState) {
       inputs['time.t'] = objectTime ?? 0;
       inputs['time.delta'] = clockState.delta ?? 0;
+      inputs['time.sceneT'] = clockState.t;
+      inputs['time.sceneDelta'] = clockState.delta ?? 0;
       inputs['time.isPaused'] = clockState.isPaused;
       inputs['time.mode'] = clockState.mode;
       inputs['time.rate'] = clockState.rate;
@@ -292,10 +294,10 @@ function createRuntimeManager({
 
   function evaluateRuntime(key, entry, clockState, now = performance.now()) {
     // object graph の実評価時刻を決定
-    // - selected/edited object: t=0 (from getObjectRuntimeTime)
-    // - normal object: Scene Clock global time (from clockState)
+    // - selected/edited object: t=0
+    // - normal object: Scene Clock global time
     const time = entry.scopeObjectId && getObjectRuntimeTime
-      ? getObjectRuntimeTime(entry.scopeObjectId, now)
+      ? getObjectRuntimeTime(entry.scopeObjectId, now, clockState)
       : (clockState?.t ?? getServerTime());
 
     // Build host inputs for object-scoped evaluations

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4397,7 +4397,9 @@ function getSceneClockDelta(now = performance.now()) {
 
   if (sceneClockState.mode === 'local') {
     const elapsed = (now - sceneClockState.lastUpdateNow) / 1000;
-    return Math.max(0, elapsed * sceneClockState.rate);
+    const delta = Math.max(0, elapsed * sceneClockState.rate);
+    sceneClockState.lastUpdateNow = now;  // Update for next frame
+    return delta;
   }
 
   // server-follow mode: delta from last server time
@@ -4451,9 +4453,13 @@ function pauseSceneClock(now = performance.now()) {
 function resumeSceneClock(now = performance.now()) {
   if (!sceneClockState.paused) return;
 
+  const pausedAt = sceneClockState.pausedAt ?? getSceneClockTime(now);
+
+  sceneClockState.mode = 'local';
+  sceneClockState.localTime = pausedAt;
+  sceneClockState.lastUpdateNow = now;
   sceneClockState.paused = false;
   sceneClockState.pausedAt = null;
-  sceneClockState.lastUpdateNow = now;
 }
 
 function seekSceneClock(t, now = performance.now()) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4122,7 +4122,13 @@ renderer.setAnimationLoop((time, frame) => {
   updateObjectGlbAnimations(now);
   updateGazeStateFromCamera();
   updateGazeDwellState(now);
-  loomIntegration?.tickObjectGraphs?.(now);
+  const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
+  loomIntegration?.tickObjectGraphs?.(sceneClockStateForTick);
+
+  // Update Scene Clock debug UI
+  if (!sceneClockPanelEl?.hidden) {
+    updateSceneClockUI();
+  }
 
   if (xrState.active) {
     updateXrGrab();
@@ -4345,6 +4351,119 @@ const sceneInspectorState = {
   },
 };
 
+// ── Scene Clock 状態 ────────────────────────────────
+// Host 所有のグローバル時刻制御システム
+// local-only: broadcast しない、room history に記録しない
+// 用途: Loomlet behavior の可制御なアニメーション
+// time.t = object graph の実評価時刻（選択中は 0）
+// time.sceneT = 将来: Scene Clock のグローバル時刻（MVP では公開しない）
+const sceneClockState = {
+  mode: 'server-follow',        // 'server-follow' | 'local'
+  paused: false,
+  localTime: 0,                 // local mode でのみ使用
+  pausedAt: null,               // 一時停止時の冷凍時刻
+  seekOffset: 0,
+  lastUpdateNow: performance.now(),
+  rate: 1,                       // 再生速度倍率
+};
+
+function getSceneClockTime(now = performance.now()) {
+  if (sceneClockState.paused) {
+    return sceneClockState.pausedAt ?? 0;
+  }
+
+  if (sceneClockState.mode === 'local') {
+    const elapsed = (now - sceneClockState.lastUpdateNow) / 1000;
+    return Math.max(0, sceneClockState.localTime + elapsed * sceneClockState.rate);
+  }
+
+  // server-follow mode: server time を使用
+  return Date.now() / 1000;
+}
+
+function getSceneClockDelta(now = performance.now()) {
+  if (sceneClockState.paused) {
+    return 0;
+  }
+
+  if (sceneClockState.mode === 'local') {
+    const elapsed = (now - sceneClockState.lastUpdateNow) / 1000;
+    return Math.max(0, elapsed * sceneClockState.rate);
+  }
+
+  return 0;
+}
+
+function getSceneClockStateForLoomlet(now = performance.now()) {
+  const t = getSceneClockTime(now);
+  const delta = getSceneClockDelta(now);
+
+  return {
+    t,
+    delta,
+    isPaused: sceneClockState.paused,
+    mode: sceneClockState.mode,
+    rate: sceneClockState.rate,
+    serverNow: Date.now() / 1000,
+  };
+}
+
+function setSceneClockMode(mode, now = performance.now()) {
+  if (mode === sceneClockState.mode) return;
+
+  if (mode === 'local') {
+    // server-follow → local: 現在時刻を localTime として記録
+    const currentTime = getSceneClockTime(now);
+    sceneClockState.localTime = currentTime;
+    sceneClockState.lastUpdateNow = now;
+    sceneClockState.paused = false;
+    sceneClockState.pausedAt = null;
+  } else if (mode === 'server-follow') {
+    // local → server-follow: ローカル状態をクリア
+    sceneClockState.localTime = 0;
+    sceneClockState.paused = false;
+    sceneClockState.pausedAt = null;
+  }
+
+  sceneClockState.mode = mode;
+}
+
+function pauseSceneClock(now = performance.now()) {
+  if (sceneClockState.paused) return;
+
+  sceneClockState.paused = true;
+  sceneClockState.pausedAt = getSceneClockTime(now);
+}
+
+function resumeSceneClock(now = performance.now()) {
+  if (!sceneClockState.paused) return;
+
+  sceneClockState.paused = false;
+  sceneClockState.pausedAt = null;
+  sceneClockState.lastUpdateNow = now;
+}
+
+function seekSceneClock(t, now = performance.now()) {
+  t = Math.max(0, t);
+
+  if (sceneClockState.mode !== 'local') {
+    setSceneClockMode('local', now);
+  }
+
+  sceneClockState.localTime = t;
+  sceneClockState.lastUpdateNow = now;
+  sceneClockState.paused = false;
+  sceneClockState.pausedAt = null;
+}
+
+function resetSceneClock(now = performance.now()) {
+  seekSceneClock(0, now);
+}
+
+function followServerClock(now = performance.now()) {
+  setSceneClockMode('server-follow', now);
+}
+
 // ── Loom 統合初期化 ──────────────────────────────────
 const loomIntegration = createSceneSyncLoomIntegration({
   getObjectById: (objectId) => managedObjects.get(objectId) || null,
@@ -4380,7 +4499,88 @@ const loomIntegration = createSceneSyncLoomIntegration({
   getGazeHit: getGazeHitForLoomlet,
   getLoomletHostEvents: getLoomletHostEventsForObject,
   clearLoomletHostEvents: clearLoomletHostEventsForObject,
+  getSceneClockStateForLoomlet,
 });
+
+// ── Scene Clock Debug UI 制御 ────────────────────────────
+const sceneClockPanelEl = document.getElementById('scene-clock-panel');
+const sceneClockCloseBtn = document.getElementById('scene-clock-close');
+const sceneClockTimeValueEl = document.getElementById('scene-clock-time-value');
+const sceneClockModeEl = document.getElementById('scene-clock-mode');
+const sceneClockStatusEl = document.getElementById('scene-clock-status');
+const sceneClockResetBtn = document.getElementById('scene-clock-reset');
+const sceneClockTogglePauseBtn = document.getElementById('scene-clock-toggle-pause');
+const sceneClockFollowBtn = document.getElementById('scene-clock-follow');
+const sceneClockSeekInput = document.getElementById('scene-clock-seek-input');
+const sceneClockRateInput = document.getElementById('scene-clock-rate-input');
+
+sceneClockCloseBtn?.addEventListener('click', () => {
+  sceneClockPanelEl?.setAttribute('hidden', '');
+});
+
+sceneClockResetBtn?.addEventListener('click', () => {
+  resetSceneClock();
+  updateSceneClockUI();
+});
+
+sceneClockTogglePauseBtn?.addEventListener('click', () => {
+  if (sceneClockState.paused) {
+    resumeSceneClock();
+  } else {
+    pauseSceneClock();
+  }
+  updateSceneClockUI();
+});
+
+sceneClockFollowBtn?.addEventListener('click', () => {
+  setSceneClockMode('server-follow');
+  updateSceneClockUI();
+});
+
+sceneClockSeekInput?.addEventListener('change', (e) => {
+  const t = parseFloat(e.target.value) || 0;
+  seekSceneClock(t);
+  updateSceneClockUI();
+});
+
+sceneClockRateInput?.addEventListener('change', (e) => {
+  sceneClockState.rate = parseFloat(e.target.value) || 1;
+  if (sceneClockState.rate < 0) sceneClockState.rate = 0;
+  sceneClockRateInput.value = sceneClockState.rate;
+  updateSceneClockUI();
+});
+
+function updateSceneClockUI() {
+  const clockState = getSceneClockStateForLoomlet?.();
+  if (!clockState) return;
+
+  if (sceneClockTimeValueEl) {
+    sceneClockTimeValueEl.textContent = clockState.t.toFixed(2);
+  }
+
+  if (sceneClockModeEl) {
+    sceneClockModeEl.textContent = sceneClockState.mode;
+    sceneClockModeEl.classList.toggle('local', sceneClockState.mode === 'local');
+  }
+
+  if (sceneClockStatusEl) {
+    sceneClockStatusEl.textContent = sceneClockState.paused ? 'paused' : 'running';
+    sceneClockStatusEl.classList.toggle('paused', sceneClockState.paused);
+  }
+
+  if (sceneClockSeekInput) {
+    sceneClockSeekInput.value = clockState.t.toFixed(2);
+  }
+
+  if (sceneClockRateInput) {
+    sceneClockRateInput.value = sceneClockState.rate;
+  }
+}
+
+// Debug UI トグル（開発用: dev-tool で開く / dev shortcut）
+// フェーズ4では常に非表示（最初からパネル開くキーボードショートカットなどを追加可）
+// 手動で右クリック→Inspector→Elements で hidden 属性を削除するか、
+// F12 devtools で document.getElementById('scene-clock-panel').removeAttribute('hidden')
 
 // ── ニックネーム編集 ───────────────────────────────────
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1486,15 +1486,21 @@ function isRuntimeFrozenForSelection(objectId) {
   return selectedObjectIds.has(objectId);
 }
 
-function getObjectRuntimeTime(objectId, now = performance.now()) {
+function getObjectRuntimeTime(objectId, now = performance.now(), clockState = null) {
   const obj = managedObjects.get(objectId);
   if (!obj) return 0;
 
   const runtime = ensureObjectRuntime(obj);
   if (!runtime?.enabled) return 0;
 
+  // selected/edited object: freeze to t=0
   if (isRuntimeFrozenForSelection(objectId)) {
     return runtime.selectedTime ?? 0;
+  }
+
+  // normal object: use Scene Clock time if available, else object runtime time
+  if (clockState) {
+    return clockState.t;
   }
 
   const speed = Number.isFinite(runtime.speed) ? runtime.speed : 1;
@@ -4355,8 +4361,10 @@ const sceneInspectorState = {
 // Host 所有のグローバル時刻制御システム
 // local-only: broadcast しない、room history に記録しない
 // 用途: Loomlet behavior の可制御なアニメーション
-// time.t = object graph の実評価時刻（選択中は 0）
-// time.sceneT = 将来: Scene Clock のグローバル時刻（MVP では公開しない）
+// time.t = object graph の実評価時刻（選択中は 0、通常は Scene Clock time）
+// time.sceneT = Scene Clock のグローバル時刻（通常は time.t と同じ）
+// time.delta = object evaluation delta
+// time.sceneDelta = Scene Clock global delta
 const sceneClockState = {
   mode: 'server-follow',        // 'server-follow' | 'local'
   paused: false,
@@ -4364,6 +4372,7 @@ const sceneClockState = {
   pausedAt: null,               // 一時停止時の冷凍時刻
   seekOffset: 0,
   lastUpdateNow: performance.now(),
+  lastServerNow: Date.now() / 1000,  // server-follow mode の delta 計算用
   rate: 1,                       // 再生速度倍率
 };
 
@@ -4391,7 +4400,11 @@ function getSceneClockDelta(now = performance.now()) {
     return Math.max(0, elapsed * sceneClockState.rate);
   }
 
-  return 0;
+  // server-follow mode: delta from last server time
+  const currentServerNow = Date.now() / 1000;
+  const delta = currentServerNow - sceneClockState.lastServerNow;
+  sceneClockState.lastServerNow = currentServerNow;
+  return Math.max(0, delta);
 }
 
 function getSceneClockStateForLoomlet(now = performance.now()) {
@@ -4544,8 +4557,21 @@ sceneClockSeekInput?.addEventListener('change', (e) => {
 });
 
 sceneClockRateInput?.addEventListener('change', (e) => {
-  sceneClockState.rate = parseFloat(e.target.value) || 1;
-  if (sceneClockState.rate < 0) sceneClockState.rate = 0;
+  const now = performance.now();
+  const nextRate = parseFloat(e.target.value) || 1;
+  if (nextRate < 0) {
+    sceneClockRateInput.value = 0;
+    return;
+  }
+
+  // rate 変更時に time jump を避ける
+  // 現在時刻を localTime に焼いてから rate を変更
+  if (sceneClockState.mode === 'local') {
+    sceneClockState.localTime = getSceneClockTime(now);
+    sceneClockState.lastUpdateNow = now;
+  }
+
+  sceneClockState.rate = nextRate;
   sceneClockRateInput.value = sceneClockState.rate;
   updateSceneClockUI();
 });

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1017,6 +1017,125 @@
         white-space: nowrap;
       }
     }
+
+    /* Scene Clock Debug Panel */
+    #scene-clock-panel {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      width: 280px;
+      max-height: 400px;
+      background: rgba(0,0,0,0.85);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      border-radius: 8px;
+      padding: 12px;
+      color: #fff;
+      font: 13px/1.4 monospace;
+      z-index: 20;
+      border: 1px solid rgba(255,255,255,0.1);
+      overflow-y: auto;
+      display: none;
+      flex-direction: column;
+      gap: 8px;
+    }
+    #scene-clock-panel:not([hidden]) {
+      display: flex;
+    }
+    .scene-clock-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+    }
+    .scene-clock-header h3 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: bold;
+    }
+    .scene-clock-body {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .scene-clock-display {
+      background: rgba(255,255,255,0.05);
+      padding: 12px;
+      border-radius: 4px;
+      text-align: center;
+    }
+    .scene-clock-time {
+      font-size: 24px;
+      font-weight: bold;
+      color: #4f8;
+      margin-bottom: 6px;
+    }
+    .scene-clock-info {
+      display: flex;
+      gap: 6px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .scene-clock-badge {
+      display: inline-block;
+      background: rgba(68,136,255,0.3);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .scene-clock-badge.paused {
+      background: rgba(255,100,100,0.3);
+    }
+    .scene-clock-badge.local {
+      background: rgba(255,200,0,0.3);
+    }
+    .scene-clock-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .scene-clock-controls .chip {
+      flex: 1;
+      min-width: 60px;
+      font-size: 12px;
+      padding: 5px 8px;
+    }
+    .scene-clock-seek,
+    .scene-clock-rate {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .scene-clock-seek label,
+    .scene-clock-rate label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    .scene-clock-seek span,
+    .scene-clock-rate span {
+      flex: 0 0 auto;
+      width: 60px;
+    }
+    .scene-clock-number-input {
+      flex: 1;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 4px 6px;
+      border-radius: 3px;
+      font: 12px/1.4 monospace;
+    }
+    .scene-clock-number-input:focus {
+      outline: none;
+      border-color: rgba(68,136,255,0.6);
+      background: rgba(255,255,255,0.15);
+    }
   </style>
 </head>
 <body>
@@ -1200,6 +1319,45 @@
   "status": "no-selection"
 }</pre>
       </section>
+    </div>
+  </aside>
+
+  <!-- Scene Clock Debug Panel -->
+  <aside id="scene-clock-panel" aria-label="Scene Clock Controls" hidden>
+    <div class="scene-clock-header">
+      <h3>Scene Clock</h3>
+      <button id="scene-clock-close" class="chip" type="button" title="Close">✕</button>
+    </div>
+    <div class="scene-clock-body">
+      <div class="scene-clock-display">
+        <div class="scene-clock-time">
+          <span id="scene-clock-time-value">0.00</span>s
+        </div>
+        <div class="scene-clock-info">
+          <span id="scene-clock-mode" class="scene-clock-badge">server-follow</span>
+          <span id="scene-clock-status" class="scene-clock-badge">running</span>
+        </div>
+      </div>
+
+      <div class="scene-clock-controls">
+        <button id="scene-clock-reset" class="chip" type="button">Reset</button>
+        <button id="scene-clock-toggle-pause" class="chip" type="button">Pause</button>
+        <button id="scene-clock-follow" class="chip" type="button">Follow Server</button>
+      </div>
+
+      <div class="scene-clock-seek">
+        <label>
+          <span>Seek (s):</span>
+          <input id="scene-clock-seek-input" class="scene-clock-number-input" type="number" min="0" step="0.1" value="0">
+        </label>
+      </div>
+
+      <div class="scene-clock-rate">
+        <label>
+          <span>Rate:</span>
+          <input id="scene-clock-rate-input" class="scene-clock-number-input" type="number" min="0" step="0.1" value="1">
+        </label>
+      </div>
     </div>
   </aside>
   <button id="add-btn" title="GLB/画像を追加">＋</button>


### PR DESCRIPTION
## 概要

Scene Sync に **Scene Clock** という Host 所有のグローバル時刻制御システムを追加しました。Loomlet behavior graphs がシーン全体の時刻を読み取り、Host が pause / seek / reset / rate control できるようになります。

- local-only: broadcast しない、room history に記録しない
- 既存の per-object selection-based `t=0` 凍結と独立して動作
- Loomlet には read-only で時刻情報を供給

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 1. Scene Clock 状態管理 (`scene.js`)
- `sceneClockState`: mode ('server-follow' | 'local'), paused, localTime, rate などを管理
- `getSceneClockTime()`: 現在の Scene Clock 時刻を取得
- `getSceneClockDelta()`: フレーム delta を取得（pause 時は 0）
- `getSceneClockStateForLoomlet()`: Loomlet に供給する時刻情報パッケージ

### 2. Scene Clock 制御 API (`scene.js`)
- `pauseSceneClock()`: 時刻を凍結
- `resumeSceneClock()`: 再開
- `seekSceneClock(t)`: 任意の時刻にジャンプ（local mode に自動切り替え）
- `resetSceneClock()`: t=0 にリセット
- `setSceneClockMode(mode)`: 'server-follow' ↔ 'local' 切り替え
- `followServerClock()`: server-follow mode に戻す

### 3. Loomlet 統合 (`loomlet-runtime-integration.js`)
- `buildHostInputsForObject()` に `clockState` パラメータを追加
- Loomlet object graph に以下の read-only host inputs を供給:
  - `time.t`: object graph の実評価時刻（selected object は 0、normal object は Scene Clock time）
  - `time.delta`: フレーム delta
  - `time.isPaused`: Scene Clock の pause 状態
  - `time.mode`: 'server-follow' | 'local'
  - `time.rate`: 再生速度倍率
  - `time.serverNow`: 常に現在の server time

### 4. Debug UI (`index.html` + `scene.js`)
- Scene Clock debug panel を追加（デフォルト hidden）
- 時刻表示、mode/status badge、Reset/Pause/Follow Server ボタン
- Seek input（任意の時刻にジャンプ）
- Rate input（再生速度調整）
- 開発時は dev console で `document.getElementById('scene-clock-panel').removeAttribute('hidden')` で表示

### 5. ドキュメント
- `docs/scene-sync-scene-clock.md`: 新規ドキュメント（API リファレンス、使用例、設計理由）
- `docs/scene-sync-runtime-time-model.md`: Scene Clock との関係を追記

## 変更していないこと

- Per-object selection-based `t=0` 凍結は変更なし
- Server-follow mode での時刻同期は変更なし
- Broadcast / room history への記録は行わない（local-only）
- Loomlet behavior graphs は時刻を読み取るのみ、制御はできない

## staging確認

未確認（staging への deploy は別途）

## テスト/チェック

- Scene Clock API の基本動作（pause/resume/seek/reset）

https://claude.ai/code/session_0116HYz3gGcVHA8Tg8AqjFPt