### PR TITLE
[codex] Require explicit dev TURN opt-in

### DIFF
--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -986,8 +986,8 @@ function buildTurnServers() {
   const urls = raw.split(',').map(u => u.trim()).filter(Boolean);
   if (!urls.length) {
     const devTurn = process.env.DEV_TURN_URL || 'turn:localhost:3478?transport=udp';
-    const enableDev = process.env.ENABLE_DEV_TURN !== 'false';
-    if (enableDev && process.env.NODE_ENV !== 'production') {
+    const enableDev = process.env.ENABLE_DEV_TURN === 'true';
+    if (enableDev) {
       urls.push(devTurn);
     }
   }


### PR DESCRIPTION
## Summary
- Require explicit opt-in before advertising the development localhost TURN URL.
- Keep `TURN_URL` / `TURN_URLS` behavior unchanged for real TURN configuration.

## Why
The production `/presence/api/ice-config` endpoint could advertise `turn:localhost:3478` when TURN was not configured. That is only useful for local development and should not leak into default runtime configuration.

## Validation
- Confirmed `/api/ice-config` returns only STUN when `TURN_URL`, `TURN_URLS`, and `ENABLE_DEV_TURN` are unset.
- Confirmed localhost TURN is included only when `ENABLE_DEV_TURN=true`.
- Ran `npm test` in `apps/presence-server`; emitted tests were passing, but the local Node process did not exit due to open handles.
