### PR TITLE
[codex] Add Blender Scene Sync addon export fixes

### DIFF
--- a/blender/addons/scene_sync/README.md
+++ b/blender/addons/scene_sync/README.md
@@ -1,0 +1,62 @@
+# Scene Sync Blender Addon
+
+Blender authoring addon for Scene Sync.
+
+This is intentionally an authoring integration, not a runtime integration. It does not include a Blender runtime/player equivalent to Unity Runtime.
+
+## Install
+
+Copy `blender/addons/scene_sync` into Blender's addons directory, then enable **Scene Sync** from Blender Preferences.
+
+The panel appears in:
+
+```text
+View3D > Sidebar > Scene Sync
+```
+
+## Workflow
+
+1. Connect to `wss://afjk.jp/presence`.
+2. Set a room if needed.
+3. Select Blender mesh roots and run **選択を Publish**.
+4. Move, rotate, scale, rename, or hide published objects to send `scene-delta`.
+5. Use **選択を Unpublish** to remove published objects from Scene Sync without deleting the Blender source object.
+
+Connecting never publishes Blender objects by itself. Objects become visible to other Scene Sync clients only after an explicit publish action.
+
+The publish unit is one selected hierarchy root. If a parent and its children are selected at the same time, only the highest selected parent is published, and its children are included in the same GLB carrier instead of becoming separate Scene Sync objects.
+
+Blender source objects are protected. If another client sends `scene-remove` for a Blender-authored object, the addon unpublishes it locally but does not delete it from the `.blend` scene.
+
+## Wire Model
+
+The addon follows the current Scene Sync carrier asset model:
+
+- `origin: "blender"` for Blender-authored objects
+- `asset.type: "mesh"`
+- `asset.source: "carrier"`
+- `asset.meshPath`
+- `asset.assetId`
+- `asset.mime: "model/gltf-binary"`
+- explicit `visible`
+
+GLB carrier files are exported as shape-only assets. Placement stays in the Scene Sync wire transform.
+
+## Animation
+
+Animation export is enabled by default.
+
+When a published object has Action, NLA, Armature, material, or shape-key animation, the addon exports those animations into the GLB carrier and sends the initial Scene Sync animation state:
+
+```json
+{
+  "animation": {
+    "enabled": true,
+    "clip": 0,
+    "mode": "loop",
+    "speed": 1
+  }
+}
+```
+
+The addon does not run a Blender runtime. Animation playback happens in clients that support GLB animation, such as the Scene Sync web viewer. Root placement is still controlled by Scene Sync wire transforms.

