### PR TITLE
[codex] Improve Unity Scene Sync connection room handling

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2111,7 +2111,14 @@ function setupObjectGlbAnimation(objectId, model) {
   };
 
   const mixer = new THREE.AnimationMixer(model);
-  const clipIndex = clampAnimationClipIndex(state.clip, clips.length);
+  let clipIndex = clampAnimationClipIndex(state.clip, clips.length);
+  if (typeof state.clipName === 'string' && state.clipName.trim()) {
+    const resolution = resolveAnimationClipIndex(model, { clipName: state.clipName });
+    if (resolution.ok) {
+      clipIndex = resolution.clipIndex;
+      state.clipName = resolution.clipName;
+    }
+  }
   state.clip = clipIndex;
   const clip = clips[clipIndex];
   const action = createLoopingAnimationAction(mixer, clip);
@@ -2159,6 +2166,7 @@ function getObjectAnimationState(obj) {
   return {
     enabled: raw.enabled !== false,
     clip: Number.isInteger(raw.clip) ? raw.clip : 0,
+    clipName: typeof raw.clipName === 'string' ? raw.clipName : null,
     mode: raw.mode === 'once' ? 'once' : 'loop',
     speed: Number.isFinite(raw.speed) ? raw.speed : 1,
   };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2112,11 +2112,22 @@ function setupObjectGlbAnimation(objectId, model) {
 
   const mixer = new THREE.AnimationMixer(model);
   let clipIndex = clampAnimationClipIndex(state.clip, clips.length);
-  if (typeof state.clipName === 'string' && state.clipName.trim()) {
-    const resolution = resolveAnimationClipIndex(model, { clipName: state.clipName });
-    if (resolution.ok) {
-      clipIndex = resolution.clipIndex;
-      state.clipName = resolution.clipName;
+  const requestedClipName = typeof state.clipName === 'string' && state.clipName.trim()
+    ? state.clipName.trim()
+    : null;
+  let requestedClipResolution = null;
+  if (requestedClipName) {
+    requestedClipResolution = resolveAnimationClipIndex(model, { clipName: requestedClipName });
+    if (requestedClipResolution.ok) {
+      clipIndex = requestedClipResolution.clipIndex;
+      state.clipName = requestedClipResolution.clipName;
+    } else {
+      console.warn('[SceneSync] GLB animation clipName was not found', {
+        objectId,
+        requestedClipName,
+        availableClipNames: clips.map((clip) => clip?.name || '(unnamed)'),
+        error: requestedClipResolution.error,
+      });
     }
   }
   state.clip = clipIndex;
@@ -2127,6 +2138,17 @@ function setupObjectGlbAnimation(objectId, model) {
     clipIndex: index,
     action: createLoopingAnimationAction(mixer, clips[index]),
   }));
+
+  if (requestedClipName || clips.length > 1) {
+    console.info('[SceneSync] GLB animation selected', {
+      objectId,
+      clipIndex,
+      clipName: clip?.name || `Animation ${clipIndex}`,
+      requestedClipName,
+      matchedBy: requestedClipResolution?.matchedBy || null,
+      companionClipIndices,
+    });
+  }
 
   model.userData.animationState = state;
   model.userData.scenesync = {

--- a/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
+++ b/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
@@ -101,19 +101,19 @@ namespace Afjk.SceneSync.Editor
             OnDisconnected?.Invoke();
         }
 
-        public async Task Broadcast(string payloadJson)
+        public async Task<bool> Broadcast(string payloadJson)
         {
-            await SendRaw("{\"type\":\"broadcast\",\"payload\":" + payloadJson + "}");
+            return await SendRaw("{\"type\":\"broadcast\",\"payload\":" + payloadJson + "}");
         }
 
-        public async Task SendHandoff(string targetId, string payloadJson)
+        public async Task<bool> SendHandoff(string targetId, string payloadJson)
         {
-            await SendRaw("{\"type\":\"handoff\",\"targetId\":\"" + targetId + "\",\"payload\":" + payloadJson + "}");
+            return await SendRaw("{\"type\":\"handoff\",\"targetId\":\"" + targetId + "\",\"payload\":" + payloadJson + "}");
         }
 
-        private async Task SendRaw(string text)
+        private async Task<bool> SendRaw(string text)
         {
-            if (!IsConnected) return;
+            if (!IsConnected) return false;
             var bytes = Encoding.UTF8.GetBytes(text);
             try
             {
@@ -123,10 +123,12 @@ namespace Afjk.SceneSync.Editor
                     true,
                     _cts.Token
                 );
+                return true;
             }
             catch (Exception ex)
             {
                 Debug.LogWarning("[SceneSync] Send failed: " + ex.Message);
+                return false;
             }
         }
 

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Editor
+{
+    public static class SceneSyncExportSupport
+    {
+        private static readonly string[] TransparentNameHints =
+        {
+            "glass",
+            "lens",
+            "wing",
+            "cheek",
+            "shadow",
+            "fade",
+            "trans",
+            "transparent",
+            "alpha",
+            "semi",
+        };
+
+        [MenuItem("Tools/Scene Sync/Support/Apply Transparent Name Hints To Selection")]
+        private static void ApplyTransparentNameHintsToSelection()
+        {
+            var materials = CollectSelectedMaterials();
+            var changed = 0;
+
+            foreach (var material in materials)
+            {
+                if (!ShouldTreatAsTransparent(material)) continue;
+
+                Undo.RecordObject(material, "Apply Transparent Name Hints");
+                ConfigureTransparentMaterial(material);
+                EditorUtility.SetDirty(material);
+                changed++;
+            }
+
+            if (changed > 0)
+            {
+                AssetDatabase.SaveAssets();
+            }
+
+            Debug.Log($"Scene Sync export support: updated {changed} material(s) from {materials.Count} selected material candidate(s).");
+        }
+
+        [MenuItem("Tools/Scene Sync/Support/Report Animation Events In Selection")]
+        private static void ReportAnimationEventsInSelection()
+        {
+            var clips = CollectSelectedAnimationClips();
+            var eventCount = 0;
+
+            foreach (var clip in clips)
+            {
+                var events = AnimationUtility.GetAnimationEvents(clip);
+                if (events == null || events.Length == 0) continue;
+
+                eventCount += events.Length;
+                Debug.LogWarning(
+                    $"Scene Sync export support: animation clip '{clip.name}' contains {events.Length} event(s). " +
+                    "GLB export does not preserve Unity animation events or MonoBehaviour callbacks. " +
+                    "Bake the resulting transform, material, or blend shape changes into animation curves before publishing.",
+                    clip);
+            }
+
+            Debug.Log($"Scene Sync export support: scanned {clips.Count} animation clip(s), found {eventCount} event(s).");
+        }
+
+        private static HashSet<Material> CollectSelectedMaterials()
+        {
+            var materials = new HashSet<Material>();
+
+            foreach (var selected in Selection.objects)
+            {
+                if (selected is Material material)
+                {
+                    materials.Add(material);
+                    continue;
+                }
+
+                if (selected is GameObject go)
+                {
+                    foreach (var renderer in go.GetComponentsInChildren<Renderer>(true))
+                    {
+                        if (renderer == null) continue;
+
+                        foreach (var rendererMaterial in renderer.sharedMaterials)
+                        {
+                            if (rendererMaterial != null)
+                                materials.Add(rendererMaterial);
+                        }
+                    }
+                }
+            }
+
+            return materials;
+        }
+
+        private static HashSet<AnimationClip> CollectSelectedAnimationClips()
+        {
+            var clips = new HashSet<AnimationClip>();
+
+            foreach (var selected in Selection.objects)
+            {
+                if (selected is AnimationClip clip)
+                {
+                    clips.Add(clip);
+                    continue;
+                }
+
+                if (selected is GameObject go)
+                {
+                    CollectClipsFromHierarchy(go, clips);
+                    CollectClipsFromAsset(go, clips);
+                }
+            }
+
+            return clips;
+        }
+
+        private static void CollectClipsFromHierarchy(GameObject root, HashSet<AnimationClip> clips)
+        {
+            foreach (var animation in root.GetComponentsInChildren<Animation>(true))
+            {
+                if (animation == null) continue;
+
+                foreach (AnimationState state in animation)
+                {
+                    if (state != null && state.clip != null)
+                        clips.Add(state.clip);
+                }
+            }
+
+            foreach (var animator in root.GetComponentsInChildren<Animator>(true))
+            {
+                var controller = animator != null ? animator.runtimeAnimatorController : null;
+                if (controller == null) continue;
+
+                foreach (var clip in controller.animationClips)
+                {
+                    if (clip != null)
+                        clips.Add(clip);
+                }
+            }
+        }
+
+        private static void CollectClipsFromAsset(GameObject go, HashSet<AnimationClip> clips)
+        {
+            var path = AssetDatabase.GetAssetPath(go);
+            if (string.IsNullOrEmpty(path)) return;
+
+            foreach (var asset in AssetDatabase.LoadAllAssetsAtPath(path))
+            {
+                if (asset is AnimationClip clip)
+                    clips.Add(clip);
+            }
+        }
+
+        private static bool ShouldTreatAsTransparent(Material material)
+        {
+            if (material == null) return false;
+
+            var renderType = material.GetTag("RenderType", false, "");
+            if (renderType == "Transparent" || renderType == "Fade" || renderType == "TransparentCutout")
+                return false;
+
+            var materialName = material.name ?? "";
+            var shaderName = material.shader != null ? material.shader.name ?? "" : "";
+            var combined = (materialName + " " + shaderName).ToLowerInvariant();
+
+            foreach (var hint in TransparentNameHints)
+            {
+                if (combined.Contains(hint))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static void ConfigureTransparentMaterial(Material material)
+        {
+            material.SetOverrideTag("RenderType", "Transparent");
+            material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+
+            if (material.HasProperty("_Mode"))
+                material.SetFloat("_Mode", 3f);
+            if (material.HasProperty("_Surface"))
+                material.SetFloat("_Surface", 1f);
+            if (material.HasProperty("_SrcBlend"))
+                material.SetFloat("_SrcBlend", (float)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            if (material.HasProperty("_DstBlend"))
+                material.SetFloat("_DstBlend", (float)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            if (material.HasProperty("_ZWrite"))
+                material.SetFloat("_ZWrite", 0f);
+
+            material.EnableKeyword("_ALPHABLEND_ON");
+            material.DisableKeyword("_ALPHATEST_ON");
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
@@ -6,8 +6,11 @@ using UnityEngine;
 
 namespace Afjk.SceneSync.Editor
 {
+    [InitializeOnLoad]
     public static class SceneSyncExportSupport
     {
+        private const string BakedClipSuffix = "_scenesync_baked";
+        private const float StepKeyEpsilon = 1f / 1200f;
         private static readonly string[] TransparentNameHints =
         {
             "glass",
@@ -21,6 +24,11 @@ namespace Afjk.SceneSync.Editor
             "alpha",
             "semi",
         };
+
+        static SceneSyncExportSupport()
+        {
+            GlbExporter.EditorExportPreparationHandler = BeginTemporaryBakedEventClipOverridesForExport;
+        }
 
         [MenuItem("Tools/Scene Sync/Support/Apply Transparent Name Hints To Selection")]
         private static void ApplyTransparentNameHintsToSelection()
@@ -77,29 +85,13 @@ namespace Afjk.SceneSync.Editor
 
             foreach (var targetClip in context.TargetClips)
             {
-                var events = AnimationUtility.GetAnimationEvents(targetClip);
-                if (events == null || events.Length == 0) continue;
-
-                var bakedClip = new AnimationClip();
-                EditorUtility.CopySerialized(targetClip, bakedClip);
-                bakedClip.name = targetClip.name + "_scenesync_baked";
-                AnimationUtility.SetAnimationEvents(bakedClip, Array.Empty<AnimationEvent>());
-
-                var appliedToClip = 0;
-                foreach (var animationEvent in events)
-                {
-                    if (!TryFindNamedClip(animationEvent, context.NamedClips, targetClip, out var eventClip))
-                        continue;
-
-                    appliedToClip += CopyCurvesWithOffset(eventClip, bakedClip, animationEvent.time);
-                    appliedEventCount++;
-                }
-
-                if (appliedToClip == 0) continue;
+                if (!TryCreateBakedEventClip(targetClip, context.NamedClips, out var bakedClip, out var appliedToClip))
+                    continue;
 
                 var outputPath = GetBakedClipPath(targetClip);
                 AssetDatabase.CreateAsset(bakedClip, AssetDatabase.GenerateUniqueAssetPath(outputPath));
                 bakedCount++;
+                appliedEventCount += appliedToClip;
             }
 
             if (bakedCount > 0)
@@ -110,7 +102,59 @@ namespace Afjk.SceneSync.Editor
 
             Debug.Log(
                 $"Scene Sync export support: created {bakedCount} baked clip(s) from {appliedEventCount} named animation event(s). " +
-                "Use the baked clips for GLB publishing.");
+                "Scene Sync publish also applies this baking in memory during UnityGLTF export.");
+        }
+
+        private static IDisposable BeginTemporaryBakedEventClipOverridesForExport(GameObject root)
+        {
+            if (root == null) return null;
+
+            var context = CollectAnimationContext(root);
+            var scope = new AnimationExportOverrideScope();
+            var bakedClipCount = 0;
+            var appliedEventCount = 0;
+
+            foreach (var animator in root.GetComponentsInChildren<Animator>(true))
+            {
+                if (animator == null || animator.runtimeAnimatorController == null)
+                    continue;
+
+                var controller = animator.runtimeAnimatorController;
+                var overridePairs = new List<KeyValuePair<AnimationClip, AnimationClip>>();
+                var controllerClips = new HashSet<AnimationClip>();
+
+                foreach (var clip in controller.animationClips)
+                {
+                    if (clip == null || !controllerClips.Add(clip)) continue;
+
+                    if (!TryCreateBakedEventClip(clip, context.NamedClips, out var bakedClip, out var appliedToClip))
+                        continue;
+
+                    overridePairs.Add(new KeyValuePair<AnimationClip, AnimationClip>(clip, bakedClip));
+                    scope.AddTemporaryObject(bakedClip);
+                    bakedClipCount++;
+                    appliedEventCount += appliedToClip;
+                }
+
+                if (overridePairs.Count == 0) continue;
+
+                var overrideController = new AnimatorOverrideController(controller)
+                {
+                    name = controller.name + "_SceneSyncExportOverride",
+                    hideFlags = HideFlags.HideAndDontSave,
+                };
+                overrideController.ApplyOverrides(overridePairs);
+                scope.AddAnimator(animator, controller, overrideController);
+                animator.runtimeAnimatorController = overrideController;
+            }
+
+            if (!scope.HasChanges)
+                return null;
+
+            Debug.Log(
+                $"Scene Sync export support: temporarily baked {bakedClipCount} clip(s) from " +
+                $"{appliedEventCount} named animation event(s) for GLB export.");
+            return scope;
         }
 
         private static HashSet<Material> CollectSelectedMaterials()
@@ -189,6 +233,23 @@ namespace Afjk.SceneSync.Editor
                         AddNamedClip(context.NamedClips, collectedClip);
                     }
                 }
+            }
+
+            return context;
+        }
+
+        private static AnimationContext CollectAnimationContext(GameObject root)
+        {
+            var context = new AnimationContext();
+            if (root == null) return context;
+
+            CollectClipsFromHierarchy(root, context.TargetClips);
+            CollectClipsFromAsset(root, context.TargetClips);
+            CollectSerializedClipsFromHierarchy(root, context.NamedClips);
+
+            foreach (var clip in context.TargetClips)
+            {
+                AddNamedClip(context.NamedClips, clip);
             }
 
             return context;
@@ -305,6 +366,13 @@ namespace Afjk.SceneSync.Editor
 
             if (animationEvent == null) return false;
 
+            if (animationEvent.objectReferenceParameter is AnimationClip referencedClip &&
+                referencedClip != targetClip)
+            {
+                clip = referencedClip;
+                return true;
+            }
+
             var names = new[]
             {
                 animationEvent.stringParameter,
@@ -334,11 +402,24 @@ namespace Afjk.SceneSync.Editor
                 if (sourceCurve == null) continue;
 
                 var targetCurve = AnimationUtility.GetEditorCurve(targetClip, binding) ?? new AnimationCurve();
-                foreach (var key in sourceCurve.keys)
+                var keys = sourceCurve.keys;
+                if (keys.Length == 0)
+                    continue;
+
+                if (IsPoseCurve(keys))
                 {
-                    var nextKey = key;
-                    nextKey.time += timeOffset;
-                    targetCurve.AddKey(nextKey);
+                    var nextKey = keys[keys.Length - 1];
+                    nextKey.time = timeOffset;
+                    AddSteppedKey(targetCurve, nextKey);
+                }
+                else
+                {
+                    foreach (var key in keys)
+                    {
+                        var nextKey = key;
+                        nextKey.time += timeOffset;
+                        SetOrAddKey(targetCurve, nextKey);
+                    }
                 }
 
                 AnimationUtility.SetEditorCurve(targetClip, binding, targetCurve);
@@ -346,6 +427,101 @@ namespace Afjk.SceneSync.Editor
             }
 
             return copied;
+        }
+
+        private static bool TryCreateBakedEventClip(
+            AnimationClip targetClip,
+            Dictionary<string, AnimationClip> namedClips,
+            out AnimationClip bakedClip,
+            out int appliedEventCount)
+        {
+            bakedClip = null;
+            appliedEventCount = 0;
+
+            if (targetClip == null || targetClip.name.EndsWith(BakedClipSuffix, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var events = AnimationUtility.GetAnimationEvents(targetClip);
+            if (events == null || events.Length == 0) return false;
+
+            var nextClip = new AnimationClip
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            EditorUtility.CopySerialized(targetClip, nextClip);
+            nextClip.name = targetClip.name + BakedClipSuffix;
+            nextClip.hideFlags = HideFlags.HideAndDontSave;
+            AnimationUtility.SetAnimationEvents(nextClip, Array.Empty<AnimationEvent>());
+
+            var copiedCurveCount = 0;
+            foreach (var animationEvent in events)
+            {
+                if (!TryFindNamedClip(animationEvent, namedClips, targetClip, out var eventClip))
+                    continue;
+
+                var copied = CopyCurvesWithOffset(eventClip, nextClip, animationEvent.time);
+                if (copied == 0) continue;
+
+                copiedCurveCount += copied;
+                appliedEventCount++;
+            }
+
+            if (copiedCurveCount > 0)
+            {
+                bakedClip = nextClip;
+                return true;
+            }
+
+            UnityEngine.Object.DestroyImmediate(nextClip);
+            return false;
+        }
+
+        private static bool IsPoseCurve(Keyframe[] keys)
+        {
+            if (keys == null || keys.Length == 0) return false;
+
+            for (var i = 0; i < keys.Length; i++)
+            {
+                if (keys[i].time > StepKeyEpsilon)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static void AddSteppedKey(AnimationCurve curve, Keyframe key)
+        {
+            if (curve == null) return;
+
+            if (key.time > StepKeyEpsilon)
+            {
+                var previousValue = curve.length > 0 ? curve.Evaluate(key.time - StepKeyEpsilon) : 0f;
+                var previousKey = new Keyframe(key.time - StepKeyEpsilon, previousValue)
+                {
+                    inSlope = 0f,
+                    outSlope = 0f,
+                };
+                SetOrAddKey(curve, previousKey);
+            }
+
+            SetOrAddKey(curve, key);
+        }
+
+        private static void SetOrAddKey(AnimationCurve curve, Keyframe key)
+        {
+            var keys = new List<Keyframe>(curve.keys);
+            for (var i = 0; i < keys.Count; i++)
+            {
+                if (Mathf.Abs(keys[i].time - key.time) > 0.00001f) continue;
+
+                keys[i] = key;
+                curve.keys = keys.ToArray();
+                return;
+            }
+
+            keys.Add(key);
+            keys.Sort((a, b) => a.time.CompareTo(b.time));
+            curve.keys = keys.ToArray();
         }
 
         private static string GetBakedClipPath(AnimationClip targetClip)
@@ -381,6 +557,54 @@ namespace Afjk.SceneSync.Editor
             public readonly HashSet<AnimationClip> TargetClips = new HashSet<AnimationClip>();
             public readonly Dictionary<string, AnimationClip> NamedClips =
                 new Dictionary<string, AnimationClip>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class AnimationExportOverrideScope : IDisposable
+        {
+            private readonly List<AnimatorRestore> _animators = new List<AnimatorRestore>();
+            private readonly List<UnityEngine.Object> _temporaryObjects = new List<UnityEngine.Object>();
+
+            public bool HasChanges => _animators.Count > 0;
+
+            public void AddAnimator(
+                Animator animator,
+                RuntimeAnimatorController originalController,
+                RuntimeAnimatorController temporaryController)
+            {
+                _animators.Add(new AnimatorRestore
+                {
+                    Animator = animator,
+                    OriginalController = originalController,
+                });
+                AddTemporaryObject(temporaryController);
+            }
+
+            public void AddTemporaryObject(UnityEngine.Object temporaryObject)
+            {
+                if (temporaryObject != null)
+                    _temporaryObjects.Add(temporaryObject);
+            }
+
+            public void Dispose()
+            {
+                foreach (var restore in _animators)
+                {
+                    if (restore.Animator != null)
+                        restore.Animator.runtimeAnimatorController = restore.OriginalController;
+                }
+
+                foreach (var temporaryObject in _temporaryObjects)
+                {
+                    if (temporaryObject != null)
+                        UnityEngine.Object.DestroyImmediate(temporaryObject);
+                }
+            }
+
+            private struct AnimatorRestore
+            {
+                public Animator Animator;
+                public RuntimeAnimatorController OriginalController;
+            }
         }
     }
 }

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
@@ -113,6 +113,9 @@ namespace Afjk.SceneSync.Editor
             var scope = new AnimationExportOverrideScope();
             var bakedClipCount = 0;
             var appliedEventCount = 0;
+            var eventClipCount = 0;
+            var preferredClipName = "";
+            var preferredClipEventCount = 0;
 
             foreach (var animator in root.GetComponentsInChildren<Animator>(true))
             {
@@ -127,13 +130,24 @@ namespace Afjk.SceneSync.Editor
                 {
                     if (clip == null || !controllerClips.Add(clip)) continue;
 
+                    var events = AnimationUtility.GetAnimationEvents(clip);
+                    if (events != null && events.Length > 0)
+                        eventClipCount++;
+
                     if (!TryCreateBakedEventClip(clip, context.NamedClips, out var bakedClip, out var appliedToClip))
                         continue;
 
+                    bakedClip.name = clip.name;
                     overridePairs.Add(new KeyValuePair<AnimationClip, AnimationClip>(clip, bakedClip));
                     scope.AddTemporaryObject(bakedClip);
                     bakedClipCount++;
                     appliedEventCount += appliedToClip;
+
+                    if (appliedToClip > preferredClipEventCount)
+                    {
+                        preferredClipName = clip.name;
+                        preferredClipEventCount = appliedToClip;
+                    }
                 }
 
                 if (overridePairs.Count == 0) continue;
@@ -149,7 +163,17 @@ namespace Afjk.SceneSync.Editor
             }
 
             if (!scope.HasChanges)
+            {
+                if (eventClipCount > 0)
+                {
+                    Debug.LogWarning(
+                        $"Scene Sync export support: found {eventClipCount} animation clip(s) with event(s), " +
+                        "but no event-referenced clip curves were matched for GLB export.");
+                }
                 return null;
+            }
+
+            GlbExporter.LastExportPreferredAnimationClipName = preferredClipName;
 
             Debug.Log(
                 $"Scene Sync export support: temporarily baked {bakedClipCount} clip(s) from " +
@@ -496,11 +520,7 @@ namespace Afjk.SceneSync.Editor
             if (key.time > StepKeyEpsilon)
             {
                 var previousValue = curve.length > 0 ? curve.Evaluate(key.time - StepKeyEpsilon) : 0f;
-                var previousKey = new Keyframe(key.time - StepKeyEpsilon, previousValue)
-                {
-                    inSlope = 0f,
-                    outSlope = 0f,
-                };
+                var previousKey = new Keyframe(key.time - StepKeyEpsilon, previousValue, 0f, 0f);
                 SetOrAddKey(curve, previousKey);
             }
 

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -66,6 +68,51 @@ namespace Afjk.SceneSync.Editor
             Debug.Log($"Scene Sync export support: scanned {clips.Count} animation clip(s), found {eventCount} event(s).");
         }
 
+        [MenuItem("Tools/Scene Sync/Support/Bake Event-Named Clip Curves To New Clips")]
+        private static void BakeEventNamedClipCurvesToNewClips()
+        {
+            var context = CollectSelectedAnimationContext();
+            var bakedCount = 0;
+            var appliedEventCount = 0;
+
+            foreach (var targetClip in context.TargetClips)
+            {
+                var events = AnimationUtility.GetAnimationEvents(targetClip);
+                if (events == null || events.Length == 0) continue;
+
+                var bakedClip = new AnimationClip();
+                EditorUtility.CopySerialized(targetClip, bakedClip);
+                bakedClip.name = targetClip.name + "_scenesync_baked";
+                AnimationUtility.SetAnimationEvents(bakedClip, Array.Empty<AnimationEvent>());
+
+                var appliedToClip = 0;
+                foreach (var animationEvent in events)
+                {
+                    if (!TryFindNamedClip(animationEvent, context.NamedClips, targetClip, out var eventClip))
+                        continue;
+
+                    appliedToClip += CopyCurvesWithOffset(eventClip, bakedClip, animationEvent.time);
+                    appliedEventCount++;
+                }
+
+                if (appliedToClip == 0) continue;
+
+                var outputPath = GetBakedClipPath(targetClip);
+                AssetDatabase.CreateAsset(bakedClip, AssetDatabase.GenerateUniqueAssetPath(outputPath));
+                bakedCount++;
+            }
+
+            if (bakedCount > 0)
+            {
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+            }
+
+            Debug.Log(
+                $"Scene Sync export support: created {bakedCount} baked clip(s) from {appliedEventCount} named animation event(s). " +
+                "Use the baked clips for GLB publishing.");
+        }
+
         private static HashSet<Material> CollectSelectedMaterials()
         {
             var materials = new HashSet<Material>();
@@ -118,6 +165,35 @@ namespace Afjk.SceneSync.Editor
             return clips;
         }
 
+        private static AnimationContext CollectSelectedAnimationContext()
+        {
+            var context = new AnimationContext();
+
+            foreach (var selected in Selection.objects)
+            {
+                if (selected is AnimationClip clip)
+                {
+                    context.TargetClips.Add(clip);
+                    AddNamedClip(context, clip);
+                    continue;
+                }
+
+                if (selected is GameObject go)
+                {
+                    CollectClipsFromHierarchy(go, context.TargetClips);
+                    CollectClipsFromAsset(go, context.TargetClips);
+                    CollectSerializedClipsFromHierarchy(go, context.NamedClips);
+
+                    foreach (var collectedClip in context.TargetClips)
+                    {
+                        AddNamedClip(context.NamedClips, collectedClip);
+                    }
+                }
+            }
+
+            return context;
+        }
+
         private static void CollectClipsFromHierarchy(GameObject root, HashSet<AnimationClip> clips)
         {
             foreach (var animation in root.GetComponentsInChildren<Animation>(true))
@@ -153,6 +229,27 @@ namespace Afjk.SceneSync.Editor
             {
                 if (asset is AnimationClip clip)
                     clips.Add(clip);
+            }
+        }
+
+        private static void CollectSerializedClipsFromHierarchy(GameObject root, Dictionary<string, AnimationClip> clips)
+        {
+            foreach (var component in root.GetComponentsInChildren<Component>(true))
+            {
+                if (component == null) continue;
+
+                var serializedObject = new SerializedObject(component);
+                var property = serializedObject.GetIterator();
+                var enterChildren = true;
+
+                while (property.NextVisible(enterChildren))
+                {
+                    enterChildren = false;
+                    if (property.propertyType != SerializedPropertyType.ObjectReference) continue;
+
+                    if (property.objectReferenceValue is AnimationClip clip)
+                        AddNamedClip(clips, clip);
+                }
             }
         }
 
@@ -196,6 +293,94 @@ namespace Afjk.SceneSync.Editor
             material.EnableKeyword("_ALPHABLEND_ON");
             material.DisableKeyword("_ALPHATEST_ON");
             material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        }
+
+        private static bool TryFindNamedClip(
+            AnimationEvent animationEvent,
+            Dictionary<string, AnimationClip> namedClips,
+            AnimationClip targetClip,
+            out AnimationClip clip)
+        {
+            clip = null;
+
+            if (animationEvent == null) return false;
+
+            var names = new[]
+            {
+                animationEvent.stringParameter,
+                animationEvent.functionName,
+            };
+
+            foreach (var name in names)
+            {
+                if (string.IsNullOrWhiteSpace(name)) continue;
+                if (!namedClips.TryGetValue(name.Trim(), out var candidate)) continue;
+                if (candidate == null || candidate == targetClip) continue;
+
+                clip = candidate;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static int CopyCurvesWithOffset(AnimationClip sourceClip, AnimationClip targetClip, float timeOffset)
+        {
+            var copied = 0;
+
+            foreach (var binding in AnimationUtility.GetCurveBindings(sourceClip))
+            {
+                var sourceCurve = AnimationUtility.GetEditorCurve(sourceClip, binding);
+                if (sourceCurve == null) continue;
+
+                var targetCurve = AnimationUtility.GetEditorCurve(targetClip, binding) ?? new AnimationCurve();
+                foreach (var key in sourceCurve.keys)
+                {
+                    var nextKey = key;
+                    nextKey.time += timeOffset;
+                    targetCurve.AddKey(nextKey);
+                }
+
+                AnimationUtility.SetEditorCurve(targetClip, binding, targetCurve);
+                copied++;
+            }
+
+            return copied;
+        }
+
+        private static string GetBakedClipPath(AnimationClip targetClip)
+        {
+            var sourcePath = AssetDatabase.GetAssetPath(targetClip);
+            var directory = string.IsNullOrEmpty(sourcePath)
+                ? "Assets"
+                : Path.GetDirectoryName(sourcePath);
+
+            if (string.IsNullOrEmpty(directory))
+                directory = "Assets";
+
+            return Path.Combine(directory, targetClip.name + "_scenesync_baked.anim");
+        }
+
+        private static void AddNamedClip(AnimationContext context, AnimationClip clip)
+        {
+            context.TargetClips.Add(clip);
+            AddNamedClip(context.NamedClips, clip);
+        }
+
+        private static void AddNamedClip(Dictionary<string, AnimationClip> clips, AnimationClip clip)
+        {
+            if (clip == null || string.IsNullOrWhiteSpace(clip.name)) return;
+
+            var name = clip.name.Trim();
+            if (!clips.ContainsKey(name))
+                clips.Add(name, clip);
+        }
+
+        private sealed class AnimationContext
+        {
+            public readonly HashSet<AnimationClip> TargetClips = new HashSet<AnimationClip>();
+            public readonly Dictionary<string, AnimationClip> NamedClips =
+                new Dictionary<string, AnimationClip>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs.meta
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncExportSupport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd12095a554b4a86a48ef4d19c73a4b9

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -14,6 +14,7 @@ namespace Afjk.SceneSync.Editor
     {
         private const string ShowSceneSyncGizmosPrefKey = "Afjk.SceneSync.ShowSceneSyncGizmos";
         private const string MaxGlbUploadMiBPrefKey = "Afjk.SceneSync.MaxGlbUploadMiB";
+        private const string ApplyTransparentNameHintsForExportPrefKey = "Afjk.SceneSync.ApplyTransparentNameHintsForExport";
         private const float DefaultMaxGlbUploadMiB = 50f;
         private const int MaxPersistentGlbSizeBytes = 50 * 1024 * 1024;
         private const long MaxPersistentGlbCacheBytes = 512L * 1024L * 1024L;
@@ -59,6 +60,7 @@ namespace Afjk.SceneSync.Editor
         private bool _connected;
         private List<PeerInfo> _peers = new List<PeerInfo>();
         private float _maxGlbUploadMiB = DefaultMaxGlbUploadMiB;
+        private bool _applyTransparentNameHintsForExport;
 
         private Dictionary<string, TransformSnapshot> _lastSnapshots = new Dictionary<string, TransformSnapshot>();
         private double _lastSendTime;
@@ -89,6 +91,8 @@ namespace Afjk.SceneSync.Editor
             {
                 _maxGlbUploadMiB = DefaultMaxGlbUploadMiB;
             }
+            _applyTransparentNameHintsForExport = EditorPrefs.GetBool(ApplyTransparentNameHintsForExportPrefKey, false);
+            GlbExporter.ApplyTransparentNameHintsForExport = _applyTransparentNameHintsForExport;
 
             SceneSyncUnityGltfInstaller.RefreshUnityGltfPackageStatus();
 
@@ -195,8 +199,13 @@ namespace Afjk.SceneSync.Editor
                 "Reconnecting to send the scene update."
             );
 
+            var reconnectRoom = !string.IsNullOrWhiteSpace(_client.Room)
+                ? _client.Room
+                : _room;
+            _room = reconnectRoom ?? "";
+
             _connected = false;
-            await _client.ConnectAsync(_presenceUrl, _room, _nickname);
+            await _client.ConnectAsync(_presenceUrl, reconnectRoom, _nickname);
 
             if (_client.IsConnected)
             {
@@ -570,6 +579,26 @@ namespace Afjk.SceneSync.Editor
             GUILayout.Space(8);
 
             EditorGUI.BeginChangeCheck();
+            var applyTransparentNameHintsForExport = EditorGUILayout.Toggle(
+                "Apply Transparent Name Hints",
+                _applyTransparentNameHintsForExport
+            );
+            if (EditorGUI.EndChangeCheck())
+            {
+                _applyTransparentNameHintsForExport = applyTransparentNameHintsForExport;
+                GlbExporter.ApplyTransparentNameHintsForExport = _applyTransparentNameHintsForExport;
+                EditorPrefs.SetBool(ApplyTransparentNameHintsForExportPrefKey, _applyTransparentNameHintsForExport);
+            }
+
+            EditorGUILayout.HelpBox(
+                "Off by default. When enabled, export temporarily treats materials with transparent-looking material or shader names as transparent. " +
+                "For safer permanent changes, use Tools > Scene Sync > Support > Apply Transparent Name Hints To Selection.",
+                MessageType.Info
+            );
+
+            GUILayout.Space(8);
+
+            EditorGUI.BeginChangeCheck();
             var newMaxGlbUploadMiB = EditorGUILayout.FloatField("Max GLB Upload Size (MiB)", _maxGlbUploadMiB);
             if (EditorGUI.EndChangeCheck())
             {
@@ -761,13 +790,14 @@ namespace Afjk.SceneSync.Editor
 
         private void SyncRoomFromSceneSyncManager()
         {
+            if (_connected) return;
+
             var manager = FindSceneSyncManager();
             if (manager == null) return;
 
-            var managerRoom = manager.ConfiguredRoom;
-            if (string.IsNullOrEmpty(managerRoom)) return;
-            if (_connected) return;
+            var managerRoom = manager.ConfiguredRoom ?? "";
 
+            if (_room == managerRoom) return;
             _room = managerRoom;
             Repaint();
         }

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -180,6 +180,33 @@ namespace Afjk.SceneSync.Editor
             return glb != null && glb.Length <= MaxGlbUploadBytes;
         }
 
+        private async System.Threading.Tasks.Task<bool> EnsureConnectedForPublishBroadcast()
+        {
+            if (_client != null && _client.IsConnected)
+            {
+                _connected = true;
+                return true;
+            }
+
+            if (_client == null) return false;
+
+            Debug.LogWarning(
+                "[SceneSync] Connection closed before publish broadcast. " +
+                "Reconnecting to send the scene update."
+            );
+
+            _connected = false;
+            await _client.ConnectAsync(_presenceUrl, _room, _nickname);
+
+            if (_client.IsConnected)
+            {
+                _connected = true;
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// 同期対象かどうかを判定する。
         /// MeshFilter または SkinnedMeshRenderer を持つオブジェクトのみ対象。
@@ -1949,13 +1976,6 @@ namespace Afjk.SceneSync.Editor
                 return;
             }
 
-            _meshPaths[objectId] = path;
-            identity.MeshPath = path;
-            identity.AssetId = assetId;
-            identity.State = SceneSyncState.Synced;
-            EditorUtility.SetDirty(identity);
-            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
-
             var pos = go.transform.position;
             var rot = go.transform.rotation;
             var scl = go.transform.localScale;
@@ -1977,7 +1997,40 @@ namespace Afjk.SceneSync.Editor
                 (!string.IsNullOrEmpty(assetId) ? ",\"assetId\":\"" + JsonEscape(assetId) + "\"" : "") +
                 ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") +
                 animationPayload + "}";
-            await _client.Broadcast(payload);
+
+            if (!await EnsureConnectedForPublishBroadcast())
+            {
+                identity.State = SceneSyncState.Error;
+                EditorUtility.SetDirty(identity);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+
+                Debug.LogError(
+                    $"[SceneSync] Publish aborted because the connection could not be restored before broadcast: " +
+                    $"{go.name}, objectId={objectId}, path={path}"
+                );
+                return;
+            }
+
+            var broadcasted = await _client.Broadcast(payload);
+            if (!broadcasted)
+            {
+                identity.State = SceneSyncState.Error;
+                EditorUtility.SetDirty(identity);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+
+                Debug.LogError(
+                    $"[SceneSync] Publish aborted because scene update broadcast failed: " +
+                    $"{go.name}, objectId={objectId}, path={path}"
+                );
+                return;
+            }
+
+            _meshPaths[objectId] = path;
+            identity.MeshPath = path;
+            identity.AssetId = assetId;
+            identity.State = SceneSyncState.Synced;
+            EditorUtility.SetDirty(identity);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
 
             _managedObjects[objectId] = go;
             _instanceToObjectId[go.GetInstanceID()] = objectId;

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -79,6 +79,7 @@ namespace Afjk.SceneSync.Editor
         private Vector2 _scrollPosition;
         private bool _isSceneSwitching = false;
         private bool _isManualDisconnect = false;
+        private bool _publishInProgress = false;
         private string _envId = null;
 
         private void OnEnable()
@@ -482,17 +483,22 @@ namespace Afjk.SceneSync.Editor
         {
             GUILayout.Label("Actions", EditorStyles.boldLabel);
 
-            using (new EditorGUI.DisabledScope(!_connected))
+            using (new EditorGUI.DisabledScope(!_connected || _publishInProgress))
             {
                 if (GUILayout.Button("Publish Selected"))
                 {
-                    PublishSelectedObjects();
+                    QueuePublishSelectedObjects();
                 }
 
                 if (GUILayout.Button("Publish Managed Objects"))
                 {
-                    PublishManagedObjects();
+                    QueuePublishManagedObjects();
                 }
+            }
+
+            if (_publishInProgress)
+            {
+                EditorGUILayout.LabelField("Publishing...", EditorStyles.miniLabel);
             }
 
             if (GUILayout.Button("Fix Remote Object Selection"))
@@ -1675,7 +1681,47 @@ namespace Afjk.SceneSync.Editor
             return identity;
         }
 
-        private async void PublishSelectedObjects()
+        private void QueuePublishSelectedObjects()
+        {
+            QueuePublishOperation(PublishSelectedObjectsAsync);
+        }
+
+        private void QueuePublishManagedObjects()
+        {
+            QueuePublishOperation(PublishManagedObjectsAsync);
+        }
+
+        private void QueuePublishOperation(Func<System.Threading.Tasks.Task> operation)
+        {
+            if (_publishInProgress)
+            {
+                Debug.LogWarning("[SceneSync] Publish is already in progress.");
+                return;
+            }
+
+            _publishInProgress = true;
+            Repaint();
+
+            EditorApplication.delayCall += async () =>
+            {
+                try
+                {
+                    if (operation != null)
+                        await operation();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+                finally
+                {
+                    _publishInProgress = false;
+                    Repaint();
+                }
+            };
+        }
+
+        private async System.Threading.Tasks.Task PublishSelectedObjectsAsync()
         {
             if (!_connected)
             {
@@ -1710,7 +1756,7 @@ namespace Afjk.SceneSync.Editor
             }
         }
 
-        private async void PublishManagedObjects()
+        private async System.Threading.Tasks.Task PublishManagedObjectsAsync()
         {
             if (!_connected)
             {
@@ -1914,6 +1960,10 @@ namespace Afjk.SceneSync.Editor
             var rot = go.transform.rotation;
             var scl = go.transform.localScale;
             var preferredAnimationClipName = GlbExporter.LastExportPreferredAnimationClipName;
+            if (!string.IsNullOrWhiteSpace(preferredAnimationClipName))
+            {
+                Debug.Log("[SceneSync] Initial GLB animation clip: " + preferredAnimationClipName);
+            }
             var animationPayload = !string.IsNullOrWhiteSpace(preferredAnimationClipName)
                 ? ",\"animation\":{\"enabled\":true,\"clipName\":\"" + JsonEscape(preferredAnimationClipName) + "\",\"mode\":\"loop\",\"speed\":1}"
                 : "";

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1913,6 +1913,10 @@ namespace Afjk.SceneSync.Editor
             var pos = go.transform.position;
             var rot = go.transform.rotation;
             var scl = go.transform.localScale;
+            var preferredAnimationClipName = GlbExporter.LastExportPreferredAnimationClipName;
+            var animationPayload = !string.IsNullOrWhiteSpace(preferredAnimationClipName)
+                ? ",\"animation\":{\"enabled\":true,\"clipName\":\"" + JsonEscape(preferredAnimationClipName) + "\",\"mode\":\"loop\",\"speed\":1}"
+                : "";
             var payload = "{\"kind\":\"scene-add\",\"objectId\":\"" + JsonEscape(objectId) + "\",\"name\":\"" + JsonEscape(go.name) + "\"" +
                 ",\"origin\":\"unity\"" +
                 ",\"unityHierarchyPath\":\"" + JsonEscape(SceneSyncWireJson.GetUnityHierarchyPath(go)) + "\"" +
@@ -1921,7 +1925,8 @@ namespace Afjk.SceneSync.Editor
                 ",\"scale\":[" + FormatFloat(scl.x) + "," + FormatFloat(scl.y) + "," + FormatFloat(scl.z) + "]" +
                 ",\"meshPath\":\"" + JsonEscape(path) + "\"" +
                 (!string.IsNullOrEmpty(assetId) ? ",\"assetId\":\"" + JsonEscape(assetId) + "\"" : "") +
-                ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") + "}";
+                ",\"asset\":" + SceneSyncWireJson.BuildMeshAssetJson(path, assetId, "unity") +
+                animationPayload + "}";
             await _client.Broadcast(payload);
 
             _managedObjects[objectId] = go;

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -78,6 +78,7 @@ namespace Afjk.SceneSync.Editor
         private bool _showManagedUnityObjects = true;
         private Vector2 _scrollPosition;
         private bool _isSceneSwitching = false;
+        private bool _isManualDisconnect = false;
         private string _envId = null;
 
         private void OnEnable()
@@ -94,14 +95,20 @@ namespace Afjk.SceneSync.Editor
             _client.OnConnected += () =>
             {
                 _connected = true;
+                SyncRoomToSceneSyncManager();
                 RebindPublishedUnityObjects();
                 Repaint();
             };
             _client.OnDisconnected += () =>
             {
+                var wasConnected = _connected;
                 _connected = false;
                 _sceneReceived = false;
                 _firstPeersReceived = false;
+                if (wasConnected && !_isSceneSwitching && !_isManualDisconnect)
+                {
+                    ClearTemporaryObjects();
+                }
                 Repaint();
             };
             _client.OnPeersUpdated += (peers) =>
@@ -125,6 +132,8 @@ namespace Afjk.SceneSync.Editor
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
             EditorSceneManager.sceneClosing += OnSceneClosing;
             EditorSceneManager.sceneOpened += OnSceneOpened;
+
+            SyncRoomFromSceneSyncManager();
         }
 
         private void OnDisable()
@@ -133,7 +142,9 @@ namespace Afjk.SceneSync.Editor
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             EditorSceneManager.sceneClosing -= OnSceneClosing;
             EditorSceneManager.sceneOpened -= OnSceneOpened;
+            _isManualDisconnect = true;
             _client?.Disconnect();
+            _isManualDisconnect = false;
         }
 
         private string GetBlobUrl()
@@ -263,14 +274,22 @@ namespace Afjk.SceneSync.Editor
 
             _presenceUrl = EditorGUILayout.TextField("Presence URL", _presenceUrl);
             _blobUrl = EditorGUILayout.TextField("Blob URL", _blobUrl);
+            EditorGUI.BeginChangeCheck();
             _room = EditorGUILayout.TextField("Room", _room);
+            if (EditorGUI.EndChangeCheck())
+            {
+                SyncRoomToSceneSyncManager();
+            }
             _nickname = EditorGUILayout.TextField("Nickname", _nickname);
             GUILayout.Space(8);
+
+            DrawConnectionStatus();
 
             if (!_connected)
             {
                 if (GUILayout.Button("Connect"))
                 {
+                    SyncRoomToSceneSyncManager();
                     _ = _client.ConnectAsync(_presenceUrl, _room, _nickname);
                 }
             }
@@ -296,9 +315,30 @@ namespace Afjk.SceneSync.Editor
                 if (GUILayout.Button("Disconnect"))
                 {
                     ClearTemporaryObjects();
+                    _isManualDisconnect = true;
                     _client.Disconnect();
+                    _isManualDisconnect = false;
                 }
             }
+        }
+
+        private void DrawConnectionStatus()
+        {
+            var connected = _connected && _client != null && _client.IsConnected;
+            var previousColor = GUI.color;
+            GUI.color = connected ? new Color(0.1f, 0.65f, 0.2f) : new Color(0.85f, 0.15f, 0.12f);
+
+            var activeRoom = connected && _client != null && !string.IsNullOrEmpty(_client.Room)
+                ? _client.Room
+                : _room;
+            GUILayout.Label(
+                (connected ? "● Connected" : "● Disconnected") +
+                (string.IsNullOrWhiteSpace(activeRoom) ? "" : "  Room: " + activeRoom),
+                EditorStyles.boldLabel
+            );
+
+            GUI.color = previousColor;
+            GUILayout.Space(4);
         }
 
         private void DrawQuickGuide()
@@ -322,7 +362,8 @@ namespace Afjk.SceneSync.Editor
                 "Remote objects:\n" +
                 "- Remote GLB objects are temporary.\n" +
                 "- Move the Scene Sync root, not imported children.\n" +
-                "- Temporary objects are removed on manual Disconnect.",
+                "- Temporary objects are removed on Disconnect.\n" +
+                "- Fix Remote Object Selection is only needed if imported child meshes become selectable.",
                 MessageType.Info
             );
         }
@@ -454,10 +495,14 @@ namespace Afjk.SceneSync.Editor
                 }
             }
 
-            if (GUILayout.Button("Apply Picking Rules"))
+            if (GUILayout.Button("Fix Remote Object Selection"))
             {
                 ApplyPickingRules();
             }
+            EditorGUILayout.LabelField(
+                "Repair only: makes imported remote roots selectable while imported child meshes stay unpickable.",
+                EditorStyles.wordWrappedMiniLabel
+            );
 
             var showSceneSyncGizmos = EditorGUILayout.ToggleLeft("Show Scene Sync Gizmos", ShowSceneSyncGizmos);
             if (showSceneSyncGizmos != ShowSceneSyncGizmos)
@@ -675,8 +720,33 @@ namespace Afjk.SceneSync.Editor
 
             if (manager != null)
             {
+                manager.ConfiguredRoom = _room;
+                MarkManagerDirty(manager);
                 Selection.activeGameObject = manager.gameObject;
             }
+        }
+
+        private void SyncRoomFromSceneSyncManager()
+        {
+            var manager = FindSceneSyncManager();
+            if (manager == null) return;
+
+            var managerRoom = manager.ConfiguredRoom;
+            if (string.IsNullOrEmpty(managerRoom)) return;
+            if (_connected) return;
+
+            _room = managerRoom;
+            Repaint();
+        }
+
+        private void SyncRoomToSceneSyncManager()
+        {
+            var manager = FindSceneSyncManager();
+            if (manager == null) return;
+            if (manager.ConfiguredRoom == _room) return;
+
+            manager.ConfiguredRoom = _room;
+            MarkManagerDirty(manager);
         }
 
         private SceneSyncManager FindSceneSyncManager()
@@ -847,6 +917,7 @@ namespace Afjk.SceneSync.Editor
 
             // Restore _connected from _client state
             // (The next manual Connect action will establish a fresh connection)
+            SyncRoomFromSceneSyncManager();
         }
 
         private void RebindPublishedUnityObjects()

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -146,7 +146,9 @@ Editor の補助メニューとして **Tools > Scene Sync > Support** を利用
   - 選択中の GameObject 配下の Animation / Animator / serialized field から AnimationClip 候補を集めます
   - 任意の MonoBehaviour callback の実行結果までは推測できないため、curve として表現されている blend shape / material / transform などが対象です
 
-透明補正は汎用的な名前ヒントだけを使います。表情や状態変化が Animation Event / MonoBehaviour callback に依存している場合は、GLB publish 前に transform / material / blend shape の animation curve として bake してください。
+UnityGLTF による publish 時は、名前付き clip を呼ぶ Animation Event を検出し、export 中だけ一時的な AnimatorOverrideController で焼き込み済み clip に差し替えます。元の AnimatorController や AnimationClip asset は変更しません。
+
+透明補正は汎用的な名前ヒントだけを使います。表情や状態変化が任意の MonoBehaviour callback に依存している場合、その callback の実行結果までは自動推測できません。AnimationCurve として表現されている blend shape / material / transform などが自動 bake の対象です。
 
 ## 技術仕様
 

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -131,6 +131,19 @@ Window > Scene Sync の Export Settings で backend を選択:
 - **glTFast**: 常に glTFast を使用（Animation 非対応）
 - **UnityGltf**: 常に UnityGLTF を使用（Editor のみ）
 
+### Export Support
+
+Editor の補助メニューとして **Tools > Scene Sync > Support** を利用できます。
+
+- **Apply Transparent Name Hints To Selection**
+  - 選択中の Material または GameObject 配下の Material を走査します
+  - Material 名または Shader 名に `transparent` / `trans` / `alpha` / `cheek` / `glass` などのヒントがある場合、透明 Material として扱われるように設定します
+- **Report Animation Events In Selection**
+  - 選択中の AnimationClip、Prefab、GameObject 配下の AnimationClip を走査します
+  - Animation Event が含まれている場合、GLB にそのまま保持されない可能性を Console に警告します
+
+透明補正は汎用的な名前ヒントだけを使います。表情や状態変化が Animation Event / MonoBehaviour callback に依存している場合は、GLB publish 前に transform / material / blend shape の animation curve として bake してください。
+
 ## 技術仕様
 
 詳細は [docs/scene-sync-spec.md](../../docs/scene-sync-spec.md) を参照。

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -141,6 +141,10 @@ Editor の補助メニューとして **Tools > Scene Sync > Support** を利用
 - **Report Animation Events In Selection**
   - 選択中の AnimationClip、Prefab、GameObject 配下の AnimationClip を走査します
   - Animation Event が含まれている場合、GLB にそのまま保持されない可能性を Console に警告します
+- **Bake Event-Named Clip Curves To New Clips**
+  - Animation Event の `stringParameter` または `functionName` が別の AnimationClip 名と一致する場合、その clip の curve を event 時刻へコピーした publish 用 clip を作成します
+  - 選択中の GameObject 配下の Animation / Animator / serialized field から AnimationClip 候補を集めます
+  - 任意の MonoBehaviour callback の実行結果までは推測できないため、curve として表現されている blend shape / material / transform などが対象です
 
 透明補正は汎用的な名前ヒントだけを使います。表情や状態変化が Animation Event / MonoBehaviour callback に依存している場合は、GLB publish 前に transform / material / blend shape の animation curve として bake してください。
 

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -32,6 +32,7 @@ namespace Afjk.SceneSync
 
 #if UNITY_EDITOR
         public static Func<GameObject, byte[]> UnityGltfExportHandler { get; set; }
+        public static Func<GameObject, IDisposable> EditorExportPreparationHandler { get; set; }
 
         public static bool IsUnityGltfExportAvailable => UnityGltfExportHandler != null;
 
@@ -52,6 +53,7 @@ namespace Afjk.SceneSync
             var originalPos = go.transform.position;
             var originalRot = go.transform.rotation;
             var originalScale = go.transform.localScale;
+            var editorExportPreparation = BeginEditorExportPreparation(go, backend);
             var materialRestores = BeginTemporaryTransparentMaterialOverrides(go);
 
             try
@@ -80,7 +82,27 @@ namespace Afjk.SceneSync
                 go.transform.rotation = originalRot;
                 go.transform.localScale = originalScale;
                 RestoreTemporaryMaterialOverrides(materialRestores);
+                editorExportPreparation?.Dispose();
             }
+        }
+
+        private static IDisposable BeginEditorExportPreparation(GameObject go, SceneSyncGlbExportBackend backend)
+        {
+#if UNITY_EDITOR
+            if (backend != SceneSyncGlbExportBackend.UnityGltf || EditorExportPreparationHandler == null)
+                return null;
+
+            try
+            {
+                return EditorExportPreparationHandler(go);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[SceneSync] Editor export preparation failed: " + ex.Message);
+            }
+#endif
+
+            return null;
         }
 
         private static SceneSyncGlbExportBackend ResolveExportBackend(GameObject root)

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -33,6 +33,7 @@ namespace Afjk.SceneSync
 #if UNITY_EDITOR
         public static Func<GameObject, byte[]> UnityGltfExportHandler { get; set; }
         public static Func<GameObject, IDisposable> EditorExportPreparationHandler { get; set; }
