### PR TITLE
[codex] Play companion GLB morph clips

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2025,6 +2025,72 @@ function updateRecoveringOverlaysAnimation() {
 
 // ── GLB Animation Setup and Updates ──────────────────────
 
+function getClipTracks(clip) {
+  return Array.isArray(clip?.tracks) ? clip.tracks : [];
+}
+
+function isMorphWeightTrack(track) {
+  return typeof track?.name === 'string' && track.name.includes('.morphTargetInfluences');
+}
+
+function isTransformAnimationTrack(track) {
+  if (typeof track?.name !== 'string') return false;
+  return (
+    track.name.endsWith('.position') ||
+    track.name.endsWith('.quaternion') ||
+    track.name.endsWith('.scale')
+  );
+}
+
+function clipHasMorphWeightTracks(clip) {
+  return getClipTracks(clip).some(isMorphWeightTrack);
+}
+
+function clipHasTransformTracks(clip) {
+  return getClipTracks(clip).some(isTransformAnimationTrack);
+}
+
+function normalizeClipStemName(clip, index) {
+  let name = normalizeAnimationClipName(clip?.name || `Animation ${index}`);
+  for (let i = 0; i < 3; i += 1) {
+    name = name
+      .replace(/[._-]?(?:bone|bones|body|facial|face|morph|shape|blendshape|blendshapes)$/g, '')
+      .replace(/(?:[._-]\d+)$/g, '');
+  }
+  return name;
+}
+
+function getCompanionMorphClipIndices(clips, primaryClipIndex) {
+  const primaryClip = clips[primaryClipIndex];
+  if (!primaryClip) return [];
+  const primaryHasMorph = clipHasMorphWeightTracks(primaryClip);
+  const primaryHasTransform = clipHasTransformTracks(primaryClip);
+  if (primaryHasMorph && !primaryHasTransform) return [];
+
+  const morphOnlyCandidates = clips
+    .map((clip, index) => ({ clip, index }))
+    .filter(({ clip, index }) => (
+      index !== primaryClipIndex &&
+      clipHasMorphWeightTracks(clip) &&
+      !clipHasTransformTracks(clip)
+    ));
+
+  const primaryStem = normalizeClipStemName(primaryClip, primaryClipIndex);
+  const matching = morphOnlyCandidates
+    .filter(({ clip, index }) => normalizeClipStemName(clip, index) === primaryStem)
+    .map(({ index }) => index);
+
+  return matching;
+}
+
+function createLoopingAnimationAction(mixer, clip) {
+  const action = mixer.clipAction(clip);
+  action.reset();
+  action.setLoop(THREE.LoopRepeat, Infinity);
+  action.play();
+  return action;
+}
+
 function setupObjectGlbAnimation(objectId, model) {
   const clips = model.userData?.scenesync?.animations;
   if (!Array.isArray(clips) || clips.length === 0) return;
@@ -2044,11 +2110,12 @@ function setupObjectGlbAnimation(objectId, model) {
   const clipIndex = clampAnimationClipIndex(state.clip, clips.length);
   state.clip = clipIndex;
   const clip = clips[clipIndex];
-  const action = mixer.clipAction(clip);
-
-  action.reset();
-  action.setLoop(THREE.LoopRepeat, Infinity);
-  action.play();
+  const action = createLoopingAnimationAction(mixer, clip);
+  const companionClipIndices = getCompanionMorphClipIndices(clips, clipIndex);
+  const companionActions = companionClipIndices.map((index) => ({
+    clipIndex: index,
+    action: createLoopingAnimationAction(mixer, clips[index]),
+  }));
 
   model.userData.animationState = state;
   model.userData.scenesync = {
@@ -2063,6 +2130,7 @@ function setupObjectGlbAnimation(objectId, model) {
     clips,
     action,
     clipIndex,
+    companionActions,
   });
 }
 
@@ -2231,15 +2299,22 @@ function updateObjectGlbAnimationClip(objectId, nextClipIndex) {
     entry.action.stop();
     entry.mixer.uncacheAction(entry.clips[entry.clipIndex]);
   }
+  for (const companion of entry.companionActions || []) {
+    companion.action?.stop?.();
+    entry.mixer.uncacheAction(entry.clips[companion.clipIndex]);
+  }
 
   const clip = entry.clips[clipIndex];
-  const action = entry.mixer.clipAction(clip);
-  action.reset();
-  action.setLoop(THREE.LoopRepeat, Infinity);
-  action.play();
+  const action = createLoopingAnimationAction(entry.mixer, clip);
+  const companionClipIndices = getCompanionMorphClipIndices(entry.clips, clipIndex);
+  const companionActions = companionClipIndices.map((index) => ({
+    clipIndex: index,
+    action: createLoopingAnimationAction(entry.mixer, entry.clips[index]),
+  }));
 
   entry.action = action;
   entry.clipIndex = clipIndex;
+  entry.companionActions = companionActions;
 
   const obj = managedObjects.get(objectId);
   if (obj) {
@@ -2263,6 +2338,10 @@ function updateObjectGlbAnimationClip(objectId, nextClipIndex) {
     clipIndex,
     name: clip?.name || `Animation ${clipIndex}`,
     duration: clip?.duration || null,
+    companionMorphClips: companionClipIndices.map((index) => ({
+      index,
+      name: entry.clips[index]?.name || `Animation ${index}`,
+    })),
   });
 }
 
@@ -2392,6 +2471,17 @@ function updateObjectGlbAnimations(now = performance.now()) {
     entry.action.enabled = true;
     entry.action.paused = false;
     entry.action.time = clipTime;
+
+    for (const companion of entry.companionActions || []) {
+      const companionClip = entry.clips[companion.clipIndex];
+      if (!companionClip || !companion.action) continue;
+      const companionDuration = companionClip.duration || duration || 1;
+      companion.action.enabled = true;
+      companion.action.paused = false;
+      companion.action.time = state.mode === 'loop'
+        ? t % companionDuration
+        : Math.min(t, companionDuration);
+    }
 
     entry.mixer.update(0);
   }


### PR DESCRIPTION
## Summary

Updates the Scene Sync web viewer so GLB morph-only animation clips can play alongside the selected primary animation clip.

## Root cause

Some exported GLB files split transform or bone animation and morph target weights into separate clips. The viewer selected and played only one clip at a time, so choosing the primary motion clip left companion morph-weight clips inactive.

## What changed

- Detects morph-target weight tracks in GLB animation clips.
- Detects transform tracks separately from morph tracks.
- Finds morph-only companion clips that share the same normalized clip stem as the selected primary clip.
- Allows companion lookup when the primary clip contains both transform and morph tracks, skipping only morph-only primary clips.
- Normalizes clip stems repeatedly so names such as `Walk_001` and `Walk_001_Morph` match.
- Starts companion morph actions with the primary action and keeps their playback time synchronized.
- Rebuilds companion actions when the selected GLB animation clip changes.
- Emits companion morph clip metadata in the animation-change event payload.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- Ran a local stem-normalization check for `Walk`, `Walk_Morph`, `Walk_001`, `Walk_001_Morph`, `Walk.001.Facial`, and `Walk-001-blendshapes`.
- Confirmed the commit only changes `html/assets/js/scenesync/scene.js`.
- Checked the committed diff for the requested excluded wording.

## Notes

This PR does not include local test assets or Blender addon changes.