### PR TITLE
Add Loomlet-backed object audio in Scene Sync

### DIFF
--- a/apps/presence-server/tests/audio-url-importer.test.mjs
+++ b/apps/presence-server/tests/audio-url-importer.test.mjs
@@ -26,6 +26,53 @@ test('importAudioUrl', async (t) => {
     assert.equal(result.payload.kind, 'scene-bgm');
   });
 
+  await t.test('sets object audio when an object target is resolved', async () => {
+    let setCalled = false;
+    const mockCtx = {
+      resolveObjectAudioTarget: () => 'speaker-1',
+      setObjectAudioComponent: (objectId, audio) => {
+        setCalled = true;
+        assert.equal(objectId, 'speaker-1');
+        assert.equal(audio.url, 'https://example.com/sound.mp3');
+        assert.equal(audio.playOnAwake, true);
+        assert.equal(audio.loop, true);
+        return { type: 'scene-graph-set', scope: { object: objectId } };
+      },
+      showToast: (toast) => {
+        assert.equal(toast.type, 'success');
+      },
+    };
+
+    const result = await importAudioUrl('https://example.com/sound.mp3', mockCtx);
+    assert.equal(setCalled, true);
+    assert.equal(result.objectId, 'speaker-1');
+    assert.equal(result.payload.type, 'scene-graph-set');
+  });
+
+  await t.test('object audio does not require BGM functions', async () => {
+    const mockCtx = {
+      resolveObjectAudioTarget: () => 'speaker-1',
+      setObjectAudioComponent: () => ({ type: 'scene-graph-set' }),
+      showToast: () => {},
+    };
+
+    await importAudioUrl('https://example.com/sound.mp3', mockCtx);
+  });
+
+  await t.test('rejects object audio context missing setter', async () => {
+    const mockCtx = {
+      resolveObjectAudioTarget: () => 'speaker-1',
+      showToast: () => {},
+    };
+
+    try {
+      await importAudioUrl('https://example.com/sound.mp3', mockCtx);
+      assert.fail('should throw error when setObjectAudioComponent is missing');
+    } catch (err) {
+      assert.match(err.message, /audio importer requires ctx.setObjectAudioComponent/);
+    }
+  });
+
   await t.test('rejects incomplete context: missing broadcastSceneBgm', async () => {
     const mockCtx = {
       applySceneBgm: () => {},

--- a/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
+++ b/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
@@ -89,7 +89,7 @@ test('Scene Sync Loomlet integration keeps offsetPosition relative to captured b
   );
 });
 
-test('Scene Sync Loomlet integration applies object audio effects', () => {
+test('Scene Sync Loomlet integration pauses object audio effects while edited', () => {
   const object = makeObject();
   const effects = [];
   const integration = createSceneSyncLoomIntegration({
@@ -126,4 +126,5 @@ test('Scene Sync Loomlet integration applies object audio effects', () => {
   assert.equal(effects[0].type, 'scene.setAudio');
   assert.equal(effects[0].objectId, 'box-1');
   assert.equal(effects[0].url, 'https://example.com/sound.mp3');
+  assert.equal(effects[0].pausedAtStart, true);
 });

--- a/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
+++ b/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
@@ -88,3 +88,42 @@ test('Scene Sync Loomlet integration keeps offsetPosition relative to captured b
     { x: 11, y: 22, z: 33 }
   );
 });
+
+test('Scene Sync Loomlet integration applies object audio effects', () => {
+  const object = makeObject();
+  const effects = [];
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (id) => id === 'box-1' ? object : null,
+    send: () => {},
+    getHostTime: () => 0,
+    getObjectRuntimeTime: () => 0,
+    isObjectBeingEdited: () => true,
+    applyObjectAudioEffect: (effect) => effects.push(effect),
+  });
+
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        {
+          id: 'audio',
+          type: 'sceneSetAudio',
+          params: {
+            target: 'box-1',
+            url: 'https://example.com/sound.mp3',
+            playOnAwake: true,
+            loop: true,
+          },
+        },
+      ],
+      edges: [],
+    },
+  });
+  integration.tickObjectGraphs(null, 0);
+
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].type, 'scene.setAudio');
+  assert.equal(effects[0].objectId, 'box-1');
+  assert.equal(effects[0].url, 'https://example.com/sound.mp3');
+});