--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -1,0 +1,1017 @@
+"""Scene Sync Blender addon."""
+
+from __future__ import annotations
+
+import time
+
+import bpy
+from bpy.props import BoolProperty, FloatProperty, StringProperty
+from bpy.types import Operator, Panel, PropertyGroup
+
+from . import blob_client, protocol, ws_client
+from .glb_helper import export_object_as_glb, import_glb, object_has_animation
+
+bl_info = {
+    "name": "Scene Sync",
+    "author": "afjk",
+    "version": (0, 19, 6),
+    "blender": (4, 0, 0),
+    "location": "View3D > Sidebar > Scene Sync",
+    "description": "Scene Sync authoring addon for Blender",
+    "category": "3D View",
+    "doc_url": "https://github.com/afjk/afjk.jp",
+}
+
+POLL_INTERVAL = 0.05
+DELTA_THRESHOLD = 0.0001
+OBJECT_ID_PROP = "scene_sync_id"
+REMOTE_PROP = "scene_sync_remote"
+MESH_PATH_PROP = "scene_sync_mesh_path"
+ASSET_ID_PROP = "scene_sync_asset_id"
+ORIGIN_PROP = "scene_sync_origin"
+
+
+class _State:
+    def __init__(self) -> None:
+        self.ws = ws_client.SceneSyncWSClient()
+        self.blob_url = ""
+        self.status = "未接続"
+        self.peers: list[dict] = []
+        self.managed: dict[str, dict] = {}
+        self.locks: dict[str, str] = {}
+        self.scene_received = False
+        self.first_peers_seen = False
+        self.env_id: str | None = None
+        self.currently_locked_object_id: str | None = None
+        self.last_tick = 0.0
+
+    def reset_connection_state(self) -> None:
+        self.status = "未接続"
+        self.peers = []
+        self.locks.clear()
+        self.scene_received = False
+        self.first_peers_seen = False
+        self.currently_locked_object_id = None
+
+    def reset_tracking(self) -> None:
+        self.managed.clear()
+        self.locks.clear()
+        self.scene_received = False
+        self.first_peers_seen = False
+        self.currently_locked_object_id = None
+
+
+_state = _State()
+
+
+def _settings():
+    scene = getattr(bpy.context, "scene", None)
+    return getattr(scene, "scene_sync", None)
+
+
+def _snap(loc, rot, scale, visible: bool) -> list:
+    return [list(loc), list(rot), list(scale), [1.0 if visible else 0.0]]
+
+
+def _snaps_equal(a: list, b: list) -> bool:
+    if not a or not b or len(a) != len(b):
+        return False
+    for va, vb in zip(a, b):
+        if len(va) != len(vb):
+            return False
+        for x, y in zip(va, vb):
+            if abs(float(x) - float(y)) > DELTA_THRESHOLD:
+                return False
+    return True
+
+
+def _is_visible(obj: bpy.types.Object) -> bool:
+    return not bool(obj.hide_viewport)
+
+
+def _obj_snapshot(obj: bpy.types.Object) -> list:
+    loc, rot, scale = obj.matrix_world.decompose()
+    return _snap(
+        protocol.pos_to_wire(loc),
+        protocol.rot_to_wire(rot),
+        protocol.scale_to_wire(scale),
+        _is_visible(obj),
+    )
+
+
+def _has_mesh_visual(obj: bpy.types.Object) -> bool:
+    if obj.type == "MESH":
+        return True
+    return any(child.type == "MESH" for child in obj.children_recursive)
+
+
+def _is_local_authoring_object(obj: bpy.types.Object) -> bool:
+    return bool(obj) and not bool(obj.get(REMOTE_PROP)) and _has_mesh_visual(obj)
+
+
+def _resolve_sync_root(obj: bpy.types.Object | None) -> bpy.types.Object | None:
+    current = obj
+    while current is not None:
+        if current.get(OBJECT_ID_PROP):
+            return current
+        current = current.parent
+    return obj
+
+
+def _find_blender_obj(object_id: str) -> bpy.types.Object | None:
+    for obj in bpy.data.objects:
+        if obj.get(OBJECT_ID_PROP) == object_id:
+            return obj
+    return None
+
+
+def _selected_roots() -> list[bpy.types.Object]:
+    result = []
+    seen = set()
+    for obj in bpy.context.selected_objects:
+        root = _resolve_sync_root(obj)
+        if root is None:
+            continue
+        if root.name in seen:
+            continue
+        seen.add(root.name)
+        result.append(root)
+
+    # If a parent and its children are selected together, publish only the
+    # highest selected parent. One selected root maps to one Scene Sync object.
+    selected_names = {obj.name for obj in result}
+    filtered = []
+    for obj in result:
+        current = obj.parent
+        has_selected_ancestor = False
+        while current is not None:
+            if current.name in selected_names:
+                has_selected_ancestor = True
+                break
+            current = current.parent
+        if not has_selected_ancestor:
+            filtered.append(obj)
+
+    return filtered
+
+
+def _asset_from_payload(payload: dict) -> dict | None:
+    asset = payload.get("asset")
+    if isinstance(asset, dict):
+        mesh_path = payload.get("meshPath")
+        asset_id = payload.get("assetId")
+        if mesh_path and not asset.get("meshPath"):
+            asset = {**asset, "meshPath": mesh_path}
+        if asset_id and not asset.get("assetId"):
+            asset = {**asset, "assetId": asset_id}
+        return asset
+    mesh_path = payload.get("meshPath")
+    if mesh_path:
+        return protocol.build_mesh_asset(str(mesh_path), payload.get("assetId"))
+    return None
+
+
+def _metadata_from_payload(payload: dict) -> dict | None:
+    metadata = payload.get("metadata")
+    return metadata if isinstance(metadata, dict) else None
+
+
+def _animation_from_payload(payload: dict) -> dict | None:
+    animation = payload.get("animation")
+    return animation if isinstance(animation, dict) else None
+
+
+def _remember_object(
+    object_id: str,
+    obj: bpy.types.Object,
+    *,
+    remote: bool,
+    mesh_path: str = "",
+    asset_id: str | None = None,
+    asset: dict | None = None,
+    metadata: dict | None = None,
+    animation: dict | None = None,
+    origin: str | None = None,
+) -> None:
+    obj[OBJECT_ID_PROP] = object_id
+    obj[REMOTE_PROP] = bool(remote)
+    if mesh_path:
+        obj[MESH_PATH_PROP] = mesh_path
+    if asset_id:
+        obj[ASSET_ID_PROP] = asset_id
+    if origin:
+        obj[ORIGIN_PROP] = origin
+
+    _state.managed[object_id] = {
+        "name": obj.name,
+        "snapshot": _obj_snapshot(obj),
+        "remote": bool(remote),
+        "mesh_path": mesh_path,
+        "asset_id": asset_id,
+        "asset": asset,
+        "metadata": metadata,
+        "animation": animation,
+        "origin": origin or ("remote" if remote else "blender"),
+    }
+
+
+def _clear_publish_asset_props(obj: bpy.types.Object | None) -> None:
+    if obj is None:
+        return
+    for key in (MESH_PATH_PROP, ASSET_ID_PROP):
+        if key in obj:
+            del obj[key]
+
+
+def _walk_object_hierarchy(root: bpy.types.Object) -> list[bpy.types.Object]:
+    items = [root]
+    for child in root.children:
+        items.extend(_walk_object_hierarchy(child))
+    return items
+
+
+def _remove_object_hierarchy(root: bpy.types.Object | None) -> None:
+    if root is None:
+        return
+    for obj in reversed(_walk_object_hierarchy(root)):
+        if obj.name in bpy.data.objects:
+            bpy.data.objects.remove(obj, do_unlink=True)
+
+
+def _mark_remote(obj: bpy.types.Object) -> None:
+    obj[REMOTE_PROP] = True
+    for child in obj.children:
+        _mark_remote(child)
+
+
+def _clear_remote_objects() -> None:
+    for object_id, info in list(_state.managed.items()):
+        if not info.get("remote"):
+            continue
+        obj = _find_blender_obj(object_id)
+        _remove_object_hierarchy(obj)
+        _state.managed.pop(object_id, None)
+
+    # Catch orphaned remote children left by older addon versions.
+    for obj in sorted(list(bpy.data.objects), key=lambda item: len(item.children_recursive), reverse=True):
+        if obj.get(REMOTE_PROP):
+            _remove_object_hierarchy(obj)
+
+
+def _handle_ws_messages() -> None:
+    for msg in _state.ws.poll():
+        internal = msg.get("_internal")
+        if internal == "_connected":
+            _state.status = f"接続中 - {_state.ws.room or 'room pending'}"
+            _force_redraw()
+            continue
+        if internal == "_disconnected":
+            _state.reset_connection_state()
+            _force_redraw()
+            continue
+
+        msg_type = msg.get("type", "")
+        if msg_type == "welcome":
+            _state.ws.my_id = str(msg.get("id", ""))
+            _state.ws.room = str(msg.get("room", _state.ws.room))
+            _state.status = f"接続中 - {_state.ws.room}"
+            _force_redraw()
+
+        elif msg_type == "peers":
+            raw = msg.get("peers", [])
+            _state.peers = [p for p in raw if isinstance(p, dict)]
+            _state.ws.peers = _state.peers
+            _state.status = f"接続中 - {_state.ws.room} - {len(_state.peers)} peers"
+            if not _state.first_peers_seen and _state.peers:
+                _state.first_peers_seen = True
+                if not _state.scene_received:
+                    _request_scene()
+            _force_redraw()
+
+        elif msg_type == "handoff":
+            payload = msg.get("payload", {})
+            from_info = msg.get("from", {})
+            if isinstance(payload, dict):
+                _handle_payload(payload, from_info if isinstance(from_info, dict) else {})
+
+        elif msg_type == "ping":
+            _state.ws.send_json({"type": "pong"})
+
+
+def _request_scene() -> None:
+    for peer in _state.peers:
+        peer_id = str(peer.get("id", ""))
+        if peer_id and peer_id != _state.ws.my_id:
+            _state.ws.send_json({
+                "type": "handoff",
+                "targetId": peer_id,
+                "payload": protocol.make_scene_request(),
+            })
+            return
+    _state.scene_received = True
+
+
+def _handle_payload(payload: dict, from_info: dict) -> None:
+    from_id = str(from_info.get("id", ""))
+    if from_id and from_id == _state.ws.my_id:
+        return
+
+    kind = str(payload.get("kind", ""))
+    if kind == "scene-request":
+        _send_scene_state(from_id)
+    elif kind == "scene-state":
+        _apply_scene_state(payload)
+    elif kind == "scene-batch":
+        for op in payload.get("ops") or payload.get("actions") or []:
+            if isinstance(op, dict):
+                _handle_payload(op, from_info)
+    elif kind == "scene-add":
+        _apply_scene_add(payload)
+    elif kind == "scene-delta":
+        _apply_scene_delta(payload)
+    elif kind in {"scene-remove", "scene-delete"}:
+        _apply_scene_remove(payload)
+    elif kind == "scene-mesh":
+        _apply_scene_mesh(payload)
+    elif kind == "scene-env":
+        env_id = payload.get("envId")
+        if isinstance(env_id, str) and env_id:
+            _state.env_id = env_id
+    elif kind == "scene-lock":
+        object_id = str(payload.get("objectId", ""))
+        if object_id and from_id:
+            _state.locks[object_id] = from_id
+    elif kind == "scene-unlock":
+        object_id = str(payload.get("objectId", ""))
+        _state.locks.pop(object_id, None)
+
+
+def _apply_scene_state(payload: dict) -> None:
+    _state.scene_received = True
+    env_id = payload.get("envId")
+    if isinstance(env_id, str) and env_id:
+        _state.env_id = env_id
+
+    objects = payload.get("objects", {})
+    if not isinstance(objects, dict):
+        return
+    for object_id, info in objects.items():
+        if isinstance(info, dict):
+            _apply_scene_add({**info, "objectId": object_id})
+
+
+def _apply_scene_add(payload: dict) -> None:
+    object_id = str(payload.get("objectId", ""))
+    if not object_id:
+        return
+
+    existing = _find_blender_obj(object_id)
+    if existing is not None:
+        _apply_scene_delta(payload)
+        return
+
+    name = str(payload.get("name", object_id))
+    asset = _asset_from_payload(payload)
+    metadata = _metadata_from_payload(payload)
+    animation = _animation_from_payload(payload)
+    mesh_path = str(payload.get("meshPath") or (asset or {}).get("meshPath") or "")
+    asset_id = payload.get("assetId") or (asset or {}).get("assetId")
+    origin = str(payload.get("origin", "remote"))
+    obj = _create_object_for_asset(name, asset, metadata, mesh_path)
+
+    _mark_remote(obj)
+    _apply_transform(obj, protocol.extract_transform(payload))
+    if "visible" in payload:
+        _set_visible(obj, bool(payload.get("visible")))
+
+    _remember_object(
+        object_id,
+        obj,
+        remote=True,
+        mesh_path=mesh_path,
+        asset_id=str(asset_id) if asset_id else None,
+        asset=asset,
+        metadata=metadata,
+        animation=animation,
+        origin=origin,
+    )
+
+
+def _apply_scene_delta(payload: dict) -> None:
+    object_id = str(payload.get("objectId", ""))
+    obj = _find_blender_obj(object_id)
+    if obj is None:
+        return
+
+    name = payload.get("name")
+    if isinstance(name, str) and name:
+        obj.name = name
+
+    if "visible" in payload:
+        _set_visible(obj, bool(payload.get("visible")))
+
+    _apply_transform(obj, protocol.extract_transform(payload))
+
+    if object_id in _state.managed:
+        info = _state.managed[object_id]
+        info["name"] = obj.name
+        info["snapshot"] = _obj_snapshot(obj)
+        asset = _asset_from_payload(payload)
+        metadata = _metadata_from_payload(payload)
+        animation = _animation_from_payload(payload)
+        if asset is not None:
+            info["asset"] = asset
+            mesh_path = asset.get("meshPath")
+            asset_id = asset.get("assetId")
+            if mesh_path:
+                info["mesh_path"] = mesh_path
+                obj[MESH_PATH_PROP] = mesh_path
+            if asset_id:
+                info["asset_id"] = asset_id
+                obj[ASSET_ID_PROP] = asset_id
+        if metadata is not None:
+            info["metadata"] = metadata
+        if animation is not None:
+            info["animation"] = animation
+
+
+def _apply_scene_remove(payload: dict) -> None:
+    object_id = str(payload.get("objectId", ""))
+    info = _state.managed.get(object_id)
+    obj = _find_blender_obj(object_id)
+
+    if info and not info.get("remote"):
+        # Blender is an authoring tool, not a runtime. Remote removal unpublishes
+        # the local source object but never deletes it from the .blend scene.
+        _clear_publish_asset_props(obj)
+        del _state.managed[object_id]
+        _state.locks.pop(object_id, None)
+        return
+
+    _remove_object_hierarchy(obj)
+    _state.managed.pop(object_id, None)
+    _state.locks.pop(object_id, None)
+
+
+def _apply_scene_mesh(payload: dict) -> None:
+    object_id = str(payload.get("objectId", ""))
+    asset = _asset_from_payload(payload)
+    mesh_path = str(payload.get("meshPath") or (asset or {}).get("meshPath") or "")
+    if not object_id or not mesh_path:
+        return
+
+    data = blob_client.download_glb(_state.blob_url, mesh_path)
+    if not data:
+        return
+
+    old = _find_blender_obj(object_id)
+    info = _state.managed.get(object_id, {})
+    if info and not info.get("remote"):
+        info["mesh_path"] = mesh_path
+        info["asset"] = asset
+        if old is not None:
+            old[MESH_PATH_PROP] = mesh_path
+        return
+
+    name = str(payload.get("name") or (old.name if old else object_id))
+    visual_basis = (asset or {}).get("visualBasis")
+    new = import_glb(data, name, visual_basis)
+    if new is None:
+        return
+    _mark_remote(new)
+    if old is not None:
+        new.matrix_world = old.matrix_world.copy()
+        _remove_object_hierarchy(old)
+    _remember_object(
+        object_id,
+        new,
+        remote=True,
+        mesh_path=mesh_path,
+        asset_id=(asset or {}).get("assetId"),
+        asset=asset,
+        metadata=info.get("metadata"),
+        animation=info.get("animation"),
+        origin=info.get("origin", "remote"),
+    )
+
+
+def _create_object_for_asset(
+    name: str,
+    asset: dict | None,
+    metadata: dict | None,
+    mesh_path: str,
+) -> bpy.types.Object:
+    asset_type = (asset or {}).get("type")
+    if asset_type == "primitive":
+        return _create_primitive(
+            str((asset or {}).get("primitive", "box")),
+            str((asset or {}).get("color", "#888888")),
+            name,
+        )
+
+    if asset_type == "text":
+        return _create_text_placeholder(name, str((asset or {}).get("text", name)))
+
+    if mesh_path:
+        data = blob_client.download_glb(_state.blob_url, mesh_path)
+        if data:
+            imported = import_glb(data, name, (asset or {}).get("visualBasis"))
+            if imported is not None:
+                return imported
+
+    label = asset_type or (metadata or {}).get("role") or "remote"
+    return _create_primitive("box", "#88ccff", f"{name} ({label})")
+
+
+def _send_scene_state(to_peer_id: str) -> None:
+    if not to_peer_id:
+        return
+
+    objects = {}
+    for object_id, info in list(_state.managed.items()):
+        obj = _find_blender_obj(object_id)
+        if obj is None:
+            continue
+        loc, rot, scale = obj.matrix_world.decompose()
+        entry = {
+            "name": obj.name,
+            "origin": info.get("origin") or ("remote" if info.get("remote") else "blender"),
+            "position": protocol.pos_to_wire(loc),
+            "rotation": protocol.rot_to_wire(rot),
+            "scale": protocol.scale_to_wire(scale),
+            "visible": _is_visible(obj),
+        }
+        mesh_path = info.get("mesh_path") or obj.get(MESH_PATH_PROP)
+        asset_id = info.get("asset_id") or obj.get(ASSET_ID_PROP)
+        asset = info.get("asset")
+        metadata = info.get("metadata")
+        animation = info.get("animation")
+        if mesh_path:
+            entry["meshPath"] = mesh_path
+        if asset_id:
+            entry["assetId"] = asset_id
+        if asset:
+            entry["asset"] = asset
+        elif mesh_path:
+            entry["asset"] = protocol.build_mesh_asset(mesh_path, asset_id)
+        if metadata:
+            entry["metadata"] = metadata
+        if animation:
+            entry["animation"] = animation
+        objects[object_id] = entry
+
+    _state.ws.send_json({
+        "type": "handoff",
+        "targetId": to_peer_id,
+        "payload": protocol.make_scene_state(objects, _state.env_id),
+    })
+
+
+def _check_scene_changes() -> None:
+    if not _state.ws.connected:
+        return
+
+    current_ids = set()
+    for object_id, info in list(_state.managed.items()):
+        obj = _find_blender_obj(object_id)
+        if obj is None:
+            _state.ws.send_json({
+                "type": "broadcast",
+                "payload": protocol.make_scene_remove(object_id),
+            })
+            _state.managed.pop(object_id, None)
+            continue
+
+        current_ids.add(object_id)
+        snap = _obj_snapshot(obj)
+        if not _snaps_equal(snap, info.get("snapshot")):
+            info["snapshot"] = snap
+            loc, rot, scale = obj.matrix_world.decompose()
+            _state.ws.send_json({
+                "type": "broadcast",
+                "payload": protocol.make_scene_delta(
+                    object_id,
+                    loc,
+                    rot,
+                    scale,
+                    name=obj.name,
+                    visible=_is_visible(obj),
+                ),
+            })
+
+    _update_selection_lock(current_ids)
+
+
+def _update_selection_lock(current_ids: set[str]) -> None:
+    active = _resolve_sync_root(bpy.context.view_layer.objects.active)
+    object_id = None
+    if active is not None:
+        maybe_id = str(active.get(OBJECT_ID_PROP, ""))
+        if maybe_id in current_ids:
+            object_id = maybe_id
+
+    if object_id == _state.currently_locked_object_id:
+        return
+
+    if _state.currently_locked_object_id:
+        _state.ws.send_json({
+            "type": "broadcast",
+            "payload": protocol.make_scene_unlock(_state.currently_locked_object_id),
+        })
+
+    _state.currently_locked_object_id = object_id
+    if object_id:
+        _state.ws.send_json({
+            "type": "broadcast",
+            "payload": protocol.make_scene_lock(object_id),
+        })
+
+
+def _publish_object(obj: bpy.types.Object, *, force_upload: bool = False) -> bool:
+    if not _is_local_authoring_object(obj):
+        return False
+
+    object_id = str(obj.get(OBJECT_ID_PROP, "")) or protocol.generate_object_id()
+    obj[OBJECT_ID_PROP] = object_id
+    obj[ORIGIN_PROP] = "blender"
+
+    settings = _settings()
+    include_animations = bool(getattr(settings, "export_animations", True))
+    has_animation = include_animations and object_has_animation(obj)
+
+    loc, rot, scale = obj.matrix_world.decompose()
+    glb = export_object_as_glb(obj, include_animations=include_animations)
+    if not glb:
+        return False
+
+    max_mib = float(getattr(settings, "max_upload_mib", 50.0) or 50.0)
+    if len(glb) > max_mib * 1024 * 1024:
+        print(f"[SceneSync] GLB upload skipped: {obj.name} is larger than {max_mib:.1f} MiB")
+        return False
+
+    mesh_path = protocol.generate_mesh_path()
+    asset_id = protocol.compute_asset_id(glb)
+    if not blob_client.upload_glb(_state.blob_url, mesh_path, glb):
+        return False
+
+    asset = protocol.build_mesh_asset(
+        mesh_path,
+        asset_id,
+        size=len(glb),
+        original_name=obj.name,
+    )
+    if has_animation:
+        asset["animation"] = True
+
+    metadata = None
+    animation = None
+    if has_animation:
+        metadata = {
+            "animationExport": {
+                "source": "blender",
+                "enabled": True,
+            }
+        }
+        animation = {
+            "enabled": True,
+            "clip": 0,
+            "mode": "loop",
+            "speed": 1,
+        }
+
+    payload = protocol.make_scene_add(
+        object_id,
+        obj.name,
+        loc,
+        rot,
+        scale,
+        mesh_path=mesh_path,
+        asset_id=asset_id,
+        asset=asset,
+        metadata=metadata,
+        animation=animation,
+        visible=_is_visible(obj),
+        origin="blender",
+    )
+    _state.ws.send_json({"type": "broadcast", "payload": payload})
+    _remember_object(
+        object_id,
+        obj,
+        remote=False,
+        mesh_path=mesh_path,
+        asset_id=asset_id,
+        asset=asset,
+        metadata=metadata,
+        animation=animation,
+        origin="blender",
+    )
+    return True
+
+
+def _unpublish_object(obj: bpy.types.Object) -> bool:
+    object_id = str(obj.get(OBJECT_ID_PROP, ""))
+    if not object_id:
+        return False
+    if _state.ws.connected:
+        _state.ws.send_json({
+            "type": "broadcast",
+            "payload": protocol.make_scene_remove(object_id),
+        })
+    _clear_publish_asset_props(obj)
+    _state.managed.pop(object_id, None)
+    _state.locks.pop(object_id, None)
+    return True
+
+
+def _set_visible(obj: bpy.types.Object, visible: bool) -> None:
+    obj.hide_viewport = not visible
+    obj.hide_render = not visible
+
+
+def _create_primitive(primitive: str, color_hex: str, name: str) -> bpy.types.Object:
+    dispatch = {
+        "box": lambda: bpy.ops.mesh.primitive_cube_add(size=1),
+        "cube": lambda: bpy.ops.mesh.primitive_cube_add(size=1),
+        "sphere": lambda: bpy.ops.mesh.primitive_uv_sphere_add(radius=0.5),
+        "cylinder": lambda: bpy.ops.mesh.primitive_cylinder_add(radius=0.5, depth=1),
+        "cone": lambda: bpy.ops.mesh.primitive_cone_add(radius1=0.5, depth=1),
+        "plane": lambda: bpy.ops.mesh.primitive_plane_add(size=1),
+        "torus": lambda: bpy.ops.mesh.primitive_torus_add(),
+    }
+    dispatch.get(primitive, dispatch["box"])()
+    obj = bpy.context.active_object
+    obj.name = name
+    mat = bpy.data.materials.new(f"SceneSync_{name}")
+    mat.use_nodes = True
+    principled = mat.node_tree.nodes.get("Principled BSDF")
+    if principled:
+        r, g, b = protocol.hex_to_rgb(color_hex)
+        principled.inputs["Base Color"].default_value = (r, g, b, 1.0)
+    obj.data.materials.append(mat)
+    return obj
+
+
+def _create_text_placeholder(name: str, text: str) -> bpy.types.Object:
+    bpy.ops.object.text_add()
+    obj = bpy.context.active_object
+    obj.name = name
+    obj.data.body = text[:512]
+    obj.data.align_x = "CENTER"
+    obj.data.align_y = "CENTER"
+    obj.data.size = 0.4
+    return obj
+
+
+def _apply_transform(obj: bpy.types.Object, tf: dict) -> None:
+    from mathutils import Matrix
+
+    if not tf:
+        return
+
+    cur_loc, cur_rot, cur_scl = obj.matrix_world.decompose()
+    loc = tf.get("loc", cur_loc)
+    rot = tf.get("rot", cur_rot)
+    scale = tf.get("scale", cur_scl)
+    obj.matrix_world = (
+        Matrix.Translation(loc)
+        @ rot.to_matrix().to_4x4()
+        @ Matrix.Diagonal([scale.x, scale.y, scale.z, 1.0])
+    )
+
+
+def _timer_callback() -> float:
+    try:
+        _handle_ws_messages()
+        now = time.monotonic()
+        if _state.ws.connected and now - _state.last_tick >= POLL_INTERVAL:
+            _state.last_tick = now
+            _check_scene_changes()
+    except Exception as e:
+        print(f"[SceneSync] Timer error: {e}")
+    return POLL_INTERVAL
+
+
+def _force_redraw() -> None:
+    screen = getattr(bpy.context, "screen", None)
+    for area in screen.areas if screen else []:
+        if area.type == "VIEW_3D":
+            area.tag_redraw()
+
+
+class SCENE_SYNC_OT_connect(Operator):
+    bl_idname = "scene_sync.connect"
+    bl_label = "接続"
+    bl_description = "Scene Sync サーバーに接続する"
+
+    def execute(self, context):
+        settings = context.scene.scene_sync
+        url = settings.presence_url.strip()
+        room = settings.room.strip()
+        nickname = settings.nickname.strip() or "Blender"
+
+        _clear_remote_objects()
+        _state.blob_url = settings.blob_url.strip() or blob_client.presence_url_to_blob_url(url)
+        _state.reset_tracking()
+        _state.status = "接続中..."
+        _state.ws.connect(url, room, nickname, f"Blender {bpy.app.version_string}")
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_disconnect(Operator):
+    bl_idname = "scene_sync.disconnect"
+    bl_label = "切断"
+    bl_description = "Scene Sync サーバーから切断する"
+
+    def execute(self, context):
+        _clear_remote_objects()
+        _state.ws.disconnect()
+        _state.reset_connection_state()
+        _force_redraw()
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_publish_selected(Operator):
+    bl_idname = "scene_sync.publish_selected"
+    bl_label = "選択を Publish"
+    bl_description = "選択中の Blender オブジェクトを Scene Sync に公開する"
+
+    def execute(self, context):
+        if not _state.ws.connected:
+            self.report({"WARNING"}, "接続されていません")
+            return {"CANCELLED"}
+
+        count = sum(1 for obj in _selected_roots() if _publish_object(obj, force_upload=True))
+        self.report({"INFO"}, f"{count} 個のオブジェクトを Publish しました")
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_publish_all_meshes(Operator):
+    bl_idname = "scene_sync.publish_all_meshes"
+    bl_label = "全メッシュを Publish"
+    bl_description = "シーン内のローカルメッシュを Scene Sync に公開する"
+
+    def execute(self, context):
+        if not _state.ws.connected:
+            self.report({"WARNING"}, "接続されていません")
+            return {"CANCELLED"}
+
+        count = 0
+        for obj in context.scene.objects:
+            if obj.parent is None and _publish_object(obj, force_upload=True):
+                count += 1
+        self.report({"INFO"}, f"{count} 個のオブジェクトを Publish しました")
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_unpublish_selected(Operator):
+    bl_idname = "scene_sync.unpublish_selected"
+    bl_label = "選択を Unpublish"
+    bl_description = "選択中のオブジェクトを Scene Sync から削除する。Blender の原本は削除しない"
+
+    def execute(self, context):
+        count = sum(1 for obj in _selected_roots() if _unpublish_object(obj))
+        self.report({"INFO"}, f"{count} 個のオブジェクトを Unpublish しました")
+        return {"FINISHED"}
+
+
+class SCENE_SYNC_OT_sync_meshes(Operator):
+    bl_idname = "scene_sync.sync_meshes"
+    bl_label = "公開済みメッシュを再送信"
+    bl_description = "公開済みローカルメッシュを再エクスポートして blob にアップロードする"
+
+    def execute(self, context):
+        if not _state.ws.connected:
+            self.report({"WARNING"}, "接続されていません")
+            return {"CANCELLED"}
+
+        count = 0
+        for object_id, info in list(_state.managed.items()):
+            if info.get("remote"):
+                continue
+            obj = _find_blender_obj(object_id)
+            if obj is not None and _publish_object(obj, force_upload=True):
+                count += 1
+        self.report({"INFO"}, f"{count} 個のメッシュを再送信しました")
+        return {"FINISHED"}
+
+
+class SceneSyncSettings(PropertyGroup):
+    presence_url: StringProperty(
+        name="サーバー URL",
+        default="wss://afjk.jp/presence",
+        description="Scene Sync presence server の WebSocket URL",
+    )  # type: ignore[assignment]
+
+    blob_url: StringProperty(
+        name="Blob URL",
+        default="",
+        description="空の場合はサーバー URL から /blob を自動推定します",
+    )  # type: ignore[assignment]
+
+    room: StringProperty(
+        name="ルーム",
+        default="",
+        description="参加するルーム ID",
+    )  # type: ignore[assignment]
+
+    nickname: StringProperty(
+        name="ニックネーム",
+        default="Blender",
+        description="表示名",
+    )  # type: ignore[assignment]
+
+    max_upload_mib: FloatProperty(
+        name="最大 GLB サイズ (MiB)",
+        default=50.0,
+        min=1.0,
+        description="このサイズを超える GLB はアップロードしません",
+    )  # type: ignore[assignment]
+
+    export_animations: BoolProperty(
+        name="Animation を GLB に含める",
+        default=True,
+        description="Action / NLA / Armature / shape key animation を GLB carrier に含めます",
+    )  # type: ignore[assignment]
+
+
+class SCENE_SYNC_PT_panel(Panel):
+    bl_label = "Scene Sync"
+    bl_idname = "SCENE_SYNC_PT_panel"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Scene Sync"
+
+    def draw(self, context):
+        layout = self.layout
+        settings = context.scene.scene_sync
+        connected = _state.ws.connected
+
+        col = layout.column(align=True)
+        col.enabled = not connected
+        col.prop(settings, "presence_url", text="URL")
+        col.prop(settings, "blob_url", text="Blob")
+        col.prop(settings, "room", text="ルーム")
+        col.prop(settings, "nickname", text="名前")
+
+        row = layout.row(align=True)
+        if connected:
+            row.operator("scene_sync.disconnect", icon="UNLINKED")
+        else:
+            row.operator("scene_sync.connect", icon="LINKED")
+
+        box = layout.box()
+        box.label(text=_state.status, icon="INFO")
+        if connected:
+            box.label(text=f"Room: {_state.ws.room or '-'}")
+            box.label(text=f"Managed: {len(_state.managed)} / Peers: {len(_state.peers)}")
+
+        layout.separator()
+        layout.label(text="Authoring", icon="OUTLINER_OB_MESH")
+        col = layout.column(align=True)
+        col.enabled = connected
+        col.operator("scene_sync.publish_selected", icon="EXPORT")
+        col.operator("scene_sync.publish_all_meshes", icon="OUTLINER_COLLECTION")
+        col.operator("scene_sync.sync_meshes", icon="FILE_REFRESH")
+        col.operator("scene_sync.unpublish_selected", icon="TRASH")
+
+        layout.separator()
+        layout.prop(settings, "max_upload_mib")
+        layout.prop(settings, "export_animations")
+
+        if connected and _state.peers:
+            layout.separator()
+            layout.label(text="参加者:", icon="COMMUNITY")
+            for peer in _state.peers:
+                nick = str(peer.get("nickname") or peer.get("id") or "?")
+                device = str(peer.get("device") or "")
+                layout.label(text=f"{nick} {f'({device})' if device else ''}")
+
+
+_classes = (
+    SceneSyncSettings,
+    SCENE_SYNC_OT_connect,
+    SCENE_SYNC_OT_disconnect,
+    SCENE_SYNC_OT_publish_selected,
+    SCENE_SYNC_OT_publish_all_meshes,
+    SCENE_SYNC_OT_unpublish_selected,
+    SCENE_SYNC_OT_sync_meshes,
+    SCENE_SYNC_PT_panel,
+)
+
+
+def register():
+    for cls in _classes:
+        bpy.utils.register_class(cls)
+    bpy.types.Scene.scene_sync = bpy.props.PointerProperty(type=SceneSyncSettings)
+    if not bpy.app.timers.is_registered(_timer_callback):
+        bpy.app.timers.register(_timer_callback, first_interval=POLL_INTERVAL, persistent=True)
+
+
+def unregister():
+    if bpy.app.timers.is_registered(_timer_callback):
+        bpy.app.timers.unregister(_timer_callback)
+    if hasattr(bpy.types.Scene, "scene_sync"):
+        del bpy.types.Scene.scene_sync
+    for cls in reversed(_classes):
+        bpy.utils.unregister_class(cls)
+    _state.ws.disconnect()

