### PR TITLE
[codex] Improve Godot SceneSync publish UX

### DIFF
--- a/godot/addons/scene_sync/README.md
+++ b/godot/addons/scene_sync/README.md
@@ -22,7 +22,7 @@ Recommended first-time flow:
 2. Place 3D objects under `SceneSyncRoot`.
 3. Click `Publish Children`.
 
-Godot publishes `Node3D` nodes as Scene Sync objects. A publish target must contain a `MeshInstance3D` on itself or in its descendants. Set `sync_root` to make the publish boundary explicit; `Publish Children` scans the direct children of that root. If a node cannot be published, the dock shows the skipped reason, such as `selected node is not Node3D` or `no mesh found in this node or children`.
+Godot publishes `Node3D` nodes as Scene Sync objects. The managed objects are the direct `Node3D` children of the Target Root. A publish target must contain a `MeshInstance3D` on itself or in its descendants. Set `sync_root` to make the publish boundary explicit; `Publish Children` scans the direct children of that root. If a node cannot be published, the dock shows the skipped reason, such as `selected node is not Node3D` or `no mesh found in this node or children`.
 
 Use `Republish Meshes` to export the current sync targets as `.glb` and publish updated mesh data through the blob store.
 

--- a/godot/addons/scene_sync/README.md
+++ b/godot/addons/scene_sync/README.md
@@ -14,7 +14,17 @@ Enable the plugin, open the dock on the right side, then set:
 - `Room`: shared room code
 - `Name`: display name
 
-Use `Connect` to join the room and `Sync Meshes` to export local meshes as `.glb` and publish them through the blob store.
+Use `Connect` to join the room. The `Publish` section exposes the current publish target root and explicit publish actions for selected nodes.
+
+Recommended first-time flow:
+
+1. Click `Create SceneSyncRoot`.
+2. Place 3D objects under `SceneSyncRoot`.
+3. Click `Publish Children`.
+
+Godot publishes `Node3D` nodes as Scene Sync objects. A publish target must contain a `MeshInstance3D` on itself or in its descendants. Set `sync_root` to make the publish boundary explicit; `Publish Children` scans the direct children of that root. If a node cannot be published, the dock shows the skipped reason, such as `selected node is not Node3D` or `no mesh found in this node or children`.
+
+Use `Republish Meshes` to export the current sync targets as `.glb` and publish updated mesh data through the blob store.
 
 ## Runtime
 

--- a/godot/addons/scene_sync/README.md
+++ b/godot/addons/scene_sync/README.md
@@ -22,7 +22,7 @@ Recommended first-time flow:
 2. Place 3D objects under `SceneSyncRoot`.
 3. Click `Publish Children`.
 
-Godot publishes `Node3D` nodes as Scene Sync objects. The managed objects are the direct `Node3D` children of the Target Root. A publish target must contain a `MeshInstance3D` on itself or in its descendants. Set `sync_root` to make the publish boundary explicit; `Publish Children` scans the direct children of that root. If a node cannot be published, the dock shows the skipped reason, such as `selected node is not Node3D` or `no mesh found in this node or children`.
+Godot publishes `Node3D` nodes as Scene Sync objects. The managed objects are the direct `Node3D` children of the Target Root, and the dock lists those children as `READY` or `SKIP`. A publish target must contain a `MeshInstance3D` on itself or in its descendants. Set `sync_root` to make the publish boundary explicit; `Publish Children` scans the direct children of that root. If a node cannot be published, the dock shows the skipped reason, such as `selected node is not Node3D` or `no mesh found in this node or children`.
 
 Use `Republish Meshes` to export the current sync targets as `.glb` and publish updated mesh data through the blob store.
 

--- a/godot/addons/scene_sync/scene_sync_dock.gd
+++ b/godot/addons/scene_sync/scene_sync_dock.gd
@@ -12,6 +12,7 @@ var _manager: SceneSyncManager
 @onready var _peers_container: VBoxContainer = %PeersContainer
 @onready var _sync_meshes_button: Button = %SyncMeshesButton
 @onready var _target_root_value: Label = %TargetRootValue
