### PR TITLE
[codex] Fix SceneSync GLB recovery

### DIFF
--- a/html/assets/js/scenesync/assets/expired-glb-recovery.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.js
@@ -91,16 +91,7 @@ export function createExpiredGlbRecovery({
       }
 
       if (peerIndex >= peers.length) {
-        console.log('[ExpiredGlbRecovery] All peers exhausted for requestId:', requestId);
-        const recovery = pendingRecoveries.get(requestId);
-        pendingRecoveries.delete(requestId);
-        recoveryFailedCallbacks.forEach(cb => {
-          try {
-            cb({ objectId, requestId, reason: 'no-response', info: recovery?.info });
-          } catch (err) {
-            console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
-          }
-        });
+        console.log('[ExpiredGlbRecovery] All peers requested for requestId:', requestId, 'waiting for file handoff or timeout');
         return;
       }
 
@@ -276,14 +267,36 @@ export function createExpiredGlbRecovery({
       recovery = pendingRecoveries.get(recoveryRequestId);
     }
 
+    let computedAssetId = null;
+    try {
+      computedAssetId = await computeAssetId(file);
+    } catch (err) {
+      console.warn('[ExpiredGlbRecovery] Failed to compute asset ID:', err);
+    }
+
     if (!recovery && fromPeerId) {
+      let fallback = null;
       for (const [, rec] of pendingRecoveries) {
         if (!rec.requestedPeerIds.has(fromPeerId)) {
           continue;
         }
-        recovery = rec;
-        break;
+        if (rec.expectedSize && rec.expectedSize !== file.size) {
+          continue;
+        }
+        if (computedAssetId && rec.assetId) {
+          if (rec.assetId === computedAssetId) {
+            recovery = rec;
+            break;
+          }
+          continue;
+        }
+        if (rec.assetId && file.name?.startsWith?.(rec.assetId)) {
+          recovery = rec;
+          break;
+        }
+        if (!fallback) fallback = rec;
       }
+      recovery ||= fallback;
     }
 
     if (!recovery) {
@@ -292,13 +305,6 @@ export function createExpiredGlbRecovery({
     }
 
     console.log('[ExpiredGlbRecovery] Matching recovered file to pending recovery:', recovery.requestId);
-
-    let computedAssetId = null;
-    try {
-      computedAssetId = await computeAssetId(file);
-    } catch (err) {
-      console.warn('[ExpiredGlbRecovery] Failed to compute asset ID:', err);
-    }
 
     if (recovery.assetId) {
       if (!computedAssetId) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5225,6 +5225,7 @@ function handleHandoff(data) {
       filename: payload.filename,
       size: payload.size,
       mime: payload.mime,
+      recoveryRequestId: payload.recoveryRequestId,
     });
 
     if (canAccept) {

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -405,6 +405,7 @@ namespace Afjk.SceneSync
                     _assetIdCache[assetId] = glb;
                 if (path != null)
                     _meshPathCache[path] = glb;
+                StorePersistentCachedGlb(glb, assetId, path);
 
                 var assetIdJson = assetId != null ? ",\"assetId\":\"" + SceneSyncWireJson.JsonEscape(assetId) + "\"" : "";
                 var payload = "{\"kind\":\"scene-mesh\",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\",\"name\":\"" + SceneSyncWireJson.JsonEscape(go.name) + "\",\"meshPath\":\"" + SceneSyncWireJson.JsonEscape(path) + "\"" +
@@ -512,6 +513,96 @@ namespace Afjk.SceneSync
             {
                 Debug.LogWarning("[SceneSync] Failed to parse Piping display URL from: " + _presenceUrl);
                 return "https://pipe.afjk.jp";
+            }
+        }
+
+        private string GetPersistentGlbCacheDirectory()
+        {
+            return System.IO.Path.Combine(Application.persistentDataPath, "SceneSyncGlbCache");
+        }
+
+        private static string SanitizeCacheKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return null;
+            var invalid = System.IO.Path.GetInvalidFileNameChars();
+            var chars = value.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                if (Array.IndexOf(invalid, chars[i]) >= 0)
+                    chars[i] = '_';
+            }
+            return new string(chars);
+        }
+
+        private string GetPersistentGlbCachePath(string prefix, string key)
+        {
+            var sanitized = SanitizeCacheKey(key);
+            if (string.IsNullOrWhiteSpace(sanitized)) return null;
+            return System.IO.Path.Combine(GetPersistentGlbCacheDirectory(), prefix + "-" + sanitized + ".glb");
+        }
+
+        private bool TryLoadPersistentCachedGlb(string assetId, string meshPath, out byte[] glbBytes, out string source)
+        {
+            glbBytes = null;
+            source = null;
+
+            var candidates = new List<KeyValuePair<string, string>>();
+            if (!string.IsNullOrWhiteSpace(assetId))
+                candidates.Add(new KeyValuePair<string, string>("assetId", GetPersistentGlbCachePath("asset", assetId)));
+            if (!string.IsNullOrWhiteSpace(meshPath))
+                candidates.Add(new KeyValuePair<string, string>("meshPath", GetPersistentGlbCachePath("mesh", meshPath)));
+
+            foreach (var candidate in candidates)
+            {
+                var path = candidate.Value;
+                if (string.IsNullOrWhiteSpace(path) || !System.IO.File.Exists(path)) continue;
+                try
+                {
+                    var bytes = System.IO.File.ReadAllBytes(path);
+                    if (bytes == null || bytes.Length == 0 || bytes.Length > MAX_GLB_SIZE) continue;
+                    glbBytes = bytes;
+                    source = candidate.Key;
+                    if (!string.IsNullOrWhiteSpace(assetId))
+                        _assetIdCache[assetId] = bytes;
+                    if (!string.IsNullOrWhiteSpace(meshPath))
+                        _meshPathCache[meshPath] = bytes;
+                    return true;
+                }
+                catch (Exception err)
+                {
+                    Debug.LogWarning("[SceneSync] Failed to read persistent GLB cache: " + path + "\n" + err.Message);
+                }
+            }
+
+            return false;
+        }
+
+        private void StorePersistentCachedGlb(byte[] glbBytes, string assetId, string meshPath)
+        {
+            if (glbBytes == null || glbBytes.Length == 0 || glbBytes.Length > MAX_GLB_SIZE) return;
+
+            try
+            {
+                var dir = GetPersistentGlbCacheDirectory();
+                System.IO.Directory.CreateDirectory(dir);
+
+                if (!string.IsNullOrWhiteSpace(assetId))
+                {
+                    var assetPath = GetPersistentGlbCachePath("asset", assetId);
+                    if (!string.IsNullOrWhiteSpace(assetPath))
+                        System.IO.File.WriteAllBytes(assetPath, glbBytes);
+                }
+
+                if (!string.IsNullOrWhiteSpace(meshPath))
+                {
+                    var meshPathCachePath = GetPersistentGlbCachePath("mesh", meshPath);
+                    if (!string.IsNullOrWhiteSpace(meshPathCachePath))
+                        System.IO.File.WriteAllBytes(meshPathCachePath, glbBytes);
+                }
+            }
+            catch (Exception err)
+            {
+                Debug.LogWarning("[SceneSync] Failed to write persistent GLB cache: " + err.Message);
             }
         }
 
@@ -1036,6 +1127,11 @@ namespace Afjk.SceneSync
                 cachedGlb = glbByAssetId;
             else if (!string.IsNullOrEmpty(meshPath) && _meshPathCache.TryGetValue(meshPath, out var glbByMeshPath))
                 cachedGlb = glbByMeshPath;
+            else if (TryLoadPersistentCachedGlb(assetId, meshPath, out var persistentGlb, out var persistentSource))
+            {
+                Debug.Log("[ExpiredGlbRecovery] Using persistent cached GLB by " + persistentSource + ": " + cacheKey);
+                cachedGlb = persistentGlb;
+            }
 
             if (cachedGlb == null)
             {
@@ -2109,9 +2205,17 @@ namespace Afjk.SceneSync
             if (_runtimeFallbackImportMaterial != null)
                 return _runtimeFallbackImportMaterial;
 
-            var shader = Shader.Find("Universal Render Pipeline/Lit");
-            if (shader == null)
-                shader = Shader.Find("URP/Lit");
+            Shader shader = null;
+            if (UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline == null)
+            {
+                shader = Shader.Find("Standard");
+            }
+            else
+            {
+                shader = Shader.Find("Universal Render Pipeline/Lit");
+                if (shader == null)
+                    shader = Shader.Find("URP/Lit");
+            }
             if (shader == null)
                 shader = Shader.Find("Standard");
 
@@ -2244,6 +2348,12 @@ namespace Afjk.SceneSync
                 Debug.Log("[SceneSync] Using cached GLB by meshPath: " + meshPath);
                 glbBytes = cachedByMeshPath;
             }
+            else if (TryLoadPersistentCachedGlb(assetId, meshPath, out var persistentGlb, out var persistentSource))
+            {
+                Debug.Log("[SceneSync] Using persistent cached GLB by " + persistentSource + ": " +
+                    (persistentSource == "assetId" ? assetId : meshPath));
+                glbBytes = persistentGlb;
+            }
 
             // Download if not in cache
             if (glbBytes == null)
@@ -2300,6 +2410,7 @@ namespace Afjk.SceneSync
                     _assetIdCache[assetId] = glbBytes;
                 if (!string.IsNullOrEmpty(meshPath))
                     _meshPathCache[meshPath] = glbBytes;
+                StorePersistentCachedGlb(glbBytes, assetId, meshPath);
             }
 
             try
@@ -2645,8 +2756,8 @@ namespace Afjk.SceneSync
 
                 if (peerIndex >= peers.Count)
                 {
-                    Debug.Log("[ExpiredGlbRecovery] All peers exhausted for requestId: " + requestId);
-                    _pendingRecoveries.Remove(requestId);
+                    Debug.Log("[ExpiredGlbRecovery] All peers requested for requestId: " + requestId +
+                        "; waiting for file handoff or timeout");
                     onComplete?.Invoke();
                     return;
                 }
@@ -2712,6 +2823,40 @@ namespace Afjk.SceneSync
             return false;
         }
 