--- a/docs/scene-sync-bgm.md
+++ b/docs/scene-sync-bgm.md
@@ -147,6 +147,9 @@ Object Audio は、`asset.type = audio` の独立オブジェクトというよ�
 
 これはアニメーション拡張に近い位置付けになる可能性が高い。
 
+現在の Object Audio 実装では、ブラウザの autoplay 制限により remote participant 側で自動再生がブロックされる場合がある。
+BGM と同等の unlock UI は未実装で、ブロック時は toast による通知のみを行う。
+
 将来の payload 例:
 
 ```js

--- a/html/assets/js/scenesync/loaders/url-importers/audio.js
+++ b/html/assets/js/scenesync/loaders/url-importers/audio.js
@@ -13,6 +13,25 @@ export async function importAudioUrl(url, ctx) {
   }
 
   try {
+    const objectId = typeof ctx?.resolveObjectAudioTarget === 'function'
+      ? ctx.resolveObjectAudioTarget()
+      : null;
+
+    if (objectId) {
+      const setObjectAudioComponent = requireFn('setObjectAudioComponent');
+      const showToast = requireFn('showToast');
+      const payload = setObjectAudioComponent(objectId, {
+        url,
+        playOnAwake: true,
+        loop: true,
+      });
+      showToast({
+        type: 'success',
+        message: 'オブジェクトに音声を設定しました',
+      });
+      return { objectId, payload };
+    }
+
     const broadcastSceneBgm = requireFn('broadcastSceneBgm');
     const applySceneBgm = requireFn('applySceneBgm');
     const showToast = requireFn('showToast');

--- a/html/assets/js/scenesync/loaders/url-importers/audio.js
+++ b/html/assets/js/scenesync/loaders/url-importers/audio.js
@@ -64,7 +64,7 @@ export async function importAudioUrl(url, ctx) {
     const showToast = typeof ctx?.showToast === 'function' ? ctx.showToast : console.error;
     showToast({
       type: 'error',
-      message: `BGM URL の設定に失敗しました: ${err?.message || 'Unknown error'}`,
+      message: `音声URLの設定に失敗しました: ${err?.message || 'Unknown error'}`,
     });
     throw err;
   }

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -251,6 +251,11 @@ function createRuntimeManager({
     const objectId = effect?.objectId;
 
     if (effect?.type === 'scene.setAudio') {
+      if (!objectId) return;
+      if (isObjectBeingEdited?.(objectId)) {
+        applyObjectAudioEffect?.({ ...effect, pausedAtStart: true });
+        return;
+      }
       applyObjectAudioEffect?.(effect);
       return;
     }

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -34,12 +34,14 @@ const OBJECT_TARGET_NODE_TYPES = new Set([
   'sceneSetScale',
   'sceneSetColor',
   'sceneSetVisible',
+  'sceneSetAudio',
   'scene.setPosition',
   'scene.offsetPosition',
   'scene.setRotation',
   'scene.setScale',
   'scene.setColor',
   'scene.setVisible',
+  'scene.setAudio',
 ]);
 
 function graphForRuntime(graph, scopeObjectId) {
@@ -106,6 +108,7 @@ function createRuntimeManager({
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
+  applyObjectAudioEffect,
 }) {
   const runtimes = new Map();
   const definitions = new Map();
@@ -246,6 +249,12 @@ function createRuntimeManager({
 
   function applySceneEffect(effect, key) {
     const objectId = effect?.objectId;
+
+    if (effect?.type === 'scene.setAudio') {
+      applyObjectAudioEffect?.(effect);
+      return;
+    }
+
     if (!objectId || isObjectBeingEdited?.(objectId)) return;
 
     const object = resolveTarget(objectId);
@@ -452,6 +461,7 @@ export function createSceneSyncLoomIntegration({
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
+  applyObjectAudioEffect,
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
@@ -467,6 +477,7 @@ export function createSceneSyncLoomIntegration({
     clearLoomletHostEvents,
     getSceneClockStateForLoomlet,
     getInputRoutingMode,
+    applyObjectAudioEffect,
   });
 
   function isSceneGraphMessage(payload) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8156,6 +8156,12 @@ function syncObjectAudioPlayback(objectId, state) {
   const config = state?.current;
   if (!audio || !config) return;
 
+  if (state.pausedAtStart) {
+    audio.pause();
+    seekAudioElement(audio, 0);
+    return;
+  }
+
   const objectTime = getObjectRuntimeTime(objectId, performance.now());
   const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
   const targetTime = duration
@@ -8198,6 +8204,8 @@ function applyObjectAudioEffect(effect) {
   }
 
   const state = getOrCreateObjectAudioState(objectId);
+  state.pausedAtStart = effect.pausedAtStart === true;
+
   if (shouldRecreateObjectAudio(state, config)) {
     if (state.audio) {
       state.audio.pause();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1361,6 +1361,9 @@ const sceneBgmState = {
   autoplayBlocked: false,
 };
 
+// objectId -> { audio, current, autoplayBlocked }
+const objectAudioStates = new Map();
+
 // ── トランスフォームツイーン（AI/GPT アニメーション） ────────
 
 const activeTransformTweens = new Map();
@@ -3956,6 +3959,7 @@ function deleteObjectById(objectId, options = {}) {
   locks.delete(objectId);
 
   disposeObjectGlbAnimation(objectId);
+  disposeObjectAudio(objectId);
 
   // 削除前にオブジェクト情報を保存
   const name = attached.userData.name || objectId;
@@ -4626,6 +4630,122 @@ function getSceneClockStateForLoomlet(now = performance.now()) {
   };
 }
 
+// ── Object Audio Component / Loomlet graph helpers ─────────
+
+const OBJECT_AUDIO_NODE_TYPES = new Set(['scene.setAudio', 'sceneSetAudio']);
+
+function normalizeObjectAudioConfig(audio) {
+  if (!audio || typeof audio !== 'object') return null;
+  const url = typeof audio.url === 'string' ? audio.url.trim() : '';
+  if (!url) return null;
+  return {
+    url,
+    playOnAwake: audio.playOnAwake !== false,
+    loop: audio.loop !== false,
+  };
+}
+
+function removeObjectAudioNodes(graph) {
+  const source = graph && typeof graph === 'object' ? graph : {};
+  const removedIds = new Set();
+  const nodes = Array.isArray(source.nodes)
+    ? source.nodes.filter((node) => {
+        if (OBJECT_AUDIO_NODE_TYPES.has(node?.type)) {
+          removedIds.add(node.id);
+          return false;
+        }
+        return true;
+      })
+    : [];
+  const edges = Array.isArray(source.edges)
+    ? source.edges.filter((edge) => {
+        const fromId = String(edge?.from || '').split('.')[0];
+        const toId = String(edge?.to || '').split('.')[0];
+        return !removedIds.has(fromId) && !removedIds.has(toId);
+      })
+    : [];
+  return { nodes, edges };
+}
+
+function makeObjectAudioGraphNode(objectId, audio) {
+  return {
+    id: 'objectAudio',
+    type: 'sceneSetAudio',
+    params: {
+      target: objectId,
+      url: audio.url,
+      playOnAwake: audio.playOnAwake !== false,
+      loop: audio.loop !== false,
+    },
+  };
+}
+
+function upsertObjectAudioGraph(baseGraph, objectId, audio) {
+  const graph = removeObjectAudioNodes(baseGraph);
+  const normalized = normalizeObjectAudioConfig(audio);
+  if (normalized) {
+    graph.nodes.push(makeObjectAudioGraphNode(objectId, normalized));
+  }
+  return graph;
+}
+
+function graphHasExecutableNodes(graph) {
+  return Array.isArray(graph?.nodes) && graph.nodes.length > 0;
+}
+
+function createObjectAudioGraphOperation(objectId, audio) {
+  const current = loomIntegration?.exportState?.()?.objects?.[objectId] || { nodes: [], edges: [] };
+  const graph = upsertObjectAudioGraph(current, objectId, audio);
+  if (!graphHasExecutableNodes(graph)) {
+    return { type: 'scene-graph-clear', scope: { object: objectId } };
+  }
+  return { type: 'scene-graph-set', scope: { object: objectId }, graph };
+}
+
+function getObjectAudioConfigFromGraph(graph) {
+  const node = Array.isArray(graph?.nodes)
+    ? graph.nodes.find((entry) => OBJECT_AUDIO_NODE_TYPES.has(entry?.type))
+    : null;
+  if (!node) return null;
+  return normalizeObjectAudioConfig(node.params || null);
+}
+
+function getObjectAudioConfigFromLoomState(loomState, objectId) {
+  return getObjectAudioConfigFromGraph(loomState?.objects?.[objectId]);
+}
+
+function applySceneGraphOperation(operation) {
+  if (!operation || typeof operation.type !== 'string' || !operation.type.startsWith('scene-graph-')) {
+    return false;
+  }
+  const objectId = operation.scope && typeof operation.scope === 'object' ? operation.scope.object : null;
+  if (objectId && (
+    operation.type === 'scene-graph-clear' ||
+    ((operation.type === 'scene-graph-set' || operation.type === 'scene-graph-patch') && !getObjectAudioConfigFromGraph(operation.graph))
+  )) {
+    disposeObjectAudio(objectId);
+  }
+  loomIntegration.handlePayload(operation);
+  notifySceneStateChanged('scene-graph-operation-applied');
+  return true;
+}
+
+function setObjectAudioComponent(objectId, audio, options = {}) {
+  const normalized = normalizeObjectAudioConfig(audio);
+  if (!objectId) throw new Error('objectId is required');
+  if (normalized && !/^https?:\/\//i.test(normalized.url)) {
+    throw new Error('audio url must start with http(s)');
+  }
+
+  const operation = createObjectAudioGraphOperation(objectId, normalized);
+  applySceneGraphOperation(operation);
+  if (options.broadcast !== false) {
+    broadcast(operation);
+  }
+  notifySelectionChanged('object-audio-updated');
+  return operation;
+}
+
 function setSceneClockMode(mode, now = performance.now()) {
   if (mode === sceneClockState.mode) return;
 
@@ -4723,6 +4843,7 @@ const loomIntegration = createSceneSyncLoomIntegration({
   clearLoomletHostEvents: clearLoomletHostEventsForObject,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
+  applyObjectAudioEffect,
 });
 
 // ── Scene Clock Debug UI 制御 ────────────────────────────
@@ -5787,7 +5908,7 @@ function handleHandoff(data) {
 }
 
 function handleSceneGraphMessage(msg) {
-  loomIntegration.handlePayload(msg);
+  applySceneGraphOperation(msg);
 }
 
 function sendAiResult(targetId, requestId, result = {}) {
@@ -6130,6 +6251,18 @@ function createSceneUrlImportContext(options = {}) {
     broadcastSceneAdd: broadcast,
     applySceneBgm,
     broadcastSceneBgm: broadcast,
+    setObjectAudioComponent,
+    resolveObjectAudioTarget: () => {
+      const explicitObjectId = extraImporterContext?.objectId;
+      if (explicitObjectId && managedObjects.has(explicitObjectId)) return explicitObjectId;
+      const hitObjectId = sourceContext?.hitObjectId;
+      if (hitObjectId && managedObjects.has(hitObjectId)) return hitObjectId;
+      if (selectedObjectIds.size === 1) {
+        const [selected] = Array.from(selectedObjectIds);
+        if (managedObjects.has(selected)) return selected;
+      }
+      return null;
+    },
     showToast,
     generateObjectId: generateObjectIdOverride || ((prefix) => generateObjectId(prefix)),
     getSpawnTransform: () => ({
@@ -6303,6 +6436,11 @@ function serializeSceneObjectForExternalUse(objectId, obj) {
   const animationClips = serializeObjectAnimationClipSummariesForExternalUse(obj);
   if (animationClips.length > 0) {
     result.animationClips = animationClips;
+  }
+
+  const audio = getObjectAudioConfigFromLoomState(loomIntegration.exportState(), objectId);
+  if (audio) {
+    result.audio = audio;
   }
 
   return result;
@@ -7973,6 +8111,111 @@ function updateBgmControls() {
   clearButton.style.display = sceneBgmState.current ? 'block' : 'none';
 }
 
+function disposeObjectAudio(objectId) {
+  const state = objectAudioStates.get(objectId);
+  if (!state) return;
+  state.audio?.pause?.();
+  if (state.audio) {
+    state.audio.src = '';
+    state.audio.load?.();
+  }
+  objectAudioStates.delete(objectId);
+}
+
+function getOrCreateObjectAudioState(objectId) {
+  let state = objectAudioStates.get(objectId);
+  if (!state) {
+    state = {
+      audio: null,
+      current: null,
+      autoplayBlocked: false,
+    };
+    objectAudioStates.set(objectId, state);
+  }
+  return state;
+}
+
+function shouldRecreateObjectAudio(state, config) {
+  return !state.audio ||
+    state.current?.url !== config.url ||
+    state.current?.loop !== config.loop ||
+    state.current?.playOnAwake !== config.playOnAwake;
+}
+
+function seekAudioElement(audio, targetTime) {
+  if (!Number.isFinite(targetTime) || targetTime < 0) return;
+  if (!Number.isFinite(audio.duration) && targetTime > 0) return;
+  if (Math.abs((audio.currentTime || 0) - targetTime) < 0.25) return;
+  try {
+    audio.currentTime = targetTime;
+  } catch {}
+}
+
+function syncObjectAudioPlayback(objectId, state) {
+  const audio = state?.audio;
+  const config = state?.current;
+  if (!audio || !config) return;
+
+  const objectTime = getObjectRuntimeTime(objectId, performance.now());
+  const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
+  const targetTime = duration
+    ? config.loop
+      ? objectTime % duration
+      : Math.min(objectTime, duration)
+    : 0;
+
+  seekAudioElement(audio, targetTime);
+
+  if (!config.playOnAwake || (duration && !config.loop && objectTime >= duration)) {
+    audio.pause();
+    return;
+  }
+
+  if (audio.paused) {
+    audio.play().then(() => {
+      state.autoplayBlocked = false;
+    }).catch((err) => {
+      if (!state.autoplayBlocked) {
+        console.warn('[SceneSync] object audio autoplay blocked:', err?.message);
+        showToast?.({
+          type: 'warning',
+          message: 'オブジェクト音声の自動再生がブロックされました',
+        });
+      }
+      state.autoplayBlocked = true;
+    });
+  }
+}
+
+function applyObjectAudioEffect(effect) {
+  const objectId = effect?.objectId;
+  if (!objectId || !managedObjects.has(objectId)) return;
+
+  const config = normalizeObjectAudioConfig(effect);
+  if (!config) {
+    disposeObjectAudio(objectId);
+    return;
+  }
+
+  const state = getOrCreateObjectAudioState(objectId);
+  if (shouldRecreateObjectAudio(state, config)) {
+    if (state.audio) {
+      state.audio.pause();
+      state.audio.src = '';
+      state.audio.load?.();
+    }
+    const audio = new Audio();
+    audio.src = config.url;
+    audio.loop = config.loop;
+    audio.preload = 'auto';
+    state.audio = audio;
+    state.current = config;
+    state.autoplayBlocked = false;
+  }
+
+  syncObjectAudioPlayback(objectId, state);
+}
+
 // ── Undo/Redo 処理 ──────────────────────────────────────
 
 function performUndo() {
@@ -7998,6 +8241,10 @@ function performRedo() {
 }
 
 function applyOperationToScene(operation) {
+  if (applySceneGraphOperation(operation)) {
+    return;
+  }
+
   switch (operation.kind) {
     case 'scene-add': {
       addOrUpdateObject(operation.objectId, operation);
@@ -9597,6 +9844,7 @@ const EDITABLE_SCENE_OBJECT_FIELDS = new Set([
   'scale',
   'visible',
   'asset',
+  'audio',
 ]);
 
 const EDITABLE_TEXT_ASSET_FIELDS = new Set([
@@ -9648,6 +9896,27 @@ function validateColorValue(value, path, errors) {
     errors.push(`${path} must be a string or number color value.`);
   }
   return valid;
+}
+
+function validateInspectorAudioValue(value, path, errors) {
+  if (value === null) return true;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push(`${path} must be an object or null.`);
+    return false;
+  }
+  if (typeof value.url !== 'string' || !/^https?:\/\//i.test(value.url.trim())) {
+    errors.push(`${path}.url must be an http(s) URL.`);
+    return false;
+  }
+  if (value.playOnAwake !== undefined && typeof value.playOnAwake !== 'boolean') {
+    errors.push(`${path}.playOnAwake must be a boolean.`);
+    return false;
+  }
+  if (value.loop !== undefined && typeof value.loop !== 'boolean') {
+    errors.push(`${path}.loop must be a boolean.`);
+    return false;
+  }
+  return true;
 }
 
 function validateFontSize(value, path, errors) {
@@ -9792,6 +10061,7 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       objectId,
     };
     const changedFields = [];
+    const graphActions = [];
 
     const editedLabel = typeof editedObject.label === 'string' ? editedObject.label : undefined;
     const editedName = typeof editedObject.name === 'string'
@@ -9960,6 +10230,13 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       }
     }
 
+    if (!valuesEqual(baseObject.audio ?? null, editedObject.audio ?? null)) {
+      if (validateInspectorAudioValue(editedObject.audio ?? null, `objects.${objectId}.audio`, errors)) {
+        graphActions.push(createObjectAudioGraphOperation(objectId, editedObject.audio ?? null));
+        changedFields.push('audio');
+      }
+    }
+
     const objectKeys = new Set([
       ...Object.keys(baseObject || {}),
       ...Object.keys(editedObject || {}),
@@ -9976,7 +10253,10 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
     }
 
     if (changedFields.length > 0) {
-      actions.push(objectDelta);
+      if (Object.keys(objectDelta).length > 2) {
+        actions.push(objectDelta);
+      }
+      actions.push(...graphActions);
       changedFieldsByObject.push({ objectId, fields: changedFields });
     }
   }
@@ -10277,7 +10557,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (sceneInspectorEditMetaEl) {
     const baseTime = baseSnapshot?.generatedAt || 'unknown';
     sceneInspectorEditMetaEl.textContent =
-      `Base snapshot captured at ${baseTime}.\nApplied fields: existing object \`name\`, \`position\`, \`rotation\`, \`scale\`, \`visible\`, and primitive \`asset.color\`.\nIgnored fields: root metadata, object add/remove, ids, locks, room, connection, environment, Loom graph state, \`meshPath\`, and all other non-editable fields.`;
+      `Base snapshot captured at ${baseTime}.\nApplied fields: existing object \`name\`, \`position\`, \`rotation\`, \`scale\`, \`visible\`, \`audio\`, and primitive \`asset.color\`.\nIgnored fields: root metadata, object add/remove, ids, locks, room, connection, environment, raw Loom graph state, \`meshPath\`, and all other non-editable fields.`;
   }
 
   const hasErrors = sceneInspectorState.validationErrors.length > 0;