+@onready var _publish_rules_label: Label = %PublishRulesLabel
 @onready var _create_root_button: Button = %CreateRootButton
 @onready var _use_selected_root_button: Button = %UseSelectedRootButton
 @onready var _publish_selected_button: Button = %PublishSelectedButton
@@ -31,7 +32,7 @@ func _ready() -> void:
     _room_edit.text = _manager.room
     _nickname_edit.text = _manager.nickname
     _refresh_status()
-    _refresh_publish_status("Select a Node3D under the target root, then publish it.")
+    _refresh_publish_status("Create or choose a Target Root to start publishing.")
 
 
 func set_editor_interface(editor_interface: EditorInterface) -> void:
@@ -86,7 +87,7 @@ func _on_create_root_pressed() -> void:
             if selection != null:
                 selection.clear()
                 selection.add_node(root)
-        _refresh_publish_status(String(result.get("message", "SceneSyncRoot ready.")))
+        _refresh_publish_status("%s.\nMove 3D objects under this root, then click Publish Children." % String(result.get("message", "SceneSyncRoot ready")))
     else:
         _refresh_publish_status(_format_publish_result(result))
 
@@ -95,7 +96,7 @@ func _on_use_selected_root_pressed() -> void:
     _ensure_manager()
     var result := _manager.use_publish_root(_get_selected_node())
     if bool(result.get("ok", false)):
-        _refresh_publish_status(String(result.get("message", "Publish root updated.")))
+        _refresh_publish_status("%s.\nDirect Node3D children with meshes are now managed." % String(result.get("message", "Publish root updated")))
     else:
         _refresh_publish_status(_format_publish_result(result))
 
@@ -156,7 +157,13 @@ func _refresh_target_root() -> void:
         _target_root_value.text = "No sync root selected"
         return
     var root_status := _manager.get_publish_root_status()
-    _target_root_value.text = String(root_status.get("message", "No sync root selected"))
+    if bool(root_status.get("ok", false)):
+        var root = root_status.get("root")
+        _target_root_value.text = _format_root_label(root)
+        _publish_rules_label.text = "Managed objects: direct Node3D children of Target Root that contain a MeshInstance3D."
+    else:
+        _target_root_value.text = "No sync root selected"
+        _publish_rules_label.text = "Click Create SceneSyncRoot, place 3D objects under it, then click Publish Children."
 
 
 func _refresh_publish_status(message: String) -> void:
@@ -188,6 +195,18 @@ func _candidate_message(node: Node) -> String:
     if bool(status.get("publishable", false)):
         return "%s is ready to publish." % String(status.get("name", "Selected node"))
     return "Skipped\nReason: %s" % String(status.get("reason", "not publishable"))
+
+
+func _format_root_label(root) -> String:
+    if not (root is Node):
+        return "No sync root selected"
+
+    var scene_root := _get_edited_scene_root()
+    if scene_root != null and root == scene_root:
+        return "%s (scene root)" % root.name
+    if scene_root != null and root is Node and root.is_inside_tree() and scene_root.is_inside_tree() and scene_root.is_ancestor_of(root):
+        return String(scene_root.get_path_to(root))
+    return root.name
 
 
 func _format_publish_result(result: Dictionary) -> String:

--- a/godot/addons/scene_sync/scene_sync_dock.gd
+++ b/godot/addons/scene_sync/scene_sync_dock.gd
@@ -11,16 +11,27 @@ var _manager: SceneSyncManager
 @onready var _status_label: Label = %StatusLabel
 @onready var _peers_container: VBoxContainer = %PeersContainer
 @onready var _sync_meshes_button: Button = %SyncMeshesButton
+@onready var _target_root_value: Label = %TargetRootValue
+@onready var _create_root_button: Button = %CreateRootButton
+@onready var _use_selected_root_button: Button = %UseSelectedRootButton
+@onready var _publish_selected_button: Button = %PublishSelectedButton
+@onready var _publish_children_button: Button = %PublishChildrenButton
+@onready var _publish_status_label: Label = %PublishStatusLabel
 
 
 func _ready() -> void:
     _connect_button.pressed.connect(_on_connect_button_pressed)
     _sync_meshes_button.pressed.connect(_on_sync_meshes_pressed)