+        private ExpiredGlbRecovery FindMatchingRecovery(string fromPeerId, string filename, int size, string assetId = null)
+        {
+            ExpiredGlbRecovery fallback = null;
+
+            foreach (var kvp in _pendingRecoveries)
+            {
+                var rec = kvp.Value;
+                if (!rec.requestedPeerIds.Contains(fromPeerId))
+                    continue;
+
+                if (rec.expectedSize.HasValue && rec.expectedSize.Value != size)
+                    continue;
+
+                if (!string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(rec.assetId))
+                {
+                    if (rec.assetId == assetId)
+                        return rec;
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(rec.assetId) &&
+                    !string.IsNullOrEmpty(filename) &&
+                    filename.StartsWith(rec.assetId, StringComparison.Ordinal))
+                {
+                    return rec;
+                }
+
+                if (fallback == null)
+                    fallback = rec;
+            }
+
+            return fallback;
+        }
+
         private async System.Threading.Tasks.Task HandleReceivedFile(string fromPeerId, string filename, byte[] data, string mime)
         {
             if (data == null || data.Length == 0)
@@ -2736,21 +2881,17 @@ namespace Afjk.SceneSync
                 return;
             }
 
-            // Find matching pending recovery
-            ExpiredGlbRecovery recovery = null;
-            foreach (var kvp in _pendingRecoveries)
+            string computedAssetId = null;
+            try
             {
-                var rec = kvp.Value;
-                if (!rec.requestedPeerIds.Contains(fromPeerId))
-                    continue;
-
-                if (rec.expectedSize.HasValue && rec.expectedSize.Value != data.Length)
-                    continue;
-
-                recovery = rec;
-                break;
+                computedAssetId = PresenceClientRuntime.ComputeAssetId(data);
+            }
+            catch (Exception err)
+            {
+                Debug.LogWarning("[ExpiredGlbRecovery] Failed to compute asset ID: " + err);
             }
 
