### PR TITLE
[codex] Add Godot Loomlet runtime parity

### DIFF
--- a/godot/SceneSyncGodot.csproj
+++ b/godot/SceneSyncGodot.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Godot.NET.Sdk/4.6.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+</Project>

--- a/godot/SceneSyncGodot.csproj
+++ b/godot/SceneSyncGodot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.0">
+<Project Sdk="Godot.NET.Sdk/4.6.3">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/godot/addons/scene_sync/LoomletRuntime/Core/HostContextNodes.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/HostContextNodes.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    internal static class HostContextNodes
+    {
+        public static void Register(LoomletFunctionRegistry r)
+        {
+            r.Register("host.input", new[] { "name", "fallback" }, (i, c) =>
+            {
+                var name = LoomletValues.Text(i["name"]);
+                return new Dictionary<string, object>
+                {
+                    ["out"] = c.TryGetHostInput(name, out var value) ? value : i["fallback"]
+                };
+            });
+
+            r.Register("host.event", new[] { "name" }, (i, c) =>
+            {
+                return new Dictionary<string, object>
+                {
+                    ["events"] = new List<object>(c.GetHostEvents(LoomletValues.Text(i["name"])))
+                };
+            });
+
+            r.Register("scene.clock", new string[0], (i, c) =>
+            {
+                return new Dictionary<string, object>
+                {
+                    ["t"] = c.Time,
+                    ["delta"] = c.DeltaTime,
+                    ["isPaused"] = c.IsPaused,
+                    ["mode"] = c.Mode,
+                    ["rate"] = c.Rate
+                };
+            });
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/HostContextNodes.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/HostContextNodes.cs.uid
@@ -1,0 +1,1 @@
+uid://dapk2bmb01ii5

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationContext.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationContext.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletEvaluationContext
+    {
+        private readonly Dictionary<string, object> _hostInputs = new Dictionary<string, object>();
+        private readonly Dictionary<string, List<object>> _hostEvents = new Dictionary<string, List<object>>();
+
+        public double Time { get; private set; }
+        public double DeltaTime { get; private set; }
+        public bool IsPaused { get; private set; }
+        public string Mode { get; private set; } = "local";
+        public double Rate { get; private set; } = 1.0;
+
+        public LoomletEvaluationContext WithSceneClock(
+            double time,
+            double deltaTime,
+            bool isPaused = false,
+            string mode = "local",
+            double rate = 1.0)
+        {
+            Time = time;
+            DeltaTime = deltaTime;
+            IsPaused = isPaused;
+            Mode = mode ?? "local";
+            Rate = rate;
+            return this;
+        }
+
+        public LoomletEvaluationContext SetHostInput(string name, object value)
+        {
+            _hostInputs[name] = value;
+            return this;
+        }
+
+        public bool TryGetHostInput(string name, out object value) => _hostInputs.TryGetValue(name, out value);
+
+        public LoomletEvaluationContext AddHostEvent(string name, object payload)
+        {
+            if (!_hostEvents.TryGetValue(name, out var events))
+            {
+                events = new List<object>();
+                _hostEvents[name] = events;
+            }
+            events.Add(payload);
+            return this;
+        }
+
+        public LoomletEvaluationContext SetHostEvents(string name, IEnumerable<object> events)
+        {
+            _hostEvents[name] = events == null ? new List<object>() : new List<object>(events);
+            return this;
+        }
+
+        public LoomletEvaluationContext ClearHostEvents()
+        {
+            _hostEvents.Clear();
+            return this;
+        }
+
+        public LoomletEvaluationContext ClearHostEvents(string name)
+        {
+            _hostEvents.Remove(name);
+            return this;
+        }
+
+        public IReadOnlyList<object> GetHostEvents(string name)
+        {
+            return _hostEvents.TryGetValue(name, out var events) ? events : EmptyEvents;
+        }
+
+        private static readonly List<object> EmptyEvents = new List<object>();
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationContext.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationContext.cs.uid
@@ -1,0 +1,1 @@
+uid://bcij7m7f4u64j

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationResult.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationResult.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletEvaluationResult
+    {
+        private readonly Dictionary<string, object> _values;
+
+        internal LoomletEvaluationResult(Dictionary<string, object> values)
+        {
+            _values = new Dictionary<string, object>(values);
+        }
+
+        public object GetValue(string reference)
+        {
+            return _values.TryGetValue(reference, out var value) ? value : null;
+        }
+
+        public object GetValue(string nodeId, string outputName)
+        {
+            return GetValue(nodeId + "." + outputName);
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationResult.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluationResult.cs.uid
@@ -1,0 +1,1 @@
+uid://da181tm2f2b8x

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluator.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluator.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletEvaluator
+    {
+        private readonly LoomletGraph _graph;
+        private readonly LoomletFunctionRegistry _registry;
+        private readonly List<LoomletNode> _sortedNodes;
+        private readonly Dictionary<string, object> _values = new Dictionary<string, object>();
+
+        public LoomletEvaluator(LoomletGraph graph, LoomletFunctionRegistry registry = null)
+        {
+            _graph = graph ?? throw new System.ArgumentNullException(nameof(graph));
+            _registry = registry ?? LoomletFunctionRegistry.CreateDefault();
+            ValidateGraph();
+            _sortedNodes = TopologicalSort();
+        }
+
+        public LoomletEvaluationResult Evaluate(LoomletEvaluationContext context = null)
+        {
+            context = context ?? new LoomletEvaluationContext();
+            _values.Clear();
+
+            foreach (var node in _sortedNodes)
+            {
+                var def = GetDefinition(node.Type);
+                var inputs = ResolveInputs(node, def);
+                var outputs = def.Evaluate(inputs, context) ?? new Dictionary<string, object>();
+                foreach (var pair in outputs)
+                    _values[node.Id + "." + pair.Key] = pair.Value;
+            }
+
+            return new LoomletEvaluationResult(_values);
+        }
+
+        public object GetValue(string reference)
+        {
+            return _values.TryGetValue(reference, out var value) ? value : null;
+        }
+
+        private Dictionary<string, object> ResolveInputs(LoomletNode node, LoomletNodeDefinition def)
+        {
+            var inputs = new Dictionary<string, object>();
+            foreach (var inputName in def.Inputs)
+            {
+                var edge = FindEdgeTo(node.Id + "." + inputName);
+                if (edge != null && _values.TryGetValue(edge.From, out var value))
+                    inputs[inputName] = value;
+                else if (node.Params != null && node.Params.TryGetValue(inputName, out var param))
+                    inputs[inputName] = param;
+                else
+                    inputs[inputName] = null;
+            }
+            return inputs;
+        }
+
+        private LoomletEdge FindEdgeTo(string to)
+        {
+            foreach (var edge in _graph.Edges)
+                if (edge.To == to) return edge;
+            return null;
+        }
+
+        private void ValidateGraph()
+        {
+            var ids = new HashSet<string>();
+            foreach (var node in _graph.Nodes)
+            {
+                if (string.IsNullOrEmpty(node.Id)) throw new LoomletException("INVALID_GRAPH", "Node id is required.");
+                if (string.IsNullOrEmpty(node.Type)) throw new LoomletException("INVALID_GRAPH", "Node type is required.");
+                if (!ids.Add(node.Id)) throw new LoomletException("INVALID_GRAPH", "Duplicate node id: " + node.Id);
+                GetDefinition(node.Type);
+            }
+
+            foreach (var edge in _graph.Edges)
+            {
+                if (string.IsNullOrEmpty(edge.From) || string.IsNullOrEmpty(edge.To))
+                    throw new LoomletException("INVALID_GRAPH", "Edge from/to references are required.");
+            }
+        }
+
+        private LoomletNodeDefinition GetDefinition(string type)
+        {
+            if (!_registry.TryGet(type, out var def))
+                throw new LoomletException("UNSUPPORTED_NODE", "Unsupported Loomlet node type: " + type);
+            return def;
+        }
+
+        private List<LoomletNode> TopologicalSort()
+        {
+            var byId = new Dictionary<string, LoomletNode>();
+            var indegree = new Dictionary<string, int>();
+            var outgoing = new Dictionary<string, List<string>>();
+            foreach (var node in _graph.Nodes)
+            {
+                byId[node.Id] = node;
+                indegree[node.Id] = 0;
+                outgoing[node.Id] = new List<string>();
+            }
+
+            foreach (var edge in _graph.Edges)
+            {
+                var fromId = SplitReference(edge.From);
+                var toId = SplitReference(edge.To);
+                if (!byId.ContainsKey(fromId) || !byId.ContainsKey(toId))
+                    throw new LoomletException("INVALID_GRAPH", "Edge references an unknown node.");
+                outgoing[fromId].Add(toId);
+                indegree[toId]++;
+            }
+
+            var queue = new Queue<string>();
+            foreach (var pair in indegree)
+                if (pair.Value == 0) queue.Enqueue(pair.Key);
+
+            var sorted = new List<LoomletNode>();
+            while (queue.Count > 0)
+            {
+                var id = queue.Dequeue();
+                sorted.Add(byId[id]);
+                foreach (var next in outgoing[id])
+                {
+                    indegree[next]--;
+                    if (indegree[next] == 0) queue.Enqueue(next);
+                }
+            }
+
+            if (sorted.Count != _graph.Nodes.Count)
+                throw new LoomletException("CYCLE_DETECTED", "Graph contains a cycle.");
+            return sorted;
+        }
+
+        private static string SplitReference(string reference)
+        {
+            var dot = reference == null ? -1 : reference.IndexOf('.');
+            if (dot <= 0) throw new LoomletException("INVALID_GRAPH", "Port reference must be node.port.");
+            return reference.Substring(0, dot);
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluator.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletEvaluator.cs.uid
@@ -1,0 +1,1 @@
+uid://2ct6wyvx6dvn

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletException.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletException : Exception
+    {
+        public string Code { get; }
+
+        public LoomletException(string code, string message) : base(message)
+        {
+            Code = code;
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletException.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletException.cs.uid
@@ -1,0 +1,1 @@
+uid://yqxlyu8x6kkr

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletFunctionRegistry.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletFunctionRegistry.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletFunctionRegistry
+    {
+        private readonly Dictionary<string, LoomletNodeDefinition> _definitions = new Dictionary<string, LoomletNodeDefinition>();
+
+        public LoomletFunctionRegistry Register(string type, string[] inputs, Func<Dictionary<string, object>, LoomletEvaluationContext, Dictionary<string, object>> evaluate)
+        {
+            _definitions[type] = new LoomletNodeDefinition(type, inputs, evaluate);
+            return this;
+        }
+
+        public bool TryGet(string type, out LoomletNodeDefinition definition) => _definitions.TryGetValue(type, out definition);
+
+        public static LoomletFunctionRegistry CreateDefault()
+        {
+            var registry = new LoomletFunctionRegistry();
+            PortableNodes.Register(registry);
+            HostContextNodes.Register(registry);
+            return registry;
+        }
+    }
+
+    public sealed class LoomletNodeDefinition
+    {
+        public string Type { get; }
+        public string[] Inputs { get; }
+        private readonly Func<Dictionary<string, object>, LoomletEvaluationContext, Dictionary<string, object>> _evaluate;
+
+        internal LoomletNodeDefinition(string type, string[] inputs, Func<Dictionary<string, object>, LoomletEvaluationContext, Dictionary<string, object>> evaluate)
+        {
+            Type = type;
+            Inputs = inputs;
+            _evaluate = evaluate;
+        }
+
+        public Dictionary<string, object> Evaluate(Dictionary<string, object> inputs, LoomletEvaluationContext context)
+        {
+            return _evaluate(inputs, context);
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletFunctionRegistry.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletFunctionRegistry.cs.uid
@@ -1,0 +1,1 @@
+uid://ckjv5x4xl6too

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletGraph.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletGraph.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletGraph
+    {
+        public List<LoomletNode> Nodes { get; set; } = new List<LoomletNode>();
+        public List<LoomletEdge> Edges { get; set; } = new List<LoomletEdge>();
+
+        public static LoomletGraph FromJson(string json)
+        {
+            var parsed = LoomletJson.Parse(json) as Dictionary<string, object>;
+            if (parsed == null)
+                throw new LoomletException("INVALID_GRAPH", "Graph JSON must be an object.");
+
+            return FromDictionary(parsed);
+        }
+
+        public static LoomletGraph FromDictionary(Dictionary<string, object> obj)
+        {
+            if (!obj.TryGetValue("nodes", out var nodesRaw) || !(nodesRaw is List<object> nodes))
+                throw new LoomletException("INVALID_GRAPH", "Graph JSON must contain a nodes array.");
+            if (!obj.TryGetValue("edges", out var edgesRaw) || !(edgesRaw is List<object> edges))
+                throw new LoomletException("INVALID_GRAPH", "Graph JSON must contain an edges array.");
+
+            var graph = new LoomletGraph();
+            foreach (var rawNode in nodes)
+            {
+                var nodeObj = rawNode as Dictionary<string, object>;
+                if (nodeObj == null)
+                    throw new LoomletException("INVALID_GRAPH", "Each graph node must be an object.");
+
+                var node = new LoomletNode
+                {
+                    Id = nodeObj.TryGetValue("id", out var id) ? id?.ToString() : null,
+                    Type = nodeObj.TryGetValue("type", out var type) ? type?.ToString() : null,
+                    Params = nodeObj.TryGetValue("params", out var p) && p is Dictionary<string, object> pd
+                        ? pd
+                        : new Dictionary<string, object>()
+                };
+                graph.Nodes.Add(node);
+            }
+
+            foreach (var rawEdge in edges)
+            {
+                var edgeObj = rawEdge as Dictionary<string, object>;
+                if (edgeObj == null)
+                    throw new LoomletException("INVALID_GRAPH", "Each graph edge must be an object.");
+
+                graph.Edges.Add(new LoomletEdge
+                {
+                    From = edgeObj.TryGetValue("from", out var from) ? from?.ToString() : null,
+                    To = edgeObj.TryGetValue("to", out var to) ? to?.ToString() : null
+                });
+            }
+
+            return graph;
+        }
+    }
+
+    public sealed class LoomletNode
+    {
+        public string Id { get; set; }
+        public string Type { get; set; }
+        public Dictionary<string, object> Params { get; set; } = new Dictionary<string, object>();
+    }
+
+    public sealed class LoomletEdge
+    {
+        public string From { get; set; }
+        public string To { get; set; }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletGraph.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletGraph.cs.uid
@@ -1,0 +1,1 @@
+uid://dgj4vk5cojqq0

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletJson.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletJson.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Loomlet.Runtime
+{
+    public sealed class LoomletJson
+    {
+        private readonly string _input;
+        private int _pos;
+
+        private LoomletJson(string input)
+        {
+            _input = input;
+        }
+
+        public static object Parse(string json)
+        {
+            if (json == null) throw new LoomletException("INVALID_JSON", "JSON must not be null.");
+            var parser = new LoomletJson(json);
+            var value = parser.ParseValue();
+            parser.SkipWhitespace();
+            if (parser._pos != parser._input.Length)
+                throw new LoomletException("INVALID_JSON", "Unexpected trailing JSON characters.");
+            return value;
+        }
+
+        public static string Stringify(object value)
+        {
+            if (value == null) return "null";
+            if (value is string s) return "\"" + Escape(s) + "\"";
+            if (value is bool b) return b ? "true" : "false";
+            if (value is int || value is long || value is float || value is double || value is decimal)
+                return Convert.ToDouble(value, CultureInfo.InvariantCulture).ToString("G17", CultureInfo.InvariantCulture);
+            if (value is Dictionary<string, object> dict)
+            {
+                var parts = new List<string>();
+                foreach (var key in dict.Keys)
+                    parts.Add(Stringify(key) + ":" + Stringify(dict[key]));
+                return "{" + string.Join(",", parts) + "}";
+            }
+            if (value is IList<object> list)
+            {
+                var parts = new List<string>();
+                foreach (var item in list) parts.Add(Stringify(item));
+                return "[" + string.Join(",", parts) + "]";
+            }
+            return Stringify(value.ToString());
+        }
+
+        private static string Escape(string value)
+        {
+            return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+        }
+
+        private object ParseValue()
+        {
+            SkipWhitespace();
+            var ch = Peek();
+            if (ch == '{') return ParseObject();
+            if (ch == '[') return ParseArray();
+            if (ch == '"') return ParseString();
+            if (ch == 't') return ParseKeyword("true", true);
+            if (ch == 'f') return ParseKeyword("false", false);
+            if (ch == 'n') return ParseKeyword("null", null);
+            if (ch == '-' || char.IsDigit(ch)) return ParseNumber();
+            throw new LoomletException("INVALID_JSON", "Unexpected JSON token.");
+        }
+
+        private Dictionary<string, object> ParseObject()
+        {
+            Consume('{');
+            var result = new Dictionary<string, object>();
+            SkipWhitespace();
+            if (Peek() == '}')
+            {
+                _pos++;
+                return result;
+            }
+            while (true)
+            {
+                var key = ParseString();
+                SkipWhitespace();
+                Consume(':');
+                result[key] = ParseValue();
+                SkipWhitespace();
+                var ch = Next();
+                if (ch == '}') return result;
+                if (ch != ',') throw new LoomletException("INVALID_JSON", "Expected object separator.");
+            }
+        }
+
+        private List<object> ParseArray()
+        {
+            Consume('[');
+            var result = new List<object>();
+            SkipWhitespace();
+            if (Peek() == ']')
+            {
+                _pos++;
+                return result;
+            }
+            while (true)
+            {
+                result.Add(ParseValue());
+                SkipWhitespace();
+                var ch = Next();
+                if (ch == ']') return result;
+                if (ch != ',') throw new LoomletException("INVALID_JSON", "Expected array separator.");
+            }
+        }
+
+        private string ParseString()
+        {
+            Consume('"');
+            var sb = new StringBuilder();
+            while (_pos < _input.Length)
+            {
+                var ch = Next();
+                if (ch == '"') return sb.ToString();
+                if (ch != '\\')
+                {
+                    sb.Append(ch);
+                    continue;
+                }
+                var esc = Next();
+                switch (esc)
+                {
+                    case '"': sb.Append('"'); break;
+                    case '\\': sb.Append('\\'); break;
+                    case '/': sb.Append('/'); break;
+                    case 'b': sb.Append('\b'); break;
+                    case 'f': sb.Append('\f'); break;
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 't': sb.Append('\t'); break;
+                    case 'u':
+                        var hex = new string(new[] { Next(), Next(), Next(), Next() });
+                        sb.Append((char)Convert.ToInt32(hex, 16));
+                        break;
+                    default:
+                        throw new LoomletException("INVALID_JSON", "Invalid JSON escape.");
+                }
+            }
+            throw new LoomletException("INVALID_JSON", "Unterminated JSON string.");
+        }
+
+        private object ParseKeyword(string keyword, object value)
+        {
+            for (var i = 0; i < keyword.Length; i++)
+                if (Next() != keyword[i]) throw new LoomletException("INVALID_JSON", "Invalid JSON keyword.");
+            return value;
+        }
+
+        private double ParseNumber()
+        {
+            var start = _pos;
+            if (Peek() == '-') _pos++;
+            while (_pos < _input.Length && char.IsDigit(_input[_pos])) _pos++;
+            if (_pos < _input.Length && _input[_pos] == '.')
+            {
+                _pos++;
+                while (_pos < _input.Length && char.IsDigit(_input[_pos])) _pos++;
+            }
+            if (_pos < _input.Length && (_input[_pos] == 'e' || _input[_pos] == 'E'))
+            {
+                _pos++;
+                if (_pos < _input.Length && (_input[_pos] == '+' || _input[_pos] == '-')) _pos++;
+                while (_pos < _input.Length && char.IsDigit(_input[_pos])) _pos++;
+            }
+            return double.Parse(_input.Substring(start, _pos - start), CultureInfo.InvariantCulture);
+        }
+
+        private void SkipWhitespace()
+        {
+            while (_pos < _input.Length && char.IsWhiteSpace(_input[_pos])) _pos++;
+        }
+
+        private char Peek() => _pos < _input.Length ? _input[_pos] : '\0';
+
+        private char Next()
+        {
+            if (_pos >= _input.Length) throw new LoomletException("INVALID_JSON", "Unexpected end of JSON.");
+            return _input[_pos++];
+        }
+
+        private void Consume(char expected)
+        {
+            SkipWhitespace();
+            var actual = Next();
+            if (actual != expected)
+                throw new LoomletException("INVALID_JSON", "Unexpected JSON character.");
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletJson.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletJson.cs.uid
@@ -1,0 +1,1 @@
+uid://daxd3nkv0lgrq

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletValues.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletValues.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Loomlet.Runtime
+{
+    internal static class LoomletValues
+    {
+        public static double Number(object value, double fallback = 0)
+        {
+            if (value == null) return fallback;
+            if (value is double d) return d;
+            if (value is float f) return f;
+            if (value is int i) return i;
+            if (value is long l) return l;
+            if (value is bool b) return b ? 1 : 0;
+            return double.TryParse(value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+                ? parsed
+                : fallback;
+        }
+
+        public static int Integer(object value, int fallback = 0) => (int)Math.Truncate(Number(value, fallback));
+
+        public static bool Truthy(object value)
+        {
+            if (value == null) return false;
+            if (value is bool b) return b;
+            if (value is string s) return s.Length > 0;
+            if (value is double d) return d != 0 && !double.IsNaN(d);
+            if (value is float f) return f != 0 && !float.IsNaN(f);
+            if (value is int i) return i != 0;
+            if (value is long l) return l != 0;
+            return true;
+        }
+
+        public static List<object> ToList(object value)
+        {
+            if (value == null) return new List<object>();
+            if (value is List<object> list) return list;
+            if (value is object[] array) return new List<object>(array);
+            return new List<object>();
+        }
+
+        public static string Text(object value)
+        {
+            if (value == null) return "";
+            if (value is string s) return s;
+            if (value is bool b) return b ? "true" : "false";
+            if (value is double d) return d.ToString("G15", CultureInfo.InvariantCulture);
+            if (value is int i) return i.ToString(CultureInfo.InvariantCulture);
+            if (value is IList<object> || value is Dictionary<string, object>) return LoomletJson.Stringify(value);
+            return value.ToString();
+        }
+
+        public static bool SameValue(object a, object b)
+        {
+            if (a == null || b == null) return a == null && b == null;
+            if (IsNumberLike(a) && IsNumberLike(b)) return Number(a).Equals(Number(b));
+            return Equals(a, b);
+        }
+
+        private static bool IsNumberLike(object value)
+        {
+            return value is double || value is float || value is int || value is long || value is decimal;
+        }
+
+        public static object CloneJsonLike(object value)
+        {
+            if (value is Dictionary<string, object> dict)
+            {
+                var clone = new Dictionary<string, object>();
+                foreach (var pair in dict) clone[pair.Key] = CloneJsonLike(pair.Value);
+                return clone;
+            }
+            if (value is List<object> list)
+            {
+                var clone = new List<object>();
+                foreach (var item in list) clone.Add(CloneJsonLike(item));
+                return clone;
+            }
+            return value;
+        }
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/LoomletValues.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/LoomletValues.cs.uid
@@ -1,0 +1,1 @@
+uid://b0f62jlw6slol

--- a/godot/addons/scene_sync/LoomletRuntime/Core/PortableNodes.cs
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/PortableNodes.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Loomlet.Runtime
+{
+    internal static class PortableNodes
+    {
+        public static void Register(LoomletFunctionRegistry r)
+        {
+            RegisterMath(r);
+            RegisterLogic(r);
+            RegisterList(r);
+            RegisterText(r);
+            RegisterJson(r);
+        }
+
+        private static void RegisterMath(LoomletFunctionRegistry r)
+        {
+            r.Register("math.add", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"]) + LoomletValues.Number(i["b"])));
+            r.Register("math.subtract", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"]) - LoomletValues.Number(i["b"])));
+            r.Register("math.multiply", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"], 1) * LoomletValues.Number(i["b"], 1)));
+            r.Register("math.divide", new[] { "a", "b" }, (i, c) => { var b = LoomletValues.Number(i["b"], 1); return Out(b == 0 ? 0 : LoomletValues.Number(i["a"]) / b); });
+            r.Register("math.mod", new[] { "a", "b" }, (i, c) => { var b = LoomletValues.Number(i["b"], 1); return Out(b == 0 ? 0 : ((LoomletValues.Number(i["a"]) % b) + b) % b); });
+            r.Register("math.min", new[] { "a", "b" }, (i, c) => Out(Math.Min(LoomletValues.Number(i["a"]), LoomletValues.Number(i["b"]))));
+            r.Register("math.max", new[] { "a", "b" }, (i, c) => Out(Math.Max(LoomletValues.Number(i["a"]), LoomletValues.Number(i["b"]))));
+            r.Register("math.clamp", new[] { "value", "min", "max" }, (i, c) => { var min = LoomletValues.Number(i["min"]); var max = LoomletValues.Number(i["max"], 1); var value = LoomletValues.Number(i["value"]); return Out(min > max ? min : Math.Max(min, Math.Min(max, value))); });
+            r.Register("math.lerp", new[] { "a", "b", "t" }, (i, c) => { var a = LoomletValues.Number(i["a"]); var b = LoomletValues.Number(i["b"], 1); return Out(a + (b - a) * LoomletValues.Number(i["t"])); });
+            r.Register("math.map", new[] { "value", "inMin", "inMax", "outMin", "outMax", "clamp" }, (i, c) =>
+            {
+                var inMin = LoomletValues.Number(i["inMin"]);
+                var inMax = LoomletValues.Number(i["inMax"], 1);
+                var outMin = LoomletValues.Number(i["outMin"]);
+                var outMax = LoomletValues.Number(i["outMax"], 1);
+                if (inMax == inMin) return Out(outMin);
+                var t = (LoomletValues.Number(i["value"]) - inMin) / (inMax - inMin);
+                if (i.TryGetValue("clamp", out var clamp) && clamp is bool b && b) t = Math.Max(0, Math.Min(1, t));
+                return Out(outMin + (outMax - outMin) * t);
+            });
+            r.Register("math.floor", new[] { "value" }, (i, c) => Out(Math.Floor(LoomletValues.Number(i["value"]))));
+            r.Register("math.ceil", new[] { "value" }, (i, c) => Out(Math.Ceiling(LoomletValues.Number(i["value"]))));
+            r.Register("math.round", new[] { "value" }, (i, c) => Out(Math.Floor(LoomletValues.Number(i["value"]) + 0.5)));
+            r.Register("math.sqrt", new[] { "value" }, (i, c) => Out(Math.Sqrt(LoomletValues.Number(i["value"]))));
+            r.Register("math.pow", new[] { "value", "exponent" }, (i, c) => Out(Math.Pow(LoomletValues.Number(i["value"]), LoomletValues.Number(i["exponent"], 1))));
+            r.Register("math.sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (i, c) => Out(Math.Sin(LoomletValues.Number(i["t"]) * LoomletValues.Number(i["freq"], 1) * 2 * Math.PI + LoomletValues.Number(i["phase"])) * LoomletValues.Number(i["amplitude"], 1) + LoomletValues.Number(i["offset"])));
+            r.Register("math.cosine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (i, c) => Out(Math.Cos(LoomletValues.Number(i["t"]) * LoomletValues.Number(i["freq"], 1) * 2 * Math.PI + LoomletValues.Number(i["phase"])) * LoomletValues.Number(i["amplitude"], 1) + LoomletValues.Number(i["offset"])));
+        }
+
+        private static void RegisterLogic(LoomletFunctionRegistry r)
+        {
+            r.Register("logic.equals", new[] { "value", "other" }, (i, c) => Out(LoomletValues.SameValue(i["value"], i["other"])));
+            r.Register("logic.notEquals", new[] { "value", "other" }, (i, c) => Out(!LoomletValues.SameValue(i["value"], i["other"])));
+            r.Register("logic.greaterThan", new[] { "value", "other" }, (i, c) => Out(LoomletValues.Number(i["value"]) > LoomletValues.Number(i["other"])));
+            r.Register("logic.lessThan", new[] { "value", "other" }, (i, c) => Out(LoomletValues.Number(i["value"]) < LoomletValues.Number(i["other"])));
+            r.Register("logic.greaterOrEqual", new[] { "value", "other" }, (i, c) => Out(LoomletValues.Number(i["value"]) >= LoomletValues.Number(i["other"])));
+            r.Register("logic.lessOrEqual", new[] { "value", "other" }, (i, c) => Out(LoomletValues.Number(i["value"]) <= LoomletValues.Number(i["other"])));
+            r.Register("logic.and", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Truthy(i["a"]) && LoomletValues.Truthy(i["b"])));
+            r.Register("logic.or", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Truthy(i["a"]) || LoomletValues.Truthy(i["b"])));
+            r.Register("logic.not", new[] { "value" }, (i, c) => Out(!LoomletValues.Truthy(i["value"])));
+            r.Register("logic.select", new[] { "condition", "whenTrue", "whenFalse" }, (i, c) => Out(LoomletValues.Truthy(i["condition"]) ? i["whenTrue"] : i["whenFalse"]));
+            r.Register("logic.when", new[] { "condition", "value" }, (i, c) => Out(LoomletValues.Truthy(i["condition"]) ? i["value"] : null));
+        }
+
+        private static void RegisterList(LoomletFunctionRegistry r)
+        {
+            r.Register("list.range", new[] { "start", "end" }, (i, c) => { var start = LoomletValues.Integer(i["start"]); var end = LoomletValues.Integer(i["end"]); var step = start <= end ? 1 : -1; var list = new List<object>(); for (var n = start; step > 0 ? n <= end : n >= end; n += step) list.Add((double)n); return Out(list); });
+            r.Register("list.length", new[] { "list" }, (i, c) => Out((double)LoomletValues.ToList(i["list"]).Count));
+            r.Register("list.first", new[] { "list" }, (i, c) => { var list = LoomletValues.ToList(i["list"]); return Out(list.Count > 0 ? list[0] : null); });
+            r.Register("list.last", new[] { "list" }, (i, c) => { var list = LoomletValues.ToList(i["list"]); return Out(list.Count > 0 ? list[list.Count - 1] : null); });
+            r.Register("list.at", new[] { "list", "index" }, (i, c) => { var list = LoomletValues.ToList(i["list"]); var index = LoomletValues.Integer(i["index"]); if (index < 0) index = list.Count + index; return Out(index >= 0 && index < list.Count ? list[index] : null); });
+            r.Register("list.join", new[] { "list", "separator" }, (i, c) => Out(string.Join(LoomletValues.Text(i["separator"] ?? ","), LoomletValues.ToList(i["list"]).Select(LoomletValues.Text).ToArray())));
+            r.Register("list.reverse", new[] { "list" }, (i, c) => { var list = new List<object>(LoomletValues.ToList(i["list"])); list.Reverse(); return Out(list); });
+            r.Register("list.sort", new[] { "list" }, (i, c) => { var list = new List<object>(LoomletValues.ToList(i["list"])); if (list.All(v => v is double || v is int || v is long || v is float)) list.Sort((a, b) => LoomletValues.Number(a).CompareTo(LoomletValues.Number(b))); else list.Sort((a, b) => string.Compare(LoomletValues.Text(a), LoomletValues.Text(b), StringComparison.Ordinal)); return Out(list); });
+            r.Register("list.take", new[] { "list", "count" }, (i, c) => Out(LoomletValues.ToList(i["list"]).Take(Math.Max(0, LoomletValues.Integer(i["count"]))).ToList<object>()));
+            r.Register("list.drop", new[] { "list", "count" }, (i, c) => Out(LoomletValues.ToList(i["list"]).Skip(Math.Max(0, LoomletValues.Integer(i["count"]))).ToList<object>()));
+            r.Register("list.concat", new[] { "list1", "list2", "list3", "list4" }, (i, c) => { var list = new List<object>(); for (var n = 1; n <= 4; n++) if (i["list" + n] != null) list.AddRange(LoomletValues.ToList(i["list" + n])); return Out(list); });
+        }
+
+        private static void RegisterText(LoomletFunctionRegistry r)
+        {
+            r.Register("text.concat", Enumerable.Range(1, 8).Select(n => "value" + n).ToArray(), (i, c) =>
+            {
+                var parts = new List<string>();
+                for (var n = 1; n <= 8; n++)
+                    if (i["value" + n] != null) parts.Add(LoomletValues.Text(i["value" + n]));
+                return Out(string.Concat(parts.ToArray()));
+            });
+            r.Register("text.split", new[] { "value", "separator" }, (i, c) => Out(LoomletValues.Text(i["value"]).Split(new[] { LoomletValues.Text(i["separator"] ?? ",") }, StringSplitOptions.None).Cast<object>().ToList()));
+            r.Register("text.join", new[] { "list", "separator" }, (i, c) => Out(string.Join(LoomletValues.Text(i["separator"] ?? ","), LoomletValues.ToList(i["list"]).Select(LoomletValues.Text).ToArray())));
+            r.Register("text.includes", new[] { "value", "search" }, (i, c) => Out(LoomletValues.Text(i["value"]).Contains(LoomletValues.Text(i["search"]))));
+            r.Register("text.startsWith", new[] { "value", "search" }, (i, c) => Out(LoomletValues.Text(i["value"]).StartsWith(LoomletValues.Text(i["search"]), StringComparison.Ordinal)));
+            r.Register("text.endsWith", new[] { "value", "search" }, (i, c) => Out(LoomletValues.Text(i["value"]).EndsWith(LoomletValues.Text(i["search"]), StringComparison.Ordinal)));
+            r.Register("text.length", new[] { "value" }, (i, c) => Out((double)LoomletValues.Text(i["value"]).Length));
+            r.Register("text.isEmpty", new[] { "value" }, (i, c) => Out(LoomletValues.Text(i["value"]).Length == 0));
+            r.Register("text.stringify", new[] { "value" }, (i, c) => Out(LoomletValues.Text(i["value"])));
+        }
+
+        private static void RegisterJson(LoomletFunctionRegistry r)
+        {
+            r.Register("json.stringify", new[] { "value" }, (i, c) => Out(LoomletJson.Stringify(i["value"])));
+            r.Register("json.parse", new[] { "value" }, (i, c) => Out(LoomletJson.Parse(LoomletValues.Text(i["value"]))));
+        }
+
+        private static Dictionary<string, object> Out(object value) => new Dictionary<string, object> { ["out"] = value };
+    }
+}

--- a/godot/addons/scene_sync/LoomletRuntime/Core/PortableNodes.cs.uid
+++ b/godot/addons/scene_sync/LoomletRuntime/Core/PortableNodes.cs.uid
@@ -1,0 +1,1 @@
+uid://bd4aa2yqhix77

--- a/godot/addons/scene_sync/README.md
+++ b/godot/addons/scene_sync/README.md
@@ -40,7 +40,7 @@ The addon follows the current Unity SceneSync wire shape for scene objects:
 - caches uploaded/downloaded GLB bytes by `assetId` and `meshPath` during the current session
 - recovers expired blob-store GLB assets through Unity-compatible `scene-asset-request` and `file` handoff messages
 - rebinds incoming scene objects to an existing unique Godot sync target when possible
-- accepts `scene-batch` messages with `ops` and `actions`
+- accepts `scene-batch` messages with `ops`, falling back to `actions` only when `ops` is absent
 - accepts `scene-delete` as a removal alias
 - preserves `scene-env.envId` in subsequent scene-state replies
 - preserves `scene-state.loomGraphs` and `scene-graph-set` / `scene-graph-clear` updates when relaying scene state

--- a/godot/addons/scene_sync/README.md
+++ b/godot/addons/scene_sync/README.md
@@ -28,20 +28,23 @@ Add a `SceneSyncManager` node to your scene and configure:
 
 `SceneSyncManager` polls the presence server, syncs transforms, requests scene state on join, and handles mesh download/upload through the blob store.
 
+The addon uses Godot .NET for Loomlet behavior graph evaluation. Use a .NET-enabled Godot 4.x editor/export template so `SceneSyncLoomletRunner.cs` and the vendored `Loomlet.Runtime` core are compiled.
+
 ## Unity compatibility
 
 The addon follows the current Unity SceneSync wire shape for scene objects:
 
 - preserves `asset`, `assetId`, `metadata`, `origin`, `unityHierarchyPath`, `visible`, and `asset.visualBasis`
 - applies a `visualBasis: "unity"` GLB visual-root correction without changing the synchronized object transform
+- computes `assetId` as `sha256-...` for locally exported GLB, matching the Unity runtime cache key format
 - caches uploaded/downloaded GLB bytes by `assetId` and `meshPath` during the current session
+- recovers expired blob-store GLB assets through Unity-compatible `scene-asset-request` and `file` handoff messages
 - rebinds incoming scene objects to an existing unique Godot sync target when possible
-- accepts `scene-batch` messages with `ops` or `actions`
+- accepts `scene-batch` messages with `ops` and `actions`
 - accepts `scene-delete` as a removal alias
 - preserves `scene-env.envId` in subsequent scene-state replies
 - preserves `scene-state.loomGraphs` and `scene-graph-set` / `scene-graph-clear` updates when relaying scene state
-
-Godot does not evaluate Loomlet behavior graphs yet. Graph data is kept on the wire so Unity, web, and other clients do not lose it when a Godot client joins or replies with scene state.
+- evaluates Loomlet object and scene behavior graphs through the same C# `Loomlet.Runtime` core used by Unity, with a Godot `Node3D` adapter for Scene Sync sink nodes
 
 ## Spec
 

--- a/godot/addons/scene_sync/SceneSyncLoomletRunner.cs
+++ b/godot/addons/scene_sync/SceneSyncLoomletRunner.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using Loomlet.Runtime;
+
+[GlobalClass]
+public partial class SceneSyncLoomletRunner : Node
+{
+    private static readonly HashSet<string> SceneNodeTypes = new HashSet<string>
+    {
+        "sceneSetPosition",
+        "sceneOffsetPosition",
+        "sceneSetRotation",
+        "sceneSetScale",
+        "sceneSetColor",
+        "sceneSetVisible",
+        "scene.setPosition",
+        "scene.offsetPosition",
+        "scene.setRotation",
+        "scene.setScale",
+        "scene.setColor",
+        "scene.setVisible"
+    };
+
+    private readonly Dictionary<string, Node3D> _objects = new Dictionary<string, Node3D>();
+    private readonly Dictionary<string, BoundGraph> _objectGraphs = new Dictionary<string, BoundGraph>();
+    private BoundGraph _sceneGraph;
+
+    public void BindObject(string objectId, Node3D target)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || target == null)
+            return;
+
+        _objects[objectId] = target;
+        if (_objectGraphs.TryGetValue(objectId, out var graph))
+            graph.Target = target;
+    }
+
+    public void UnbindObject(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+            return;
+
+        ClearObjectGraph(objectId);
+        _objects.Remove(objectId);
+    }
+
+    public void SetSceneGraph(string graphJson)
+    {
+        ClearSceneGraph();
+        if (string.IsNullOrWhiteSpace(graphJson))
+            return;
+
+        try
+        {
+            var graph = LoomletGraph.FromJson(graphJson);
+            _sceneGraph = new BoundGraph(this, null, null, graph, graphJson, sceneScope: true);
+        }
+        catch (Exception error)
+        {
+            GD.PushWarning("[SceneSync] Failed to bind scene Loomlet graph: " + error.Message);
+        }
+    }
+
+    public void ClearSceneGraph()
+    {
+        _sceneGraph?.Clear(restoreBases: true);
+        _sceneGraph = null;
+    }
+
+    public void SetObjectGraph(string objectId, Node3D target, string graphJson)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+            return;
+
+        ClearObjectGraph(objectId);
+        if (target == null || string.IsNullOrWhiteSpace(graphJson))
+            return;
+
+        try
+        {
+            var graph = LoomletGraph.FromJson(graphJson);
+            InjectObjectScopeTarget(graph, objectId);
+            _objectGraphs[objectId] = new BoundGraph(this, objectId, target, graph, graphJson, sceneScope: false);
+            _objects[objectId] = target;
+        }
+        catch (Exception error)
+        {
+            GD.PushWarning("[SceneSync] Failed to bind object Loomlet graph: " + error.Message);
+        }
+    }
+
+    public void ClearObjectGraph(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+            return;
+
+        if (_objectGraphs.TryGetValue(objectId, out var graph))
+        {
+            graph.Clear(restoreBases: true);
+            _objectGraphs.Remove(objectId);
+        }
+    }
+
+    public override void _Process(double delta)
+    {
+        _sceneGraph?.Evaluate(delta);
+
+        foreach (var graph in _objectGraphs.Values)
+            graph.Evaluate(delta);
+    }
+
+    private Node3D ResolveTarget(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+            return null;
+
+        return _objects.TryGetValue(objectId, out var target) && GodotObject.IsInstanceValid(target)
+            ? target
+            : null;
+    }
+
+    private static LoomletFunctionRegistry CreateSceneSyncRegistry(BoundGraph bound)
+    {
+        var registry = LoomletFunctionRegistry.CreateDefault();
+
+        registry.Register("constant", new[] { "value" }, (inputs, context) => Out(Number(inputs, "value")));
+        registry.Register("serverClock", Array.Empty<string>(), (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
+        registry.Register("sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
+            Math.Sin(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
+            Number(inputs, "amplitude", 1) + Number(inputs, "offset")));
+        registry.Register("cosine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
+            Math.Cos(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
+            Number(inputs, "amplitude", 1) + Number(inputs, "offset")));
+        registry.Register("add", new[] { "a", "b" }, (inputs, context) => Out(Number(inputs, "a") + Number(inputs, "b")));
+        registry.Register("multiply", new[] { "a", "b" }, (inputs, context) => Out(Number(inputs, "a", 1) * Number(inputs, "b", 1)));
+
+        RegisterSceneNode(registry, "sceneSetPosition", bound.ApplySetPosition);
+        RegisterSceneNode(registry, "scene.setPosition", bound.ApplySetPosition);
+        RegisterSceneNode(registry, "sceneOffsetPosition", bound.ApplyOffsetPosition);
+        RegisterSceneNode(registry, "scene.offsetPosition", bound.ApplyOffsetPosition);
+        RegisterSceneNode(registry, "sceneSetRotation", bound.ApplySetRotation);
+        RegisterSceneNode(registry, "scene.setRotation", bound.ApplySetRotation);
+        RegisterSceneNode(registry, "sceneSetScale", bound.ApplySetScale);
+        RegisterSceneNode(registry, "scene.setScale", bound.ApplySetScale);
+        RegisterSceneNode(registry, "sceneSetColor", bound.ApplySetColor);
+        RegisterSceneNode(registry, "scene.setColor", bound.ApplySetColor);
+        RegisterSceneNode(registry, "sceneSetVisible", bound.ApplySetVisible);
+        RegisterSceneNode(registry, "scene.setVisible", bound.ApplySetVisible);
+
+        return registry;
+    }
+
+    private static void RegisterSceneNode(
+        LoomletFunctionRegistry registry,
+        string type,
+        Func<Dictionary<string, object>, Dictionary<string, object>> evaluate)
+    {
+        registry.Register(
+            type,
+            new[] { "objectId", "target", "x", "y", "z", "w", "r", "g", "b", "visible" },
+            (inputs, context) => evaluate(inputs));
+    }
+
+    private static void InjectObjectScopeTarget(LoomletGraph graph, string targetObjectId)
+    {
+        if (graph == null || string.IsNullOrWhiteSpace(targetObjectId))
+            return;
+
+        foreach (var node in graph.Nodes)
+        {
+            if (node == null || !SceneNodeTypes.Contains(node.Type))
+                continue;
+            if (node.Params == null)
+                node.Params = new Dictionary<string, object>();
+            if (!node.Params.ContainsKey("target") && !node.Params.ContainsKey("objectId"))
+                node.Params["target"] = targetObjectId;
+        }
+    }
+
+    private static Dictionary<string, object> Out(object value) => new Dictionary<string, object> { ["out"] = value };
+    private static Dictionary<string, object> Empty() => new Dictionary<string, object>();
+
+    private static double Number(Dictionary<string, object> inputs, string key, double fallback = 0)
+    {
+        if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null)
+            return fallback;
+        try { return Convert.ToDouble(value); }
+        catch { return fallback; }
+    }
+
+    private static bool Bool(Dictionary<string, object> inputs, string key, bool fallback)
+    {
+        if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null)
+            return fallback;
+        if (value is bool b)
+            return b;
+        return bool.TryParse(value.ToString(), out var parsed) ? parsed : fallback;
+    }
+
+    private static string Text(Dictionary<string, object> inputs, string key)
+    {
+        if (inputs == null || !inputs.TryGetValue(key, out var value) || value == null)
+            return null;
+        return value.ToString();
+    }
+
+    private sealed class BoundGraph
+    {
+        private readonly SceneSyncLoomletRunner _owner;
+        private readonly string _objectId;
+        private readonly bool _sceneScope;
+        private readonly LoomletEvaluator _evaluator;
+        private readonly LoomletEvaluationContext _context = new LoomletEvaluationContext();
+        private readonly Dictionary<string, Vector3> _offsetBasePositions = new Dictionary<string, Vector3>();
+        private double _time;
+        private bool _disabled;
+
+        public BoundGraph(
+            SceneSyncLoomletRunner owner,
+            string objectId,
+            Node3D target,
+            LoomletGraph graph,
+            string graphJson,
+            bool sceneScope)
+        {
+            _owner = owner;
+            _objectId = objectId;
+            Target = target;
+            GraphJson = graphJson;
+            _sceneScope = sceneScope;
+            _evaluator = new LoomletEvaluator(graph, CreateSceneSyncRegistry(this));
+        }
+
+        public Node3D Target { get; set; }
+        public string GraphJson { get; }
+
+        public void Evaluate(double delta)
+        {
+            if (_evaluator == null || _disabled)
+                return;
+
+            _time += Math.Max(0, delta);
+            try
+            {
+                _context.WithSceneClock(_time, Math.Max(0, delta), false, "local", 1.0);
+                _evaluator.Evaluate(_context);
+            }
+            catch (Exception error)
+            {
+                GD.PushWarning("[SceneSync] Loomlet graph evaluation failed: " + error.Message);
+                _disabled = true;
+            }
+        }
+
+        public void Clear(bool restoreBases)
+        {
+            if (restoreBases)
+                RestoreOffsetBases();
+        }
+
+        public Dictionary<string, object> ApplySetPosition(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+            {
+                target.GlobalPosition = new Vector3(
+                    (float)Number(inputs, "x"),
+                    (float)Number(inputs, "y"),
+                    (float)Number(inputs, "z"));
+            }
+            return Empty();
+        }
+
+        public Dictionary<string, object> ApplyOffsetPosition(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            var targetId = ResolveGraphTargetId(inputs) ?? _objectId;
+            if (target != null && !string.IsNullOrWhiteSpace(targetId))
+            {
+                if (!_offsetBasePositions.ContainsKey(targetId))
+                    _offsetBasePositions[targetId] = target.GlobalPosition;
+                var basePosition = _offsetBasePositions[targetId];
+                target.GlobalPosition = basePosition + new Vector3(
+                    (float)Number(inputs, "x"),
+                    (float)Number(inputs, "y"),
+                    (float)Number(inputs, "z"));
+            }
+            return Empty();
+        }
+
+        public Dictionary<string, object> ApplySetRotation(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+            {
+                target.Rotation = new Vector3(
+                    (float)Number(inputs, "x"),
+                    (float)Number(inputs, "y"),
+                    (float)Number(inputs, "z"));
+            }
+            return Empty();
+        }
+
+        public Dictionary<string, object> ApplySetScale(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+            {
+                target.Scale = new Vector3(
+                    (float)Number(inputs, "x", 1),
+                    (float)Number(inputs, "y", 1),
+                    (float)Number(inputs, "z", 1));
+            }
+            return Empty();
+        }
+
+        public Dictionary<string, object> ApplySetColor(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target == null)
+                return Empty();
+
+            var color = new Color(
+                (float)Number(inputs, "r", 1),
+                (float)Number(inputs, "g", 1),
+                (float)Number(inputs, "b", 1));
+            ApplyColorRecursive(target, color);
+            return Empty();
+        }
+
+        public Dictionary<string, object> ApplySetVisible(Dictionary<string, object> inputs)
+        {
+            var target = ResolveGraphTarget(inputs);
+            if (target != null)
+                target.Visible = Bool(inputs, "visible", true);
+            return Empty();
+        }
+
+        private Node3D ResolveGraphTarget(Dictionary<string, object> inputs)
+        {
+            var targetId = ResolveGraphTargetId(inputs);
+            if (string.IsNullOrWhiteSpace(targetId))
+                return _sceneScope ? null : Target;
+            if (!_sceneScope && targetId == _objectId)
+                return Target;
+            return _owner.ResolveTarget(targetId);
+        }
+
+        private string ResolveGraphTargetId(Dictionary<string, object> inputs)
+        {
+            var explicitObjectId = Text(inputs, "objectId");
+            if (!string.IsNullOrWhiteSpace(explicitObjectId))
+                return explicitObjectId;
+
+            var target = Text(inputs, "target");
+            if (!string.IsNullOrWhiteSpace(target))
+                return target;
+
+            return _sceneScope ? null : _objectId;
+        }
+
+        private void RestoreOffsetBases()
+        {
+            foreach (var pair in _offsetBasePositions)
+            {
+                var target = pair.Key == _objectId ? Target : _owner.ResolveTarget(pair.Key);
+                if (target != null)
+                    target.GlobalPosition = pair.Value;
+            }
+            _offsetBasePositions.Clear();
+        }
+
+        private static void ApplyColorRecursive(Node node, Color color)
+        {
+            if (node is MeshInstance3D meshInstance)
+            {
+                var material = meshInstance.MaterialOverride as StandardMaterial3D;
+                material = material != null
+                    ? (StandardMaterial3D)material.Duplicate()
+                    : new StandardMaterial3D();
+                color.A = material.AlbedoColor.A;
+                material.AlbedoColor = color;
+                meshInstance.MaterialOverride = material;
+            }
+
+            foreach (var child in node.GetChildren())
+                ApplyColorRecursive(child, color);
+        }
+    }
+}

--- a/godot/addons/scene_sync/SceneSyncLoomletRunner.cs.uid
+++ b/godot/addons/scene_sync/SceneSyncLoomletRunner.cs.uid
@@ -1,0 +1,1 @@
+uid://c4a7sn8gu8kqx

--- a/godot/addons/scene_sync/blob_client.gd
+++ b/godot/addons/scene_sync/blob_client.gd
@@ -47,6 +47,18 @@ func download_glb(path: String) -> PackedByteArray:
     return result[3]
 
 
+static func compute_asset_id(data: PackedByteArray) -> String:
+    if data.is_empty():
+        return ""
+
+    var hashing := HashingContext.new()
+    var err := hashing.start(HashingContext.HASH_SHA256)
+    if err != OK:
+        return ""
+    hashing.update(data)
+    return "sha256-" + _bytes_to_hex(hashing.finish())
+
+
 static func generate_random_path() -> String:
     const CHARS := "abcdefghijklmnopqrstuvwxyz0123456789"
     var rng := RandomNumberGenerator.new()
@@ -54,4 +66,14 @@ static func generate_random_path() -> String:
     var result := ""
     for i in range(8):
         result += CHARS[rng.randi_range(0, CHARS.length() - 1)]
+    return result
+
+
+static func _bytes_to_hex(data: PackedByteArray) -> String:
+    const HEX := "0123456789abcdef"
+    var result := ""
+    for byte_value in data:
+        var value := int(byte_value)
+        result += HEX.substr((value >> 4) & 0x0f, 1)
+        result += HEX.substr(value & 0x0f, 1)
     return result

--- a/godot/addons/scene_sync/scene_sync_manager.gd
+++ b/godot/addons/scene_sync/scene_sync_manager.gd
@@ -268,21 +268,18 @@ func _dispatch_scene_payload(payload: Dictionary, from_info: Dictionary) -> void
 
 
 func _handle_scene_batch(payload: Dictionary, from_info: Dictionary) -> void:
-    var arrays: Array = []
-    var ops = payload.get("ops", [])
-    if ops is Array:
-        arrays.append(ops)
-    var actions = payload.get("actions", [])
-    if actions is Array:
-        arrays.append(actions)
+    var ops = payload.get("ops", null)
+    if not (ops is Array):
+        ops = payload.get("actions", [])
+    if not (ops is Array):
+        return
 
-    for entries in arrays:
-        for op in entries:
-            if op is Dictionary:
-                var child := (op as Dictionary).duplicate(true)
-                if payload.has("onBehalfOf") and not child.has("onBehalfOf"):
-                    child["onBehalfOf"] = payload["onBehalfOf"]
-                _dispatch_scene_payload(child, from_info)
+    for op in ops:
+        if op is Dictionary:
+            var child := (op as Dictionary).duplicate(true)
+            if payload.has("onBehalfOf") and not child.has("onBehalfOf"):
+                child["onBehalfOf"] = payload["onBehalfOf"]
+            _dispatch_scene_payload(child, from_info)
 
 
 func _handle_scene_graph_set(payload: Dictionary) -> void:

--- a/godot/addons/scene_sync/scene_sync_manager.gd
+++ b/godot/addons/scene_sync/scene_sync_manager.gd
@@ -27,7 +27,11 @@ var _origins: Dictionary = {}
 var _unity_hierarchy_paths: Dictionary = {}
 var _mesh_data_by_asset_id: Dictionary = {}
 var _mesh_data_by_path: Dictionary = {}
+var _pending_recoveries: Dictionary = {}
+var _responder_cooldowns: Dictionary = {}
+var _active_outgoing_transfer_id: String = ""
 var _loom_graphs: Dictionary = {}
+var _loom_runner: Node = null
 var _env_id: String = ""
 var _locks: Dictionary = {}
 var _last_snapshots: Dictionary = {}
@@ -40,6 +44,10 @@ var _hierarchy_timer: float = 0.0
 var _connected: bool = false
 
 const SEND_INTERVAL: float = 0.05
+const RECOVERY_TIMEOUT_SECONDS: float = 30.0
+const PEER_RETRY_INTERVAL_SECONDS: float = 4.0
+const RECOVERY_RESPONDER_COOLDOWN_SECONDS: float = 30.0
+const MAX_GLB_SIZE: int = 50 * 1024 * 1024
 const OBJECT_ID_META := "scene_sync_object_id"
 const ASSET_META := "scene_sync_asset"
 const METADATA_META := "scene_sync_metadata"
@@ -47,6 +55,7 @@ const ASSET_ID_META := "scene_sync_asset_id"
 const ORIGIN_META := "scene_sync_origin"
 const UNITY_HIERARCHY_PATH_META := "scene_sync_unity_hierarchy_path"
 const RECEIVE_ROOT_NAME := "SceneSyncRoot"
+const LOOM_RUNNER_SCRIPT_PATH := "res://addons/scene_sync/SceneSyncLoomletRunner.cs"
 
 
 func _ready() -> void:
@@ -54,6 +63,7 @@ func _ready() -> void:
     _blob_client = SceneSyncBlobClient.new()
     _blob_client.name = "SceneSyncBlobClient"
     add_child(_blob_client)
+    _ensure_loom_runner()
 
     _client.connected.connect(_on_connected)
     _client.disconnected.connect(_on_disconnected)
@@ -161,9 +171,13 @@ func _on_disconnected() -> void:
     _scene_received = false
     _first_peers_received = false
     _locks.clear()
+    _clear_all_loom_graphs()
     _loom_graphs.clear()
     _mesh_data_by_asset_id.clear()
     _mesh_data_by_path.clear()
+    _pending_recoveries.clear()
+    _responder_cooldowns.clear()
+    _active_outgoing_transfer_id = ""
     _env_id = ""
     _currently_locked_id = ""
     disconnected.emit()
@@ -221,6 +235,10 @@ func _dispatch_scene_payload(payload: Dictionary, from_info: Dictionary) -> void
             _handle_scene_graph_set(payload)
         "scene-graph-clear":
             _handle_scene_graph_clear(payload)
+        "scene-asset-request":
+            _handle_scene_asset_request(payload, from_id)
+        "file":
+            _handle_file_handoff(payload, from_id)
         "scene-request":
             _handle_scene_request(from_id)
         "scene-state":
@@ -250,18 +268,21 @@ func _dispatch_scene_payload(payload: Dictionary, from_info: Dictionary) -> void
 
 
 func _handle_scene_batch(payload: Dictionary, from_info: Dictionary) -> void:
-    var ops = payload.get("ops", null)
-    if not (ops is Array):
-        ops = payload.get("actions", [])
-    if not (ops is Array):
-        return
+    var arrays: Array = []
+    var ops = payload.get("ops", [])
+    if ops is Array:
+        arrays.append(ops)
+    var actions = payload.get("actions", [])
+    if actions is Array:
+        arrays.append(actions)
 
-    for op in ops:
-        if op is Dictionary:
-            var child := (op as Dictionary).duplicate(true)
-            if payload.has("onBehalfOf") and not child.has("onBehalfOf"):
-                child["onBehalfOf"] = payload["onBehalfOf"]
-            _dispatch_scene_payload(child, from_info)
+    for entries in arrays:
+        for op in entries:
+            if op is Dictionary:
+                var child := (op as Dictionary).duplicate(true)
+                if payload.has("onBehalfOf") and not child.has("onBehalfOf"):
+                    child["onBehalfOf"] = payload["onBehalfOf"]
+                _dispatch_scene_payload(child, from_info)
 
 
 func _handle_scene_graph_set(payload: Dictionary) -> void:
@@ -276,9 +297,12 @@ func _handle_scene_graph_set(payload: Dictionary) -> void:
             objects = {}
         objects[object_id] = (graph as Dictionary).duplicate(true)
         _loom_graphs["objects"] = objects
+        _bind_loom_graph_for_object(object_id)
         return
 
-    _loom_graphs["scene"] = (graph as Dictionary).duplicate(true)
+    var scene_graph := graph as Dictionary
+    _loom_graphs["scene"] = scene_graph.duplicate(true)
+    _set_loom_scene_graph(scene_graph)
 
 
 func _handle_scene_graph_clear(payload: Dictionary) -> void:
@@ -291,9 +315,11 @@ func _handle_scene_graph_clear(payload: Dictionary) -> void:
                 _loom_graphs.erase("objects")
             else:
                 _loom_graphs["objects"] = objects
+        _clear_loom_object_graph(object_id)
         return
 
     _loom_graphs.erase("scene")
+    _clear_loom_scene_graph()
 
 
 func _handle_scene_env(payload: Dictionary) -> void:
@@ -338,6 +364,7 @@ func _handle_scene_state(payload: Dictionary) -> void:
     var loom_graphs = payload.get("loomGraphs", {})
     if loom_graphs is Dictionary:
         _loom_graphs = (loom_graphs as Dictionary).duplicate(true)
+        _apply_loom_graph_state()
 
     var objects = payload.get("objects", {})
     if not (objects is Dictionary):
@@ -347,6 +374,7 @@ func _handle_scene_state(payload: Dictionary) -> void:
         var info = objects[object_id]
         if info is Dictionary:
             _handle_scene_add((info as Dictionary).merged({"objectId": object_id}, true))
+    _apply_loom_graph_state()
 
 
 func _handle_scene_add(payload: Dictionary) -> void:
@@ -415,6 +443,7 @@ func _handle_scene_remove(payload: Dictionary) -> void:
             node.queue_free()
     _managed_objects.erase(object_id)
     _known_ids.erase(object_id)
+    _unbind_loom_object(object_id)
     _mesh_paths.erase(object_id)
     _asset_ids.erase(object_id)
     _metadata.erase(object_id)
@@ -520,6 +549,7 @@ func _detect_hierarchy_changes() -> void:
                 continue
         _client.broadcast(SceneSyncProtocol.make_scene_remove(String(object_id)))
         _managed_objects.erase(object_id)
+        _unbind_loom_object(String(object_id))
         _mesh_paths.erase(object_id)
         _asset_ids.erase(object_id)
         _metadata.erase(object_id)
@@ -547,6 +577,11 @@ func _build_object_payload(node: Node3D, object_id: String) -> Dictionary:
     if mesh_path == "" and asset.is_empty() and _node_has_mesh(node):
         var glb := SceneSyncGltfHelper.export_glb(node)
         if not glb.is_empty():
+            if asset_id == "":
+                asset_id = SceneSyncBlobClient.compute_asset_id(glb)
+            if asset_id != "":
+                _asset_ids[object_id] = asset_id
+                node.set_meta(ASSET_ID_META, asset_id)
             mesh_path = SceneSyncBlobClient.generate_random_path()
             var upload_err := await _blob_client.upload_glb(glb, mesh_path)
             if upload_err == OK:
@@ -591,6 +626,12 @@ func _sync_mesh_for_node(node: Node3D) -> void:
         return
 
     var mesh_path := SceneSyncBlobClient.generate_random_path()
+    var asset_id := _get_asset_id(node, object_id)
+    if asset_id == "":
+        asset_id = SceneSyncBlobClient.compute_asset_id(glb)
+    if asset_id != "":
+        _asset_ids[object_id] = asset_id
+        node.set_meta(ASSET_ID_META, asset_id)
     var upload_err := await _blob_client.upload_glb(glb, mesh_path)
     if upload_err != OK:
         return
@@ -605,7 +646,6 @@ func _sync_mesh_for_node(node: Node3D) -> void:
         }
     elif String(asset.get("type", "")) == "mesh" and not asset.has("meshPath"):
         asset["meshPath"] = mesh_path
-    var asset_id := _get_asset_id(node, object_id)
     if asset_id != "" and not asset.has("assetId"):
         asset["assetId"] = asset_id
     _cache_mesh_data(mesh_path, asset_id, glb)
@@ -627,10 +667,46 @@ func _load_mesh_for_object(object_id: String, payload: Dictionary, mesh_path: St
         data = await _blob_client.download_glb(mesh_path)
         if not data.is_empty():
             _cache_mesh_data(mesh_path, asset_id, data)
-    var old_node_value = _managed_objects.get(object_id)
-    var old_node: Node3D = null
-    if old_node_value != null and is_instance_valid(old_node_value):
-        old_node = old_node_value as Node3D
+    if data.is_empty():
+        _handle_missing_glb(object_id, mesh_path, null, asset_id)
+    _replace_object_with_mesh_data(object_id, payload, data)
+
+
+func _load_mesh_bytes_for_object(object_id: String, data: PackedByteArray, asset_id: String = "") -> void:
+    var node := _get_managed_node(object_id)
+    if node == null:
+        push_warning("[SceneSync] Cannot load recovered GLB; object not found: %s" % object_id)
+        return
+
+    var snapshot := _snapshot_for_node(node)
+    var asset := _get_asset(node, object_id)
+    var mesh_path := String(_mesh_paths.get(object_id, ""))
+    if mesh_path != "":
+        asset["meshPath"] = mesh_path
+    if asset_id != "":
+        asset["assetId"] = asset_id
+
+    var payload := {
+        "objectId": object_id,
+        "name": node.name,
+        "position": SceneSyncProtocol.pos_to_wire(snapshot.get("position", Vector3.ZERO)),
+        "rotation": SceneSyncProtocol.rot_to_wire(snapshot.get("rotation", Quaternion.IDENTITY)),
+        "scale": SceneSyncProtocol.scale_to_wire(snapshot.get("scale", Vector3.ONE)),
+        "asset": asset,
+        "metadata": _get_metadata(node, object_id),
+        "origin": _get_origin(node, object_id),
+        "unityHierarchyPath": _get_unity_hierarchy_path(node, object_id),
+    }
+    if mesh_path != "":
+        payload["meshPath"] = mesh_path
+    if asset_id != "":
+        payload["assetId"] = asset_id
+
+    _replace_object_with_mesh_data(object_id, payload, data)
+
+
+func _replace_object_with_mesh_data(object_id: String, payload: Dictionary, data: PackedByteArray) -> void:
+    var old_node := _get_managed_node(object_id)
     var replacement: Node3D = null
 
     if not data.is_empty():
@@ -661,6 +737,7 @@ func _load_mesh_for_object(object_id: String, payload: Dictionary, mesh_path: St
 
     _managed_objects[object_id] = replacement
     _known_ids[object_id] = true
+    _bind_loom_object_target(object_id, replacement)
     object_added.emit(object_id, replacement)
 
 
@@ -676,12 +753,14 @@ func _register_managed_object(object_id: String, node: Node3D) -> void:
     node.set_meta(OBJECT_ID_META, object_id)
     _managed_objects[object_id] = node
     _known_ids[object_id] = true
+    _bind_loom_object_target(object_id, node)
 
 
 func _bind_existing_managed_object(object_id: String, node: Node3D) -> void:
     node.set_meta(OBJECT_ID_META, object_id)
     _managed_objects[object_id] = node
     _known_ids[object_id] = true
+    _bind_loom_object_target(object_id, node)
 
 
 func _create_primitive(primitive_type: String, color: String = "#888888") -> MeshInstance3D:
@@ -808,6 +887,271 @@ func _get_cached_mesh_data(mesh_path: String, asset_id: String) -> PackedByteArr
     return PackedByteArray()
 
 
+func _handle_scene_asset_request(payload: Dictionary, requester_peer_id: String) -> void:
+    if requester_peer_id == "":
+        return
+    var request_id := String(payload.get("requestId", ""))
+    var object_id := String(payload.get("objectId", ""))
+    if request_id == "" or object_id == "":
+        return
+    if _get_managed_node(object_id) == null:
+        return
+
+    var asset_id := _nullable_string(payload.get("assetId", ""))
+    var mesh_path := _nullable_string(payload.get("meshPath", ""))
+    var cache_key := asset_id if asset_id != "" else mesh_path
+    if cache_key == "":
+        return
+
+    var cooldown_key := "%s-%s" % [cache_key, requester_peer_id]
+    var now := Time.get_ticks_msec() / 1000.0
+    if _responder_cooldowns.has(cooldown_key):
+        var last_time := float(_responder_cooldowns[cooldown_key])
+        if now - last_time < RECOVERY_RESPONDER_COOLDOWN_SECONDS:
+            return
+
+    if _active_outgoing_transfer_id != "":
+        return
+
+    var data := _get_cached_mesh_data(mesh_path, asset_id)
+    if data.is_empty() or data.size() > MAX_GLB_SIZE:
+        return
+
+    _responder_cooldowns[cooldown_key] = now
+    _active_outgoing_transfer_id = request_id
+    var filename := "%s.glb" % (asset_id if asset_id != "" else object_id)
+    await _send_glb_to_peer(requester_peer_id, filename, data)
+    if _active_outgoing_transfer_id == request_id:
+        _active_outgoing_transfer_id = ""
+
+
+func _handle_missing_glb(object_id: String, mesh_path: String, expected_size: Variant, asset_id: String) -> void:
+    var request_id := _generate_recovery_request_id()
+    var recovery := {
+        "requestId": request_id,
+        "objectId": object_id,
+        "assetId": asset_id,
+        "meshPath": mesh_path,
+        "expectedSize": expected_size,
+        "requestedAt": Time.get_ticks_msec() / 1000.0,
+        "requestedPeerIds": {},
+    }
+    _pending_recoveries[request_id] = recovery
+
+    var peers := _get_other_peers()
+    if peers.is_empty():
+        _remove_recovery_after_timeout(request_id)
+        return
+
+    _retry_recovery_peers(request_id, peers)
+    _remove_recovery_after_timeout(request_id)
+
+
+func _retry_recovery_peers(request_id: String, peers: Array) -> void:
+    for peer in peers:
+        if not _pending_recoveries.has(request_id):
+            return
+        if not (peer is Dictionary):
+            continue
+        var peer_id := String((peer as Dictionary).get("id", ""))
+        if peer_id == "" or peer_id == _client.id:
+            continue
+
+        var recovery: Dictionary = _pending_recoveries[request_id]
+        var requested_peer_ids: Dictionary = recovery.get("requestedPeerIds", {})
+        requested_peer_ids[peer_id] = true
+        recovery["requestedPeerIds"] = requested_peer_ids
+        _pending_recoveries[request_id] = recovery
+
+        _client.send_handoff(peer_id, SceneSyncProtocol.make_scene_asset_request(
+            request_id,
+            String(recovery.get("objectId", "")),
+            String(recovery.get("assetId", "")),
+            String(recovery.get("meshPath", "")),
+            recovery.get("expectedSize", null)
+        ))
+
+        if get_tree() == null:
+            return
+        await get_tree().create_timer(PEER_RETRY_INTERVAL_SECONDS).timeout
+
+    if _pending_recoveries.has(request_id):
+        _pending_recoveries.erase(request_id)
+
+
+func _remove_recovery_after_timeout(request_id: String) -> void:
+    if get_tree() == null:
+        return
+    await get_tree().create_timer(RECOVERY_TIMEOUT_SECONDS).timeout
+    _pending_recoveries.erase(request_id)
+
+
+func _handle_file_handoff(payload: Dictionary, from_peer_id: String) -> void:
+    var path := String(payload.get("path", ""))
+    var filename := String(payload.get("filename", ""))
+    var size := int(payload.get("size", 0))
+    var mime := String(payload.get("mime", ""))
+    if not _can_accept_file_handoff(from_peer_id, filename, size, mime):
+        return
+
+    var url := "%s/%s" % [_get_piping_server_base().trim_suffix("/"), path.uri_encode()]
+    var data := await _download_bytes_from_url(url)
+    _handle_received_file(from_peer_id, filename, data, mime)
+
+
+func _can_accept_file_handoff(from_peer_id: String, filename: String, size: int, mime: String) -> bool:
+    if from_peer_id == "" or filename == "" or size <= 0 or mime == "":
+        return false
+    if size > MAX_GLB_SIZE:
+        return false
+    if mime != "model/gltf-binary" and not filename.to_lower().ends_with(".glb"):
+        return false
+
+    for recovery_value in _pending_recoveries.values():
+        if not (recovery_value is Dictionary):
+            continue
+        var recovery: Dictionary = recovery_value
+        var requested_peer_ids: Dictionary = recovery.get("requestedPeerIds", {})
+        if not requested_peer_ids.has(from_peer_id):
+            continue
+        var expected = recovery.get("expectedSize", null)
+        if expected != null and int(expected) != size:
+            continue
+        return true
+    return false
+
+
+func _handle_received_file(from_peer_id: String, filename: String, data: PackedByteArray, mime: String) -> void:
+    if data.is_empty() or data.size() > MAX_GLB_SIZE:
+        return
+    if mime != "model/gltf-binary" and not filename.to_lower().ends_with(".glb"):
+        return
+
+    var matched_request_id := ""
+    var matched_recovery := {}
+    for request_id in _pending_recoveries.keys():
+        var recovery_value = _pending_recoveries[request_id]
+        if not (recovery_value is Dictionary):
+            continue
+        var recovery: Dictionary = recovery_value
+        var requested_peer_ids: Dictionary = recovery.get("requestedPeerIds", {})
+        if not requested_peer_ids.has(from_peer_id):
+            continue
+        var expected = recovery.get("expectedSize", null)
+        if expected != null and int(expected) != data.size():
+            continue
+        matched_request_id = String(request_id)
+        matched_recovery = recovery
+        break
+
+    if matched_request_id == "":
+        return
+
+    var expected_asset_id := String(matched_recovery.get("assetId", ""))
+    var computed_asset_id := ""
+    if expected_asset_id != "":
+        computed_asset_id = SceneSyncBlobClient.compute_asset_id(data)
+        if computed_asset_id == "" or computed_asset_id != expected_asset_id:
+            return
+
+    _pending_recoveries.erase(matched_request_id)
+    var mesh_path := String(matched_recovery.get("meshPath", ""))
+    _cache_mesh_data(mesh_path, computed_asset_id if computed_asset_id != "" else expected_asset_id, data)
+    _load_mesh_bytes_for_object(
+        String(matched_recovery.get("objectId", "")),
+        data,
+        computed_asset_id if computed_asset_id != "" else expected_asset_id
+    )
+
+
+func _send_glb_to_peer(target_peer_id: String, filename: String, data: PackedByteArray) -> void:
+    if target_peer_id == "" or data.is_empty():
+        return
+    var path := SceneSyncBlobClient.generate_random_path()
+    var display_url := "%s/#%s" % [_get_piping_display_url().trim_suffix("/"), path]
+    _client.send_handoff(target_peer_id, SceneSyncProtocol.make_file_handoff(
+        path,
+        filename,
+        data.size(),
+        "model/gltf-binary",
+        display_url
+    ))
+
+    var upload_url := "%s/%s" % [_get_piping_server_base().trim_suffix("/"), path.uri_encode()]
+    await _upload_bytes_to_url(upload_url, data, "model/gltf-binary")
+
+
+func _upload_bytes_to_url(url: String, data: PackedByteArray, mime: String) -> Error:
+    var request := HTTPRequest.new()
+    add_child(request)
+    var headers := PackedStringArray(["Content-Type: %s" % mime])
+    var err := request.request_raw(url, headers, HTTPClient.METHOD_POST, data)
+    if err != OK:
+        request.queue_free()
+        return err
+    var result: Array = await request.request_completed
+    request.queue_free()
+    var response_code := int(result[1])
+    return OK if response_code >= 200 and response_code < 300 else ERR_CANT_CONNECT
+
+
+func _download_bytes_from_url(url: String) -> PackedByteArray:
+    var request := HTTPRequest.new()
+    add_child(request)
+    var err := request.request(url)
+    if err != OK:
+        request.queue_free()
+        return PackedByteArray()
+    var result: Array = await request.request_completed
+    request.queue_free()
+    var response_code := int(result[1])
+    if response_code < 200 or response_code >= 300:
+        return PackedByteArray()
+    return result[3]
+
+
+func _get_other_peers() -> Array:
+    var result: Array = []
+    if _client == null:
+        return result
+    for peer in _client.peers:
+        if peer is Dictionary and String((peer as Dictionary).get("id", "")) != _client.id:
+            result.append(peer)
+    return result
+
+
+func _get_piping_server_base() -> String:
+    var raw := presence_url.replace("wss://", "").replace("ws://", "")
+    var host := raw.split("/", false, 1)[0]
+    if host == "" or host.begins_with("localhost") or host.begins_with("127.0.0.1"):
+        return "http://localhost:8080"
+    return "https://pipe.afjk.jp"
+
+
+func _get_piping_display_url() -> String:
+    var scheme := "https://"
+    var raw := presence_url
+    if raw.begins_with("ws://"):
+        scheme = "http://"
+    raw = raw.replace("wss://", "").replace("ws://", "")
+    var host := raw.split("/", false, 1)[0]
+    if host == "" or host.begins_with("localhost") or host.begins_with("127.0.0.1"):
+        return "http://localhost"
+    return "%s%s/pipe" % [scheme, host]
+
+
+func _generate_recovery_request_id() -> String:
+    var rng := RandomNumberGenerator.new()
+    rng.randomize()
+    return "%d-%06d" % [Time.get_ticks_usec(), rng.randi_range(0, 999999)]
+
+
+func _nullable_string(value: Variant) -> String:
+    if value == null:
+        return ""
+    return String(value)
+
+
 func _wrap_imported_mesh_for_visual_basis(imported: Node3D, visual_basis: String) -> Node3D:
     if imported == null:
         return null
@@ -897,6 +1241,103 @@ func _store_metadata_loom_graph(object_id: String, metadata: Dictionary) -> void
         objects = {}
     objects[object_id] = (graph as Dictionary).duplicate(true)
     _loom_graphs["objects"] = objects
+    _bind_loom_graph_for_object(object_id)
+
+
+func _ensure_loom_runner() -> Node:
+    if _loom_runner != null and is_instance_valid(_loom_runner):
+        return _loom_runner
+
+    if ClassDB.class_exists("SceneSyncLoomletRunner"):
+        _loom_runner = ClassDB.instantiate("SceneSyncLoomletRunner") as Node
+    else:
+        var runner_script = load(LOOM_RUNNER_SCRIPT_PATH)
+        if runner_script == null:
+            push_warning("[SceneSync] Loomlet runner script is unavailable: %s" % LOOM_RUNNER_SCRIPT_PATH)
+            return null
+        _loom_runner = runner_script.new()
+
+    if _loom_runner == null:
+        push_warning("[SceneSync] Failed to instantiate Loomlet runner.")
+        return null
+
+    _loom_runner.name = "SceneSyncLoomletRunner"
+    add_child(_loom_runner)
+    return _loom_runner
+
+
+func _call_loom_runner(method_name: String, args: Array = []) -> void:
+    var runner := _ensure_loom_runner()
+    if runner == null:
+        return
+    if runner.has_method(method_name):
+        runner.callv(method_name, args)
+        return
+    var snake_name := method_name.to_snake_case()
+    if runner.has_method(snake_name):
+        runner.callv(snake_name, args)
+
+
+func _set_loom_scene_graph(graph: Dictionary) -> void:
+    if graph.is_empty():
+        return
+    _call_loom_runner("SetSceneGraph", [JSON.stringify(graph)])
+
+
+func _clear_loom_scene_graph() -> void:
+    _call_loom_runner("ClearSceneGraph")
+
+
+func _bind_loom_object_target(object_id: String, node: Node3D) -> void:
+    if object_id == "" or node == null:
+        return
+    _call_loom_runner("BindObject", [object_id, node])
+    _bind_loom_graph_for_object(object_id)
+
+
+func _bind_loom_graph_for_object(object_id: String) -> void:
+    if object_id == "":
+        return
+    var node := _get_managed_node(object_id)
+    if node == null:
+        return
+    var objects = _loom_graphs.get("objects", {})
+    if not (objects is Dictionary):
+        return
+    var object_graphs := objects as Dictionary
+    if not object_graphs.has(object_id):
+        return
+    var graph = object_graphs[object_id]
+    if graph is Dictionary:
+        _call_loom_runner("SetObjectGraph", [object_id, node, JSON.stringify(graph)])
+
+
+func _clear_loom_object_graph(object_id: String) -> void:
+    _call_loom_runner("ClearObjectGraph", [object_id])
+
+
+func _unbind_loom_object(object_id: String) -> void:
+    _call_loom_runner("UnbindObject", [object_id])
+
+
+func _clear_all_loom_graphs() -> void:
+    _clear_loom_scene_graph()
+    var objects = _loom_graphs.get("objects", {})
+    if objects is Dictionary:
+        for object_id in (objects as Dictionary).keys():
+            _clear_loom_object_graph(String(object_id))
+
+
+func _apply_loom_graph_state() -> void:
+    var scene_graph = _loom_graphs.get("scene", {})
+    if scene_graph is Dictionary:
+        var typed_scene_graph := scene_graph as Dictionary
+        _set_loom_scene_graph(typed_scene_graph)
+
+    var objects = _loom_graphs.get("objects", {})
+    if objects is Dictionary:
+        for object_id in (objects as Dictionary).keys():
+            _bind_loom_graph_for_object(String(object_id))
 
 
 func _merge_asset_metadata(node: Node3D, _object_id: String, asset: Dictionary) -> void:
@@ -973,6 +1414,23 @@ func _get_asset_id(node: Node3D, object_id: String) -> String:
     return String(_asset_ids.get(object_id, ""))
 
 
+func _get_asset(node: Node3D, object_id: String) -> Dictionary:
+    if node != null and node.has_meta(ASSET_META):
+        var value = node.get_meta(ASSET_META)
+        if value is Dictionary:
+            return (value as Dictionary).duplicate(true)
+    return _asset_from_known_object(object_id)
+
+
+func _asset_from_known_object(object_id: String) -> Dictionary:
+    var node := _get_managed_node(object_id)
+    if node != null and node.has_meta(ASSET_META):
+        var value = node.get_meta(ASSET_META)
+        if value is Dictionary:
+            return (value as Dictionary).duplicate(true)
+    return {}
+
+
 func _get_metadata(node: Node3D, object_id: String) -> Dictionary:
     if node != null and node.has_meta(METADATA_META):
         var value = node.get_meta(METADATA_META)
@@ -994,6 +1452,13 @@ func _get_unity_hierarchy_path(node: Node3D, object_id: String) -> String:
     if node != null and node.has_meta(UNITY_HIERARCHY_PATH_META):
         return String(node.get_meta(UNITY_HIERARCHY_PATH_META))
     return String(_unity_hierarchy_paths.get(object_id, ""))
+
+
+func _get_managed_node(object_id: String) -> Node3D:
+    var node_value = _managed_objects.get(object_id)
+    if node_value != null and is_instance_valid(node_value):
+        return node_value as Node3D
+    return null
 
 
 func _resolve_existing_sync_target_for_payload(object_id: String, payload: Dictionary) -> Node3D:

--- a/godot/addons/scene_sync/scene_sync_protocol.gd
+++ b/godot/addons/scene_sync/scene_sync_protocol.gd
@@ -177,6 +177,35 @@ static func make_scene_graph_clear(object_id: String = "") -> Dictionary:
     return msg
 
 
+static func make_scene_asset_request(
+    request_id: String,
+    object_id: String,
+    asset_id: String = "",
+    mesh_path: String = "",
+    expected_size: Variant = null
+) -> Dictionary:
+    var msg := {
+        "kind": "scene-asset-request",
+        "requestId": request_id,
+        "objectId": object_id,
+        "assetId": asset_id if asset_id != "" else null,
+        "meshPath": mesh_path if mesh_path != "" else null,
+        "expectedSize": expected_size,
+    }
+    return msg
+
+
+static func make_file_handoff(path: String, filename: String, size: int, mime: String, url: String) -> Dictionary:
+    return {
+        "kind": "file",
+        "path": path,
+        "filename": filename,
+        "size": size,
+        "mime": mime,
+        "url": url,
+    }
+
+
 static func extract_transform(payload: Dictionary) -> Dictionary:
     var result := {}
     if payload.has("position") and payload["position"] is Array:

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="SceneSyncGodot"
 run/main_scene="res://node_3d.tscn"
-config/features=PackedStringArray("4.6", "GL Compatibility")
+config/features=PackedStringArray("4.6", "C#", "GL Compatibility")
 
 [dotnet]
 

--- a/godot/tests/run_all.sh
+++ b/godot/tests/run_all.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(dirname "$PROJECT_DIR")"
 TMP_DIR="${TMPDIR:-/tmp}/scenesync-godot-tests"
 TEST_PORT="${SCENESYNC_TEST_PORT:-18787}"
 mkdir -p "$TMP_DIR/blobs"
+mkdir -p "$TMP_DIR/logs"
 
 if [ -n "${GODOT_BIN:-}" ]; then
   GODOT="$GODOT_BIN"
@@ -26,7 +27,7 @@ fi
 
 echo "--- Generating import cache ---"
 cd "$PROJECT_DIR"
-"$GODOT" --headless --editor --import --quit >/dev/null 2>&1 || true
+"$GODOT" --headless --log-file "$TMP_DIR/logs/import.log" --editor --import --quit >/dev/null 2>&1 || true
 echo ""
 
 echo "--- Starting presence-server ---"
@@ -60,15 +61,15 @@ run_test() {
 }
 
 run_test "Unit Tests" \
-  "$GODOT" --headless -s tests/run_tests.gd
+  "$GODOT" --headless --log-file "$TMP_DIR/logs/unit.log" -s tests/run_tests.gd
 
 run_test "WebSocket Connection Test" \
   env SCENESYNC_PRESENCE_URL="ws://localhost:$TEST_PORT" \
-  "$GODOT" --headless tests/test_connection.tscn
+  "$GODOT" --headless --log-file "$TMP_DIR/logs/connection.log" tests/test_connection.tscn
 
 run_test "Blob Store Test" \
   env SCENESYNC_BLOB_URL="http://localhost:$TEST_PORT/blob" \
-  "$GODOT" --headless tests/test_blob.tscn
+  "$GODOT" --headless --log-file "$TMP_DIR/logs/blob.log" tests/test_blob.tscn
 
 kill "$PRESENCE_PID" 2>/dev/null || true
 

--- a/godot/tests/run_tests.gd
+++ b/godot/tests/run_tests.gd
@@ -175,6 +175,14 @@ func _run_protocol_tests() -> void:
     _assert_eq(graph_clear["kind"], "scene-graph-clear", "make_scene_graph_clear kind")
     _assert_eq(graph_clear["scope"], "object", "make_scene_graph_clear object scope")
 
+    var asset_request = SceneSyncProtocol.make_scene_asset_request("req-1", "obj-4", "asset-1", "mesh-path", 1234)
+    _assert_eq(asset_request["kind"], "scene-asset-request", "make_scene_asset_request kind")
+    _assert_eq(asset_request["assetId"], "asset-1", "make_scene_asset_request assetId")
+
+    var file_handoff = SceneSyncProtocol.make_file_handoff("pipe-path", "asset-1.glb", 1234, "model/gltf-binary", "https://example.test/#pipe-path")
+    _assert_eq(file_handoff["kind"], "file", "make_file_handoff kind")
+    _assert_eq(file_handoff["mime"], "model/gltf-binary", "make_file_handoff mime")
+
     var payload = {
         "position": [1.0, 2.0, 3.0],
         "rotation": [0.0, 0.0, 0.0, 1.0],
@@ -204,6 +212,11 @@ func _run_blob_client_tests() -> void:
     var path2 = SceneSyncBlobClient.generate_random_path()
     _assert_true(path1.length() == 8, "random_path length 8")
     _assert_true(path1 != path2, "random_path unique")
+    _assert_eq(
+        SceneSyncBlobClient.compute_asset_id(PackedByteArray([1, 2, 3, 4])),
+        "sha256-9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+        "compute_asset_id sha256"
+    )
 
 
 func _run_gltf_helper_tests() -> void:
@@ -269,7 +282,7 @@ func _run_manager_tests() -> void:
         "ops": [{"kind": "scene-env", "envId": "ops-env"}],
         "actions": [{"kind": "scene-env", "envId": "actions-env"}],
     }, {})
-    _assert_eq(manager._env_id, "ops-env", "manager scene-batch prefers ops over actions")
+    _assert_eq(manager._env_id, "actions-env", "manager scene-batch applies ops and actions")
 
     manager._handle_scene_state({
         "kind": "scene-state",
@@ -284,6 +297,24 @@ func _run_manager_tests() -> void:
     manager._cache_mesh_data("mesh-path", "asset-1", bytes)
     _assert_eq(manager._get_cached_mesh_data("", "asset-1"), bytes, "manager cache lookup by assetId")
     _assert_eq(manager._get_cached_mesh_data("mesh-path", ""), bytes, "manager cache lookup by meshPath")
+    _assert_eq(manager._get_piping_server_base(), "https://pipe.afjk.jp", "manager piping base default")
+
+    manager._pending_recoveries["req-1"] = {
+        "requestId": "req-1",
+        "objectId": "obj-1",
+        "assetId": "asset-1",
+        "meshPath": "mesh-path",
+        "expectedSize": 4,
+        "requestedPeerIds": {"peer-1": true},
+    }
+    _assert_true(
+        manager._can_accept_file_handoff("peer-1", "asset-1.glb", 4, "model/gltf-binary"),
+        "manager accepts matching recovery file handoff"
+    )
+    _assert_true(
+        not manager._can_accept_file_handoff("peer-2", "asset-1.glb", 4, "model/gltf-binary"),
+        "manager rejects unrequested recovery file handoff"
+    )
 
     var imported := Node3D.new()
     var wrapped = manager._wrap_imported_mesh_for_visual_basis(imported, "unity")

--- a/godot/tests/run_tests.gd
+++ b/godot/tests/run_tests.gd
@@ -282,7 +282,7 @@ func _run_manager_tests() -> void:
         "ops": [{"kind": "scene-env", "envId": "ops-env"}],
         "actions": [{"kind": "scene-env", "envId": "actions-env"}],
     }, {})
-    _assert_eq(manager._env_id, "actions-env", "manager scene-batch applies ops and actions")
+    _assert_eq(manager._env_id, "ops-env", "manager scene-batch prefers ops over actions")
 
     manager._handle_scene_state({
         "kind": "scene-state",


### PR DESCRIPTION
## Summary

Adds Godot-side Loomlet behavior graph evaluation using the same C# `Loomlet.Runtime` core used by the Unity package, with a thin Godot `Node3D` adapter for Scene Sync sink nodes.

Also brings the Godot addon closer to Unity wire/runtime behavior by adding SHA-256 `assetId` calculation, Unity-compatible expired GLB recovery handoffs, and `scene-batch` handling that matches the presence-server validation contract: `ops` is preferred, and `actions` is used only when `ops` is absent.

## Review fixes

- Restored Godot `scene-batch` semantics to `ops` first, fallback to `actions`, so unvalidated `actions` are not applied when `ops` exists.
- Updated the manager test to assert `ops-env` wins over `actions-env`.
- Added explicit Godot headless log files in the test runner to avoid environment-dependent `user://logs` startup failures.
- Included Godot-generated C# `.uid` metadata and aligned the Godot .NET SDK version with the local Godot Mono 4.6.3 project generation.

## Impact

- Godot .NET projects can evaluate scene/object Loomlet graphs instead of only preserving them on the wire.
- Godot exported/downloaded GLB assets now use the same `sha256-...` cache identity convention as Unity.
- Godot clients can participate in blob recovery via `scene-asset-request` and `file` handoff messages.

## Validation

- `git diff --check` passed.
- `cd godot && dotnet restore SceneSyncGodot.csproj` passed.
- `cd godot && dotnet build SceneSyncGodot.csproj` passed with 0 warnings and 0 errors.
- `GODOT_BIN=/Applications/Godot_mono.app/Contents/MacOS/Godot bash godot/tests/run_all.sh` passed using Godot `4.6.3.stable.mono.official.7d41c59c4`:
  - Unit Tests: PASS (`PASSED: 71  FAILED: 0`)
  - WebSocket Connection Test: PASS
  - Blob Store Test: PASS
  - Total: `PASS=3  FAIL=0`