+    _create_root_button.pressed.connect(_on_create_root_pressed)
+    _use_selected_root_button.pressed.connect(_on_use_selected_root_pressed)
+    _publish_selected_button.pressed.connect(_on_publish_selected_pressed)
+    _publish_children_button.pressed.connect(_on_publish_children_pressed)
     _ensure_manager()
     _presence_url_edit.text = _manager.presence_url
     _room_edit.text = _manager.room
     _nickname_edit.text = _manager.nickname
     _refresh_status()
+    _refresh_publish_status("Select a Node3D under the target root, then publish it.")
 
 
 func set_editor_interface(editor_interface: EditorInterface) -> void:
@@ -39,8 +50,10 @@ func on_editor_selection_changed() -> void:
     for node in selected_nodes:
         if node is Node3D:
             _manager.select_object(node)
+            _refresh_publish_status(_candidate_message(node))
             return
     _manager.deselect_object()
+    _refresh_publish_status(_candidate_message(null if selected_nodes.is_empty() else selected_nodes[0]))
 
 
 func _on_connect_button_pressed() -> void:
@@ -59,6 +72,44 @@ func _on_connect_button_pressed() -> void:
 func _on_sync_meshes_pressed() -> void:
     _ensure_manager()
     _manager.sync_all_meshes()
+    _refresh_publish_status("Republish Meshes requested.")
+
+
+func _on_create_root_pressed() -> void:
+    _ensure_manager()
+    var scene_root := _get_edited_scene_root()
+    var result := _manager.create_scene_sync_root(scene_root)
+    if bool(result.get("ok", false)):
+        var root = result.get("root")
+        if _editor_interface != null and root is Node:
+            var selection := _editor_interface.get_selection()
+            if selection != null:
+                selection.clear()
+                selection.add_node(root)
+        _refresh_publish_status(String(result.get("message", "SceneSyncRoot ready.")))
+    else:
+        _refresh_publish_status(_format_publish_result(result))
+
+
+func _on_use_selected_root_pressed() -> void:
+    _ensure_manager()
+    var result := _manager.use_publish_root(_get_selected_node())
+    if bool(result.get("ok", false)):
+        _refresh_publish_status(String(result.get("message", "Publish root updated.")))
+    else:
+        _refresh_publish_status(_format_publish_result(result))
+
+
+func _on_publish_selected_pressed() -> void:
+    _ensure_manager()
+    var result = await _manager.publish_node(_get_selected_node())
+    _refresh_publish_status(_format_publish_result(result))
+
+
+func _on_publish_children_pressed() -> void:
+    _ensure_manager()
+    var result = await _manager.publish_children_of_root()
+    _refresh_publish_status(_format_publish_result(result))
 
 
 func _ensure_manager() -> void:
@@ -97,6 +148,64 @@ func _refresh_status() -> void:
 
     _status_label.text = _manager.get_status_text()
     _connect_button.text = "Disconnect" if _manager.is_connected_to_server() else "Connect"
+    _refresh_target_root()
+
+
+func _refresh_target_root() -> void:
+    if _manager == null:
+        _target_root_value.text = "No sync root selected"
+        return
+    var root_status := _manager.get_publish_root_status()
+    _target_root_value.text = String(root_status.get("message", "No sync root selected"))
+
+
+func _refresh_publish_status(message: String) -> void:
+    _refresh_target_root()
+    _publish_status_label.text = message
+
+
+func _get_edited_scene_root() -> Node:
+    if _editor_interface == null:
+        return null
+    return _editor_interface.get_edited_scene_root()
+
+
+func _get_selected_node() -> Node:
+    if _editor_interface == null:
+        return null
+    var selection := _editor_interface.get_selection()
+    if selection == null:
+        return null
+    var selected_nodes := selection.get_selected_nodes()
+    if selected_nodes.is_empty():
+        return null
+    return selected_nodes[0]
+
+
+func _candidate_message(node: Node) -> String:
+    _ensure_manager()
+    var status := _manager.get_publish_candidate_status(node)
+    if bool(status.get("publishable", false)):
+        return "%s is ready to publish." % String(status.get("name", "Selected node"))
+    return "Skipped\nReason: %s" % String(status.get("reason", "not publishable"))
+
+
+func _format_publish_result(result: Dictionary) -> String:
+    var lines: Array[String] = [
+        "Published: %d" % int(result.get("published", 0)),
+        "Skipped: %d" % int(result.get("skipped", 0)),
+    ]
+    var reasons = result.get("reasons", [])
+    if reasons is Array:
+        for entry in reasons:
+            if entry is Dictionary:
+                var name := String(entry.get("name", ""))
+                var reason := String(entry.get("reason", "not publishable"))
+                if name == "":
+                    lines.append("- %s" % reason)
+                else:
+                    lines.append("- %s: %s" % [name, reason])
+    return "\n".join(lines)
 
 
 func _rebuild_peers(peers: Array) -> void:

