### PR TITLE
Add input routing mode toggle (Edit/Interact)

### DIFF
--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -105,6 +105,7 @@ function createRuntimeManager({
   getLoomletHostEvents,
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
+  getInputRoutingMode,
 }) {
   const runtimes = new Map();
   const definitions = new Map();
@@ -114,7 +115,7 @@ function createRuntimeManager({
     return `${key}:${target}`;
   }
 
-  function buildHostInputsForObject(objectId, objectTime, clockState) {
+  function buildHostInputsForObject(objectId, objectTime, clockState, options = {}) {
     const inputs = {};
 
     // Viewer inputs
@@ -188,6 +189,15 @@ function createRuntimeManager({
     inputs['isSelected'] = hoverState?.isSelected || false;
     inputs['isHovered'] = hoverState?.isHovered || false;
     inputs['isBeingEdited'] = isObjectBeingEdited?.(objectId) || false;
+
+    // Input routing mode inputs (local-only, read-only)
+    // Loomlet behavior can read the current mode but cannot change it
+    const mode = options?.getInputRoutingMode?.();
+    if (mode) {
+      inputs['input.mode'] = mode;
+      inputs['input.isEditMode'] = mode === 'edit';
+      inputs['input.isInteractMode'] = mode === 'interact';
+    }
 
     // Gaze state inputs (local-only, not broadcast)
     const gazeState = getObjectGazeState?.(objectId);
@@ -301,7 +311,7 @@ function createRuntimeManager({
       : (clockState?.t ?? getServerTime());
 
     // Build host inputs for object-scoped evaluations
-    const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId, time, clockState) : {};
+    const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId, time, clockState, { getInputRoutingMode }) : {};
 
     // Gather host events for object-scoped evaluations
     let events = [];
@@ -441,6 +451,7 @@ export function createSceneSyncLoomIntegration({
   getLoomletHostEvents,
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
+  getInputRoutingMode,
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
@@ -455,6 +466,7 @@ export function createSceneSyncLoomIntegration({
     getLoomletHostEvents,
     clearLoomletHostEvents,
     getSceneClockStateForLoomlet,
+    getInputRoutingMode,
   });
 
   function isSceneGraphMessage(payload) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -216,6 +216,26 @@ dom.clearBgmButton?.addEventListener('click', () => {
   notifySceneStateChanged('bgm-cleared');
 });
 
+// Input routing mode toggle
+function updateInputRoutingModeUI() {
+  const modeBtn = document.getElementById('mode');
+  if (!modeBtn) return;
+
+  const isInteract = inputRoutingMode === 'interact';
+  modeBtn.textContent = `Mode: ${isInteract ? 'Interact' : 'Edit'}`;
+  if (isInteract) {
+    modeBtn.classList.add('interact');
+  } else {
+    modeBtn.classList.remove('interact');
+  }
+}
+
+document.getElementById('mode')?.addEventListener('click', () => {
+  const nextMode = inputRoutingMode === 'edit' ? 'interact' : 'edit';
+  setInputRoutingMode(nextMode);
+  showToast(`Mode: ${nextMode.toUpperCase()}`);
+});
+
 setupXrButtons({
   renderer,
   dom,
@@ -2577,6 +2597,10 @@ const loomletHostEvents = new Map(); // objectId -> Set<eventName>
 const tmpViewerPosition = new THREE.Vector3();
 const tmpViewerForward = new THREE.Vector3();
 
+// Input routing mode (local-only host UI state)
+let inputRoutingMode = 'edit';
+const INPUT_ROUTING_MODES = new Set(['edit', 'interact']);
+
 // Gaze tracking state (local-only, not broadcast)
 let currentGazedObjectId = null;
 let gazeEnterTime = null;
@@ -2585,6 +2609,16 @@ const gazeDwellThresholdSeconds = 1.0;
 const tmpGazeOrigin = new THREE.Vector3();
 const tmpGazeDirection = new THREE.Vector3();
 let currentGazeHit = null;
+
+function getInputRoutingMode() {
+  return inputRoutingMode;
+}
+
+function setInputRoutingMode(mode) {
+  if (!INPUT_ROUTING_MODES.has(mode)) return;
+  inputRoutingMode = mode;
+  updateInputRoutingModeUI();
+}
 
 function enqueueLoomletHostEvent(objectId, eventName) {
   if (!objectId || !eventName) return;
@@ -2677,21 +2711,31 @@ function updateGazeStateFromCamera() {
     }
   }
 
-  // Handle gaze state changes
-  if (newGazedObjectId !== currentGazedObjectId) {
-    if (currentGazedObjectId) {
-      enqueueLoomletHostEvent(currentGazedObjectId, 'object.gaze.leave');
+  // Gaze events are Interact mode only
+  if (inputRoutingMode === 'interact') {
+    // Handle gaze state changes
+    if (newGazedObjectId !== currentGazedObjectId) {
+      if (currentGazedObjectId) {
+        enqueueLoomletHostEvent(currentGazedObjectId, 'object.gaze.leave');
+      }
+      if (newGazedObjectId) {
+        const now = performance.now();
+        gazeEnterTime = now;
+        lastGazeDwellEventAt = now;
+        enqueueLoomletHostEvent(newGazedObjectId, 'object.gaze.enter');
+      } else {
+        gazeEnterTime = null;
+        lastGazeDwellEventAt = null;
+      }
+      currentGazedObjectId = newGazedObjectId;
     }
-    if (newGazedObjectId) {
-      const now = performance.now();
-      gazeEnterTime = now;
-      lastGazeDwellEventAt = now;
-      enqueueLoomletHostEvent(newGazedObjectId, 'object.gaze.enter');
-    } else {
+  } else {
+    // Clear gaze state in Edit mode
+    if (currentGazedObjectId) {
+      currentGazedObjectId = null;
       gazeEnterTime = null;
       lastGazeDwellEventAt = null;
     }
-    currentGazedObjectId = newGazedObjectId;
   }
 
   currentGazeHit = gazeHit;
@@ -2911,15 +2955,23 @@ function updateHoverStateFromPointer(clientX, clientY) {
     }
   }
 
-  // Handle hover state changes
-  if (newHoveredObjectId !== currentHoveredObjectId) {
+  // Hover events are Interact mode only
+  if (inputRoutingMode === 'interact') {
+    // Handle hover state changes
+    if (newHoveredObjectId !== currentHoveredObjectId) {
+      if (currentHoveredObjectId) {
+        enqueueLoomletHostEvent(currentHoveredObjectId, 'object.hover.leave');
+      }
+      if (newHoveredObjectId) {
+        enqueueLoomletHostEvent(newHoveredObjectId, 'object.hover.enter');
+      }
+      currentHoveredObjectId = newHoveredObjectId;
+    }
+  } else {
+    // Clear hover state in Edit mode
     if (currentHoveredObjectId) {
-      enqueueLoomletHostEvent(currentHoveredObjectId, 'object.hover.leave');
+      currentHoveredObjectId = null;
     }
-    if (newHoveredObjectId) {
-      enqueueLoomletHostEvent(newHoveredObjectId, 'object.hover.enter');
-    }
-    currentHoveredObjectId = newHoveredObjectId;
   }
 }
 
@@ -2945,9 +2997,14 @@ function selectObjectAt(clientX, clientY, event = null) {
         showToast(`${who} が編集中です`);
         return;
       }
-      // Enqueue activate event for Loomlet behaviors
-      enqueueLoomletHostEvent(obj.userData.objectId, 'object.activate');
-      handleObjectSelection(obj, event);
+      // Input routing: Edit mode vs Interact mode
+      if (inputRoutingMode === 'edit') {
+        // Edit mode: click selects object for editing
+        handleObjectSelection(obj, event);
+      } else {
+        // Interact mode: click fires object.activate event
+        enqueueLoomletHostEvent(obj.userData.objectId, 'object.activate');
+      }
     }
   } else {
     clearSelection({ reason: 'selection-cleared-raycast' });
@@ -4519,6 +4576,7 @@ const loomIntegration = createSceneSyncLoomIntegration({
   getLoomletHostEvents: getLoomletHostEventsForObject,
   clearLoomletHostEvents: clearLoomletHostEventsForObject,
   getSceneClockStateForLoomlet,
+  getInputRoutingMode,
 });
 
 // ── Scene Clock Debug UI 制御 ────────────────────────────
@@ -11106,6 +11164,7 @@ if (sceneSyncOperatorLink) {
 // 初期状態を反映（DOM 参照と関数定義が揃った後で呼ぶ）
 updateLinkButtonState();
 updateMobileDevVisibility();
+updateInputRoutingModeUI();
 if (mobileEnvSelect && dom.envSelect) {
   mobileEnvSelect.value = dom.envSelect.value;
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2614,9 +2614,27 @@ function getInputRoutingMode() {
   return inputRoutingMode;
 }
 
+function clearInteractionRoutingState() {
+  // Clear all hover/gaze interaction state when switching to Edit mode
+  if (currentHoveredObjectId) {
+    currentHoveredObjectId = null;
+  }
+  if (currentGazedObjectId) {
+    currentGazedObjectId = null;
+    gazeEnterTime = null;
+    lastGazeDwellEventAt = null;
+  }
+  currentGazeHit = null;
+}
+
 function setInputRoutingMode(mode) {
   if (!INPUT_ROUTING_MODES.has(mode)) return;
+  if (inputRoutingMode === mode) return;
   inputRoutingMode = mode;
+  // Clear interaction state when switching to Edit mode
+  if (mode === 'edit') {
+    clearInteractionRoutingState();
+  }
   updateInputRoutingModeUI();
 }
 
@@ -3007,7 +3025,11 @@ function selectObjectAt(clientX, clientY, event = null) {
       }
     }
   } else {
-    clearSelection({ reason: 'selection-cleared-raycast' });
+    // Empty click: only clear selection in Edit mode
+    // Interact mode does not change selection on background click
+    if (inputRoutingMode === 'edit') {
+      clearSelection({ reason: 'selection-cleared-raycast' });
+    }
   }
 }
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1460,7 +1460,7 @@
       </div>
     </div>
   </div>
-  <button id="mode" type="button" title="入力ルーティングモードを切り替え">Mode: Edit</button>
+  <button id="mode" type="button" title="W: Move / E: Rotate / R: Scale">Mode: Edit</button>
   <div id="toast"></div>
   <div id="history-toolbar">
     <button id="btn-undo" class="tb-btn" title="取り消す (Ctrl+Z)">↶</button>

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -156,10 +156,24 @@
       padding: 6px 14px;
       border-radius: 6px;
       font: 13px/1.4 monospace;
-      color: #aaa;
-      background: rgba(0,0,0,0.45);
+      color: #fff;
+      background: rgba(0,0,0,0.55);
+      border: none;
+      cursor: pointer;
       z-index: 10;
       user-select: none;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+    #mode:hover {
+      background: rgba(0,0,0,0.75);
+    }
+    #mode.interact {
+      background: rgba(68,136,255,0.55);
+      color: #fff;
+    }
+    #mode.interact:hover {
+      background: rgba(68,136,255,0.8);
     }
     #add-btn {
       position: fixed;
@@ -1446,7 +1460,7 @@
       </div>
     </div>
   </div>
-  <div id="mode">W: 移動 &nbsp; E: 回転 &nbsp; R: スケール</div>
+  <button id="mode" type="button" title="入力ルーティングモードを切り替え">Mode: Edit</button>
   <div id="toast"></div>
   <div id="history-toolbar">
     <button id="btn-undo" class="tb-btn" title="取り消す (Ctrl+Z)">↶</button>


### PR DESCRIPTION
## 概要

入力ルーティングモード（Edit/Interact）の切り替え機能を追加しました。ユーザーが UI のモードボタンをクリックして、オブジェクトのクリック時の動作（編集選択 vs イベント発火）とガゼ/ホバーイベントの有効/無効を切り替えられるようになります。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### scene.js
- **入力ルーティングモード管理**: `inputRoutingMode` 状態変数と `getInputRoutingMode()` / `setInputRoutingMode()` 関数を追加
- **UI 制御**: `updateInputRoutingModeUI()` 関数でモードボタンの表示と スタイルを更新
- **モードボタンリスナー**: クリックでモード切り替え、トースト通知を表示
- **ガゼイベント制御**: `updateGazeStateFromCamera()` で `inputRoutingMode === 'interact'` の場合のみガゼイベント（enter/leave）を発火
- **ホバーイベント制御**: `updateHoverStateFromPointer()` で `inputRoutingMode === 'interact'` の場合のみホバーイベント（enter/leave）を発火
- **クリック動作の分岐**: `selectObjectAt()` で Edit モード時は `handleObjectSelection()`、Interact モード時は `object.activate` イベントを発火
- **Loomlet 統合**: `getInputRoutingMode` を `loomIntegration` に渡す
- **初期化**: `updateInputRoutingModeUI()` を初期化時に呼び出し

### index.html
- **モードボタン**: `<div id="mode">` から `<button id="mode">` に変更、初期テキストを「Mode: Edit」に
- **スタイル更新**: 
  - ボタンのカラーを白に、背景を濃くして視認性向上
  - ホバー時の背景色を追加
  - `.interact` クラスで青色（`rgba(68,136,255,0.55)`）に変更
  - `backdrop-filter: blur(6px)` でガラス効果を追加
  - `cursor: pointer` でボタンであることを明示

### loomlet-runtime-integration.js
- **入力ルーティングモード入力**: `buildHostInputsForObject()` で以下の入力を Loomlet に提供
  - `input.mode`: 現在のモード（'edit' または 'interact'）
  - `input.isEditMode`: Edit モードの場合 true
  - `input.isInteractMode`: Interact モードの場合 true
- **オプション引数**: `buildHostInputsForObject()` に `options` パラメータを追加し、`getInputRoutingMode` を渡す
- **統合**: `createSceneSyncLoomIntegration()` で `getInputRoutingMode` を受け取り、`createRuntimeManager()` に渡す

## 変更していないこと

- ガゼ/ホバーイベントの基本的な検出ロジック（モード判定の追加のみ）
- オブジェクト選択の基本的なレイキャスト処理
- Loomlet 動作の実行エンジン

## staging確認

未確認（staging への deploy 前）

## テスト/チェック

- 入力ルーティングモード管理の基本的なロ

https://claude.ai/code/session_01NAzZCx3kNzsZ1FUzvRm7Cw