### PR TITLE
[codex] Fallback to single GLB morph companion

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2080,7 +2080,11 @@ function getCompanionMorphClipIndices(clips, primaryClipIndex) {
     .filter(({ clip, index }) => normalizeClipStemName(clip, index) === primaryStem)
     .map(({ index }) => index);
 
-  return matching;
+  if (matching.length > 0) return matching;
+  if (!primaryHasMorph && primaryHasTransform && morphOnlyCandidates.length === 1) {
+    return [morphOnlyCandidates[0].index];
+  }
+  return [];
 }
 
 function createLoopingAnimationAction(mixer, clip) {


### PR DESCRIPTION
## Summary

Adds a conservative fallback for GLB animation playback when a transform-only animation clip has no exact-name companion match, but the file contains exactly one morph-only clip.

## Root cause

Some exported GLB files contain valid morph targets and a valid morph-weight animation, but the morph-only animation clip name can be truncated or otherwise differ from the transform clip name. The existing companion lookup required normalized clip stems to match exactly, so the morph-only clip was ignored.

## What changed

- Keep exact normalized stem matching as the preferred path.
- If there are no exact matches, the primary clip is transform-only, and there is exactly one morph-only candidate, play that clip as the companion.
- Keep returning no fallback when multiple morph-only candidates exist, to avoid pairing the wrong expression track.
- Do not fallback for morph-only primary clips, mixed transform+morph primary clips, or non-transform primary clips.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- Inspected the affected GLB: it has mesh morph targets, one morph-weight animation clip, and separate transform animation clips whose names do not exactly match the morph clip.
- Ran local companion-selection simulations for:
  - transform-only primary with exact match
  - transform-only primary with one fallback candidate
  - transform-only primary with multiple fallback candidates
  - morph-only primary
  - mixed transform+morph primary
  - non-transform primary
- Confirmed the commit only changes `html/assets/js/scenesync/scene.js`.
- Checked the committed diff for the requested excluded wording.

## Notes

This PR does not include local test assets.