### PR TITLE
Add inspector editor to Scene Sync dev panel

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4382,6 +4382,10 @@ const sceneInspectorEditNoteEl = document.getElementById('scene-inspector-edit-n
 const sceneInspectorEditMetaEl = document.getElementById('scene-inspector-edit-meta');
 const sceneInspectorValidationEl = document.getElementById('scene-inspector-validation');
 const sceneInspectorDiffEl = document.getElementById('scene-inspector-diff');
+const sceneInspectorEditorModeEl = document.getElementById('scene-inspector-editor-mode');
+const sceneInspectorModeInspectorBtn = document.getElementById('scene-inspector-mode-inspector');
+const sceneInspectorModeJsonBtn = document.getElementById('scene-inspector-mode-json');
+const sceneInspectorFormEl = document.getElementById('scene-inspector-form');
 const sceneInspectorEditorEl = document.getElementById('scene-inspector-editor');
 const sceneInspectorOutputEl = document.getElementById('scene-inspector-output');
 const sceneInspectorObjectMetaEl = document.getElementById('scene-inspector-object-meta');
@@ -4397,6 +4401,10 @@ const sceneInspectorObjectCancelBtn = document.getElementById('scene-inspector-o
 const sceneInspectorObjectNoteEl = document.getElementById('scene-inspector-object-note');
 const sceneInspectorObjectValidationEl = document.getElementById('scene-inspector-object-validation');
 const sceneInspectorObjectDiffEl = document.getElementById('scene-inspector-object-diff');
+const sceneInspectorObjectEditorModeEl = document.getElementById('scene-inspector-object-editor-mode');
+const sceneInspectorObjectModeInspectorBtn = document.getElementById('scene-inspector-object-mode-inspector');
+const sceneInspectorObjectModeJsonBtn = document.getElementById('scene-inspector-object-mode-json');
+const sceneInspectorObjectFormEl = document.getElementById('scene-inspector-object-form');
 const sceneInspectorObjectEditorEl = document.getElementById('scene-inspector-object-editor');
 const sceneInspectorObjectOutputEl = document.getElementById('scene-inspector-object-output');
 const sceneInspectorAnimationControlsEl = document.getElementById('scene-inspector-animation-controls');
@@ -4549,6 +4557,7 @@ const sceneInspectorState = {
   baseSnapshot: null,
   draftText: '',
   parsedSnapshot: null,
+  editorMode: 'inspector',
   validationErrors: [],
   diffSummary: null,
   lastAppliedSummary: null,
@@ -4558,6 +4567,7 @@ const sceneInspectorState = {
     baseObject: null,
     draftText: '',
     parsedObject: null,
+    editorMode: 'inspector',
     validationErrors: [],
     diffSummary: null,
     lastAppliedSummary: null,
@@ -10470,6 +10480,243 @@ function formatObjectBlockHeader(objectId, objectSnapshot) {
   ].join('\n');
 }
 
+function formatInspectorControlLabel(value) {
+  const raw = String(value ?? 'Value')
+    .replace(/_/g, ' ')
+    .replace(/-/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : 'Value';
+}
+
+function isPlainInspectorObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function makeInspectorPathAttribute(path) {
+  return escapeHtml(JSON.stringify(path));
+}
+
+function getInspectorObjectMeta(value) {
+  if (!isPlainInspectorObject(value)) return '';
+  const name = typeof value.name === 'string' && value.name.trim() ? value.name.trim() : '';
+  const objectId = typeof value.objectId === 'string' && value.objectId.trim() ? value.objectId.trim() : '';
+  if (name && objectId) return `${name} / ${objectId}`;
+  return name || objectId;
+}
+
+function getInspectorArrayItemLabel(arrayLabel, index, arrayLength) {
+  const key = String(arrayLabel ?? '').toLowerCase();
+  const axisLabels = ['x', 'y', 'z'];
+
+  if (['position', 'scale'].includes(key) && index < axisLabels.length) {
+    return axisLabels[index];
+  }
+
+  if (key === 'rotation') {
+    const labels = arrayLength === 4 ? ['x', 'y', 'z', 'w'] : axisLabels;
+    if (index < labels.length) return labels[index];
+  }
+
+  return `[${index}]`;
+}
+
+function getInspectorNumberConfig(path, value) {
+  const key = String(path[path.length - 1] ?? '').toLowerCase();
+  const parent = String(path[path.length - 2] ?? '').toLowerCase();
+  const absValue = Math.abs(Number(value) || 0);
+  let min = -100;
+  let max = 100;
+  let step = 0.01;
+
+  if (parent === 'position' || ['x', 'y', 'z'].includes(key)) {
+    min = -20;
+    max = 20;
+  } else if (parent === 'scale' || key.includes('scale')) {
+    min = 0;
+    max = 10;
+  } else if (parent === 'rotation' || key.includes('rotation')) {
+    min = -1;
+    max = 1;
+  } else if (['opacity', 'alpha', 'volume', 'weight', 'intensity'].some((token) => key.includes(token))) {
+    min = 0;
+    max = 1;
+    step = 0.001;
+  }
+
+  if (absValue > Math.max(Math.abs(min), Math.abs(max))) {
+    const range = Math.ceil(absValue * 1.25);
+    min = Math.min(min, -range);
+    max = Math.max(max, range);
+  }
+
+  return { min, max, step };
+}
+
+function renderSceneInspectorPrimitiveControl(label, value, path, pathPrefix) {
+  const pathAttribute = makeInspectorPathAttribute(path);
+  const labelText = escapeHtml(formatInspectorControlLabel(label));
+  const prefixAttribute = escapeHtml(pathPrefix);
+
+  if (typeof value === 'boolean') {
+    return `
+      <label class="scene-inspector-form-row">
+        <span>${labelText}</span>
+        <input type="checkbox" ${value ? 'checked' : ''} data-inspector-prefix="${prefixAttribute}" data-inspector-type="boolean" data-inspector-path="${pathAttribute}">
+      </label>
+    `;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const { min, max, step } = getInspectorNumberConfig(path, value);
+    const safeValue = escapeHtml(String(value));
+    return `
+      <label class="scene-inspector-form-row">
+        <span>${labelText}</span>
+        <div class="scene-inspector-form-number">
+          <input type="range" min="${min}" max="${max}" step="${step}" value="${safeValue}" data-inspector-prefix="${prefixAttribute}" data-inspector-type="number" data-inspector-path="${pathAttribute}">
+          <input type="number" step="${step}" value="${safeValue}" data-inspector-prefix="${prefixAttribute}" data-inspector-type="number" data-inspector-path="${pathAttribute}">
+        </div>
+      </label>
+    `;
+  }
+
+  if (typeof value === 'string') {
+    const safeValue = escapeHtml(value);
+    const isColor = /^#[0-9a-f]{6}$/i.test(value);
+    return `
+      <label class="scene-inspector-form-row">
+        <span>${labelText}</span>
+        <div class="${isColor ? 'scene-inspector-form-text color' : 'scene-inspector-form-text'}">
+          ${isColor ? `<input type="color" value="${safeValue}" data-inspector-prefix="${prefixAttribute}" data-inspector-type="string" data-inspector-path="${pathAttribute}">` : ''}
+          <input type="text" value="${safeValue}" spellcheck="false" data-inspector-prefix="${prefixAttribute}" data-inspector-type="string" data-inspector-path="${pathAttribute}">
+        </div>
+      </label>
+    `;
+  }
+
+  const jsonValue = value === null ? 'null' : JSON.stringify(value);
+  return `
+    <label class="scene-inspector-form-row">
+      <span>${labelText}</span>
+      <input type="text" value="${escapeHtml(jsonValue)}" spellcheck="false" data-inspector-prefix="${prefixAttribute}" data-inspector-type="json" data-inspector-path="${pathAttribute}">
+    </label>
+  `;
+}
+
+function renderSceneInspectorFormValue(value, path = [], label = 'Payload', pathPrefix = 'scene') {
+  if (Array.isArray(value)) {
+    const rows = value.map((item, index) => (
+      renderSceneInspectorFormValue(item, [...path, index], getInspectorArrayItemLabel(label, index, value.length), pathPrefix)
+    )).join('');
+    return `
+      <fieldset class="scene-inspector-form-group">
+        <legend>${escapeHtml(formatInspectorControlLabel(label))}</legend>
+        <div class="scene-inspector-form-children">${rows || '<p class="scene-inspector-form-empty">[]</p>'}</div>
+      </fieldset>
+    `;
+  }
+
+  if (isPlainInspectorObject(value)) {
+    const entries = Object.entries(value);
+    const meta = getInspectorObjectMeta(value);
+    const rows = entries.map(([key, item]) => (
+      renderSceneInspectorFormValue(item, [...path, key], key, pathPrefix)
+    )).join('');
+    return `
+      <fieldset class="scene-inspector-form-group">
+        <legend>
+          <span>${escapeHtml(formatInspectorControlLabel(label))}</span>
+          ${meta ? `<small>${escapeHtml(meta)}</small>` : ''}
+        </legend>
+        <div class="scene-inspector-form-children">${rows || '<p class="scene-inspector-form-empty">{}</p>'}</div>
+      </fieldset>
+    `;
+  }
+
+  return renderSceneInspectorPrimitiveControl(label, value, path, pathPrefix);
+}
+
+function renderSceneInspectorForm(target, value, pathPrefix) {
+  if (!target) return;
+  if (!value || typeof value !== 'object') {
+    target.innerHTML = '<p class="scene-inspector-form-empty">Inspector unavailable.</p>';
+    return;
+  }
+  target.innerHTML = renderSceneInspectorFormValue(value, [], 'Payload', pathPrefix);
+}
+
+function setInspectorValueAtPath(root, path, value) {
+  let target = root;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    target = target[path[index]];
+  }
+  target[path[path.length - 1]] = value;
+}
+
+function readInspectorControlValue(control) {
+  if (control.dataset.inspectorType === 'boolean') {
+    return control.checked;
+  }
+  if (control.dataset.inspectorType === 'number') {
+    if (['', '-', '.', '-.'].includes(control.value)) return undefined;
+    const number = Number(control.value);
+    return Number.isFinite(number) ? number : undefined;
+  }
+  if (control.dataset.inspectorType === 'json') {
+    try {
+      return JSON.parse(control.value);
+    } catch {
+      return undefined;
+    }
+  }
+  return control.value;
+}
+
+function mirrorInspectorControls(container, path, value) {
+  if (!container) return;
+  const serializedPath = JSON.stringify(path);
+  container.querySelectorAll('[data-inspector-path]').forEach((control) => {
+    if (control.dataset.inspectorPath !== serializedPath) return;
+    if (control.type === 'checkbox') {
+      control.checked = Boolean(value);
+    } else {
+      control.value = String(value);
+    }
+  });
+}
+
+function setSceneInspectorEditorMode(mode) {
+  sceneInspectorState.editorMode = mode === 'json' ? 'json' : 'inspector';
+  renderSceneInspector();
+}
+
+function setSceneInspectorObjectEditorMode(mode) {
+  sceneInspectorState.objectEditor.editorMode = mode === 'json' ? 'json' : 'inspector';
+  renderSceneInspector();
+}
+
+function updateSceneInspectorEditorModeUi() {
+  const isEditing = sceneInspectorState.isEditing;
+  const isJson = sceneInspectorState.editorMode === 'json';
+  if (sceneInspectorEditorModeEl) sceneInspectorEditorModeEl.hidden = !isEditing;
+  if (sceneInspectorFormEl) sceneInspectorFormEl.hidden = !isEditing || isJson;
+  if (sceneInspectorEditorEl) sceneInspectorEditorEl.hidden = !isEditing || !isJson;
+  sceneInspectorModeInspectorBtn?.classList.toggle('active', !isJson);
+  sceneInspectorModeJsonBtn?.classList.toggle('active', isJson);
+}
+
+function updateSceneInspectorObjectEditorModeUi() {
+  const objectEditor = sceneInspectorState.objectEditor;
+  const isEditing = objectEditor.isEditing;
+  const isJson = objectEditor.editorMode === 'json';
+  if (sceneInspectorObjectEditorModeEl) sceneInspectorObjectEditorModeEl.hidden = !isEditing;
+  if (sceneInspectorObjectFormEl) sceneInspectorObjectFormEl.hidden = !isEditing || isJson;
+  if (sceneInspectorObjectEditorEl) sceneInspectorObjectEditorEl.hidden = !isEditing || !isJson;
+  sceneInspectorObjectModeInspectorBtn?.classList.toggle('active', !isJson);
+  sceneInspectorObjectModeJsonBtn?.classList.toggle('active', isJson);
+}
+
 function resetSceneInspectorObjectEditor({ preserveObjectId = false } = {}) {
   const nextObjectId = preserveObjectId ? sceneInspectorState.objectEditor.objectId : null;
   sceneInspectorState.objectEditor = {
@@ -10478,6 +10725,7 @@ function resetSceneInspectorObjectEditor({ preserveObjectId = false } = {}) {
     baseObject: null,
     draftText: '',
     parsedObject: null,
+    editorMode: 'inspector',
     validationErrors: [],
     diffSummary: null,
   };
@@ -10555,11 +10803,22 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   sceneInspectorCancelBtn.hidden = !isEditing;
   sceneInspectorEditNoteEl.hidden = !isEditing;
   sceneInspectorEditMetaEl.hidden = !isEditing;
-  sceneInspectorEditorEl.hidden = !isEditing;
   sceneInspectorOutputEl.hidden = isEditing;
   if (isEditing && sceneInspectorEditorEl && sceneInspectorEditorEl.value !== sceneInspectorState.draftText) {
     sceneInspectorEditorEl.value = sceneInspectorState.draftText;
   }
+  if (isEditing) {
+    let inspectorSnapshot = sceneInspectorState.parsedSnapshot;
+    if (!inspectorSnapshot) {
+      try {
+        inspectorSnapshot = JSON.parse(sceneInspectorState.draftText);
+      } catch {
+        inspectorSnapshot = null;
+      }
+    }
+    renderSceneInspectorForm(sceneInspectorFormEl, inspectorSnapshot, 'scene');
+  }
+  updateSceneInspectorEditorModeUi();
 
   const baseSnapshot = sceneInspectorState.baseSnapshot;
   if (sceneInspectorEditMetaEl) {
@@ -10604,7 +10863,6 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   sceneInspectorObjectActionsEl.hidden = !hasSelection;
   sceneInspectorObjectNoteEl.hidden = !objectEditorIsEditing;
   sceneInspectorObjectOutputEl.hidden = !hasSelection || objectEditorIsEditing;
-  sceneInspectorObjectEditorEl.hidden = !objectEditorIsEditing;
   sceneInspectorObjectEditBtn.hidden = objectEditorIsEditing;
   sceneInspectorObjectFormatBtn.hidden = !objectEditorIsEditing;
   sceneInspectorObjectResetBtn.hidden = !objectEditorIsEditing;
@@ -10624,6 +10882,18 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (objectEditorIsEditing && sceneInspectorObjectEditorEl && sceneInspectorObjectEditorEl.value !== objectEditorState.draftText) {
     sceneInspectorObjectEditorEl.value = objectEditorState.draftText;
   }
+  if (objectEditorIsEditing) {
+    let inspectorObject = objectEditorState.parsedObject;
+    if (!inspectorObject) {
+      try {
+        inspectorObject = JSON.parse(objectEditorState.draftText);
+      } catch {
+        inspectorObject = null;
+      }
+    }
+    renderSceneInspectorForm(sceneInspectorObjectFormEl, inspectorObject, 'object');
+  }
+  updateSceneInspectorObjectEditorModeUi();
 
   renderSceneInspectorAnimationControls(selectedObject);
 
@@ -10674,12 +10944,12 @@ function enterSceneInspectorEditMode() {
   sceneInspectorState.baseSnapshot = snapshot;
   sceneInspectorState.parsedSnapshot = cloneInspectorValue(snapshot);
   sceneInspectorState.draftText = JSON.stringify(snapshot, null, 2);
+  sceneInspectorState.editorMode = 'inspector';
   sceneInspectorState.validationErrors = [];
   sceneInspectorState.diffSummary = null;
   sceneInspectorState.lastAppliedSummary = null;
   renderSceneInspector(snapshot);
-  const focused = focusTextInputIfSafe(sceneInspectorEditorEl);
-  if (focused) {
+  if (sceneInspectorState.editorMode === 'json' && focusTextInputIfSafe(sceneInspectorEditorEl)) {
     sceneInspectorEditorEl?.setSelectionRange(0, 0);
   }
 }
@@ -10690,6 +10960,7 @@ function exitSceneInspectorEditMode() {
   sceneInspectorState.baseSnapshot = null;
   sceneInspectorState.parsedSnapshot = null;
   sceneInspectorState.draftText = '';
+  sceneInspectorState.editorMode = 'inspector';
   sceneInspectorState.validationErrors = [];
   sceneInspectorState.diffSummary = null;
   sceneInspectorState.lastAppliedSummary = null;
@@ -10713,13 +10984,13 @@ function enterSceneInspectorObjectEditMode() {
     baseObject: objectSnapshot,
     draftText: JSON.stringify(objectSnapshot, null, 2),
     parsedObject: cloneInspectorValue(objectSnapshot),
+    editorMode: 'inspector',
     validationErrors: [],
     diffSummary: null,
     lastAppliedSummary: null,
   };
   renderSceneInspector(snapshot);
-  const focused = focusTextInputIfSafe(sceneInspectorObjectEditorEl);
-  if (focused) {
+  if (sceneInspectorState.objectEditor.editorMode === 'json' && focusTextInputIfSafe(sceneInspectorObjectEditorEl)) {
     sceneInspectorObjectEditorEl?.setSelectionRange(0, 0);
   }
 }
@@ -10848,9 +11119,10 @@ function formatSceneInspectorDraft() {
   try {
     sceneInspectorState.draftText = formatJsonText(sceneInspectorEditorEl?.value ?? sceneInspectorState.draftText);
     if (sceneInspectorEditorEl) sceneInspectorEditorEl.value = sceneInspectorState.draftText;
+    sceneInspectorState.parsedSnapshot = JSON.parse(sceneInspectorState.draftText);
     sceneInspectorState.validationErrors = [];
     sceneInspectorState.diffSummary = null;
-    updateSceneInspectorMode();
+    renderSceneInspector(sceneInspectorState.parsedSnapshot);
     showToast('Scene JSON formatted');
   } catch (error) {
     sceneInspectorState.validationErrors = [`Invalid JSON: ${error.message}`];
@@ -10866,6 +11138,7 @@ function resetSceneInspectorDraftToCurrent() {
   sceneInspectorState.baseSnapshot = snapshot;
   sceneInspectorState.parsedSnapshot = cloneInspectorValue(snapshot);
   sceneInspectorState.draftText = JSON.stringify(snapshot, null, 2);
+  sceneInspectorState.editorMode = 'inspector';
   sceneInspectorState.validationErrors = [];
   sceneInspectorState.diffSummary = null;
   renderSceneInspector(snapshot);
@@ -10882,9 +11155,10 @@ function formatSceneInspectorObjectDraft() {
     if (sceneInspectorObjectEditorEl) {
       sceneInspectorObjectEditorEl.value = sceneInspectorState.objectEditor.draftText;
     }
+    sceneInspectorState.objectEditor.parsedObject = JSON.parse(sceneInspectorState.objectEditor.draftText);
     sceneInspectorState.objectEditor.validationErrors = [];
     sceneInspectorState.objectEditor.diffSummary = null;
-    updateSceneInspectorMode();
+    renderSceneInspector();
     showToast('Selected object JSON formatted');
   } catch (error) {
     sceneInspectorState.objectEditor.validationErrors = [`Invalid JSON: ${error.message}`];
@@ -10906,6 +11180,7 @@ function resetSceneInspectorObjectDraftToCurrent() {
   sceneInspectorState.objectEditor.baseObject = objectSnapshot;
   sceneInspectorState.objectEditor.parsedObject = cloneInspectorValue(objectSnapshot);
   sceneInspectorState.objectEditor.draftText = JSON.stringify(objectSnapshot, null, 2);
+  sceneInspectorState.objectEditor.editorMode = 'inspector';
   sceneInspectorState.objectEditor.validationErrors = [];
   sceneInspectorState.objectEditor.diffSummary = null;
   renderSceneInspector(snapshot);
@@ -10929,6 +11204,82 @@ function tryExitSceneInspectorObjectEditMode() {
   }
   exitSceneInspectorObjectEditMode();
   return true;
+}
+
+function syncSceneInspectorDraftFromJsonInput() {
+  sceneInspectorState.draftText = sceneInspectorEditorEl?.value ?? sceneInspectorState.draftText;
+  sceneInspectorState.validationErrors = [];
+  sceneInspectorState.diffSummary = null;
+  try {
+    sceneInspectorState.parsedSnapshot = JSON.parse(sceneInspectorState.draftText);
+  } catch {
+    sceneInspectorState.parsedSnapshot = null;
+  }
+  updateSceneInspectorMode();
+}
+
+function syncSceneInspectorObjectDraftFromJsonInput() {
+  const objectEditor = sceneInspectorState.objectEditor;
+  objectEditor.draftText = sceneInspectorObjectEditorEl?.value ?? objectEditor.draftText;
+  objectEditor.validationErrors = [];
+  objectEditor.diffSummary = null;
+  try {
+    objectEditor.parsedObject = JSON.parse(objectEditor.draftText);
+  } catch {
+    objectEditor.parsedObject = null;
+  }
+  updateSceneInspectorMode();
+}
+
+function handleSceneInspectorFormInput(event) {
+  const control = event.target?.closest?.('[data-inspector-path]');
+  if (!control || control.dataset.inspectorPrefix !== 'scene') return;
+
+  const value = readInspectorControlValue(control);
+  if (value === undefined) return;
+
+  let parsedSnapshot;
+  try {
+    parsedSnapshot = JSON.parse(sceneInspectorState.draftText);
+  } catch {
+    return;
+  }
+
+  const path = JSON.parse(control.dataset.inspectorPath);
+  setInspectorValueAtPath(parsedSnapshot, path, value);
+  sceneInspectorState.parsedSnapshot = parsedSnapshot;
+  sceneInspectorState.draftText = JSON.stringify(parsedSnapshot, null, 2);
+  sceneInspectorState.validationErrors = [];
+  sceneInspectorState.diffSummary = null;
+  if (sceneInspectorEditorEl) sceneInspectorEditorEl.value = sceneInspectorState.draftText;
+  mirrorInspectorControls(sceneInspectorFormEl, path, value);
+  updateSceneInspectorMode();
+}
+
+function handleSceneInspectorObjectFormInput(event) {
+  const control = event.target?.closest?.('[data-inspector-path]');
+  if (!control || control.dataset.inspectorPrefix !== 'object') return;
+
+  const value = readInspectorControlValue(control);
+  if (value === undefined) return;
+
+  const objectEditor = sceneInspectorState.objectEditor;
+  let parsedObject;
+  try {
+    parsedObject = JSON.parse(objectEditor.draftText);
+  } catch {
+    return;
+  }
+
+  const path = JSON.parse(control.dataset.inspectorPath);
+  setInspectorValueAtPath(parsedObject, path, value);
+  objectEditor.parsedObject = parsedObject;
+  objectEditor.draftText = JSON.stringify(parsedObject, null, 2);
+  objectEditor.validationErrors = [];
+  objectEditor.diffSummary = null;
+  if (sceneInspectorObjectEditorEl) sceneInspectorObjectEditorEl.value = objectEditor.draftText;
+  mirrorInspectorControls(sceneInspectorObjectFormEl, path, value);
+  updateSceneInspectorMode();
 }
 
 function buildSceneInspectorSnapshot() {
@@ -11471,6 +11822,11 @@ sceneInspectorCopyBtn?.addEventListener('click', () => {
   copyText(text, 'Scene JSON をコピーしました');
 });
 sceneInspectorEditBtn?.addEventListener('click', enterSceneInspectorEditMode);
+sceneInspectorModeInspectorBtn?.addEventListener('click', () => setSceneInspectorEditorMode('inspector'));
+sceneInspectorModeJsonBtn?.addEventListener('click', () => {
+  setSceneInspectorEditorMode('json');
+  focusTextInputIfSafe(sceneInspectorEditorEl);
+});
 sceneInspectorFormatBtn?.addEventListener('click', formatSceneInspectorDraft);
 sceneInspectorResetBtn?.addEventListener('click', resetSceneInspectorDraftToCurrent);
 sceneInspectorValidateBtn?.addEventListener('click', () => {
@@ -11485,11 +11841,10 @@ sceneInspectorValidateBtn?.addEventListener('click', () => {
 sceneInspectorApplyBtn?.addEventListener('click', applySceneInspectorDraft);
 sceneInspectorCancelBtn?.addEventListener('click', tryExitSceneInspectorEditMode);
 sceneInspectorEditorEl?.addEventListener('input', () => {
-  sceneInspectorState.draftText = sceneInspectorEditorEl.value;
-  sceneInspectorState.validationErrors = [];
-  sceneInspectorState.diffSummary = null;
-  updateSceneInspectorMode();
+  syncSceneInspectorDraftFromJsonInput();
 });
+sceneInspectorFormEl?.addEventListener('input', handleSceneInspectorFormInput);
+sceneInspectorFormEl?.addEventListener('change', handleSceneInspectorFormInput);
 sceneInspectorEditorEl?.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
     event.preventDefault();
@@ -11502,6 +11857,11 @@ sceneInspectorEditorEl?.addEventListener('keydown', (event) => {
   }
 });
 sceneInspectorObjectEditBtn?.addEventListener('click', enterSceneInspectorObjectEditMode);
+sceneInspectorObjectModeInspectorBtn?.addEventListener('click', () => setSceneInspectorObjectEditorMode('inspector'));
+sceneInspectorObjectModeJsonBtn?.addEventListener('click', () => {
+  setSceneInspectorObjectEditorMode('json');
+  focusTextInputIfSafe(sceneInspectorObjectEditorEl);
+});
 sceneInspectorObjectFormatBtn?.addEventListener('click', formatSceneInspectorObjectDraft);
 sceneInspectorObjectResetBtn?.addEventListener('click', resetSceneInspectorObjectDraftToCurrent);
 sceneInspectorObjectValidateBtn?.addEventListener('click', () => {
@@ -11516,11 +11876,10 @@ sceneInspectorObjectValidateBtn?.addEventListener('click', () => {
 sceneInspectorObjectApplyBtn?.addEventListener('click', applySceneInspectorObjectDraft);
 sceneInspectorObjectCancelBtn?.addEventListener('click', tryExitSceneInspectorObjectEditMode);
 sceneInspectorObjectEditorEl?.addEventListener('input', () => {
-  sceneInspectorState.objectEditor.draftText = sceneInspectorObjectEditorEl.value;
-  sceneInspectorState.objectEditor.validationErrors = [];
-  sceneInspectorState.objectEditor.diffSummary = null;
-  updateSceneInspectorMode();
+  syncSceneInspectorObjectDraftFromJsonInput();
 });
+sceneInspectorObjectFormEl?.addEventListener('input', handleSceneInspectorObjectFormInput);
+sceneInspectorObjectFormEl?.addEventListener('change', handleSceneInspectorObjectFormInput);
 sceneInspectorObjectEditorEl?.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
     event.preventDefault();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -10453,14 +10453,14 @@ function updateSceneInspectorMode() {
   const parts = [];
 
   if (sceneInspectorState.isEditing) {
-    parts.push('<span class="scene-inspector-mode-badge">Editing Scene JSON</span>');
+    parts.push('<span class="scene-inspector-mode-badge">Editing Scene</span>');
     if (isSceneInspectorDirty()) {
       parts.push('<span class="scene-inspector-mode-dirty">Unsaved scene changes</span>');
     }
   }
 
   if (sceneInspectorState.objectEditor.isEditing) {
-    parts.push('<span class="scene-inspector-mode-badge object">Editing Selected Object JSON</span>');
+    parts.push('<span class="scene-inspector-mode-badge object">Editing Selected Object</span>');
     if (isSceneInspectorObjectDirty()) {
       parts.push('<span class="scene-inspector-mode-dirty">Unsaved object changes</span>');
     }
@@ -10680,6 +10680,8 @@ function mirrorInspectorControls(container, path, value) {
     if (control.dataset.inspectorPath !== serializedPath) return;
     if (control.type === 'checkbox') {
       control.checked = Boolean(value);
+    } else if (control.dataset.inspectorType === 'json') {
+      control.value = value === null ? 'null' : JSON.stringify(value);
     } else {
       control.value = String(value);
     }
@@ -10704,6 +10706,8 @@ function updateSceneInspectorEditorModeUi() {
   if (sceneInspectorEditorEl) sceneInspectorEditorEl.hidden = !isEditing || !isJson;
   sceneInspectorModeInspectorBtn?.classList.toggle('active', !isJson);
   sceneInspectorModeJsonBtn?.classList.toggle('active', isJson);
+  sceneInspectorModeInspectorBtn?.setAttribute('aria-selected', String(!isJson));
+  sceneInspectorModeJsonBtn?.setAttribute('aria-selected', String(isJson));
 }
 
 function updateSceneInspectorObjectEditorModeUi() {
@@ -10715,6 +10719,8 @@ function updateSceneInspectorObjectEditorModeUi() {
   if (sceneInspectorObjectEditorEl) sceneInspectorObjectEditorEl.hidden = !isEditing || !isJson;
   sceneInspectorObjectModeInspectorBtn?.classList.toggle('active', !isJson);
   sceneInspectorObjectModeJsonBtn?.classList.toggle('active', isJson);
+  sceneInspectorObjectModeInspectorBtn?.setAttribute('aria-selected', String(!isJson));
+  sceneInspectorObjectModeJsonBtn?.setAttribute('aria-selected', String(isJson));
 }
 
 function resetSceneInspectorObjectEditor({ preserveObjectId = false } = {}) {
@@ -10807,7 +10813,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (isEditing && sceneInspectorEditorEl && sceneInspectorEditorEl.value !== sceneInspectorState.draftText) {
     sceneInspectorEditorEl.value = sceneInspectorState.draftText;
   }
-  if (isEditing) {
+  if (isEditing && sceneInspectorState.editorMode === 'inspector') {
     let inspectorSnapshot = sceneInspectorState.parsedSnapshot;
     if (!inspectorSnapshot) {
       try {
@@ -10817,6 +10823,8 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
       }
     }
     renderSceneInspectorForm(sceneInspectorFormEl, inspectorSnapshot, 'scene');
+  } else if (sceneInspectorFormEl) {
+    sceneInspectorFormEl.innerHTML = '';
   }
   updateSceneInspectorEditorModeUi();
 
@@ -10882,7 +10890,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (objectEditorIsEditing && sceneInspectorObjectEditorEl && sceneInspectorObjectEditorEl.value !== objectEditorState.draftText) {
     sceneInspectorObjectEditorEl.value = objectEditorState.draftText;
   }
-  if (objectEditorIsEditing) {
+  if (objectEditorIsEditing && objectEditorState.editorMode === 'inspector') {
     let inspectorObject = objectEditorState.parsedObject;
     if (!inspectorObject) {
       try {
@@ -10892,6 +10900,8 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
       }
     }
     renderSceneInspectorForm(sceneInspectorObjectFormEl, inspectorObject, 'object');
+  } else if (sceneInspectorObjectFormEl) {
+    sceneInspectorObjectFormEl.innerHTML = '';
   }
   updateSceneInspectorObjectEditorModeUi();
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -421,6 +421,130 @@
     .scene-inspector-editor:focus {
       border-color: rgba(68,136,255,0.7);
     }
+    .scene-inspector-editor-mode {
+      display: inline-flex;
+      gap: 2px;
+      padding: 2px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .scene-inspector-editor-mode .chip {
+      padding: 5px 9px;
+      background: transparent;
+    }
+    .scene-inspector-editor-mode .chip.active {
+      background: rgba(68,136,255,0.62);
+    }
+    .scene-inspector-form {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-height: 220px;
+      max-height: min(42dvh, 420px);
+      padding: 10px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.055);
+      border: 1px solid rgba(255,255,255,0.1);
+      overflow: auto;
+    }
+    .scene-inspector-form-group {
+      min-width: 0;
+      margin: 0;
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.1);
+      background: rgba(0,0,0,0.18);
+    }
+    .scene-inspector-form-group legend {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      max-width: 100%;
+      padding: 0 5px;
+      color: rgba(255,255,255,0.9);
+      font-weight: 700;
+    }
+    .scene-inspector-form-group legend small {
+      min-width: 0;
+      overflow: hidden;
+      color: rgba(255,255,255,0.55);
+      font-size: 10px;
+      font-weight: 400;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .scene-inspector-form-children {
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+    }
+    .scene-inspector-form-row {
+      display: grid;
+      grid-template-columns: minmax(82px, 0.38fr) minmax(0, 1fr);
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+    .scene-inspector-form-row > span {
+      min-width: 0;
+      overflow: hidden;
+      color: rgba(255,255,255,0.68);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .scene-inspector-form-row input[type="text"],
+    .scene-inspector-form-row input[type="number"] {
+      width: 100%;
+      min-width: 0;
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: 1px solid rgba(255,255,255,0.16);
+      background: rgba(0,0,0,0.38);
+      color: #fff;
+      font: inherit;
+      outline: none;
+    }
+    .scene-inspector-form-row input[type="text"]:focus,
+    .scene-inspector-form-row input[type="number"]:focus {
+      border-color: rgba(68,136,255,0.58);
+    }
+    .scene-inspector-form-row input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+      accent-color: #48f;
+    }
+    .scene-inspector-form-row input[type="range"] {
+      width: 100%;
+      min-width: 0;
+      accent-color: #48f;
+    }
+    .scene-inspector-form-row input[type="color"] {
+      width: 34px;
+      height: 30px;
+      padding: 0;
+      border-radius: 6px;
+      border: 1px solid rgba(255,255,255,0.16);
+      background: rgba(0,0,0,0.38);
+    }
+    .scene-inspector-form-number,
+    .scene-inspector-form-text {
+      display: grid;
+      grid-template-columns: minmax(72px, 1fr) minmax(72px, 92px);
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+    .scene-inspector-form-text {
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .scene-inspector-form-text.color {
+      grid-template-columns: auto minmax(0, 1fr);
+    }
+    .scene-inspector-form-empty {
+      margin: 0;
+      color: rgba(255,255,255,0.55);
+    }
     .scene-inspector-section {
       display: flex;
       flex-direction: column;
@@ -560,6 +684,13 @@
         bottom: max(12px, env(safe-area-inset-bottom));
         width: auto;
         max-height: none;
+      }
+      .scene-inspector-form-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+      }
+      .scene-inspector-form-number {
+        grid-template-columns: 1fr;
       }
     }
 
@@ -1282,6 +1413,11 @@
       <div id="scene-inspector-edit-meta" class="scene-inspector-edit-meta" hidden></div>
       <div id="scene-inspector-validation" class="scene-inspector-validation" hidden></div>
       <div id="scene-inspector-diff" class="scene-inspector-diff" hidden></div>
+      <div id="scene-inspector-editor-mode" class="scene-inspector-editor-mode" role="tablist" aria-label="Scene editor mode" hidden>
+        <button id="scene-inspector-mode-inspector" class="chip active" type="button" data-scene-inspector-editor-mode="inspector">Inspector</button>
+        <button id="scene-inspector-mode-json" class="chip" type="button" data-scene-inspector-editor-mode="json">JSON</button>
+      </div>
+      <div id="scene-inspector-form" class="scene-inspector-form" hidden></div>
       <textarea id="scene-inspector-editor" class="scene-inspector-editor" spellcheck="false" hidden></textarea>
       <pre id="scene-inspector-output" class="scene-inspector-scene-json">{
   "status": "waiting-for-scene"
@@ -1328,6 +1464,11 @@
         </p>
         <div id="scene-inspector-object-validation" class="scene-inspector-validation" hidden></div>
         <div id="scene-inspector-object-diff" class="scene-inspector-diff" hidden></div>
+        <div id="scene-inspector-object-editor-mode" class="scene-inspector-editor-mode" role="tablist" aria-label="Selected object editor mode" hidden>
+          <button id="scene-inspector-object-mode-inspector" class="chip active" type="button" data-scene-inspector-object-editor-mode="inspector">Inspector</button>
+          <button id="scene-inspector-object-mode-json" class="chip" type="button" data-scene-inspector-object-editor-mode="json">JSON</button>
+        </div>
+        <div id="scene-inspector-object-form" class="scene-inspector-form" hidden></div>
         <textarea id="scene-inspector-object-editor" class="scene-inspector-editor" spellcheck="false" hidden></textarea>
         <pre id="scene-inspector-object-output" class="scene-inspector-selected-json" hidden>{
   "status": "no-selection"

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1399,7 +1399,7 @@
       <div class="scene-inspector-actions">
         <button id="scene-inspector-refresh" class="chip" type="button">Refresh</button>
         <button id="scene-inspector-copy" class="chip" type="button">Copy JSON</button>
-        <button id="scene-inspector-edit" class="chip primary" type="button">Edit JSON</button>
+        <button id="scene-inspector-edit" class="chip primary" type="button">Edit Scene</button>
         <button id="scene-inspector-format" class="chip" type="button" hidden>Format JSON</button>
         <button id="scene-inspector-reset" class="chip" type="button" hidden>Reset to Current</button>
         <button id="scene-inspector-validate" class="chip" type="button" hidden>Validate</button>
@@ -1414,8 +1414,8 @@
       <div id="scene-inspector-validation" class="scene-inspector-validation" hidden></div>
       <div id="scene-inspector-diff" class="scene-inspector-diff" hidden></div>
       <div id="scene-inspector-editor-mode" class="scene-inspector-editor-mode" role="tablist" aria-label="Scene editor mode" hidden>
-        <button id="scene-inspector-mode-inspector" class="chip active" type="button" data-scene-inspector-editor-mode="inspector">Inspector</button>
-        <button id="scene-inspector-mode-json" class="chip" type="button" data-scene-inspector-editor-mode="json">JSON</button>
+        <button id="scene-inspector-mode-inspector" class="chip active" type="button" role="tab" aria-selected="true" data-scene-inspector-editor-mode="inspector">Inspector</button>
+        <button id="scene-inspector-mode-json" class="chip" type="button" role="tab" aria-selected="false" data-scene-inspector-editor-mode="json">JSON</button>
       </div>
       <div id="scene-inspector-form" class="scene-inspector-form" hidden></div>
       <textarea id="scene-inspector-editor" class="scene-inspector-editor" spellcheck="false" hidden></textarea>
@@ -1452,7 +1452,7 @@
           </label>
         </div>
         <div id="scene-inspector-object-actions" class="scene-inspector-object-actions" hidden>
-          <button id="scene-inspector-object-edit" class="chip primary" type="button">Edit Object JSON</button>
+          <button id="scene-inspector-object-edit" class="chip primary" type="button">Edit Object</button>
           <button id="scene-inspector-object-format" class="chip" type="button" hidden>Format JSON</button>
           <button id="scene-inspector-object-reset" class="chip" type="button" hidden>Reset to Current</button>
           <button id="scene-inspector-object-validate" class="chip" type="button" hidden>Validate / Preview</button>
@@ -1465,8 +1465,8 @@
         <div id="scene-inspector-object-validation" class="scene-inspector-validation" hidden></div>
         <div id="scene-inspector-object-diff" class="scene-inspector-diff" hidden></div>
         <div id="scene-inspector-object-editor-mode" class="scene-inspector-editor-mode" role="tablist" aria-label="Selected object editor mode" hidden>
-          <button id="scene-inspector-object-mode-inspector" class="chip active" type="button" data-scene-inspector-object-editor-mode="inspector">Inspector</button>
-          <button id="scene-inspector-object-mode-json" class="chip" type="button" data-scene-inspector-object-editor-mode="json">JSON</button>
+          <button id="scene-inspector-object-mode-inspector" class="chip active" type="button" role="tab" aria-selected="true" data-scene-inspector-object-editor-mode="inspector">Inspector</button>
+          <button id="scene-inspector-object-mode-json" class="chip" type="button" role="tab" aria-selected="false" data-scene-inspector-object-editor-mode="json">JSON</button>
         </div>
         <div id="scene-inspector-object-form" class="scene-inspector-form" hidden></div>
         <textarea id="scene-inspector-object-editor" class="scene-inspector-editor" spellcheck="false" hidden></textarea>


### PR DESCRIPTION
## Summary
- add Inspector / JSON editor toggles to the /scenesync/ Development Tool panel
- render scene and selected-object edit drafts as recursive Inspector controls
- sync Inspector edits back into the existing JSON draft, validation, and broadcast flow

## Verification
- node --check html/assets/js/scenesync/scene.js
- git diff --check
- curl -I http://127.0.0.1:4174/scenesync/

Note: in-app Browser automation was unavailable in this environment because no browser targets were listed.