--- a/blender/addons/scene_sync/__init__.py
+++ b/blender/addons/scene_sync/__init__.py
@@ -637,10 +637,15 @@ def _publish_object(obj: bpy.types.Object, *, force_upload: bool = False) -> boo
 
     settings = _settings()
     include_animations = bool(getattr(settings, "export_animations", True))
+    normalize_alpha_modes = bool(getattr(settings, "normalize_glb_alpha_modes", True))
     has_animation = include_animations and object_has_animation(obj)
 
     loc, rot, scale = obj.matrix_world.decompose()
-    glb = export_object_as_glb(obj, include_animations=include_animations)
+    glb = export_object_as_glb(
+        obj,
+        include_animations=include_animations,
+        normalize_alpha_modes=normalize_alpha_modes,
+    )
     if not glb:
         return False
 
@@ -933,6 +938,12 @@ class SceneSyncSettings(PropertyGroup):
         description="Action / NLA / Armature / shape key animation を GLB carrier に含めます",
     )  # type: ignore[assignment]
 
+    normalize_glb_alpha_modes: BoolProperty(
+        name="GLB alpha modes を正規化",
+        default=True,
+        description="GLB export 後に材質の alphaMode を OPAQUE / MASK / BLEND に整理し、透明描画順の崩れを減らします",
+    )  # type: ignore[assignment]
+
 
 class SCENE_SYNC_PT_panel(Panel):
     bl_label = "Scene Sync"