--- a/godot/addons/scene_sync/scene_sync_dock.gd
+++ b/godot/addons/scene_sync/scene_sync_dock.gd
@@ -13,6 +13,7 @@ var _manager: SceneSyncManager
 @onready var _sync_meshes_button: Button = %SyncMeshesButton
 @onready var _target_root_value: Label = %TargetRootValue
 @onready var _publish_rules_label: Label = %PublishRulesLabel
+@onready var _managed_objects_container: VBoxContainer = %ManagedObjectsContainer
 @onready var _create_root_button: Button = %CreateRootButton
 @onready var _use_selected_root_button: Button = %UseSelectedRootButton
 @onready var _publish_selected_button: Button = %PublishSelectedButton
@@ -155,20 +156,60 @@ func _refresh_status() -> void:
 func _refresh_target_root() -> void:
     if _manager == null:
         _target_root_value.text = "No sync root selected"
+        _refresh_managed_objects(null)
         return
     var root_status := _manager.get_publish_root_status()
     if bool(root_status.get("ok", false)):
         var root = root_status.get("root")
         _target_root_value.text = _format_root_label(root)
         _publish_rules_label.text = "Managed objects: direct Node3D children of Target Root that contain a MeshInstance3D."
+        _refresh_managed_objects(root)
     else:
         _target_root_value.text = "No sync root selected"
         _publish_rules_label.text = "Click Create SceneSyncRoot, place 3D objects under it, then click Publish Children."
+        _refresh_managed_objects(null)
 
 
 func _refresh_publish_status(message: String) -> void:
     _refresh_target_root()
     _publish_status_label.text = message
+
+
+func _refresh_managed_objects(root) -> void:
+    for child in _managed_objects_container.get_children():
+        child.queue_free()
+
+    if not (root is Node):
+        _add_managed_object_line("No Publish Root yet.")
+        return
+
+    var children: Array = root.get_children()
+    if children.is_empty():
+        _add_managed_object_line("No objects under Publish Root.")
+        _add_managed_object_line("Move a 3D object here, then Publish Children.")
+        return
+
+    var ready_count := 0
+    var skipped_count := 0
+    for child in children:
+        var status := _manager.get_publish_candidate_status(child)
+        if bool(status.get("publishable", false)):
+            ready_count += 1
+            _add_managed_object_line("READY  %s" % child.name)
+        else:
+            skipped_count += 1
+            _add_managed_object_line("SKIP   %s - %s" % [
+                child.name,
+                String(status.get("reason", "not publishable")),
+            ])
+    _add_managed_object_line("Total: %d ready, %d skipped" % [ready_count, skipped_count])
+
+
+func _add_managed_object_line(text: String) -> void:
+    var label := Label.new()
+    label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    label.text = text
+    _managed_objects_container.add_child(label)
 
 
 func _get_edited_scene_root() -> Node:

--- a/godot/addons/scene_sync/scene_sync_dock.tscn
+++ b/godot/addons/scene_sync/scene_sync_dock.tscn
@@ -93,6 +93,14 @@ layout_mode = 2
 autowrap_mode = 2
 text = "Click Create SceneSyncRoot, place 3D objects under it, then click Publish Children."
 