@@ -10645,6 +10925,7 @@ function tryExitSceneInspectorObjectEditMode() {
 
 function buildSceneInspectorSnapshot() {
   const objects = {};
+  const loomGraphState = loomIntegration.exportState();
   const sortedEntries = Array.from(managedObjects.entries())
     .sort(([leftId], [rightId]) => leftId.localeCompare(rightId));
 
@@ -10679,6 +10960,11 @@ function buildSceneInspectorSnapshot() {
       entry.animationClips = getObjectAnimationClipSummaries(obj);
     }
 
+    const audio = getObjectAudioConfigFromLoomState(loomGraphState, objectId);
+    if (audio) {
+      entry.audio = audio;
+    }
+
     objects[objectId] = entry;
   }
 
@@ -10703,7 +10989,6 @@ function buildSceneInspectorSnapshot() {
     generatedAt: new Date().toISOString(),
   };
 
-  const loomGraphState = loomIntegration.exportState();
   if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
     snapshot.loomGraphs = loomGraphState;
   }

--- a/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
+++ b/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
@@ -149,6 +149,13 @@ function defaultApplySceneEffect(effect, host) {
     if (typeof material?.color?.setRGB === 'function') {
       material.color.setRGB(effect.color[0], effect.color[1], effect.color[2]);
     }
+  } else if (effect.type === 'scene.setAudio') {
+    object.userData = object.userData || {};
+    object.userData.audio = {
+      url: effect.url,
+      playOnAwake: effect.playOnAwake !== false,
+      loop: effect.loop !== false
+    };
   }
 }
 