@@ -977,6 +988,7 @@ class SCENE_SYNC_PT_panel(Panel):
         layout.separator()
         layout.prop(settings, "max_upload_mib")
         layout.prop(settings, "export_animations")
+        layout.prop(settings, "normalize_glb_alpha_modes")
 
         if connected and _state.peers:
             layout.separator()

--- a/blender/addons/scene_sync/blob_client.py
+++ b/blender/addons/scene_sync/blob_client.py
@@ -1,0 +1,53 @@
+"""HTTP helpers for the Scene Sync blob store."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from urllib.parse import urlsplit, urlunsplit
+
+
+def upload_glb(blob_base_url: str, path: str, data: bytes) -> bool:
+    """POST data to ``<blob_base_url>/<path>``."""
+    if not data:
+        print(f"[SceneSync] Blob upload skipped: empty data for {path}")
+        return False
+
+    url = f"{blob_base_url.rstrip('/')}/{path}"
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "model/gltf-binary"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as e:
+        print(f"[SceneSync] Blob upload HTTP error {e.code}: {path}")
+        return False
+    except Exception as e:
+        print(f"[SceneSync] Blob upload error: {e}")
+        return False
+
+
+def download_glb(blob_base_url: str, path: str) -> bytes | None:
+    """GET ``<blob_base_url>/<path>``."""
+    if not path:
+        return None
+
+    url = f"{blob_base_url.rstrip('/')}/{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp:
+            return resp.read()
+    except Exception as e:
+        print(f"[SceneSync] Blob download error: {e}")
+        return None
+
+
+def presence_url_to_blob_url(presence_url: str) -> str:
+    """Derive blob store URL from the presence server WebSocket URL."""
+    parts = urlsplit(presence_url)
+    scheme = "https" if parts.scheme in {"wss", "https"} else "http"
+    path = parts.path.rstrip("/") + "/blob"
+    return urlunsplit((scheme, parts.netloc, path, "", ""))

--- a/blender/addons/scene_sync/glb_alpha_modes.py
+++ b/blender/addons/scene_sync/glb_alpha_modes.py
@@ -1,0 +1,273 @@
+"""GLB material alpha-mode normalization helpers."""
+
+from __future__ import annotations
+
+import json
+import struct
+import zlib
+from collections import Counter
+
+
+GLB_MAGIC = 0x46546C67
+GLB_VERSION = 2
+JSON_CHUNK = 0x4E4F534A
+BIN_CHUNK = 0x004E4942
+
+BLEND_NAME_HINTS = (
+    "glass",
+    "lens",
+    "wing",
+    "cheek",
+    "shadow",
+    "fade",
+    "trans",
+    "alpha",
+    "semi",
+)
+
+
+def _paeth(a: int, b: int, c: int) -> int:
+    p = a + b - c
+    pa = abs(p - a)
+    pb = abs(p - b)
+    pc = abs(p - c)
+    if pa <= pb and pa <= pc:
+        return a
+    return b if pb <= pc else c
+
+
+def _decode_png_alpha(blob: bytes) -> dict:
+    if not blob.startswith(b"\x89PNG\r\n\x1a\n"):
+        return {"hasAlpha": True, "decoded": False}
+
+    pos = 8
+    ihdr = None
+    idat = []
+    trns = None
+
+    while pos + 8 <= len(blob):
+        length = int.from_bytes(blob[pos:pos + 4], "big")
+        chunk_type = blob[pos + 4:pos + 8]
+        pos += 8
+        chunk = blob[pos:pos + length]
+        pos += length + 4
+
+        if chunk_type == b"IHDR":
+            ihdr = chunk
+        elif chunk_type == b"IDAT":
+            idat.append(chunk)
+        elif chunk_type == b"tRNS":
+            trns = chunk
+        elif chunk_type == b"IEND":
+            break
+
+    if ihdr is None:
+        return {"hasAlpha": False, "decoded": False}
+
+    width, height, bit_depth, color_type, _comp, _filter, interlace = struct.unpack(">IIBBBBB", ihdr)
+    channels = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}.get(color_type)
+    has_alpha = color_type in (4, 6) or trns is not None
+
+    if not has_alpha:
+        return {"hasAlpha": False, "decoded": True}
+    if bit_depth != 8 or interlace != 0 or channels is None:
+        return {"hasAlpha": True, "decoded": False}
+
+    raw = zlib.decompress(b"".join(idat))
+    stride = width * channels
+    previous = bytearray(stride)
+    histogram = Counter()
+
+    for y in range(height):
+        row_start = y * (stride + 1)
+        filter_type = raw[row_start]
+        scanline = bytearray(raw[row_start + 1:row_start + 1 + stride])
+
+        for i in range(stride):
+            left = scanline[i - channels] if i >= channels else 0
+            up = previous[i]
+            upper_left = previous[i - channels] if i >= channels else 0
+
+            if filter_type == 1:
+                scanline[i] = (scanline[i] + left) & 255
+            elif filter_type == 2:
+                scanline[i] = (scanline[i] + up) & 255
+            elif filter_type == 3:
+                scanline[i] = (scanline[i] + ((left + up) // 2)) & 255
+            elif filter_type == 4:
+                scanline[i] = (scanline[i] + _paeth(left, up, upper_left)) & 255
+
+        if color_type == 6:
+            for x in range(width):
+                histogram[scanline[x * 4 + 3]] += 1
+        elif color_type == 4:
+            for x in range(width):
+                histogram[scanline[x * 2 + 1]] += 1
+        elif color_type == 3 and trns is not None:
+            for x in range(width):
+                index = scanline[x]
+                histogram[trns[index] if index < len(trns) else 255] += 1
+
+        previous = scanline
+
+    total = max(width * height, 1)
+    transparent = histogram[0]
+    opaque = histogram[255]
+    partial = total - transparent - opaque
+
+    return {
+        "hasAlpha": True,
+        "decoded": True,
+        "alphaMax": max(histogram) if histogram else None,
+        "transparentPct": transparent * 100.0 / total,
+        "partialPct": partial * 100.0 / total,
+    }
+
+
+def _parse_glb(data: bytes) -> tuple[dict, bytes]:
+    if len(data) < 20:
+        raise ValueError("GLB is too small")
+
+    magic, version, _length = struct.unpack_from("<III", data, 0)
+    if magic != GLB_MAGIC or version != GLB_VERSION:
+        raise ValueError("Only glTF 2.0 GLB is supported")
+
+    json_data = None
+    bin_data = None
+    offset = 12
+    while offset < len(data):
+        chunk_length, chunk_type = struct.unpack_from("<II", data, offset)
+        offset += 8
+        chunk = data[offset:offset + chunk_length]
+        offset += chunk_length
+        if chunk_type == JSON_CHUNK:
+            json_data = chunk
+        elif chunk_type == BIN_CHUNK:
+            bin_data = chunk
+
+    if json_data is None or bin_data is None:
+        raise ValueError("GLB must contain JSON and BIN chunks")
+
+    return json.loads(json_data.decode("utf-8")), bin_data
+
+
+def _pack_glb(gltf: dict, bin_data: bytes) -> bytes:
+    json_data = json.dumps(gltf, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    json_data += b" " * ((4 - len(json_data) % 4) % 4)
+    total_length = 12 + 8 + len(json_data) + 8 + len(bin_data)
+
+    return b"".join([
+        struct.pack("<III", GLB_MAGIC, GLB_VERSION, total_length),
+        struct.pack("<II", len(json_data), JSON_CHUNK),
+        json_data,
+        struct.pack("<II", len(bin_data), BIN_CHUNK),
+        bin_data,
+    ])
+
+
+def _image_blob(gltf: dict, bin_data: bytes, image_index: int) -> bytes | None:
+    images = gltf.get("images", [])
+    buffer_views = gltf.get("bufferViews", [])
+    if image_index < 0 or image_index >= len(images):
+        return None
+
+    buffer_view_index = images[image_index].get("bufferView")
+    if buffer_view_index is None:
+        return None
+
+    view = buffer_views[buffer_view_index]
+    offset = view.get("byteOffset", 0)
+    length = view.get("byteLength", 0)
+    return bin_data[offset:offset + length]
+
+
+def _base_image_index(gltf: dict, material: dict) -> int | None:
+    texture_index = material.get("pbrMetallicRoughness", {}).get("baseColorTexture", {}).get("index")
+    if texture_index is None:
+        return None
+
+    textures = gltf.get("textures", [])
+    if texture_index < 0 or texture_index >= len(textures):
+        return None
+
+    return textures[texture_index].get("source")
+
+
+def _base_alpha(material: dict) -> float:
+    factor = material.get("pbrMetallicRoughness", {}).get("baseColorFactor", [1, 1, 1, 1])
+    if isinstance(factor, list) and len(factor) >= 4:
+        try:
+            return float(factor[3])
+        except Exception:
+            return 1.0
+    return 1.0
+
+
+def _choose_alpha_mode(name: str, material: dict, alpha: dict | None) -> tuple[str, float | None]:
+    if _base_alpha(material) < 0.999:
+        return "BLEND", None
+
+    if not alpha or not alpha.get("hasAlpha"):
+        return "OPAQUE", None
+
+    if not alpha.get("decoded"):
+        return material.get("alphaMode", "OPAQUE"), material.get("alphaCutoff")
+
+    transparent_pct = float(alpha.get("transparentPct") or 0.0)
+    partial_pct = float(alpha.get("partialPct") or 0.0)
+    alpha_max = alpha.get("alphaMax")
+    wants_blend = any(hint in name.lower() for hint in BLEND_NAME_HINTS)
+
+    if alpha_max is not None and alpha_max < 255:
+        return "BLEND", None
+
+    if transparent_pct > 0.01:
+        if wants_blend:
+            return "BLEND", None
+        return "MASK", 0.10
+
+    if partial_pct > 24.0 and wants_blend:
+        return "BLEND", None
+
+    # Partial-only alpha often contains non-visibility data or baked shading.
+    return "OPAQUE", None
+
+
+def normalize_glb_alpha_modes(data: bytes) -> tuple[bytes, dict]:
+    """Return GLB bytes with material alpha modes adjusted for stable rendering."""
+    gltf, bin_data = _parse_glb(data)
+    image_alpha_cache = {}
+    changed = []
+
+    for index, material in enumerate(gltf.get("materials", [])):
+        name = material.get("name") or f"material_{index}"
+        image_index = _base_image_index(gltf, material)
+        alpha = None
+
+        if image_index is not None:
+            if image_index not in image_alpha_cache:
+                blob = _image_blob(gltf, bin_data, image_index)
+                image_alpha_cache[image_index] = _decode_png_alpha(blob) if blob else None
+            alpha = image_alpha_cache[image_index]
+
+        before = material.get("alphaMode", "OPAQUE")
+        mode, cutoff = _choose_alpha_mode(name, material, alpha)
+
+        if mode == "OPAQUE":
+            material.pop("alphaMode", None)
+            material.pop("alphaCutoff", None)
+        elif mode == "MASK":
+            material["alphaMode"] = "MASK"
+            material["alphaCutoff"] = cutoff if cutoff is not None else 0.10
+        else:
+            material["alphaMode"] = "BLEND"
+            material.pop("alphaCutoff", None)
+
+        after = material.get("alphaMode", "OPAQUE")
+        if before != after:
+            changed.append({"index": index, "name": name, "before": before, "after": after})
+
+    if not changed:
+        return data, {"changed": False, "materials": []}
+
+    return _pack_glb(gltf, bin_data), {"changed": True, "materials": changed}

--- a/blender/addons/scene_sync/glb_helper.py
+++ b/blender/addons/scene_sync/glb_helper.py
@@ -1,0 +1,207 @@
+"""GLB export / import helpers for Blender."""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+
+import bpy
+from mathutils import Matrix
+
+
+def _walk_hierarchy(root: bpy.types.Object) -> list[bpy.types.Object]:
+    items = [root]
+    for child in root.children:
+        items.extend(_walk_hierarchy(child))
+    return items
+
+
+def _has_animation_data(data) -> bool:
+    animation_data = getattr(data, "animation_data", None)
+    if animation_data is None:
+        return False
+    if getattr(animation_data, "action", None) is not None:
+        return True
+    nla_tracks = getattr(animation_data, "nla_tracks", None)
+    return bool(nla_tracks and len(nla_tracks) > 0)
+
+
+def object_has_animation(obj: bpy.types.Object) -> bool:
+    """Best-effort check for object, armature, material, or shape-key animation."""
+    for item in _walk_hierarchy(obj):
+        if _has_animation_data(item):
+            return True
+        if _has_animation_data(getattr(item, "data", None)):
+            return True
+
+        data = getattr(item, "data", None)
+        shape_keys = getattr(data, "shape_keys", None)
+        if _has_animation_data(shape_keys):
+            return True
+
+        for slot in getattr(item, "material_slots", []):
+            if _has_animation_data(getattr(slot, "material", None)):
+                return True
+
+    return False
+
+
+def _ensure_gltf_addon() -> bool:
+    if "io_scene_gltf2" in bpy.context.preferences.addons:
+        return True
+    try:
+        bpy.ops.preferences.addon_enable(module="io_scene_gltf2")
+        return True
+    except Exception:
+        print("[SceneSync] glTF importer/exporter addon is not enabled")
+        return False
+
+
+def _export_gltf(kwargs: dict) -> None:
+    try:
+        properties = bpy.ops.export_scene.gltf.get_rna_type().properties
+        supported = {prop.identifier for prop in properties}
+        kwargs = {key: value for key, value in kwargs.items() if key in supported}
+    except Exception:
+        pass
+
+    bpy.ops.export_scene.gltf(**kwargs)
+
+
+def export_object_as_glb(
+    obj: bpy.types.Object,
+    *,
+    include_animations: bool = True,
+) -> bytes | None:
+    """
+    Export an object to GLB bytes.
+
+    The exported carrier GLB is shape-only: the duplicated export root is moved
+    to identity so Scene Sync wire transforms remain the single source of
+    placement truth.
+    """
+    if not _ensure_gltf_addon():
+        return None
+
+    prev_active = bpy.context.view_layer.objects.active
+    prev_selected = list(bpy.context.selected_objects)
+    export_root = None
+
+    with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
+        tmp = f.name
+
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+        for item in _walk_hierarchy(obj):
+            item.select_set(True)
+        bpy.context.view_layer.objects.active = obj
+        bpy.ops.object.duplicate()
+        duplicated = list(bpy.context.selected_objects)
+        export_root = None
+        for item in duplicated:
+            if item.name == obj.name:
+                export_root = item
+                break
+        if export_root is None:
+            export_root = bpy.context.active_object
+        export_root.name = f"SceneSyncExport_{obj.name}"
+        export_root.matrix_world = Matrix.Identity(4)
+
+        bpy.ops.object.select_all(action="DESELECT")
+        for item in duplicated:
+            item.select_set(True)
+        bpy.context.view_layer.objects.active = export_root
+
+        _export_gltf({
+            "filepath": tmp,
+            "use_selection": True,
+            "export_format": "GLB",
+            "export_apply": True,
+            "export_animations": include_animations,
+            "export_frame_range": include_animations,
+            "export_force_sampling": include_animations,
+            "export_nla_strips": include_animations,
+            "export_skins": True,
+            "export_morph": True,
+            "export_morph_normal": True,
+            "export_morph_tangent": False,
+            "export_morph_animation": include_animations,
+        })
+
+        with open(tmp, "rb") as f:
+            return f.read()
+
+    except Exception as e:
+        print(f"[SceneSync] GLB export failed for '{obj.name}': {e}")
+        return None
+
+    finally:
+        if export_root and export_root.name in bpy.data.objects:
+            for item in reversed(_walk_hierarchy(export_root)):
+                if item.name in bpy.data.objects:
+                    bpy.data.objects.remove(item, do_unlink=True)
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+        bpy.ops.object.select_all(action="DESELECT")
+        for selected in prev_selected:
+            if selected and selected.name in bpy.data.objects:
+                selected.select_set(True)
+        if prev_active and prev_active.name in bpy.data.objects:
+            bpy.context.view_layer.objects.active = prev_active
+
+
+def import_glb(data: bytes, name: str, visual_basis: str | None = None) -> bpy.types.Object | None:
+    """Import GLB data into the current scene and return a stable root object."""
+    if not _ensure_gltf_addon():
+        return None
+
+    prev_active = bpy.context.view_layer.objects.active
+    prev_selected = list(bpy.context.selected_objects)
+
+    with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
+        f.write(data)
+        tmp = f.name
+
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+        bpy.ops.import_scene.gltf(filepath=tmp)
+
+        imported = list(bpy.context.selected_objects)
+        if not imported:
+            return None
+
+        if len(imported) == 1:
+            root = imported[0]
+        else:
+            bpy.ops.object.empty_add(type="PLAIN_AXES")
+            root = bpy.context.active_object
+            root.name = name
+            for item in imported:
+                if item != root and item.parent is None:
+                    item.parent = root
+
+        root.name = name
+
+        # Three.js applies a visual-only Y-axis 180-degree correction for
+        # Unity-authored carrier GLBs. In Blender's imported Z-up scene this is
+        # represented as a Z-axis visual correction on the imported root.
+        if visual_basis == "unity":
+            root.rotation_euler.rotate_axis("Z", math.pi)
+
+        return root
+
+    except Exception as e:
+        print(f"[SceneSync] GLB import failed: {e}")
+        return None
+
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        bpy.ops.object.select_all(action="DESELECT")
+        for selected in prev_selected:
+            if selected and selected.name in bpy.data.objects:
+                selected.select_set(True)
+        if prev_active and prev_active.name in bpy.data.objects:
+            bpy.context.view_layer.objects.active = prev_active

--- a/blender/addons/scene_sync/glb_helper.py
+++ b/blender/addons/scene_sync/glb_helper.py
@@ -9,6 +9,8 @@ import tempfile
 import bpy
 from mathutils import Matrix
 
+from .glb_alpha_modes import normalize_glb_alpha_modes
+
 
 def _walk_hierarchy(root: bpy.types.Object) -> list[bpy.types.Object]:
     items = [root]
@@ -47,6 +49,17 @@ def object_has_animation(obj: bpy.types.Object) -> bool:
     return False
 
 
+def object_has_shape_keys(obj: bpy.types.Object) -> bool:
+    """Return true when the object hierarchy contains exportable shape keys."""
+    for item in _walk_hierarchy(obj):
+        data = getattr(item, "data", None)
+        shape_keys = getattr(data, "shape_keys", None)
+        key_blocks = getattr(shape_keys, "key_blocks", None)
+        if key_blocks and len(key_blocks) > 1:
+            return True
+    return False
+
+
 def _ensure_gltf_addon() -> bool:
     if "io_scene_gltf2" in bpy.context.preferences.addons:
         return True
@@ -56,6 +69,13 @@ def _ensure_gltf_addon() -> bool:
     except Exception:
         print("[SceneSync] glTF importer/exporter addon is not enabled")
         return False
+
+
+def _new_empty(name: str) -> bpy.types.Object:
+    bpy.ops.object.empty_add(type="PLAIN_AXES")
+    obj = bpy.context.active_object
+    obj.name = name
+    return obj
 
 
 def _export_gltf(kwargs: dict) -> None:
@@ -73,6 +93,7 @@ def export_object_as_glb(
     obj: bpy.types.Object,
     *,
     include_animations: bool = True,
+    normalize_alpha_modes: bool = True,
 ) -> bytes | None:
     """
     Export an object to GLB bytes.
