### PR TITLE
[codex] Pin UnityGLTF install URL

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncUnityGltfInstaller.cs
@@ -12,7 +12,7 @@ namespace Afjk.SceneSync.Editor
     internal static class SceneSyncUnityGltfInstaller
     {
         internal const string Define = "SCENESYNC_USE_UNITYGLTF";
-        internal const string PackageUrl = "https://github.com/KhronosGroup/UnityGLTF.git";
+        internal const string PackageUrl = "https://github.com/KhronosGroup/UnityGLTF.git#release/2.19.5";
 
         private static AddRequest _addRequest;
         private static ListRequest _listRequest;

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -91,23 +91,18 @@ Git URL でインストールする場合も、`com.afjk.loomlet-runtime@0.3.0` 
 
 ##### manifest.json による方法
 
-```json
-{
-  "dependencies": {
-    "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git"
-  }
-}
-```
-
-バージョンを固定する場合:
+UnityGLTF は git package のため、default branch ではなく release tag 固定を推奨します。
 
 ```json
 {
   "dependencies": {
-    "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git#release/2.14.1"
+    "org.khronos.unitygltf": "https://github.com/KhronosGroup/UnityGLTF.git#release/2.19.5"
   }
 }
 ```
+
+既存 project で UnityGLTF の PackageCache 由来の `.meta` 警告が出る場合は、Unity Editor を閉じてから
+`Library/PackageCache/org.khronos.unitygltf@*` を削除し、Unity に再取得させてください。
 
 ##### Package Manager UI による方法
 
@@ -115,7 +110,7 @@ Git URL でインストールする場合も、`com.afjk.loomlet-runtime@0.3.0` 
 2. **+** ボタン > **Add package from git URL** を選択
 3. 以下を入力:
    ```
-   https://github.com/KhronosGroup/UnityGLTF.git
+   https://github.com/KhronosGroup/UnityGLTF.git#release/2.19.5
    ```
 
 #### 有効化


### PR DESCRIPTION
## Summary

- Pin the optional UnityGLTF installer URL to `release/2.19.5` instead of the repository default branch.
- Update Scene Sync README examples to recommend the same pinned UnityGLTF URL.
- Document clearing `Library/PackageCache/org.khronos.unitygltf@*` when Unity reports immutable-folder `.meta` warnings from stale package cache contents.

## Why

UnityGLTF's default branch can move and may leave projects with package-cache contents that produce repeated immutable-folder `.meta` warnings. Pinning the optional package install URL makes new installs deterministic and gives existing projects a clear cache recovery step.

## Validation

- Ran `git diff --check` for the two changed files.
- Compared `main...codex/pin-unitygltf-package` on GitHub: 2 files changed, branch is 2 commits ahead and 0 behind.