+            var recovery = FindMatchingRecovery(fromPeerId, filename, data.Length, computedAssetId);
             if (recovery == null)
             {
                 Debug.Log("[ExpiredGlbRecovery] No matching pending recovery for this file from requestedPeerIds");
@@ -2759,18 +2900,8 @@ namespace Afjk.SceneSync
 
             Debug.Log("[ExpiredGlbRecovery] Matching recovered file to pending recovery: " + recovery.requestId);
 
-            string computedAssetId = null;
             if (recovery.assetId != null)
             {
-                try
-                {
-                    computedAssetId = PresenceClientRuntime.ComputeAssetId(data);
-                }
-                catch (Exception err)
-                {
-                    Debug.LogWarning("[ExpiredGlbRecovery] Failed to compute asset ID: " + err);
-                }
-
                 if (string.IsNullOrEmpty(computedAssetId))
                 {
                     Debug.LogWarning("[ExpiredGlbRecovery] Expected assetId but computation failed, ignoring file");
@@ -2794,6 +2925,7 @@ namespace Afjk.SceneSync
                     _assetIdCache[computedAssetId] = data;
                 if (recovery.meshPath != null)
                     _meshPathCache[recovery.meshPath] = data;
+                StorePersistentCachedGlb(data, computedAssetId ?? recovery.assetId, recovery.meshPath);
 
                 Debug.Log("[ExpiredGlbRecovery] Loading recovered GLB into object: " + recovery.objectId);
                 await LoadGlbFromBytes(recovery.objectId, data, computedAssetId ?? recovery.assetId);

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -55,6 +55,7 @@ namespace Afjk.SceneSync
         private const double PEER_RETRY_INTERVAL_MS = 4000;
         private const double COOLDOWN_MS = 30000;
         private const int MAX_GLB_SIZE = 50 * 1024 * 1024;
+        private const long MAX_PERSISTENT_GLB_CACHE_BYTES = 512L * 1024L * 1024L;
 
         private class ExpiredGlbRecovery
         {
@@ -560,6 +561,7 @@ namespace Afjk.SceneSync
                 {
                     var bytes = System.IO.File.ReadAllBytes(path);
                     if (bytes == null || bytes.Length == 0 || bytes.Length > MAX_GLB_SIZE) continue;
+                    TouchPersistentGlbCacheFile(path);
                     glbBytes = bytes;
                     source = candidate.Key;
                     if (!string.IsNullOrWhiteSpace(assetId))
@@ -580,6 +582,7 @@ namespace Afjk.SceneSync
         private void StorePersistentCachedGlb(byte[] glbBytes, string assetId, string meshPath)
         {
             if (glbBytes == null || glbBytes.Length == 0 || glbBytes.Length > MAX_GLB_SIZE) return;
+            if (glbBytes.LongLength > MAX_PERSISTENT_GLB_CACHE_BYTES) return;
 
             try
             {
@@ -599,10 +602,64 @@ namespace Afjk.SceneSync
                     if (!string.IsNullOrWhiteSpace(meshPathCachePath))
                         System.IO.File.WriteAllBytes(meshPathCachePath, glbBytes);
                 }
+
+                PrunePersistentGlbCache(dir);
             }
             catch (Exception err)
             {
                 Debug.LogWarning("[SceneSync] Failed to write persistent GLB cache: " + err.Message);
+            }
+        }
+
+        private void TouchPersistentGlbCacheFile(string path)
+        {
+            try
+            {
+                System.IO.File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+            }
+            catch
+            {
+                // Best effort only; cache reads should not fail because metadata updates are unavailable.
+            }
+        }
+
+        private void PrunePersistentGlbCache(string dir)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(dir) || !System.IO.Directory.Exists(dir)) return;
+
+                var files = new System.IO.DirectoryInfo(dir)
+                    .EnumerateFiles("*.glb", System.IO.SearchOption.TopDirectoryOnly)
+                    .OrderBy(file => file.LastWriteTimeUtc)
+                    .ToList();
+
+                long totalBytes = 0;
+                foreach (var file in files)
+                {
+                    totalBytes += Math.Max(0L, file.Length);
+                }
+
+                foreach (var file in files)
+                {
+                    if (totalBytes <= MAX_PERSISTENT_GLB_CACHE_BYTES) break;
+
+                    var length = Math.Max(0L, file.Length);
+                    try
+                    {
+                        file.Delete();
+                        totalBytes -= length;
+                    }
+                    catch (Exception err)
+                    {
+                        Debug.LogWarning("[SceneSync] Failed to prune persistent GLB cache file: " +
+                                         file.FullName + "\n" + err.Message);
+                    }
+                }
+            }
+            catch (Exception err)
+            {
+                Debug.LogWarning("[SceneSync] Failed to prune persistent GLB cache: " + err.Message);
             }
         }
 

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
@@ -101,8 +101,9 @@ namespace Afjk.SceneSync
             var colon = json.IndexOf(':', fieldIndex + token.Length);
             if (colon < 0) return null;
 
-            var objectStart = json.IndexOf('{', colon + 1);
-            if (objectStart < 0) return null;
+            var objectStart = colon + 1;
+            SkipWhitespace(json, ref objectStart);
+            if (objectStart >= json.Length || json[objectStart] != '{') return null;
 
             var objectEnd = FindMatching(json, objectStart, '{', '}');
             if (objectEnd < 0) return null;


### PR DESCRIPTION
## Summary

Fixes SceneSync GLB recovery across the Unity plugin and web client.

- Persist recovered/downloaded GLB bytes in Unity so previously loaded assets can be restored after Play mode or editor restart.
- Cap Unity persistent GLB cache at 512 MB and prune old `.glb` files after writes, with reads touching files so recently used entries survive longer.
- Keep expired-GLB recovery requests pending until a file handoff or timeout instead of dropping them immediately after all peers are requested.
- Match incoming file handoffs more reliably by request id, computed asset id, filename, peer, and size.
- Fix scene-state raw object parsing so `scene: null` does not accidentally consume the `objects` map as a Loomlet graph.
- Pass `recoveryRequestId` through web file handoff acceptance so web recovery matching is deterministic.

## Root Cause

Recovered GLB data was only held in memory, so stopping Play mode or restarting the editor lost usable asset bytes. The recovery queues could also remove pending requests before an async file handoff arrived, which made peer recovery flaky. Separately, scene metadata parsing scanned forward to the next object even when the field value was `null`, which broke Loomlet scene-state restore.

The persistent cache also needs a bounded lifecycle because assetId and meshPath entries may both be written for the same GLB. This update keeps the recovery behavior while preventing the Unity cache directory from growing indefinitely.

## Validation

- `uloop compile --force-recompile`: `ErrorCount: 0`
- `git diff --check`
- Unity Play mode connected to `unitest` and restored a cached GLB from Unity persistent cache.
- Playwright launched the real web SceneSync app, seeded IndexedDB with a GLB, and verified web asset-request handling sent the GLB via `FileTransferAdapter`.
- Unity received that web handoff and loaded it as a real mesh: `verts=3, renderers=1`.
- Verified Loomlet graph movement on `sample-cube` after the scene-state parsing fix.