@@ -113,11 +134,16 @@ def export_object_as_glb(
             item.select_set(True)
         bpy.context.view_layer.objects.active = export_root
 
+        has_shape_keys = object_has_shape_keys(export_root)
+        # Blender's glTF exporter warns that applying modifiers/transforms during
+        # export prevents shape keys from being exported.
+        export_apply = not has_shape_keys
+
         _export_gltf({
             "filepath": tmp,
             "use_selection": True,
             "export_format": "GLB",
-            "export_apply": True,
+            "export_apply": export_apply,
             "export_animations": include_animations,
             "export_frame_range": include_animations,
             "export_force_sampling": include_animations,
@@ -130,7 +156,28 @@ def export_object_as_glb(
         })
 
         with open(tmp, "rb") as f:
-            return f.read()
+            data = f.read()
+
+        if normalize_alpha_modes:
+            try:
+                normalized, report = normalize_glb_alpha_modes(data)
+                if report.get("changed"):
+                    materials = report.get("materials", [])
+                    print(
+                        f"[SceneSync] GLB alpha modes normalized for '{obj.name}': "
+                        f"{len(materials)} material(s)"
+                    )
+                    for material in materials:
+                        print(
+                            "[SceneSync]   "
+                            f"{material.get('name', material.get('index'))}: "
+                            f"{material.get('before')} -> {material.get('after')}"
+                        )
+                data = normalized
+            except Exception as e:
+                print(f"[SceneSync] GLB alpha mode normalization skipped for '{obj.name}': {e}")
+
+        return data
 
     except Exception as e:
         print(f"[SceneSync] GLB export failed for '{obj.name}': {e}")
@@ -172,23 +219,27 @@ def import_glb(data: bytes, name: str, visual_basis: str | None = None) -> bpy.t
         if not imported:
             return None
 
-        if len(imported) == 1:
+        imported_set = set(imported)
+        top_level = [item for item in imported if item.parent not in imported_set]
+
+        if visual_basis == "unity":
+            root = _new_empty(name)
+            visual = _new_empty(f"{name} Visual")
+            visual.parent = root
+            visual.rotation_euler.rotate_axis("Z", math.pi)
+            for item in top_level:
+                if item != root and item != visual:
+                    item.parent = visual
+        elif len(imported) == 1:
             root = imported[0]
         else:
-            bpy.ops.object.empty_add(type="PLAIN_AXES")
-            root = bpy.context.active_object
+            root = _new_empty(name)
             root.name = name
-            for item in imported:
+            for item in top_level:
                 if item != root and item.parent is None:
                     item.parent = root
 
         root.name = name
-
-        # Three.js applies a visual-only Y-axis 180-degree correction for
-        # Unity-authored carrier GLBs. In Blender's imported Z-up scene this is
-        # represented as a Z-axis visual correction on the imported root.
-        if visual_basis == "unity":
-            root.rotation_euler.rotate_axis("Z", math.pi)
 
         return root
 

--- a/blender/addons/scene_sync/protocol.py
+++ b/blender/addons/scene_sync/protocol.py
@@ -1,0 +1,226 @@
+"""Wire-format helpers and coordinate conversion for Scene Sync.
+
+Scene Sync wire transforms use the Web / Three.js basis: right-handed,
+Y-up, X-right. Blender world space is right-handed Z-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+try:
+    from mathutils import Matrix, Quaternion, Vector  # available inside Blender
+
+    _M = Matrix(((1, 0, 0), (0, 0, 1), (0, -1, 0)))  # Blender Z-up -> wire Y-up
+    _MI = _M.transposed()
+    _MATHUTILS = True
+except ImportError:
+    _MATHUTILS = False
+
+
+def pos_to_wire(loc) -> list[float]:
+    return [float(loc[0]), float(loc[2]), float(-loc[1])]
+
+
+def pos_from_wire(arr: list):
+    if _MATHUTILS:
+        return Vector((arr[0], -arr[2], arr[1]))
+    return (arr[0], -arr[2], arr[1])
+
+
+def rot_to_wire(quat) -> list[float]:
+    if _MATHUTILS:
+        mat = quat.to_matrix()
+        converted = _M @ mat @ _MI
+        q = converted.to_quaternion()
+        return [float(q.x), float(q.y), float(q.z), float(q.w)]
+    return [float(quat[1]), float(quat[2]), float(quat[3]), float(quat[0])]
+
+
+def rot_from_wire(arr: list):
+    if _MATHUTILS:
+        q = Quaternion((arr[3], arr[0], arr[1], arr[2]))
+        mat = q.to_matrix()
+        converted = _MI @ mat @ _M
+        return converted.to_quaternion()
+    return (arr[3], arr[0], arr[1], arr[2])
+
+
+def scale_to_wire(scale) -> list[float]:
+    return [float(scale[0]), float(scale[2]), float(scale[1])]
+
+
+def scale_from_wire(arr: list):
+    if _MATHUTILS:
+        return Vector((arr[0], arr[2], arr[1]))
+    return (arr[0], arr[2], arr[1])
+
+
+def build_mesh_asset(
+    mesh_path: str,
+    asset_id: str | None = None,
+    *,
+    size: int | None = None,
+    original_name: str | None = None,
+    visual_basis: str | None = None,
+) -> dict:
+    asset = {
+        "type": "mesh",
+        "source": "carrier",
+        "meshPath": mesh_path,
+        "mime": "model/gltf-binary",
+    }
+    if asset_id:
+        asset["assetId"] = asset_id
+    if size is not None:
+        asset["size"] = int(size)
+    if original_name:
+        asset["originalName"] = original_name
+    if visual_basis:
+        asset["visualBasis"] = visual_basis
+    return asset
+
+
+def make_scene_add(
+    object_id: str,
+    name: str,
+    loc,
+    rot,
+    scale,
+    *,
+    mesh_path: str = "",
+    asset_id: str | None = None,
+    asset: dict | None = None,
+    metadata: dict | None = None,
+    animation: dict | None = None,
+    visible: bool = True,
+    origin: str = "blender",
+) -> dict:
+    msg: dict = {
+        "kind": "scene-add",
+        "objectId": object_id,
+        "name": name,
+        "origin": origin,
+        "position": pos_to_wire(loc),
+        "rotation": rot_to_wire(rot),
+        "scale": scale_to_wire(scale),
+        "visible": bool(visible),
+    }
+    if mesh_path:
+        msg["meshPath"] = mesh_path
+    if asset_id:
+        msg["assetId"] = asset_id
+    if asset:
+        msg["asset"] = asset
+    elif mesh_path:
+        msg["asset"] = build_mesh_asset(mesh_path, asset_id)
+    if metadata:
+        msg["metadata"] = metadata
+    if animation:
+        msg["animation"] = animation
+    return msg
+
+
+def make_scene_delta(
+    object_id: str,
+    loc,
+    rot,
+    scale,
+    *,
+    name: str | None = None,
+    visible: bool | None = None,
+) -> dict:
+    msg = {
+        "kind": "scene-delta",
+        "objectId": object_id,
+        "position": pos_to_wire(loc),
+        "rotation": rot_to_wire(rot),
+        "scale": scale_to_wire(scale),
+    }
+    if name is not None:
+        msg["name"] = name
+    if visible is not None:
+        msg["visible"] = bool(visible)
+    return msg
+
+
+def make_scene_remove(object_id: str) -> dict:
+    return {"kind": "scene-remove", "objectId": object_id}
+
+
+def make_scene_request() -> dict:
+    return {"kind": "scene-request"}
+
+
+def make_scene_state(objects: dict, env_id: str | None = None) -> dict:
+    msg = {"kind": "scene-state", "objects": objects}
+    if env_id:
+        msg["envId"] = env_id
+    return msg
+
+
+def make_scene_mesh(
+    object_id: str,
+    mesh_path: str,
+    *,
+    name: str | None = None,
+    asset_id: str | None = None,
+    asset: dict | None = None,
+) -> dict:
+    msg = {"kind": "scene-mesh", "objectId": object_id, "meshPath": mesh_path}
+    if name:
+        msg["name"] = name
+    if asset_id:
+        msg["assetId"] = asset_id
+    if asset:
+        msg["asset"] = asset
+    elif mesh_path:
+        msg["asset"] = build_mesh_asset(mesh_path, asset_id)
+    return msg
+
+
+def make_scene_lock(object_id: str) -> dict:
+    return {"kind": "scene-lock", "objectId": object_id}
+
+
+def make_scene_unlock(object_id: str) -> dict:
+    return {"kind": "scene-unlock", "objectId": object_id}
+
+
+def extract_transform(payload: dict) -> dict:
+    result = {}
+    pos = payload.get("position")
+    if isinstance(pos, list) and len(pos) == 3:
+        result["loc"] = pos_from_wire(pos)
+    rot = payload.get("rotation")
+    if isinstance(rot, list) and len(rot) == 4:
+        result["rot"] = rot_from_wire(rot)
+    scl = payload.get("scale")
+    if isinstance(scl, list) and len(scl) == 3:
+        result["scale"] = scale_from_wire(scl)
+    return result
+
+
+def generate_object_id(prefix: str = "blender") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def generate_mesh_path() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def compute_asset_id(data: bytes | None) -> str | None:
+    if not data:
+        return None
+    return "sha256-" + hashlib.sha256(data).hexdigest()
+
+
+def hex_to_rgb(hex_color: str) -> tuple[float, float, float]:
+    h = (hex_color or "").lstrip("#")
+    if len(h) != 6:
+        return (0.5, 0.5, 0.5)
+    try:
+        return tuple(int(h[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+    except ValueError:
+        return (0.5, 0.5, 0.5)

--- a/blender/addons/scene_sync/ws_client.py
+++ b/blender/addons/scene_sync/ws_client.py
@@ -1,0 +1,277 @@
+"""Minimal WebSocket client running in a background thread."""
+
+import base64
+import hashlib
+import json
+import os
+import queue
+import socket
+import ssl
+import struct
+import threading
+from urllib.parse import parse_qsl, urlencode, urlparse
+
+
+class SceneSyncWSClient:
+    """
+    WebSocket client for Scene Sync presence server.
+
+    Runs in a background thread; all inter-thread communication goes
+    through thread-safe queues.  Call poll() from the main thread to
+    retrieve received messages.
+    """
+
+    def __init__(self):
+        self._sock = None
+        self._thread = None
+        self._send_q: queue.Queue = queue.Queue()
+        self._recv_q: queue.Queue = queue.Queue()
+        self._running = False
+        self.connected = False
+        self.my_id = ""
+        self.room = ""
+        self.peers: list = []
+
+    # ------------------------------------------------------------------
+    # Public API (main thread)
+    # ------------------------------------------------------------------
+
+    def connect(self, url: str, room: str, nickname: str, device: str = "Blender") -> None:
+        self.disconnect()
+        self.room = room
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(url, room, nickname, device),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def disconnect(self) -> None:
+        self._running = False
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2)
+        self._thread = None
+        self.connected = False
+        self.my_id = ""
+        self.peers = []
+        # Drain stale messages from the previous session.
+        self._send_q = queue.Queue()
+        self._recv_q = queue.Queue()
+
+    def send_json(self, data: dict) -> None:
+        """Queue a JSON message to be sent by the background thread."""
+        self._send_q.put(json.dumps(data, ensure_ascii=False))
+
+    def poll(self) -> list:
+        """
+        Drain the receive queue and return all pending messages.
+        Internal events have the key ``_internal`` set to a string tag.
+        """
+        messages = []
+        while True:
+            try:
+                messages.append(self._recv_q.get_nowait())
+            except queue.Empty:
+                break
+        return messages
+
+    # ------------------------------------------------------------------
+    # Background thread
+    # ------------------------------------------------------------------
+
+    def _run(self, url: str, room: str, nickname: str, device: str) -> None:
+        try:
+            parsed = urlparse(url)
+            host = parsed.hostname
+            use_ssl = parsed.scheme in ("wss", "https")
+            port = parsed.port or (443 if use_ssl else 80)
+            host_header = host if parsed.port is None else f"{host}:{port}"
+            qs = parse_qsl(parsed.query)
+            if room:
+                qs.append(("room", room))
+            path = (parsed.path or "/") + ("?" + urlencode(qs) if qs else "")
+
+            raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            raw.settimeout(15)
+            raw.connect((host, port))
+
+            if use_ssl:
+                ctx = ssl.create_default_context()
+                self._sock = ctx.wrap_socket(raw, server_hostname=host)
+            else:
+                self._sock = raw
+
+            # HTTP upgrade handshake
+            ws_key = base64.b64encode(os.urandom(16)).decode()
+            self._sock.sendall(
+                (
+                    f"GET {path} HTTP/1.1\r\n"
+                    f"Host: {host_header}\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    f"Sec-WebSocket-Key: {ws_key}\r\n"
+                    "Sec-WebSocket-Version: 13\r\n"
+                    "\r\n"
+                ).encode()
+            )
+
+            hdr = b""
+            while b"\r\n\r\n" not in hdr:
+                chunk = self._sock.recv(1024)
+                if not chunk:
+                    raise ConnectionError("Server closed during handshake")
+                hdr += chunk
+            lines = hdr.split(b"\r\n\r\n")[0].split(b"\r\n")
+            status_line = lines[0]
+            if b"101" not in status_line:
+                raise ConnectionError(f"Upgrade failed: {status_line}")
+            headers = {}
+            for line in lines[1:]:
+                if b":" in line:
+                    k, v = line.split(b":", 1)
+                    headers[k.strip().lower()] = v.strip().decode()
+            try:
+                magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+                expected = base64.b64encode(
+                    hashlib.sha1((ws_key + magic).encode(), usedforsecurity=False).digest()
+                ).decode()
+                if headers.get("sec-websocket-accept") != expected:
+                    print(f"[SceneSync] Sec-WebSocket-Accept mismatch (expected {expected},"
+                          f" got {headers.get('sec-websocket-accept')})")
+            except Exception as sha_err:
+                print(f"[SceneSync] Sec-WebSocket-Accept check skipped: {sha_err}")
+
+            self._sock.settimeout(0.05)
+
+            self._ws_send(json.dumps({"type": "hello", "nickname": nickname, "device": device}))
+            self.connected = True
+            self._recv_q.put({"_internal": "_connected"})
+
+            # Any bytes after \r\n\r\n in the handshake buffer are the start of a WS frame.
+            parts = hdr.split(b"\r\n\r\n", 1)
+            buf = parts[1] if len(parts) > 1 else b""
+            while self._running:
+                # flush outgoing queue
+                try:
+                    while True:
+                        self._ws_send(self._send_q.get_nowait())
+                except queue.Empty:
+                    pass
+
+                # receive
+                try:
+                    chunk = self._sock.recv(65536)
+                    if not chunk:
+                        break
+                    buf += chunk
+                    while True:
+                        text, buf = self._parse_frame(buf)
+                        if text is None:
+                            break
+                        try:
+                            self._recv_q.put(json.loads(text))
+                        except json.JSONDecodeError:
+                            pass
+                except socket.timeout:
+                    pass
+                except (OSError, ssl.SSLError):
+                    break
+
+        except Exception as e:
+            print(f"[SceneSync] WS error: {e}")
+        finally:
+            if self._sock:
+                try:
+                    self._sock.close()
+                except Exception:
+                    pass
+                self._sock = None
+            self.connected = False
+            self._recv_q.put({"_internal": "_disconnected"})
+
+    # ------------------------------------------------------------------
+    # WebSocket frame helpers
+    # ------------------------------------------------------------------
+
+    def _ws_send(self, text: str) -> None:
+        if self._sock is None:
+            return
+        payload = text.encode("utf-8")
+        mask = os.urandom(4)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        n = len(payload)
+        if n <= 125:
+            hdr = bytes([0x81, 0x80 | n])
+        elif n <= 65535:
+            hdr = bytes([0x81, 0xFE]) + struct.pack(">H", n)
+        else:
+            hdr = bytes([0x81, 0xFF]) + struct.pack(">Q", n)
+        try:
+            self._sock.sendall(hdr + mask + masked)
+        except Exception:
+            pass
+
+    def _parse_frame(self, buf: bytes):
+        """Return (text_or_None, remaining_buf) for one frame."""
+        if len(buf) < 2:
+            return None, buf
+
+        opcode = buf[0] & 0x0F
+        masked = bool(buf[1] & 0x80)
+        length = buf[1] & 0x7F
+        off = 2
+
+        if length == 126:
+            if len(buf) < 4:
+                return None, buf
+            length = struct.unpack(">H", buf[2:4])[0]
+            off = 4
+        elif length == 127:
+            if len(buf) < 10:
+                return None, buf
+            length = struct.unpack(">Q", buf[2:10])[0]
+            off = 10
+
+        mask_key = b""
+        if masked:
+            if len(buf) < off + 4:
+                return None, buf
+            mask_key = buf[off : off + 4]
+            off += 4
+
+        if len(buf) < off + length:
+            return None, buf
+
+        payload = buf[off : off + length]
+        if masked:
+            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+        rest = buf[off + length :]
+
+        if opcode == 0x9:  # ping → pong
+            self._ws_pong(payload)
+            return None, rest
+        if opcode == 0x8:  # close
+            self._running = False
+            return None, rest
+        if opcode in (0x1, 0x2):
+            return payload.decode("utf-8", errors="replace"), rest
+
+        return None, rest
+
+    def _ws_pong(self, payload: bytes) -> None:
+        if self._sock is None:
+            return
+        p = payload[:125]
+        mask = os.urandom(4)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(p))
+        try:
+            self._sock.sendall(bytes([0x8A, 0x80 | len(p)]) + mask + masked)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Updates the Blender Scene Sync addon branch with GLB export and import fixes for stable viewer rendering, shape-key animation export, and imported carrier orientation.

## What changed

- Keeps shape keys exportable by disabling Blender glTF `export_apply` only when the exported object hierarchy contains shape keys.
- Adds optional GLB material alpha-mode normalization during publish.
- Rewrites only the GLB JSON chunk after export, leaving geometry, images, skinning, and morph target data untouched.
- Adds an addon setting to enable or disable GLB alpha-mode normalization.
- Preserves selected transparent materials as `BLEND` using general transparent-material name hints while converting ordinary alpha-cutout materials to `MASK` and fully opaque materials to `OPAQUE`.
- Applies `visualBasis: "unity"` correction on a child visual node instead of the Scene Sync root, so wire transforms and mesh refreshes do not overwrite the visual correction.
- Preserves the existing `alphaMode` for embedded textures whose alpha cannot be decoded instead of forcing them opaque.
- Logs each material alpha-mode change with material name and before/after mode.
- Rebases this branch on the current `main`, which already includes the companion GLB morph clip playback fix from PR #346.

## Impact

Published GLB files should retain shape-key based morph data while reducing transparent sorting artifacts in Scene Sync and other glTF viewers. Imported carrier GLBs with a Unity visual basis keep their visual correction when object transforms or mesh updates are applied.

## Validation

- `python3 -m py_compile blender/addons/scene_sync/glb_helper.py blender/addons/scene_sync/glb_alpha_modes.py blender/addons/scene_sync/__init__.py`
- `node --check html/assets/js/scenesync/scene.js`
- Confirmed companion morph clip playback helpers are present in the rebased head.
- Confirmed the PR diff against `main` does not modify `html/assets/js/scenesync/scene.js`.
- Checked the committed Blender addon diff for the requested excluded wording.

## Notes

This PR does not include local test assets.