@@ -163,6 +170,15 @@ function makeSceneEffect(type, inputs, params, ctx) {
   if (type === 'scene.setScale') return { ...base, scale: [inputs.x, inputs.y, inputs.z].map(Number) };
   if (type === 'scene.setVisible') return { ...base, visible: Boolean(inputs.visible) };
   if (type === 'scene.setColor') return { ...base, color: [inputs.r, inputs.g, inputs.b].map(Number) };
+  if (type === 'scene.setAudio') {
+    return {
+      ...base,
+      url: stringifyText(inputs.url),
+      playOnAwake: inputs.playOnAwake !== false,
+      loop: inputs.loop !== false,
+      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+    };
+  }
   return base;
 }
 
@@ -453,7 +469,7 @@ function buildNodeTypes() {
     }
   });
 
-  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor'];
+  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor', 'scene.setAudio'];
   for (const type of sceneTypes) {
     register(type, {
       inputs: sceneInputsFor(type),
@@ -470,7 +486,8 @@ function buildNodeTypes() {
     sceneSetRotation: 'scene.setRotation',
     sceneSetScale: 'scene.setScale',
     sceneSetVisible: 'scene.setVisible',
-    sceneSetColor: 'scene.setColor'
+    sceneSetColor: 'scene.setColor',
+    sceneSetAudio: 'scene.setAudio'
   };
   for (const [alias, canonical] of Object.entries(adapterAliases)) {
     nodes[alias] = nodes[canonical];
@@ -485,6 +502,7 @@ function sceneInputsFor(type) {
   if (type === 'scene.setScale') return [objectId, { name: 'x', default: 1 }, { name: 'y', default: 1 }, { name: 'z', default: 1 }];
   if (type === 'scene.setVisible') return [objectId, { name: 'visible', default: true }];
   if (type === 'scene.setColor') return [objectId, { name: 'r', default: 1 }, { name: 'g', default: 1 }, { name: 'b', default: 1 }];
+  if (type === 'scene.setAudio') return [objectId, { name: 'url', default: '' }, { name: 'playOnAwake', default: true }, { name: 'loop', default: true }];
   return [objectId, { name: 'x', default: 0 }, { name: 'y', default: 0 }, { name: 'z', default: 0 }];
 }
 

--- a/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
+++ b/html/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js
@@ -175,8 +175,7 @@ function makeSceneEffect(type, inputs, params, ctx) {
       ...base,
       url: stringifyText(inputs.url),
       playOnAwake: inputs.playOnAwake !== false,
-      loop: inputs.loop !== false,
-      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+      loop: inputs.loop !== false
     };
   }
   return base;


### PR DESCRIPTION
## Summary
- Add object-scoped audio components through Loomlet Scene Sync graphs
- Support audio URL paste / drag-and-drop onto selected or hit objects with playOnAwake and loop defaulting to true
- Expose object audio in DevTool JSON editing and keep audio synchronized to object runtime time
- Vendor updated Loomlet Scene Sync runtime from afjk/loomlet#296

## Tests
- node --check html/assets/js/scenesync/scene.js
- node --check html/assets/js/scenesync/loomlet-runtime-integration.js
- node --check html/assets/js/scenesync/loaders/url-importers/audio.js
- node apps/presence-server/tests/audio-url-importer.test.mjs
- node apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs

## Notes
- Broader presence-server API test runs were attempted, but the API/guard suites hung after failing immediately; the hung Node processes were stopped.