### PR TITLE
Add Scene Sync dev tool inspector editor

### DIFF
--- a/html/assets/css/scenesync-dev-tool.css
+++ b/html/assets/css/scenesync-dev-tool.css
@@ -70,27 +70,27 @@ textarea {
   padding: 12px 14px;
 }
 
-input[type="checkbox"],
-input[type="color"],
-input[type="range"] {
+.inspector input[type="checkbox"],
+.inspector input[type="color"],
+.inspector input[type="range"] {
   width: auto;
   padding: 0;
 }
 
-input[type="checkbox"] {
+.inspector input[type="checkbox"] {
   width: 18px;
   height: 18px;
   accent-color: var(--accent);
 }
 
-input[type="color"] {
+.inspector input[type="color"] {
   width: 40px;
   height: 36px;
   border-radius: 8px;
   background: var(--bg-console);
 }
 
-input[type="range"] {
+.inspector input[type="range"] {
   accent-color: var(--accent);
 }
 

--- a/html/assets/css/scenesync-dev-tool.css
+++ b/html/assets/css/scenesync-dev-tool.css
@@ -70,6 +70,30 @@ textarea {
   padding: 12px 14px;
 }
 
+input[type="checkbox"],
+input[type="color"],
+input[type="range"] {
+  width: auto;
+  padding: 0;
+}
+
+input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+input[type="color"] {
+  width: 40px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--bg-console);
+}
+
+input[type="range"] {
+  accent-color: var(--accent);
+}
+
 textarea {
   min-height: 420px;
   resize: vertical;
@@ -209,6 +233,143 @@ button:focus {
   flex-wrap: wrap;
 }
 
+.editor-toggle {
+  display: inline-flex;
+  gap: 0;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(5, 8, 13, 0.65);
+}
+
+.editor-toggle button {
+  min-width: 92px;
+  padding: 7px 10px;
+  border-color: transparent;
+  border-radius: 8px;
+  background: transparent;
+}
+
+.editor-toggle button:hover {
+  transform: none;
+}
+
+.editor-toggle button.is-active {
+  border-color: rgba(76, 201, 176, 0.45);
+  background: rgba(76, 201, 176, 0.16);
+  color: var(--accent-strong);
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+.inspector {
+  min-height: 420px;
+  max-height: 68vh;
+  overflow: auto;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(5, 8, 13, 0.65);
+}
+
+.inspector-group {
+  min-width: 0;
+  margin: 0 0 10px;
+  padding: 12px;
+  border: 1px solid rgba(139, 152, 169, 0.28);
+  border-radius: 10px;
+  background: rgba(22, 27, 34, 0.72);
+}
+
+.inspector-group:last-child {
+  margin-bottom: 0;
+}
+
+.inspector-group legend {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  max-width: 100%;
+  padding: 0 6px;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.inspector-group legend small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-children {
+  display: grid;
+  gap: 8px;
+}
+
+.inspector-row {
+  display: grid;
+  grid-template-columns: minmax(96px, 0.38fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+  padding: 6px 0;
+}
+
+.inspector-row > span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-row input {
+  min-width: 0;
+  border-radius: 8px;
+}
+
+.inspector-row input[type="text"],
+.inspector-row input[type="number"] {
+  padding: 9px 10px;
+}
+
+.inspector-row-boolean {
+  grid-template-columns: minmax(96px, 0.38fr) auto;
+  justify-content: start;
+}
+
+.number-field {
+  display: grid;
+  grid-template-columns: minmax(96px, 1fr) minmax(76px, 112px);
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.text-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.text-field-color {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.inspector-empty {
+  margin: 0;
+  padding: 8px 0;
+  color: var(--muted);
+}
+
 .route-bar {
   display: flex;
   justify-content: space-between;
@@ -306,5 +467,34 @@ button:focus {
   .hero-links,
   .history-item .history-actions {
     width: 100%;
+  }
+
+  .editor-toggle {
+    width: 100%;
+  }
+
+  .editor-toggle button {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .inspector {
+    padding: 8px;
+  }
+
+  .inspector-group {
+    padding: 10px;
+  }
+
+  .inspector-row,
+  .inspector-row-boolean {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .number-field {
+    grid-template-columns: 1fr;
   }
 }

--- a/html/assets/js/scenesync/dev-tool-console.js
+++ b/html/assets/js/scenesync/dev-tool-console.js
@@ -27,6 +27,7 @@ const elements = {
   sessionStatus: document.querySelector('#sessionStatus'),
   sessionMeta: document.querySelector('#sessionMeta'),
   payloadInput: document.querySelector('#payloadInput'),
+  payloadInspector: document.querySelector('#payloadInspector'),
   previewOutput: document.querySelector('#previewOutput'),
   validationOutput: document.querySelector('#validationOutput'),
   responseOutput: document.querySelector('#responseOutput'),
@@ -37,6 +38,7 @@ const elements = {
   snapshotButton: document.querySelector('#snapshotButton'),
   clearHistoryButton: document.querySelector('#clearHistoryButton'),
   historyList: document.querySelector('#historyList'),
+  editorModeButtons: document.querySelectorAll('[data-editor-mode]'),
 };
 
 function loadJson(key, fallback) {
@@ -115,6 +117,162 @@ function renderValidation(errors) {
   elements.validationOutput.classList.add('console-error');
 }
 
+function formatLabel(value) {
+  const raw = String(value ?? 'Value')
+    .replaceAll('_', ' ')
+    .replaceAll('-', ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : 'Value';
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function makePathAttribute(path) {
+  return escapeHtml(JSON.stringify(path));
+}
+
+function getObjectMeta(value) {
+  if (!isPlainObject(value)) return '';
+  const name = typeof value.name === 'string' && value.name.trim() ? value.name.trim() : '';
+  const objectId = typeof value.objectId === 'string' && value.objectId.trim() ? value.objectId.trim() : '';
+  if (name && objectId) return `${name} / ${objectId}`;
+  return name || objectId;
+}
+
+function getNumericConfig(path, value) {
+  const key = String(path[path.length - 1] ?? '').toLowerCase();
+  const parent = String(path[path.length - 2] ?? '').toLowerCase();
+  const absValue = Math.abs(Number(value) || 0);
+  let min = -100;
+  let max = 100;
+  let step = 0.01;
+
+  if (['position'].includes(parent) || ['x', 'y', 'z'].includes(key)) {
+    min = -20;
+    max = 20;
+  } else if (['scale'].includes(parent) || key.includes('scale')) {
+    min = 0;
+    max = 10;
+  } else if (['rotation'].includes(parent) || key.includes('rotation')) {
+    min = -1;
+    max = 1;
+  } else if (['opacity', 'alpha', 'volume', 'weight', 'intensity'].some((token) => key.includes(token))) {
+    min = 0;
+    max = 1;
+    step = 0.001;
+  }
+
+  if (absValue > Math.max(Math.abs(min), Math.abs(max))) {
+    const range = Math.ceil(absValue * 1.25);
+    min = Math.min(min, -range);
+    max = Math.max(max, range);
+  }
+
+  return { min, max, step };
+}
+
+function renderPrimitiveControl(label, value, path) {
+  const pathAttribute = makePathAttribute(path);
+  const labelText = escapeHtml(formatLabel(label));
+
+  if (typeof value === 'boolean') {
+    return `
+      <label class="inspector-row inspector-row-boolean">
+        <span>${labelText}</span>
+        <input type="checkbox" ${value ? 'checked' : ''} data-inspector-type="boolean" data-inspector-path="${pathAttribute}">
+      </label>
+    `;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const { min, max, step } = getNumericConfig(path, value);
+    const safeValue = escapeHtml(String(value));
+    return `
+      <label class="inspector-row inspector-row-number">
+        <span>${labelText}</span>
+        <div class="number-field">
+          <input type="range" min="${min}" max="${max}" step="${step}" value="${safeValue}" data-inspector-type="number" data-inspector-path="${pathAttribute}">
+          <input type="number" step="${step}" value="${safeValue}" data-inspector-type="number" data-inspector-path="${pathAttribute}">
+        </div>
+      </label>
+    `;
+  }
+
+  if (typeof value === 'string') {
+    const safeValue = escapeHtml(value);
+    const isColor = /^#[0-9a-f]{6}$/i.test(value);
+    return `
+      <label class="inspector-row inspector-row-text">
+        <span>${labelText}</span>
+        <div class="${isColor ? 'text-field text-field-color' : 'text-field'}">
+          ${isColor ? `<input type="color" value="${safeValue}" data-inspector-type="string" data-inspector-path="${pathAttribute}">` : ''}
+          <input type="text" value="${safeValue}" spellcheck="false" data-inspector-type="string" data-inspector-path="${pathAttribute}">
+        </div>
+      </label>
+    `;
+  }
+
+  const jsonValue = value === null ? 'null' : JSON.stringify(value);
+  return `
+    <label class="inspector-row inspector-row-text">
+      <span>${labelText}</span>
+      <input type="text" value="${escapeHtml(jsonValue)}" spellcheck="false" data-inspector-type="json" data-inspector-path="${pathAttribute}">
+    </label>
+  `;
+}
+
+function renderInspectorValue(value, path = [], label = 'Payload') {
+  if (Array.isArray(value)) {
+    const rows = value.map((item, index) => renderInspectorValue(item, [...path, index], `[${index}]`)).join('');
+    return `
+      <fieldset class="inspector-group">
+        <legend>${escapeHtml(formatLabel(label))}</legend>
+        <div class="inspector-children">${rows || '<p class="inspector-empty">[]</p>'}</div>
+      </fieldset>
+    `;
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    const meta = getObjectMeta(value);
+    const rows = entries.map(([key, item]) => renderInspectorValue(item, [...path, key], key)).join('');
+    return `
+      <fieldset class="inspector-group">
+        <legend>
+          <span>${escapeHtml(formatLabel(label))}</span>
+          ${meta ? `<small>${escapeHtml(meta)}</small>` : ''}
+        </legend>
+        <div class="inspector-children">${rows || '<p class="inspector-empty">{}</p>'}</div>
+      </fieldset>
+    `;
+  }
+
+  return renderPrimitiveControl(label, value, path);
+}
+
+function renderInspector(parsed) {
+  if (!parsed) {
+    elements.payloadInspector.innerHTML = '<p class="inspector-empty">Preview unavailable.</p>';
+    return;
+  }
+
+  elements.payloadInspector.innerHTML = renderInspectorValue(parsed);
+}
+
+function setEditorMode(mode) {
+  const isJson = mode === 'json';
+  elements.payloadInput.classList.toggle('is-hidden', !isJson);
+  elements.payloadInspector.classList.toggle('is-hidden', isJson);
+  elements.editorModeButtons.forEach((button) => {
+    const isActive = button.dataset.editorMode === mode;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+  });
+}
+
 function validatePayload(value) {
   const errors = [];
   let parsed = null;
@@ -172,13 +330,73 @@ function validatePayload(value) {
   return { errors, parsed, route };
 }
 
-function syncPayloadState() {
+function syncPayloadState(options = {}) {
+  const { renderInspectorView = true } = options;
   const { errors, parsed, route } = validatePayload(elements.payloadInput.value);
   renderValidation(errors);
   elements.resolvedRoute.textContent = route;
   elements.previewOutput.textContent = parsed ? JSON.stringify(parsed, null, 2) : 'Preview unavailable.';
   elements.sendButton.disabled = errors.length > 0;
+  if (renderInspectorView) {
+    renderInspector(parsed);
+  }
   return { errors, parsed, route };
+}
+
+function setValueAtPath(root, path, value) {
+  let target = root;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    target = target[path[index]];
+  }
+  target[path[path.length - 1]] = value;
+}
+
+function mirrorInspectorControls(path, value) {
+  const serializedPath = JSON.stringify(path);
+  elements.payloadInspector.querySelectorAll('[data-inspector-path]').forEach((control) => {
+    if (control.dataset.inspectorPath !== serializedPath) return;
+    if (control.type === 'checkbox') {
+      control.checked = Boolean(value);
+    } else {
+      control.value = String(value);
+    }
+  });
+}
+
+function readInspectorValue(control) {
+  if (control.dataset.inspectorType === 'boolean') {
+    return control.checked;
+  }
+  if (control.dataset.inspectorType === 'number') {
+    if (['', '-', '.', '-.'].includes(control.value)) return undefined;
+    const number = Number(control.value);
+    return Number.isFinite(number) ? number : undefined;
+  }
+  if (control.dataset.inspectorType === 'json') {
+    try {
+      return JSON.parse(control.value);
+    } catch {
+      return undefined;
+    }
+  }
+  return control.value;
+}
+
+function handleInspectorInput(event) {
+  const control = event.target.closest('[data-inspector-path]');
+  if (!control) return;
+
+  const path = JSON.parse(control.dataset.inspectorPath);
+  const value = readInspectorValue(control);
+  if (value === undefined) return;
+
+  const { parsed } = validatePayload(elements.payloadInput.value);
+  if (!parsed) return;
+
+  setValueAtPath(parsed, path, value);
+  elements.payloadInput.value = JSON.stringify(parsed, null, 2);
+  mirrorInspectorControls(path, value);
+  syncPayloadState({ renderInspectorView: false });
 }
 
 function renderResult(target, value, isError = false) {
@@ -351,6 +569,11 @@ function bindEvents() {
     updateSessionStatus();
   });
   elements.payloadInput.addEventListener('input', syncPayloadState);
+  elements.payloadInspector.addEventListener('input', handleInspectorInput);
+  elements.payloadInspector.addEventListener('change', handleInspectorInput);
+  elements.editorModeButtons.forEach((button) => {
+    button.addEventListener('click', () => setEditorMode(button.dataset.editorMode));
+  });
   elements.redeemButton.addEventListener('click', handleRedeem);
   elements.formatButton.addEventListener('click', () => {
     const { parsed } = syncPayloadState();

--- a/html/assets/js/scenesync/dev-tool-console.js
+++ b/html/assets/js/scenesync/dev-tool-console.js
@@ -174,6 +174,22 @@ function getNumericConfig(path, value) {
   return { min, max, step };
 }
 
+function getArrayItemLabel(arrayLabel, index, arrayLength) {
+  const key = String(arrayLabel ?? '').toLowerCase();
+  const axisLabels = ['x', 'y', 'z'];
+
+  if (['position', 'scale'].includes(key) && index < axisLabels.length) {
+    return axisLabels[index];
+  }
+
+  if (key === 'rotation') {
+    const labels = arrayLength === 4 ? ['x', 'y', 'z', 'w'] : axisLabels;
+    if (index < labels.length) return labels[index];
+  }
+
+  return `[${index}]`;
+}
+
 function renderPrimitiveControl(label, value, path) {
   const pathAttribute = makePathAttribute(path);
   const labelText = escapeHtml(formatLabel(label));
@@ -226,7 +242,9 @@ function renderPrimitiveControl(label, value, path) {
 
 function renderInspectorValue(value, path = [], label = 'Payload') {
   if (Array.isArray(value)) {
-    const rows = value.map((item, index) => renderInspectorValue(item, [...path, index], `[${index}]`)).join('');
+    const rows = value.map((item, index) => (
+      renderInspectorValue(item, [...path, index], getArrayItemLabel(label, index, value.length))
+    )).join('');
     return `
       <fieldset class="inspector-group">
         <legend>${escapeHtml(formatLabel(label))}</legend>

--- a/html/scenesync/dev-tool/index.html
+++ b/html/scenesync/dev-tool/index.html
@@ -49,12 +49,17 @@
         <div class="panel-head">
           <h2>Payload</h2>
           <div class="actions">
+            <div class="editor-toggle" role="tablist" aria-label="Payload editor mode">
+              <button id="inspectorModeButton" type="button" class="is-active" role="tab" aria-selected="true" data-editor-mode="inspector">Inspector</button>
+              <button id="jsonModeButton" type="button" role="tab" aria-selected="false" data-editor-mode="json">JSON</button>
+            </div>
             <button id="formatButton" type="button">Format</button>
             <button id="sendButton" type="button">Send</button>
             <button id="snapshotButton" type="button">Fetch Snapshot</button>
           </div>
         </div>
-        <textarea id="payloadInput" spellcheck="false" aria-label="Scene Sync JSON payload"></textarea>
+        <div id="payloadInspector" class="inspector" role="tabpanel" aria-labelledby="inspectorModeButton"></div>
+        <textarea id="payloadInput" class="json-editor is-hidden" spellcheck="false" aria-label="Scene Sync JSON payload" role="tabpanel" aria-labelledby="jsonModeButton"></textarea>
         <div class="route-bar">
           <span>Resolved route</span>
           <code id="resolvedRoute">broadcast</code>


### PR DESCRIPTION
## Summary
- add an Inspector/JSON editor toggle to the Scene Sync dev tool payload composer
- render payload objects recursively with checkbox, slider/number, text, and color controls
- keep inspector edits synchronized with JSON validation, preview, send, and history flows

## Verification
- node --check html/assets/js/scenesync/dev-tool-console.js
- DOM smoke test for inspector render, number sync, and JSON mode toggle
- curl -I http://127.0.0.1:4173/scenesync/dev-tool/