+        public static string LastExportPreferredAnimationClipName { get; set; }
 
         public static bool IsUnityGltfExportAvailable => UnityGltfExportHandler != null;
 
@@ -50,6 +51,9 @@ namespace Afjk.SceneSync
 
         public static async Task<byte[]> ExportGameObjectAsGlb(GameObject go, SceneSyncGlbExportBackend backend)
         {
+#if UNITY_EDITOR
+            LastExportPreferredAnimationClipName = null;
+#endif
             var originalPos = go.transform.position;
             var originalRot = go.transform.rotation;
             var originalScale = go.transform.localScale;

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -17,6 +17,7 @@ namespace Afjk.SceneSync
     public static class GlbExporter
     {
         public static SceneSyncGlbExportBackend ConfiguredBackend { get; set; } = SceneSyncGlbExportBackend.Auto;
+        public static bool ApplyTransparentNameHintsForExport { get; set; } = false;
         private static readonly string[] TransparentNameHints =
         {
             "glass",
@@ -58,7 +59,9 @@ namespace Afjk.SceneSync
             var originalRot = go.transform.rotation;
             var originalScale = go.transform.localScale;
             var editorExportPreparation = BeginEditorExportPreparation(go, backend);
-            var materialRestores = BeginTemporaryTransparentMaterialOverrides(go);
+            var materialRestores = ApplyTransparentNameHintsForExport
+                ? BeginTemporaryTransparentMaterialOverrides(go)
+                : null;
 
             try
             {
@@ -233,18 +236,25 @@ namespace Afjk.SceneSync
                     "[SceneSync] UnityGLTF exporter handler is not registered. " +
                     "Falling back to glTFast; animations will not be exported."
                 );
+                LastExportPreferredAnimationClipName = null;
                 return await ExportWithGltfFast(go);
             }
 
             try
             {
                 var bytes = UnityGltfExportHandler(go);
+                if (bytes == null || bytes.Length == 0)
+                {
+                    LastExportPreferredAnimationClipName = null;
+                    return bytes;
+                }
                 Debug.Log("[SceneSync] Export backend: UnityGLTF with animations.");
                 return bytes;
             }
             catch (Exception ex)
             {
                 Debug.LogWarning("[SceneSync] UnityGLTF export failed: " + ex.Message);
+                LastExportPreferredAnimationClipName = null;
                 return await ExportWithGltfFast(go);
             }
         }

--- a/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
+++ b/unity/com.afjk.scene-sync/Runtime/GlbExporter.cs
@@ -17,6 +17,18 @@ namespace Afjk.SceneSync
     public static class GlbExporter
     {
         public static SceneSyncGlbExportBackend ConfiguredBackend { get; set; } = SceneSyncGlbExportBackend.Auto;
+        private static readonly string[] TransparentNameHints =
+        {
+            "glass",
+            "lens",
+            "wing",
+            "cheek",
+            "shadow",
+            "fade",
+            "trans",
+            "alpha",
+            "semi",
+        };
 
 #if UNITY_EDITOR
         public static Func<GameObject, byte[]> UnityGltfExportHandler { get; set; }
@@ -40,6 +52,7 @@ namespace Afjk.SceneSync
             var originalPos = go.transform.position;
             var originalRot = go.transform.rotation;
             var originalScale = go.transform.localScale;
+            var materialRestores = BeginTemporaryTransparentMaterialOverrides(go);
 
             try
             {
@@ -66,6 +79,7 @@ namespace Afjk.SceneSync
                 go.transform.position = originalPos;
                 go.transform.rotation = originalRot;
                 go.transform.localScale = originalScale;
+                RestoreTemporaryMaterialOverrides(materialRestores);
             }
         }
 
@@ -209,5 +223,125 @@ namespace Afjk.SceneSync
             }
         }
 #endif