+[node name="ManagedObjectsHeader" type="Label" parent="."]
+layout_mode = 2
+text = "Managed Objects"
+
+[node name="ManagedObjectsContainer" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+
 [node name="CreateRootButton" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2

--- a/godot/addons/scene_sync/scene_sync_dock.tscn
+++ b/godot/addons/scene_sync/scene_sync_dock.tscn
@@ -87,6 +87,12 @@ size_flags_horizontal = 3
 autowrap_mode = 2
 text = "No sync root selected"
 
+[node name="PublishRulesLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+autowrap_mode = 2
+text = "Click Create SceneSyncRoot, place 3D objects under it, then click Publish Children."
+
 [node name="CreateRootButton" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
@@ -115,7 +121,7 @@ text = "Republish Meshes"
 [node name="PublishHelpLabel" type="Label" parent="."]
 layout_mode = 2
 autowrap_mode = 2
-text = "Publish Node3D children of the target root. A publish target must contain a MeshInstance3D in itself or its children."
+text = "Publish Selected publishes one direct child of Target Root. Publish Children publishes all direct children with meshes."
 
 [node name="PublishStatusLabel" type="Label" parent="."]
 unique_name_in_owner = true

--- a/godot/addons/scene_sync/scene_sync_dock.tscn
+++ b/godot/addons/scene_sync/scene_sync_dock.tscn
@@ -69,7 +69,56 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 
+[node name="PublishHeader" type="Label" parent="."]
+layout_mode = 2
+text = "Publish"
+
+[node name="TargetRootRow" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="TargetRootLabel" type="Label" parent="TargetRootRow"]
+layout_mode = 2
+text = "Target Root"
+
+[node name="TargetRootValue" type="Label" parent="TargetRootRow"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+autowrap_mode = 2
+text = "No sync root selected"
+
+[node name="CreateRootButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Create SceneSyncRoot"
+
+[node name="UseSelectedRootButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Use Selected As Root"
+
+[node name="PublishSelectedButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Publish Selected"
+
+[node name="PublishChildrenButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Publish Children"
+
 [node name="SyncMeshesButton" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Sync Meshes"
+text = "Republish Meshes"
+
+[node name="PublishHelpLabel" type="Label" parent="."]
+layout_mode = 2
+autowrap_mode = 2
+text = "Publish Node3D children of the target root. A publish target must contain a MeshInstance3D in itself or its children."
+
+[node name="PublishStatusLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+autowrap_mode = 2
+text = "No publish action yet."

--- a/godot/addons/scene_sync/scene_sync_manager.gd
+++ b/godot/addons/scene_sync/scene_sync_manager.gd
@@ -162,7 +162,7 @@ func sync_all_meshes() -> void:
 
 func get_publish_root_status() -> Dictionary:
     if sync_root != null and is_instance_valid(sync_root):
-        var root_path := String(sync_root.get_path()) if sync_root.is_inside_tree() else sync_root.name
+        var root_path := sync_root.name
         return {
             "ok": true,
             "root": sync_root,
@@ -236,12 +236,12 @@ func get_publish_candidate_status(node: Node) -> Dictionary:
         return _publish_candidate(false, node.name, "selected node is not Node3D")
     var root_status := get_publish_root_status()
     if not bool(root_status.get("ok", false)):
-        return _publish_candidate(false, node.name, "No sync root selected")
+        return _publish_candidate(false, node.name, "No sync root selected. Click Create SceneSyncRoot first.")
     var root = root_status.get("root")
     if root != null and node.get_parent() != root:
-        return _publish_candidate(false, node.name, "selected node is not a direct child of sync root")
+        return _publish_candidate(false, node.name, "selected node is not a direct child of Target Root. Move it under %s or use it as root." % root.name)
     if not _node_has_mesh(node as Node3D):
-        return _publish_candidate(false, node.name, "no mesh found in this node or children")
+        return _publish_candidate(false, node.name, "no mesh found in this node or children. Add a MeshInstance3D under this node.")
     return _publish_candidate(true, node.name, "")
 
 

--- a/godot/addons/scene_sync/scene_sync_manager.gd
+++ b/godot/addons/scene_sync/scene_sync_manager.gd
@@ -160,6 +160,172 @@ func sync_all_meshes() -> void:
         _sync_mesh_for_node(node)
 
 
+func get_publish_root_status() -> Dictionary:
+    if sync_root != null and is_instance_valid(sync_root):
+        var root_path := String(sync_root.get_path()) if sync_root.is_inside_tree() else sync_root.name
+        return {
+            "ok": true,
+            "root": sync_root,
+            "path": root_path,
+            "message": root_path,
+        }
+    return {
+        "ok": false,
+        "root": null,
+        "path": "",
+        "message": "No sync root selected",
+        "reason": "No sync root selected",
+    }
+
+
+func create_scene_sync_root(host_root: Node = null) -> Dictionary:
+    if host_root == null:
+        host_root = _get_host_scene_root()
+    if host_root == null:
+        return _publish_result(0, [{
+            "name": RECEIVE_ROOT_NAME,
+            "reason": "no edited scene root",
+        }])
+
+    var existing := host_root.get_node_or_null(RECEIVE_ROOT_NAME)
+    if existing != null:
+        if existing is Node3D:
+            sync_root = existing
+            _assign_owner_for_publish_root(existing, host_root)
+            return {
+                "ok": true,
+                "root": existing,
+                "created": false,
+                "message": "Using existing SceneSyncRoot",
+            }
+        return _publish_result(0, [{
+            "name": RECEIVE_ROOT_NAME,
+            "reason": "existing SceneSyncRoot is not Node3D",
+        }])
+
+    var next_root := Node3D.new()
+    next_root.name = RECEIVE_ROOT_NAME
+    host_root.add_child(next_root)
+    _assign_owner_for_publish_root(next_root, host_root)
+    sync_root = next_root
+    return {
+        "ok": true,
+        "root": next_root,
+        "created": true,
+        "message": "Created SceneSyncRoot",
+    }
+
+
+func use_publish_root(node: Node) -> Dictionary:
+    if node == null:
+        return _publish_result(0, [{"name": "", "reason": "No node selected"}])
+    if not (node is Node3D):
+        return _publish_result(0, [{"name": node.name, "reason": "selected node is not Node3D"}])
+    sync_root = node
+    return {
+        "ok": true,
+        "root": node,
+        "message": "Using %s as publish root" % node.name,
+    }
+
+
+func get_publish_candidate_status(node: Node) -> Dictionary:
+    if node == null:
+        return _publish_candidate(false, "", "No node selected")
+    if not (node is Node3D):
+        return _publish_candidate(false, node.name, "selected node is not Node3D")
+    var root_status := get_publish_root_status()
+    if not bool(root_status.get("ok", false)):
+        return _publish_candidate(false, node.name, "No sync root selected")
+    var root = root_status.get("root")
+    if root != null and node.get_parent() != root:
+        return _publish_candidate(false, node.name, "selected node is not a direct child of sync root")
+    if not _node_has_mesh(node as Node3D):
+        return _publish_candidate(false, node.name, "no mesh found in this node or children")
+    return _publish_candidate(true, node.name, "")
+
+
+func get_publish_children_status() -> Dictionary:
+    var root_status := get_publish_root_status()
+    if not bool(root_status.get("ok", false)):
+        return _publish_result(0, [{
+            "name": RECEIVE_ROOT_NAME,
+            "reason": "No sync root selected",
+        }])
+
+    var publishable := 0
+    var skipped: Array = []
+    var root := root_status.get("root") as Node3D
+    for child in root.get_children():
+        var candidate := get_publish_candidate_status(child)
+        if bool(candidate.get("publishable", false)):
+            publishable += 1
+        else:
+            skipped.append(candidate)
+
+    if root.get_child_count() == 0:
+        skipped.append({
+            "name": root.name,
+            "reason": "sync root has no children",
+        })
+    return _publish_result(publishable, skipped)
+
+
+func publish_node(node: Node) -> Dictionary:
+    var candidate := get_publish_candidate_status(node)
+    if not bool(candidate.get("publishable", false)):
+        return _publish_result(0, [candidate])
+    if not _connected:
+        return _publish_result(0, [{
+            "name": String(candidate.get("name", "")),
+            "reason": "not connected",
+        }])
+
+    var node_3d := node as Node3D
+    var object_id := _get_or_assign_object_id(node_3d)
+    await _send_scene_add(node_3d, object_id)
+    _managed_objects[object_id] = node_3d
+    _known_ids[object_id] = true
+    return _publish_result(1, [])
+
+
+func publish_children_of_root() -> Dictionary:
+    var root_status := get_publish_root_status()
+    if not bool(root_status.get("ok", false)):
+        return _publish_result(0, [{
+            "name": RECEIVE_ROOT_NAME,
+            "reason": "No sync root selected",
+        }])
+
+    var published := 0
+    var skipped: Array = []
+    var root := root_status.get("root") as Node3D
+    for child in root.get_children():
+        var candidate := get_publish_candidate_status(child)
+        if not bool(candidate.get("publishable", false)):
+            skipped.append(candidate)
+            continue
+        if not _connected:
+            skipped.append({
+                "name": child.name,
+                "reason": "not connected",
+            })
+            continue
+        var child_3d := child as Node3D
+        var object_id := _get_or_assign_object_id(child_3d)
+        await _send_scene_add(child_3d, object_id)
+        _managed_objects[object_id] = child_3d
+        _known_ids[object_id] = true
+        published += 1
+
+    if root.get_child_count() == 0:
+        skipped.append({
+            "name": root.name,
+            "reason": "sync root has no children",
+        })
+    return _publish_result(published, skipped)
+
+
 func _on_connected(new_id: String, new_room: String) -> void:
     _connected = true
     room = new_room
@@ -1586,6 +1752,34 @@ func _node_has_mesh(node: Node3D) -> bool:
         if child is Node3D and _node_has_mesh(child):
             return true
     return false
+
+
+func _publish_candidate(publishable: bool, node_name: String, reason: String) -> Dictionary:
+    return {
+        "publishable": publishable,
+        "name": node_name,
+        "reason": reason,
+    }
+
+
+func _publish_result(published: int, skipped: Array) -> Dictionary:
+    return {
+        "published": published,
+        "skipped": skipped.size(),
+        "reasons": skipped,
+        "ok": published > 0 and skipped.is_empty(),
+    }
+
+
+func _assign_owner_for_publish_root(node: Node, host_root: Node) -> void:
+    if node == null:
+        return
+    if Engine.is_editor_hint():
+        var edited_root := get_tree().edited_scene_root if get_tree() != null else null
+        node.owner = edited_root
+        return
+    if host_root != null:
+        node.owner = host_root.owner
 
 
 func _get_object_id(node: Node) -> String:

--- a/godot/tests/run_tests.gd
+++ b/godot/tests/run_tests.gd
@@ -354,6 +354,47 @@ func _run_manager_tests() -> void:
     _assert_true(manager._mesh_paths.has("obj-mesh-rebind"), "manager scene-mesh rebind stores meshPath")
     _assert_true(manager._managed_objects["obj-mesh-rebind"] != mesh_existing, "manager scene-mesh rebind loads replacement mesh")
 
+    var publish_root := Node3D.new()
+    root.add_child(publish_root)
+    manager.sync_root = publish_root
+
+    var publish_target := Node3D.new()
+    publish_target.name = "PublishTarget"
+    publish_root.add_child(publish_target)
+    var publish_mesh := MeshInstance3D.new()
+    publish_mesh.mesh = BoxMesh.new()
+    publish_target.add_child(publish_mesh)
+
+    var publish_status := manager.get_publish_candidate_status(publish_target)
+    _assert_true(bool(publish_status.get("publishable", false)), "manager publish candidate with descendant mesh")
+
+    var empty_target := Node3D.new()
+    empty_target.name = "EmptyPublishTarget"
+    publish_root.add_child(empty_target)
+    var empty_status := manager.get_publish_candidate_status(empty_target)
+    _assert_eq(empty_status.get("reason", ""), "no mesh found in this node or children", "manager publish candidate skips meshless Node3D")
+
+    var plain_node := Node.new()
+    plain_node.name = "PlainNode"
+    var plain_status := manager.get_publish_candidate_status(plain_node)
+    _assert_eq(plain_status.get("reason", ""), "selected node is not Node3D", "manager publish candidate skips non Node3D")
+    plain_node.free()
+
+    var reusable_scene := Node3D.new()
+    root.add_child(reusable_scene)
+    var reusable_root := Node3D.new()
+    reusable_root.name = "SceneSyncRoot"
+    reusable_scene.add_child(reusable_root)
+    var create_result := manager.create_scene_sync_root(reusable_scene)
+    _assert_eq(create_result.get("root", null), reusable_root, "manager create SceneSyncRoot reuses existing root")
+
+    manager.sync_root = publish_root
+    var children_status := manager.get_publish_children_status()
+    _assert_eq(children_status.get("published", 0), 1, "manager publish children counts publishable nodes")
+    _assert_eq(children_status.get("skipped", 0), 1, "manager publish children counts skipped nodes")
+
+    reusable_scene.free()
+    publish_root.free()
     wrapped.free()
     manager.free()
     sync_root.free()

--- a/godot/tests/run_tests.gd
+++ b/godot/tests/run_tests.gd
@@ -372,7 +372,7 @@ func _run_manager_tests() -> void:
     empty_target.name = "EmptyPublishTarget"
     publish_root.add_child(empty_target)
     var empty_status := manager.get_publish_candidate_status(empty_target)
-    _assert_eq(empty_status.get("reason", ""), "no mesh found in this node or children", "manager publish candidate skips meshless Node3D")
+    _assert_eq(empty_status.get("reason", ""), "no mesh found in this node or children. Add a MeshInstance3D under this node.", "manager publish candidate skips meshless Node3D")
 
     var plain_node := Node.new()
     plain_node.name = "PlainNode"


### PR DESCRIPTION
## Summary

Improves the Godot SceneSync editor dock so publishing is explicit and easier to diagnose, without changing the wire protocol, presence server, Unity behavior, or Loomlet runtime.

The dock now has a `Publish` section with the current target root, root setup actions, selected-node publishing, root-child publishing, mesh republish, visible skipped reasons, and a `Managed Objects` list. The Target Root display uses a scene-relative label such as `SceneSyncRoot` instead of Godot editor-internal absolute paths.

## Godot Dock flow

1. Connect to the Scene Sync room.
2. Click `Create SceneSyncRoot` if no target root is selected.
3. Put 3D objects under `SceneSyncRoot`, or select a `Node3D` and click `Use Selected As Root`.
4. Check `Managed Objects`: direct children with meshes show as `READY`; skipped children show as `SKIP` with a reason.
5. Use `Publish Selected` for one target, or `Publish Children` to publish direct children of the target root.
6. Use `Republish Meshes` when existing sync targets need refreshed GLB mesh data.

## Publish rules

- Godot publishes `Node3D` nodes as Scene Sync objects.
- Managed objects are direct `Node3D` children of the Target Root.
- A publish target must contain a `MeshInstance3D` on itself or in its descendants.
- `Publish Children` scans the direct children of the selected target root.
- Existing automatic mesh sync and hierarchy detection behavior is preserved.

## Skipped reason examples

- `No sync root selected. Click Create SceneSyncRoot first.`
- `No node selected`
- `selected node is not Node3D`
- `selected node is not a direct child of Target Root. Move it under SceneSyncRoot or use it as root.`
- `no mesh found in this node or children. Add a MeshInstance3D under this node.`
- `not connected`

## Validation

- `git diff --check` passed.
- `cd godot && dotnet restore SceneSyncGodot.csproj && dotnet build SceneSyncGodot.csproj` passed with 0 warnings and 0 errors.
- `GODOT_BIN=/Applications/Godot_mono.app/Contents/MacOS/Godot bash godot/tests/run_all.sh` passed using Godot `4.6.3.stable.mono.official.7d41c59c4`:
  - Unit Tests: PASS (`PASSED: 77  FAILED: 0`)
  - WebSocket Connection Test: PASS
  - Blob Store Test: PASS
  - Total: `PASS=3  FAIL=0`
- `Godot --check-only` passed for `scene_sync_dock.gd` and `plugin.gd`.