### PR TITLE
[codex] Remove Loomlet server time from Scene Sync

### DIFF
--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -653,7 +653,7 @@ describe('scene-graph protocol', () => {
 
       const graph = {
         nodes: [
-          { id: 'clock', type: 'serverClock' },
+          { id: 'clock', type: 'clock' },
           { id: 'sine', type: 'sine', params: { freq: 1, amplitude: 50 } }
         ],
         edges: [{ from: 'clock.t', to: 'sine.t' }]

--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -123,7 +123,7 @@ test('export package construction', async (t) => {
       objects: {
         'box-1': {
           nodes: [
-            { id: 't', type: 'serverClock', params: {} },
+            { id: 't', type: 'clock', params: {} },
             { id: 'set', type: 'sceneSetPosition', params: { target: 'box-1' } },
           ],
           edges: [{ from: 't.t', to: 'set.x' }],

--- a/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
+++ b/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
@@ -28,12 +28,12 @@ test('Scene Sync Loomlet integration uses vendored runtime metadata', () => {
   });
 });
 
-test('Scene Sync Loomlet integration runs object-scoped legacy graphs', () => {
+test('Scene Sync Loomlet integration runs object-scoped graphs', () => {
   const object = makeObject();
   const integration = createSceneSyncLoomIntegration({
     getObjectById: (id) => id === 'box-1' ? object : null,
     send: () => {},
-    getServerTime: () => 2,
+    getHostTime: () => 2,
     getObjectRuntimeTime: () => 2,
     isObjectBeingEdited: () => false,
   });
@@ -43,13 +43,13 @@ test('Scene Sync Loomlet integration runs object-scoped legacy graphs', () => {
     scope: { object: 'box-1' },
     graph: {
       nodes: [
-        { id: 'clock', type: 'serverClock' },
+        { id: 'clock', type: 'clock' },
         { id: 'set', type: 'sceneSetPosition', params: { y: 1, z: 2 } },
       ],
       edges: [{ from: 'clock.t', to: 'set.x' }],
     },
   });
-  integration.tickObjectGraphs(2000);
+  integration.tickObjectGraphs(null, 2000);
 
   assert.deepEqual(
     { x: object.position.x, y: object.position.y, z: object.position.z },
@@ -64,7 +64,7 @@ test('Scene Sync Loomlet integration keeps offsetPosition relative to captured b
   const integration = createSceneSyncLoomIntegration({
     getObjectById: (id) => id === 'box-1' ? object : null,
     send: () => {},
-    getServerTime: () => 0,
+    getHostTime: () => 0,
     getObjectRuntimeTime: () => 0,
     isObjectBeingEdited: () => false,
   });
@@ -80,8 +80,8 @@ test('Scene Sync Loomlet integration keeps offsetPosition relative to captured b
     },
   });
 
-  integration.tickObjectGraphs(0);
-  integration.tickObjectGraphs(1000);
+  integration.tickObjectGraphs(null, 0);
+  integration.tickObjectGraphs(null, 1000);
 
   assert.deepEqual(
     { x: object.position.x, y: object.position.y, z: object.position.z },

--- a/docs/plans/backlog/shader-generative-runtime.md
+++ b/docs/plans/backlog/shader-generative-runtime.md
@@ -13,7 +13,7 @@ GLSL / generative content を Scene Sync で扱うための runtime track を、
 - `iFrame`
 - `iMouse`
 - `iChannel0..3`
-- `iTime` synchronized with existing serverClock
+- `iTime` driven by the existing Scene Clock
 - plane / fullscreen / box / sphere / skybox targets
 - Web Three.js `ShaderMaterial` MVP
 - Godot future support
@@ -33,7 +33,7 @@ GLSL / generative content を Scene Sync で扱うための runtime track を、
 
 - shader carrier metadata shape を定義する
 - Web MVP target surface を plane first で絞る
-- `iTime` / serverClock alignment rule を整理する
+- `iTime` / clock alignment rule を整理する
 - code size / blob store threshold の初期方針を決める
 
 ## later tasks
@@ -68,4 +68,3 @@ GLSL / generative content を Scene Sync で扱うための runtime track を、
 
 - shader は direct sync primitive ではなく runtime-specific augmentation として扱う
 - large code は blob store reference 前提で考える
-

--- a/docs/plans/scenesync-loomlet-runtime-vendoring.md
+++ b/docs/plans/scenesync-loomlet-runtime-vendoring.md
@@ -13,7 +13,7 @@ Loomlet is the source of truth for Scene Sync behavior graph playback. The pinne
 into:
 
 ```text
-html/assets/vendor/loomlet/0.1.2/loomlet-scenesync-runtime.browser.js
+html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
 ```
 
 Update it with:

--- a/docs/scene-sync-animation.md
+++ b/docs/scene-sync-animation.md
@@ -15,7 +15,7 @@ Scene Sync における GLB animation と、将来的な time control / Loomlet 
 - playback speed
 - loop / once
 - selected object への一括 animation 操作
-- Scene Sync server time と同期した再生
+- Scene Sync host-provided time に合わせた再生
 - Loomlet graph からの animation control
 
 ---
@@ -97,9 +97,9 @@ Animation を複数 client で完全に同期したい場合、local `Date.now()
 
 方針:
 
-- host / server が同期時刻を提供する。
-- client は offset を推定し、shared time に基づいて animation time を計算する。
-- animation state は「今 clip X を serverTime T から再生している」と表現できるようにする。
+- host が用途に合う時刻を提供する。
+- client は host-provided time に基づいて animation time を計算する。
+- animation state は「今 clip X を hostTime T から再生している」と表現できるようにする。
 
 ---
 

--- a/docs/scene-sync-avatar-and-presence.md
+++ b/docs/scene-sync-avatar-and-presence.md
@@ -82,7 +82,7 @@ AI / external tool は通常 avatar を持たないが、linked user の操作�
   "type": "grab-start",
   "objectId": "cube-1",
   "peerId": "peer-id",
-  "serverTime": 1770000000000
+  "hostTime": 1770000000000
 }
 ```
 

--- a/docs/scene-sync-bgm.md
+++ b/docs/scene-sync-bgm.md
@@ -106,7 +106,7 @@ BGM 削除ボタンは `scene-bgm` / `bgm: null` を broadcast して、各ク�
 この場合、各クライアントは次のように再生位置を計算する。
 
 ```js
-audioTime = offset + (serverNow - startTime)
+audioTime = offset + (hostNow - startTime)
 ```
 
 ただし、ブラウザの autoplay 制限は引き続き存在するため、音が実際に鳴り始めるタイミングとシーン時間は分けて扱う。ユーザーが音声を有効化した時点で、現在のシーン時間に対応した位置から再生する。

--- a/docs/scene-sync-command-vs-behavior-graph.md
+++ b/docs/scene-sync-command-vs-behavior-graph.md
@@ -56,7 +56,7 @@ Typical protocol payloads:
 - `scene-graph-patch`
 - `scene-graph-input`
 
-A Behavior Graph shares the definition of behavior, not per-frame transform results. Each client evaluates the graph locally against the same graph and synchronized inputs such as `serverClock`.
+A Behavior Graph shares the definition of behavior, not per-frame transform results. Each client evaluates the graph locally against the same graph and host-provided inputs such as `clock`.
 
 ---
 

--- a/docs/scene-sync-loom-ai-skill.md
+++ b/docs/scene-sync-loom-ai-skill.md
@@ -92,7 +92,7 @@ SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. 
 
 ### Allowed node types:
 
-- `serverClock` — synchronized server-driven clock (recommended for shared animations)
+- `clock` — host-provided clock (`env.time`) for time-driven behavior
 - `constant` — constant value
 - `sine` — sine wave oscillator
 - `cosine` — cosine wave oscillator
@@ -105,7 +105,7 @@ SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. 
 - `sceneSetColor` — set object color (RGB)
 - `sceneSetVisible` — set object visibility
 
-Use `serverClock` for shared room animations. Avoid `clock` for AI-generated shared Scene Sync behaviors because local clocks can drift between clients.
+Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync should provide a suitable room time as `env.time`; Loomlet itself does not synchronize clocks.
 
 ### Forbidden node types:
 
@@ -200,8 +200,8 @@ Always prefer Object Behavior Graphs for object-specific behavior.
 - `edges` must be an array of edge connections
 - Every node must have a unique `id` string
 - Every edge must use `"nodeId.port"` format (e.g., `"clock.t"`, `"sine.out"`)
-- Use `serverClock` for synchronized animation across all clients
-- Use `clock` only for local-only timing (not recommended for shared behavior)
+- Use `clock` for time-driven animation
+- Treat the meaning of `clock` as host-provided `env.time`
 - Use small amplitudes first, usually `0.5` to `3.0`
 - Always set fixed values for axes that are not animated
 - For position animation:
@@ -238,7 +238,7 @@ Object `cube1` oscillates along the X axis with a sine wave.
   "scope": { "object": "cube1" },
   "graph": {
     "nodes": [
-      { "id": "clock", "type": "serverClock" },
+      { "id": "clock", "type": "clock" },
       {
         "id": "sine",
         "type": "sine",
@@ -275,7 +275,7 @@ Object `cube1` continuously rotates around the Y axis.
   "scope": { "object": "cube1" },
   "graph": {
     "nodes": [
-      { "id": "clock", "type": "serverClock" },
+      { "id": "clock", "type": "clock" },
       {
         "id": "angle",
         "type": "multiply",
@@ -312,7 +312,7 @@ This demonstrates how to **combine multiple effects in a single Object Behavior 
   "scope": { "object": "cube1" },
   "graph": {
     "nodes": [
-      { "id": "clock", "type": "serverClock" },
+      { "id": "clock", "type": "clock" },
       {
         "id": "sine_pos",
         "type": "sine",
@@ -373,7 +373,7 @@ curl -X POST "http://localhost:8787/api/room/loom-test/broadcast?name=AI" \
     "scope": { "object": "cube1" },
     "graph": {
       "nodes": [
-        { "id": "clock", "type": "serverClock" },
+        { "id": "clock", "type": "clock" },
         { "id": "sine", "type": "sine", "params": { "freq": 0.2, "amplitude": 2, "offset": 0 } },
         { "id": "pos", "type": "sceneSetPosition", "params": { "y": 0.5, "z": 0 } }
       ],
@@ -412,7 +412,7 @@ Before sending a Behavior Graph payload to the REST broadcast endpoint, verify:
 - Only allowed node types from the whitelist are used
 - Object scope sink nodes do not include `params.target`
 - Non-animated axes have fixed values in sink node `params`
-- Animation uses `serverClock` unless local-only timing is explicitly desired
+- Animation uses `clock` for host-provided time
 - Amplitude values are reasonable
 - Frequency values are appropriate for the effect
 - Loom animation results are NOT sent as `scene-delta`
@@ -441,7 +441,7 @@ Before sending a Behavior Graph payload to the REST broadcast endpoint, verify:
   "scope": { "object": "cube1" },
   "graph": {
     "nodes": [
-      { "id": "clock", "type": "serverClock" },
+      { "id": "clock", "type": "clock" },
       { "id": "angle", "type": "multiply", "params": { "b": 0.5 } },
       { "id": "rot", "type": "sceneSetRotation", "params": { "x": 0, "z": 0 } }
     ],

--- a/docs/scene-sync-loom-protocol.md
+++ b/docs/scene-sync-loom-protocol.md
@@ -129,7 +129,7 @@ Ongoing behavior graph は Scene Sync の runtime time model を使う。
 
 - selected object: `t = 0`
 - unselected object: `t = now - runtimeStartTime`
-- 将来: `serverNow` ベース
+- 将来: host-provided room time ベース
 
 詳細は [Runtime Time Model](./scene-sync-runtime-time-model.md) を参照。
 

--- a/docs/scene-sync-loomlet-dsl-ai-authoring.md
+++ b/docs/scene-sync-loomlet-dsl-ai-authoring.md
@@ -25,11 +25,10 @@ Do not invent new behavior payloads such as `scene-behavior`, `animateObject`, o
 When an AI is asked to write continuous behavior, prefer this output:
 
 ```loom
-import time
 import math
 import scene
 
-t = time.serverClock()
+t = clock()
 y = math.sine(t, freq: 0.6, amplitude: 0.4, offset: 1.2)
 
 scene.setPosition("sample-cube", x: 0, y: y, z: 0)
@@ -82,7 +81,7 @@ Use Behavior Graphs for animation-like requests such as "bounce the cat", "spin 
 
 The Scene Sync client currently allows these Behavior Graph node types:
 
-- `serverClock`
+- `clock`
 - `constant`
 - `sine`
 - `cosine`
@@ -95,7 +94,7 @@ The Scene Sync client currently allows these Behavior Graph node types:
 - `sceneSetColor`
 - `sceneSetVisible`
 
-Use `serverClock` for shared room animations. Avoid `clock` for AI-generated shared Scene Sync behaviors because local clocks can drift between clients.
+Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync should provide a suitable room time as `env.time`; Loomlet itself does not synchronize clocks.
 
 Loomlet DSL authoring should map to those runtime nodes through the compiler/adapter.
 
@@ -127,11 +126,10 @@ Scene Sync stores one Object Behavior Graph per object. Sending a new graph to t
 Therefore, combine related effects into one `.loom` program:
 
 ```loom
-import time
 import math
 import scene
 
-t = time.serverClock()
+t = clock()
 x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
 g = math.sine(t, freq: 0.5, amplitude: 0.5, offset: 0.5)
 

--- a/docs/scene-sync-runtime-time-model.md
+++ b/docs/scene-sync-runtime-time-model.md
@@ -10,7 +10,7 @@ Loomlet object graph:
   output = graph.evaluate(t)
 ```
 
-この仕様は、動的なオブジェクトを編集しやすくしつつ、将来的な server time / Loomlet 制御へ自然に拡張するための共通モデルである。
+この仕様は、動的なオブジェクトを編集しやすくしつつ、将来的な host time / Loomlet 制御へ自然に拡張するための共通モデルである。
 
 ---
 
@@ -111,34 +111,34 @@ clip 実体は各クライアントが GLB から読み込む。
 
 ---
 
-## Future: server time
+## Future: host-provided room time
 
-将来的には `now` をローカル時刻ではなく、同期済み server time に置き換える。
+必要になった場合、`now` をローカル時刻ではなく host が供給する room time に置き換える。
 
 ```txt
 selected:
   t = 0
 
 unselected:
-  t = ((serverNow - runtime.startServerTime) / 1000) * speed
+  t = ((hostNow - runtime.startHostTime) / 1000) * speed
 ```
 
-選択解除時に `runtime.startServerTime = serverNow` を設定することで、途中参加クライアントでも GLB animation / Loomlet graph を同じ時間で評価できる。
+選択解除時に `runtime.startHostTime = hostNow` を設定することで、途中参加クライアントでも GLB animation / Loomlet graph を同じ時間基準で評価できる。
 
-### Clock sync
+### Clock source
 
-最初は軽量な ping / pong による offset 推定でよい。
+Loomlet runtime は時刻同期を行わない。Scene Sync host が用途に合う clock source を選び、その値を runtime time として渡す。
 
 ```txt
-client sends time-sync-request at local time t0
-server responds with serverNow
-client receives at local time t1
-RTT = t1 - t0
-estimatedOffset = serverNow + RTT / 2 - t1
-estimatedServerNow = localNow + estimatedOffset
+local playback time
+scene clock time
+room-local time
+host-supplied room time
+externally synchronized host time
+recorded timeline time
 ```
 
-この推定を数秒〜10秒程度の間隔で更新する。
+厳密な同期が必要な場合は、Scene Sync host / device / OS / network 側で同期済みの clock を作り、それを host time として渡す。
 
 ### Event time
 
@@ -150,7 +150,7 @@ Touch / click / grab / trigger などの event は、発生時刻を environment
   "eventId": "evt-001",
   "type": "object-click",
   "objectId": "button-1",
-  "serverTime": 1770000000000,
+  "hostTime": 1770000000000,
   "peerId": "..."
 }
 ```
@@ -162,7 +162,7 @@ Touch / click / grab / trigger などの event は、発生時刻を environment
 `OnStart` は scene load / graph start 時に発火する local event として扱う。
 
 - Scene Sync では `OnStart` を同期 event として broadcast しない。
-- 各 client の scene load timing はずれるため、同期が必要な処理は server time / explicit event を使う。
+- 各 client の scene load timing はずれるため、同期が必要な処理は host-provided time / explicit event を使う。
 - `OnStart` は local 初期化や preview 用に使う。
 
 ---
@@ -175,7 +175,7 @@ Touch / click / grab / trigger などの event は、発生時刻を environment
 - GLB animation は `mixer.update(delta)` だけに依存しない
 - GLB animation と Loomlet object graph は同じ runtime time model を使う
 - 将来の particles / physics / scripts / sounds も同じ `f(t)` モデルに乗せる
-- 同期が必要な animation / behavior は、将来的に server time 基準で評価する
+- 同期が必要な animation / behavior は、必要に応じて host-provided time 基準で評価する
 
 ---
 
@@ -205,9 +205,9 @@ Loomlet object graph は、実際に評価される時刻として以下を受�
 time.t = object runtime time (選択中は 0)
 time.delta = object runtime の delta
 time.isPaused = Scene Clock の pause 状態
-time.mode = Scene Clock のモード ('server-follow' | 'local')
+time.mode = Scene Clock のモード ('host-follow' | 'local')
 time.rate = Scene Clock の再生速度
-time.serverNow = 常に現在の server time
+time.hostNow = 現在の host-provided time
 ```
 
 ### 重要: 時刻の独立性

--- a/docs/scene-sync-scene-clock.md
+++ b/docs/scene-sync-scene-clock.md
@@ -36,14 +36,14 @@ Used for: GLB animations, per-object Loomlet behavior evaluation
 A global time coordinate independent of selection state:
 
 ```text
-mode = 'server-follow':
-  t = current server time (synchronized across clients)
+mode = 'host-follow':
+  t = current host-provided time
 
 mode = 'local':
   t = controllable local time (pause, seek, reset, rate)
 ```
 
-Controlled by: Scene Clock API (reset, seek, pause, resume, follow server)
+Controlled by: Scene Clock API (reset, seek, pause, resume, follow host)
 
 Used for: global behavior control, demo/authoring animations
 
@@ -64,9 +64,9 @@ getSceneClockStateForLoomlet(now = performance.now())
       t: number,
       delta: number,
       isPaused: boolean,
-      mode: 'server-follow' | 'local',
+      mode: 'host-follow' | 'local',
       rate: number,
-      serverNow: number (always current server time),
+      hostNow: number (current host-provided time),
     }
 ```
 
@@ -90,10 +90,10 @@ resumeSceneClock(now = performance.now())
   → resumes from paused time
 
 setSceneClockMode(mode, now = performance.now())
-  → switches mode: 'server-follow' | 'local'
+  → switches mode: 'host-follow' | 'local'
 
-followServerClock(now = performance.now())
-  → alias for setSceneClockMode('server-follow')
+followHostClock(now = performance.now())
+  → alias for setSceneClockMode('host-follow')
 ```
 
 ## Loomlet Host Inputs
@@ -108,9 +108,9 @@ inputs['time.delta']     // frame delta for object evaluation
 inputs['time.sceneT']    // Scene Clock global time (same as time.t for normal objects)
 inputs['time.sceneDelta'] // Scene Clock global delta
 inputs['time.isPaused']  // whether Scene Clock is paused
-inputs['time.mode']      // 'server-follow' | 'local'
+inputs['time.mode']      // 'host-follow' | 'local'
 inputs['time.rate']      // playback rate multiplier (1.0 = normal)
-inputs['time.serverNow'] // always current synchronized server time
+inputs['time.hostNow'] // current host-provided time
 ```
 
 Inputs are read-only. Behavior graphs cannot modify time controls.
@@ -118,7 +118,7 @@ Inputs are read-only. Behavior graphs cannot modify time controls.
 ### Note on Delta
 
 - **local mode**: delta = frame-to-frame time delta with rate applied
-- **server-follow mode**: delta = server time delta since last frame
+- **host-follow mode**: delta = host time delta since last frame
 
 ## Example Loomlet Behavior
 
@@ -217,11 +217,11 @@ Each client maintains its own local Scene Clock state. Pausing on one client doe
 Scene Clock debug panel (`#scene-clock-panel`) provides manual time control:
 
 - **Time display**: current `t` in seconds
-- **Mode badge**: 'server-follow' | 'local'
+- **Mode badge**: 'host-follow' | 'local'
 - **Status badge**: 'running' | 'paused'
 - **Reset**: jump to t=0
 - **Pause/Resume**: toggle pause
-- **Follow Server**: return to server-follow mode
+- **Follow Host**: return to host-follow mode
 - **Seek input**: jump to arbitrary time
 - **Rate input**: playback speed multiplier
 

--- a/godot/addons/scene_sync/SceneSyncLoomletRunner.cs
+++ b/godot/addons/scene_sync/SceneSyncLoomletRunner.cs
@@ -125,7 +125,7 @@ public partial class SceneSyncLoomletRunner : Node
         var registry = LoomletFunctionRegistry.CreateDefault();
 
         registry.Register("constant", new[] { "value" }, (inputs, context) => Out(Number(inputs, "value")));
-        registry.Register("serverClock", Array.Empty<string>(), (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
+        registry.Register("clock", Array.Empty<string>(), (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
         registry.Register("sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
             Math.Sin(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
             Number(inputs, "amplitude", 1) + Number(inputs, "offset")));

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -12,7 +12,7 @@ export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },
   // Pinned Loomlet behavior graph runtime. Exported viewers must not depend on afjk.jp at runtime.
   {
-    src: '/assets/vendor/loomlet/0.1.2/loomlet-scenesync-runtime.browser.js',
+    src: '/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js',
     dest: 'viewer/loomlet/loomlet-scenesync-runtime.browser.js',
   },
 ];

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -1,7 +1,7 @@
 import {
   createSceneSyncRuntime,
   LoomletSceneSyncRuntimeVersion,
-} from '../../vendor/loomlet/0.1.2/loomlet-scenesync-runtime.browser.js';
+} from '../../vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js';
 
 export const LOOMLET_RUNTIME_METADATA = Object.freeze({
   version: LoomletSceneSyncRuntimeVersion,
@@ -94,7 +94,7 @@ function clonePosition(position) {
 
 function createRuntimeManager({
   resolveTarget,
-  getServerTime,
+  getHostTime,
   getObjectRuntimeTime,
   isObjectBeingEdited,
   getViewerPosition,
@@ -223,7 +223,7 @@ function createRuntimeManager({
       inputs['time.isPaused'] = clockState.isPaused;
       inputs['time.mode'] = clockState.mode;
       inputs['time.rate'] = clockState.rate;
-      inputs['time.serverNow'] = clockState.serverNow;
+      inputs['time.hostNow'] = clockState.hostNow;
     }
 
     return inputs;
@@ -308,7 +308,7 @@ function createRuntimeManager({
     // - normal object: Scene Clock global time
     const time = entry.scopeObjectId && getObjectRuntimeTime
       ? getObjectRuntimeTime(entry.scopeObjectId, now, clockState)
-      : (clockState?.t ?? getServerTime());
+      : (clockState?.t ?? getHostTime());
 
     // Build host inputs for object-scoped evaluations
     const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId, time, clockState, { getInputRoutingMode }) : {};
@@ -358,7 +358,7 @@ function createRuntimeManager({
     },
     tick(clockState = null, now = performance.now()) {
       // clockState: Scene Clock state from host
-      // If not provided, fall back to server time
+      // If not provided, fall back to host-provided time
       for (const [key, entry] of runtimes) {
         evaluateRuntime(key, entry, clockState, now);
       }
@@ -439,7 +439,7 @@ function createRuntimeManager({
 export function createSceneSyncLoomIntegration({
   getObjectById,
   send,
-  getServerTime,
+  getHostTime = () => performance.now() / 1000,
   getObjectRuntimeTime,
   isObjectBeingEdited,
   showToast,
@@ -455,7 +455,7 @@ export function createSceneSyncLoomIntegration({
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
-    getServerTime,
+    getHostTime,
     getObjectRuntimeTime,
     isObjectBeingEdited,
     getViewerPosition,
@@ -493,7 +493,13 @@ export function createSceneSyncLoomIntegration({
     exportState: () => manager.exportState(),
     importState: (state) => manager.importState(state),
     clearObjectGraph: (objectId) => manager.clearObjectGraph(objectId),
-    tickObjectGraphs: (now) => manager.tick(now),
+    tickObjectGraphs: (clockState = null, now) => {
+      if (typeof clockState === 'number' && now === undefined) {
+        manager.tick(null, clockState);
+        return;
+      }
+      manager.tick(clockState, now);
+    },
     onObjectSelected: () => {},
     onObjectDeselected: (objectId) => manager.resetBehaviorBasesForObject(objectId),
     dispose: () => manager.dispose(),

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1493,7 +1493,7 @@ function ensureObjectRuntime(obj) {
     enabled: true,
     speed: 1,
     startLocalTime: performance.now(),
-    startServerTime: null,
+    startHostTime: null,
     selectedTime: 0,
     ...(obj.userData.runtime || {}),
   };
@@ -1531,17 +1531,17 @@ function getObjectRuntimeTime(objectId, now = performance.now(), clockState = nu
   return Math.max(0, ((now - start) / 1000) * speed);
 }
 
-// TODO: Replace local performance.now() with synchronized server time.
-// Desired deterministic model:
+// The host owns the clock source used for shared runtime behavior.
+// Desired deterministic model when the host supplies a room clock:
 //
 // selected:
 //   t = 0
 //
 // unselected:
-//   t = ((serverNow - runtime.startServerTime) / 1000) * speed
+//   t = ((hostNow - runtime.startHostTime) / 1000) * speed
 //
 // On deselect:
-//   runtime.startServerTime = serverNow
+//   runtime.startHostTime = hostNow
 //
 // This should make GLB animation and Loomlet object graphs deterministic
 // for late joiners and multi-client synchronization.
@@ -4445,13 +4445,13 @@ const sceneInspectorState = {
 // time.delta = object evaluation delta
 // time.sceneDelta = Scene Clock global delta
 const sceneClockState = {
-  mode: 'server-follow',        // 'server-follow' | 'local'
+  mode: 'host-follow',          // 'host-follow' | 'local'
   paused: false,
   localTime: 0,                 // local mode でのみ使用
   pausedAt: null,               // 一時停止時の冷凍時刻
   seekOffset: 0,
   lastUpdateNow: performance.now(),
-  lastServerNow: Date.now() / 1000,  // server-follow mode の delta 計算用
+  lastHostNow: Date.now() / 1000,    // host-follow mode の delta 計算用
   rate: 1,                       // 再生速度倍率
 };
 
@@ -4465,7 +4465,7 @@ function getSceneClockTime(now = performance.now()) {
     return Math.max(0, sceneClockState.localTime + elapsed * sceneClockState.rate);
   }
 
-  // server-follow mode: server time を使用
+  // host-follow mode: host-provided wall-clock seconds
   return Date.now() / 1000;
 }
 
@@ -4481,10 +4481,10 @@ function getSceneClockDelta(now = performance.now()) {
     return delta;
   }
 
-  // server-follow mode: delta from last server time
-  const currentServerNow = Date.now() / 1000;
-  const delta = currentServerNow - sceneClockState.lastServerNow;
-  sceneClockState.lastServerNow = currentServerNow;
+  // host-follow mode: delta from last host time sample
+  const currentHostNow = Date.now() / 1000;
+  const delta = currentHostNow - sceneClockState.lastHostNow;
+  sceneClockState.lastHostNow = currentHostNow;
   return Math.max(0, delta);
 }
 
@@ -4498,7 +4498,7 @@ function getSceneClockStateForLoomlet(now = performance.now()) {
     isPaused: sceneClockState.paused,
     mode: sceneClockState.mode,
     rate: sceneClockState.rate,
-    serverNow: Date.now() / 1000,
+    hostNow: Date.now() / 1000,
   };
 }
 
@@ -4506,14 +4506,14 @@ function setSceneClockMode(mode, now = performance.now()) {
   if (mode === sceneClockState.mode) return;
 
   if (mode === 'local') {
-    // server-follow → local: 現在時刻を localTime として記録
+    // host-follow -> local: 現在時刻を localTime として記録
     const currentTime = getSceneClockTime(now);
     sceneClockState.localTime = currentTime;
     sceneClockState.lastUpdateNow = now;
     sceneClockState.paused = false;
     sceneClockState.pausedAt = null;
-  } else if (mode === 'server-follow') {
-    // local → server-follow: ローカル状態をクリア
+  } else if (mode === 'host-follow') {
+    // local -> host-follow: ローカル状態をクリア
     sceneClockState.localTime = 0;
     sceneClockState.paused = false;
     sceneClockState.pausedAt = null;
@@ -4558,15 +4558,15 @@ function resetSceneClock(now = performance.now()) {
   seekSceneClock(0, now);
 }
 
-function followServerClock(now = performance.now()) {
-  setSceneClockMode('server-follow', now);
+function followHostClock(now = performance.now()) {
+  setSceneClockMode('host-follow', now);
 }
 
 // ── Loom 統合初期化 ──────────────────────────────────
 const loomIntegration = createSceneSyncLoomIntegration({
   getObjectById: (objectId) => managedObjects.get(objectId) || null,
   send: (payload) => broadcast(payload),
-  getServerTime: () => Date.now() / 1000,
+  getHostTime: () => Date.now() / 1000,
   getObjectRuntimeTime,
   isObjectBeingEdited: (objectId) => {
     if (!objectId) return false;
@@ -4632,7 +4632,7 @@ sceneClockTogglePauseBtn?.addEventListener('click', () => {
 });
 
 sceneClockFollowBtn?.addEventListener('click', () => {
-  setSceneClockMode('server-follow');
+  setSceneClockMode('host-follow');
   updateSceneClockUI();
 });
 

--- a/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
+++ b/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
@@ -470,8 +470,7 @@ function buildNodeTypes() {
     sceneSetRotation: 'scene.setRotation',
     sceneSetScale: 'scene.setScale',
     sceneSetVisible: 'scene.setVisible',
-    sceneSetColor: 'scene.setColor',
-    serverClock: 'clock'
+    sceneSetColor: 'scene.setColor'
   };
   for (const [alias, canonical] of Object.entries(adapterAliases)) {
     nodes[alias] = nodes[canonical];

--- a/html/scenesync-loom-demo.html
+++ b/html/scenesync-loom-demo.html
@@ -208,7 +208,7 @@
         <div class="control-group">
           <label>Nodes (JSON array):</label>
           <textarea id="setNodes">[
-  { "id": "clock", "type": "serverClock" },
+  { "id": "clock", "type": "clock" },
   { "id": "sine", "type": "sine", "params": { "freq": 1, "amplitude": 50 } },
   { "id": "pos", "type": "sceneSetPosition", "params": { "target": "cube1" } }
 ]</textarea>

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1348,7 +1348,7 @@
           <span id="scene-clock-time-value">0.00</span>s
         </div>
         <div class="scene-clock-info">
-          <span id="scene-clock-mode" class="scene-clock-badge">server-follow</span>
+          <span id="scene-clock-mode" class="scene-clock-badge">host-follow</span>
           <span id="scene-clock-status" class="scene-clock-badge">running</span>
         </div>
       </div>
@@ -1356,7 +1356,7 @@
       <div class="scene-clock-controls">
         <button id="scene-clock-reset" class="chip" type="button">Reset</button>
         <button id="scene-clock-toggle-pause" class="chip" type="button">Pause</button>
-        <button id="scene-clock-follow" class="chip" type="button">Follow Server</button>
+        <button id="scene-clock-follow" class="chip" type="button">Follow Host</button>
       </div>
 
       <div class="scene-clock-seek">

--- a/packages/scene-sync-mcp/GRAPH_TOOLS.md
+++ b/packages/scene-sync-mcp/GRAPH_TOOLS.md
@@ -35,7 +35,7 @@ Set an **Object Behavior Graph** for one object.
   "objectId": "cat-123",
   "graph": {
     "nodes": [
-      { "id": "clock", "type": "serverClock" },
+      { "id": "clock", "type": "clock" },
       { "id": "jump", "type": "sine", "params": { "freq": 1.2, "amplitude": 0.35, "offset": 0.35 } },
       { "id": "pos", "type": "sceneSetPosition", "params": { "x": 3, "z": -2 } }
     ],
@@ -80,7 +80,7 @@ Clear the room-level **Scene Behavior Graph**.
 
 ## Supported node types
 
-- `serverClock`
+- `clock`
 - `sine`
 - `cosine`
 - `add`

--- a/packages/scene-sync-mcp/src/scene-graph-tools.mjs
+++ b/packages/scene-sync-mcp/src/scene-graph-tools.mjs
@@ -12,11 +12,14 @@ const GRAPH_TOOL_PATCHED = Symbol.for('scene-sync-mcp.scene-graph-tools.patched'
 const GRAPH_TOOLS_REGISTERED = Symbol.for('scene-sync-mcp.scene-graph-tools.registered')
 
 const supportedGraphNodeTypes = [
-  'serverClock',
+  'clock',
   'sine',
   'cosine',
   'add',
+  'multiply',
+  'constant',
   'sceneSetPosition',
+  'sceneOffsetPosition',
   'sceneSetRotation',
   'sceneSetScale',
   'sceneSetColor',

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncLoomletBehaviour.cs
@@ -136,7 +136,7 @@ namespace Afjk.SceneSync
             var registry = LoomletFunctionRegistry.CreateDefault();
 
             registry.Register("constant", new[] { "value" }, (inputs, context) => Out(Number(inputs, "value")));
-            registry.Register("serverClock", new string[0], (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
+            registry.Register("clock", new string[0], (inputs, context) => new Dictionary<string, object> { ["t"] = context.Time });
             registry.Register("sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (inputs, context) => Out(
                 Math.Sin(Number(inputs, "t") * Number(inputs, "freq", 1) * 2 * Math.PI + Number(inputs, "phase")) *
                 Number(inputs, "amplitude", 1) + Number(inputs, "offset")));


### PR DESCRIPTION
## Summary
- remove Loomlet-facing server time/serverClock usage from Scene Sync runtime integration, MCP graph tools, examples, docs, tests, Unity, and Godot bridges
- switch Behavior Graph examples and whitelists to `clock`, with `env.time` supplied by the host
- vendor the updated Loomlet Scene Sync browser runtime under `html/assets/vendor/loomlet/0.3.0` and update export packaging to use it

## Notes
- Scene Sync now treats clock values as host-provided time. Loomlet does not fetch or synchronize time.
- The Scene Clock UI mode name is now `host-follow`; the default implementation still uses the client wall clock unless a host supplies another clock source.

## Validation
- `rg -n "serverClock|time\.serverClock|getServerTime|serverTime|server time|server-synchronized" . -g '!node_modules' -g '!dist' -g '!build'`
- `rg -n "server-follow|serverNow|startServerTime|lastServerNow|Follow Server|followServerClock|import time|offset estimation|offset 推定|RTT" docs html apps packages unity godot -g '!node_modules' -g '!dist' -g '!build' -g '!assets/vendor'`
- `node --test tests/scenesync-loomlet-runtime-integration.test.mjs tests/build-export-package.test.mjs tests/export-scene-document.test.mjs` from `apps/presence-server`
- `node --test tests/scenesync-loomlet-runtime-integration.test.mjs` from `apps/presence-server`
- `npm test` from `packages/scene-sync-mcp`

## Caveat
- `npm test` from `apps/presence-server` printed passing output through the Scene Sync/GPT API suites, but the local process did not terminate in this sandbox. The targeted presence-server tests above completed successfully.