+
+        private struct MaterialRestore
+        {
+            public Renderer Renderer;
+            public Material[] Materials;
+        }
+
+        private static List<MaterialRestore> BeginTemporaryTransparentMaterialOverrides(GameObject root)
+        {
+            var restores = new List<MaterialRestore>();
+            if (root == null) return restores;
+
+            foreach (var renderer in root.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer == null) continue;
+
+                var materials = renderer.sharedMaterials;
+                if (materials == null || materials.Length == 0) continue;
+
+                Material[] nextMaterials = null;
+                for (var i = 0; i < materials.Length; i++)
+                {
+                    var material = materials[i];
+                    if (!ShouldTreatAsTransparentForExport(material)) continue;
+
+                    if (nextMaterials == null)
+                        nextMaterials = (Material[])materials.Clone();
+                    var copy = new Material(material)
+                    {
+                        name = material.name
+                    };
+                    ConfigureTransparentMaterialForExport(copy);
+                    nextMaterials[i] = copy;
+                }
+
+                if (nextMaterials == null) continue;
+
+                restores.Add(new MaterialRestore
+                {
+                    Renderer = renderer,
+                    Materials = materials,
+                });
+                renderer.sharedMaterials = nextMaterials;
+            }
+
+            return restores;
+        }
+
+        private static void RestoreTemporaryMaterialOverrides(List<MaterialRestore> restores)
+        {
+            if (restores == null) return;
+
+            foreach (var restore in restores)
+            {
+                if (restore.Renderer == null) continue;
+
+                var current = restore.Renderer.sharedMaterials;
+                restore.Renderer.sharedMaterials = restore.Materials;
+
+                if (current == null) continue;
+                foreach (var material in current)
+                {
+                    if (material == null) continue;
+                    if (restore.Materials != null && Array.IndexOf(restore.Materials, material) >= 0) continue;
+
+                    if (Application.isPlaying)
+                    {
+                        UnityEngine.Object.Destroy(material);
+                    }
+                    else
+                    {
+                        UnityEngine.Object.DestroyImmediate(material);
+                    }
+                }
+            }
+        }
+
+        private static bool ShouldTreatAsTransparentForExport(Material material)
+        {
+            if (material == null) return false;
+
+            var renderType = material.GetTag("RenderType", false, "");
+            if (renderType == "Transparent" || renderType == "Fade" || renderType == "TransparentCutout")
+                return false;
+
+            var materialName = material.name ?? "";
+            var shaderName = material.shader != null ? material.shader.name ?? "" : "";
+            var combined = (materialName + " " + shaderName).ToLowerInvariant();
+
+            foreach (var hint in TransparentNameHints)
+            {
+                if (combined.Contains(hint))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static void ConfigureTransparentMaterialForExport(Material material)
+        {
+            if (material == null) return;
+
+            material.SetOverrideTag("RenderType", "Transparent");
+            material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+
+            if (material.HasProperty("_Mode"))
+                material.SetFloat("_Mode", 3f);
+            if (material.HasProperty("_Surface"))
+                material.SetFloat("_Surface", 1f);
+            if (material.HasProperty("_SrcBlend"))
+                material.SetFloat("_SrcBlend", (float)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            if (material.HasProperty("_DstBlend"))
+                material.SetFloat("_DstBlend", (float)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            if (material.HasProperty("_ZWrite"))
+                material.SetFloat("_ZWrite", 0f);
+
+            material.EnableKeyword("_ALPHABLEND_ON");
+            material.DisableKeyword("_ALPHATEST_ON");
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        }
     }
 }

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -70,7 +70,12 @@ namespace Afjk.SceneSync
         }
 
         public bool IsConnected => _connected;
-        public string Room => _client?.Room;
+        public string Room => _client != null && !string.IsNullOrEmpty(_client.Room) ? _client.Room : _room;
+        public string ConfiguredRoom
+        {
+            get => _room;
+            set => _room = value ?? "";
+        }
         public List<PeerInfo> Peers => _peers;
         public GameObject SelectedObject => _selectedObject;
         public bool IncludeManagerChildren


### PR DESCRIPTION
## Summary
- Add a green/red connection status indicator to the Unity Scene Sync editor window.
- Synchronize the editor Room field with the active scene's SceneSyncManager configuration.
- Initialize the editor Room from the open scene's SceneSyncManager and resync it when scenes open.
- Clear SceneSync Temporary objects after unexpected editor disconnects, while preserving scene-switch behavior.
- Rename the unclear Apply Picking Rules action to Fix Remote Object Selection and add inline guidance.

## Why
The Unity plugin could show a stale or unclear connection state, and Editor/Runtime room settings could drift apart. Remote temporary objects could also remain after an unexpected disconnect, making the scene state confusing.

## Validation
- `git diff --check`
- Attempted `dotnet build ../SceneSyncClient/com.afjk.scene-sync.Editor.csproj --no-restore`, but the generated Unity csproj currently fails on existing unresolved references such as `SceneSyncWireJson`, `SceneSyncLoomletBehaviour`, `SceneSyncPanelFactory`, and `SceneSyncWireMetadata`.