### PR TITLE
Scene Sync: replace SetAudio with AudioSource component

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -32,6 +32,47 @@ function hasFiniteNumberArray(value, size) {
     && value.every(item => typeof item === 'number' && Number.isFinite(item));
 }
 
+// AudioSource component map（audioSources）のバリデーション。
+// value が null のキーは「その AudioSource を削除する」patch を意味する。
+// 完全な型の正規化は html/assets/js/scenesync/audio/audio-source.js が担当する。
+function validateAudioSourcesMap(map, maxStringLength, maxUrlLength = 2048) {
+  if (map === null) return { ok: true };
+  if (typeof map !== 'object' || Array.isArray(map)) {
+    return { ok: false, reason: 'audioSources must be an object map or null' };
+  }
+  for (const [name, source] of Object.entries(map)) {
+    if (!isReasonableString(name, maxStringLength)) {
+      return { ok: false, reason: 'audioSources keys must be reasonable strings' };
+    }
+    if (source === null) continue;
+    if (typeof source !== 'object' || Array.isArray(source)) {
+      return { ok: false, reason: `audioSources.${name} must be an object or null` };
+    }
+    if (!isReasonableString(source.url, maxUrlLength)) {
+      return { ok: false, reason: `audioSources.${name}.url must be a reasonable string` };
+    }
+    if (source.volume !== undefined && (typeof source.volume !== 'number' || !Number.isFinite(source.volume))) {
+      return { ok: false, reason: `audioSources.${name}.volume must be a finite number` };
+    }
+    if (source.loop !== undefined && typeof source.loop !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.loop must be a boolean` };
+    }
+    if (source.playOnAwake !== undefined && typeof source.playOnAwake !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.playOnAwake must be a boolean` };
+    }
+    if (source.offset !== undefined && (typeof source.offset !== 'number' || !Number.isFinite(source.offset))) {
+      return { ok: false, reason: `audioSources.${name}.offset must be a finite number` };
+    }
+    if (source.playbackRate !== undefined && (typeof source.playbackRate !== 'number' || !Number.isFinite(source.playbackRate))) {
+      return { ok: false, reason: `audioSources.${name}.playbackRate must be a finite number` };
+    }
+    if (source.spatial !== undefined && typeof source.spatial !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.spatial must be a boolean` };
+    }
+  }
+  return { ok: true };
+}
+
 export function validateSceneSyncPayload(payload, options = {}) {
   const {
     maxStringLength = 128,
@@ -70,6 +111,14 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-env' && !ENV_IDS.has(payload.envId)) {
     return { ok: false, reason: 'envId is invalid' };
+  }
+
+  // audioSources は scene-add / scene-delta などでオブジェクトに AudioSource を付与する。
+  if (payload.audioSources !== undefined) {
+    const audioValidation = validateAudioSourcesMap(payload.audioSources, maxStringLength);
+    if (!audioValidation.ok) {
+      return audioValidation;
+    }
   }
 
   if (payload.kind === 'scene-bgm') {

--- a/apps/presence-server/tests/audio-source-controller.test.mjs
+++ b/apps/presence-server/tests/audio-source-controller.test.mjs
@@ -1,0 +1,151 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAudioSourceController } from '../../../html/assets/js/scenesync/audio/audio-source-controller.js';
+
+function makeHarness(overrides = {}) {
+  const created = [];
+  function makeFakeAudio(url) {
+    const audio = {
+      url,
+      src: url,
+      paused: true,
+      currentTime: 0,
+      duration: 10,
+      loop: false,
+      volume: 1,
+      playbackRate: 1,
+      play() { this.paused = false; return Promise.resolve(); },
+      pause() { this.paused = true; },
+      load() {},
+      addEventListener(type, fn) { this[`on_${type}`] = fn; },
+    };
+    created.push(audio);
+    return audio;
+  }
+  const controller = createAudioSourceController({
+    createAudio: makeFakeAudio,
+    getObjectRuntimeTime: () => 0,
+    isObjectBeingEdited: () => false,
+    ...overrides,
+  });
+  return { controller, created };
+}
+
+test('AudioSource controller', async (t) => {
+  await t.test('playOnAwake autoplays on tick', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3', playOnAwake: true, loop: true },
+    });
+    controller.tick(0);
+    assert.equal(created.length, 1);
+    assert.equal(created[0].paused, false);
+    assert.equal(created[0].loop, true);
+  });
+
+  await t.test('does not autoplay without playOnAwake', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3', playOnAwake: false },
+    });
+    controller.tick(0);
+    // entry stays stopped; no audio element is forced to play
+    assert.ok(created.length === 0 || created[0].paused === true);
+  });
+
+  await t.test('play / pause / stop host API', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    assert.equal(controller.play('speaker-1', 'default'), true);
+    assert.equal(created[0].paused, false);
+
+    controller.pause('speaker-1', 'default');
+    assert.equal(created[0].paused, true);
+
+    created[0].currentTime = 5;
+    controller.stop('speaker-1', 'default');
+    assert.equal(created[0].paused, true);
+    assert.equal(created[0].currentTime, 0);
+  });
+
+  await t.test('seek and setVolume', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    controller.seek('speaker-1', 'default', 3.5);
+    assert.equal(created[0].currentTime, 3.5);
+    controller.setVolume('speaker-1', 'default', 0.25);
+    assert.equal(created[0].volume, 0.25);
+    assert.equal(controller.getObjectAudioSources('speaker-1').default.volume, 0.25);
+  });
+
+  await t.test('setClip swaps the underlying url and keeps playing', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    controller.play('speaker-1', 'default');
+    controller.setClip('speaker-1', 'default', 'https://x/b.mp3');
+    const last = created[created.length - 1];
+    assert.equal(last.url, 'https://x/b.mp3');
+    assert.equal(last.paused, false);
+    assert.equal(controller.getObjectAudioSources('speaker-1').default.url, 'https://x/b.mp3');
+  });
+
+  await t.test('playOneShot creates a non-looping transient audio', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    controller.playOneShot('speaker-1', 'default');
+    const last = created[created.length - 1];
+    assert.equal(last.loop, false);
+    assert.equal(last.paused, false);
+  });
+
+  await t.test('syncToAnimation locks currentTime to animation sample on tick', () => {
+    let sampleTime = 2;
+    const { controller, created } = makeHarness({
+      getAnimationSample: () => ({ time: sampleTime, duration: 10 }),
+    });
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    controller.play('speaker-1', 'default');
+    controller.syncToAnimation('speaker-1', 'default', { animationClipName: 'dance', offset: 0.5 });
+    controller.tick(0);
+    assert.ok(Math.abs(created[0].currentTime - 2.5) < 0.001);
+
+    // animation loops back to near 0 -> audio resyncs
+    sampleTime = 0.1;
+    controller.tick(16);
+    assert.ok(Math.abs(created[0].currentTime - 0.6) < 0.001);
+  });
+
+  await t.test('freezes playback while object is being edited', () => {
+    let editing = true;
+    const { controller, created } = makeHarness({ isObjectBeingEdited: () => editing });
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3', playOnAwake: true },
+    });
+    controller.play('speaker-1', 'default');
+    created[0].currentTime = 4;
+    controller.tick(0);
+    assert.equal(created[0].paused, true);
+    assert.equal(created[0].currentTime, 0);
+  });
+
+  await t.test('disposeObject stops and clears playback', () => {
+    const { controller, created } = makeHarness();
+    controller.setObjectAudioSources('speaker-1', {
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+    });
+    controller.play('speaker-1', 'default');
+    controller.disposeObject('speaker-1');
+    assert.equal(created[0].paused, true);
+    assert.deepEqual(controller.getObjectAudioSources('speaker-1'), {});
+  });
+});

--- a/apps/presence-server/tests/audio-source-controller.test.mjs
+++ b/apps/presence-server/tests/audio-source-controller.test.mjs
@@ -82,17 +82,20 @@ test('AudioSource controller', async (t) => {
     assert.equal(controller.getObjectAudioSources('speaker-1').default.volume, 0.25);
   });
 
-  await t.test('setClip swaps the underlying url and keeps playing', () => {
+  await t.test('setClip swaps the underlying url, keeps playing, and preserves config', () => {
     const { controller, created } = makeHarness();
     controller.setObjectAudioSources('speaker-1', {
-      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3' },
+      default: { type: 'audioSource', name: 'default', url: 'https://x/a.mp3', loop: true, volume: 0.4 },
     });
     controller.play('speaker-1', 'default');
     controller.setClip('speaker-1', 'default', 'https://x/b.mp3');
     const last = created[created.length - 1];
     assert.equal(last.url, 'https://x/b.mp3');
     assert.equal(last.paused, false);
-    assert.equal(controller.getObjectAudioSources('speaker-1').default.url, 'https://x/b.mp3');
+    const config = controller.getObjectAudioSources('speaker-1').default;
+    assert.equal(config.url, 'https://x/b.mp3');
+    assert.equal(config.loop, true);
+    assert.equal(config.volume, 0.4);
   });
 
   await t.test('playOneShot creates a non-looping transient audio', () => {

--- a/apps/presence-server/tests/audio-source-model.test.mjs
+++ b/apps/presence-server/tests/audio-source-model.test.mjs
@@ -1,0 +1,134 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeAudioSource,
+  normalizeAudioSourcesMap,
+  mergeAudioSourcesPatch,
+  validateAudioSourcesMap,
+  normalizeAudioSourceSync,
+  isHttpUrl,
+  DEFAULT_AUDIO_SOURCE_NAME,
+} from '../../../html/assets/js/scenesync/audio/audio-source.js';
+
+test('normalizeAudioSource', async (t) => {
+  await t.test('applies defaults and trims url', () => {
+    const source = normalizeAudioSource({ url: '  https://example.com/a.mp3  ' });
+    assert.equal(source.type, 'audioSource');
+    assert.equal(source.name, DEFAULT_AUDIO_SOURCE_NAME);
+    assert.equal(source.url, 'https://example.com/a.mp3');
+    assert.equal(source.volume, 1);
+    assert.equal(source.loop, false);
+    assert.equal(source.playOnAwake, false);
+    assert.equal(source.offset, 0);
+    assert.equal(source.playbackRate, 1);
+    assert.equal(source.spatial, true);
+    assert.equal(source.sync, undefined);
+  });
+
+  await t.test('returns null without a url', () => {
+    assert.equal(normalizeAudioSource({ name: 'x' }), null);
+    assert.equal(normalizeAudioSource(null), null);
+  });
+
+  await t.test('honors explicit name from options', () => {
+    const source = normalizeAudioSource({ url: 'https://example.com/a.mp3' }, { name: 'music' });
+    assert.equal(source.name, 'music');
+  });
+
+  await t.test('clamps volume and coerces flags', () => {
+    const source = normalizeAudioSource({
+      url: 'https://example.com/a.mp3',
+      volume: 5,
+      loop: true,
+      playOnAwake: true,
+      playbackRate: 0,
+      spatial: false,
+      offset: -2,
+    });
+    assert.equal(source.volume, 1);
+    assert.equal(source.loop, true);
+    assert.equal(source.playOnAwake, true);
+    assert.equal(source.playbackRate, 1); // 0 falls back to default
+    assert.equal(source.spatial, false);
+    assert.equal(source.offset, 0); // negative falls back to default
+  });
+
+  await t.test('normalizes sync block', () => {
+    const source = normalizeAudioSource({
+      url: 'https://example.com/a.mp3',
+      sync: { mode: 'animation', animationClipName: 'dance', offset: 0.5, resyncOnLoop: false, driftThreshold: 0.1 },
+    });
+    assert.deepEqual(source.sync, {
+      mode: 'animation',
+      offset: 0.5,
+      resyncOnLoop: false,
+      animationClipName: 'dance',
+      driftThreshold: 0.1,
+    });
+  });
+});
+
+test('normalizeAudioSourceSync defaults', () => {
+  assert.equal(normalizeAudioSourceSync(null), null);
+  assert.deepEqual(normalizeAudioSourceSync({}), { mode: 'none', offset: 0, resyncOnLoop: true });
+});
+
+test('normalizeAudioSourcesMap drops invalid and null entries', () => {
+  const map = normalizeAudioSourcesMap({
+    default: { url: 'https://example.com/a.mp3' },
+    broken: { name: 'broken' },
+    removed: null,
+  });
+  assert.deepEqual(Object.keys(map), ['default']);
+});
+
+test('mergeAudioSourcesPatch', async (t) => {
+  const existing = {
+    default: normalizeAudioSource({ url: 'https://example.com/a.mp3' }),
+  };
+
+  await t.test('adds a new source', () => {
+    const merged = mergeAudioSourcesPatch(existing, {
+      voice: { url: 'https://example.com/v.mp3' },
+    });
+    assert.deepEqual(Object.keys(merged).sort(), ['default', 'voice']);
+  });
+
+  await t.test('removes a source when value is null', () => {
+    const merged = mergeAudioSourcesPatch(existing, { default: null });
+    assert.deepEqual(Object.keys(merged), []);
+  });
+
+  await t.test('does not mutate the existing map', () => {
+    mergeAudioSourcesPatch(existing, { default: null });
+    assert.ok(existing.default);
+  });
+});
+
+test('validateAudioSourcesMap', async (t) => {
+  await t.test('accepts null (clear)', () => {
+    assert.equal(validateAudioSourcesMap(null).ok, true);
+  });
+  await t.test('accepts a valid map', () => {
+    assert.equal(validateAudioSourcesMap({ default: { url: 'https://example.com/a.mp3', loop: true } }).ok, true);
+  });
+  await t.test('accepts null source value (removal patch)', () => {
+    assert.equal(validateAudioSourcesMap({ default: null }).ok, true);
+  });
+  await t.test('rejects arrays', () => {
+    assert.equal(validateAudioSourcesMap([]).ok, false);
+  });
+  await t.test('rejects missing url', () => {
+    assert.equal(validateAudioSourcesMap({ default: { loop: true } }).ok, false);
+  });
+  await t.test('rejects non-boolean loop', () => {
+    assert.equal(validateAudioSourcesMap({ default: { url: 'https://x/a.mp3', loop: 'yes' } }).ok, false);
+  });
+});
+
+test('isHttpUrl', () => {
+  assert.equal(isHttpUrl('https://example.com/a.mp3'), true);
+  assert.equal(isHttpUrl('http://example.com/a.mp3'), true);
+  assert.equal(isHttpUrl('ftp://example.com/a.mp3'), false);
+  assert.equal(isHttpUrl('not a url'), false);
+});

--- a/apps/presence-server/tests/audio-url-importer.test.mjs
+++ b/apps/presence-server/tests/audio-url-importer.test.mjs
@@ -26,17 +26,22 @@ test('importAudioUrl', async (t) => {
     assert.equal(result.payload.kind, 'scene-bgm');
   });
 
-  await t.test('sets object audio when an object target is resolved', async () => {
+  await t.test('adds an AudioSource component when an object target is resolved', async () => {
     let setCalled = false;
     const mockCtx = {
       resolveObjectAudioTarget: () => 'speaker-1',
-      setObjectAudioComponent: (objectId, audio) => {
+      addOrUpdateAudioSource: (objectId, audio) => {
         setCalled = true;
         assert.equal(objectId, 'speaker-1');
+        assert.equal(audio.name, 'default');
         assert.equal(audio.url, 'https://example.com/sound.mp3');
         assert.equal(audio.playOnAwake, true);
         assert.equal(audio.loop, true);
-        return { type: 'scene-graph-set', scope: { object: objectId } };
+        return {
+          kind: 'scene-delta',
+          objectId,
+          audioSources: { default: { type: 'audioSource', name: 'default', url: audio.url } },
+        };
       },
       showToast: (toast) => {
         assert.equal(toast.type, 'success');
@@ -46,13 +51,14 @@ test('importAudioUrl', async (t) => {
     const result = await importAudioUrl('https://example.com/sound.mp3', mockCtx);
     assert.equal(setCalled, true);
     assert.equal(result.objectId, 'speaker-1');
-    assert.equal(result.payload.type, 'scene-graph-set');
+    assert.equal(result.payload.kind, 'scene-delta');
+    assert.ok(result.payload.audioSources.default);
   });
 
   await t.test('object audio does not require BGM functions', async () => {
     const mockCtx = {
       resolveObjectAudioTarget: () => 'speaker-1',
-      setObjectAudioComponent: () => ({ type: 'scene-graph-set' }),
+      addOrUpdateAudioSource: () => ({ kind: 'scene-delta', objectId: 'speaker-1', audioSources: {} }),
       showToast: () => {},
     };
 
@@ -67,9 +73,9 @@ test('importAudioUrl', async (t) => {
 
     try {
       await importAudioUrl('https://example.com/sound.mp3', mockCtx);
-      assert.fail('should throw error when setObjectAudioComponent is missing');
+      assert.fail('should throw error when addOrUpdateAudioSource is missing');
     } catch (err) {
-      assert.match(err.message, /audio importer requires ctx.setObjectAudioComponent/);
+      assert.match(err.message, /audio importer requires ctx.addOrUpdateAudioSource/);
     }
   });
 

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -196,6 +196,60 @@ describe('Scene Sync guard helpers', () => {
     });
     assert.equal(result.ok, false);
   });
+
+  it('accepts scene-delta with an audioSources map', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'speaker-1',
+      audioSources: {
+        default: {
+          type: 'audioSource',
+          name: 'default',
+          url: 'https://example.com/sound.mp3',
+          loop: true,
+          playOnAwake: true,
+          volume: 0.8,
+        },
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('accepts audioSources entry set to null (removal patch)', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'speaker-1',
+      audioSources: { default: null },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects audioSources that is not an object map', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'speaker-1',
+      audioSources: ['https://example.com/sound.mp3'],
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects audioSources entry missing a url', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'speaker-1',
+      audioSources: { default: { loop: true } },
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects audioSources entry with non-boolean loop', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'speaker-1',
+      audioSources: { default: { url: 'https://example.com/sound.mp3', loop: 'yes' } },
+    });
+    assert.equal(result.ok, false);
+  });
 });
 
 describe('Scene Sync server guards', () => {

--- a/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
+++ b/apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
@@ -89,16 +89,16 @@ test('Scene Sync Loomlet integration keeps offsetPosition relative to captured b
   );
 });
 
-test('Scene Sync Loomlet integration pauses object audio effects while edited', () => {
+test('Scene Sync Loomlet integration ignores removed sceneSetAudio graph nodes', () => {
+  // scene.setAudio / sceneSetAudio graph nodes are no longer object-target node types.
+  // Such a node must not move the object position or throw.
   const object = makeObject();
-  const effects = [];
   const integration = createSceneSyncLoomIntegration({
     getObjectById: (id) => id === 'box-1' ? object : null,
     send: () => {},
     getHostTime: () => 0,
     getObjectRuntimeTime: () => 0,
-    isObjectBeingEdited: () => true,
-    applyObjectAudioEffect: (effect) => effects.push(effect),
+    isObjectBeingEdited: () => false,
   });
 
   integration.handlePayload({
@@ -109,22 +109,16 @@ test('Scene Sync Loomlet integration pauses object audio effects while edited', 
         {
           id: 'audio',
           type: 'sceneSetAudio',
-          params: {
-            target: 'box-1',
-            url: 'https://example.com/sound.mp3',
-            playOnAwake: true,
-            loop: true,
-          },
+          params: { url: 'https://example.com/sound.mp3', playOnAwake: true, loop: true },
         },
       ],
       edges: [],
     },
   });
-  integration.tickObjectGraphs(null, 0);
 
-  assert.equal(effects.length, 1);
-  assert.equal(effects[0].type, 'scene.setAudio');
-  assert.equal(effects[0].objectId, 'box-1');
-  assert.equal(effects[0].url, 'https://example.com/sound.mp3');
-  assert.equal(effects[0].pausedAtStart, true);
+  assert.doesNotThrow(() => integration.tickObjectGraphs(null, 0));
+  assert.deepEqual(
+    { x: object.position.x, y: object.position.y, z: object.position.z },
+    { x: 0, y: 0, z: 0 }
+  );
 });

--- a/docs/scene-sync-bgm.md
+++ b/docs/scene-sync-bgm.md
@@ -173,6 +173,7 @@ type SceneSyncAudioSource = {
 ### payload（scene-delta / scene-add）
 
 `audioSources` は map（部分 patch）として流す。値が `null` のキーはその AudioSource を削除する。
+`audioSources` 自体を `null` にすると、そのオブジェクトの全 AudioSource を削除する（clear-all）。
 
 ```json
 {
@@ -214,7 +215,7 @@ audioSource.stop(objectId, name = 'default')
 audioSource.seek(objectId, name = 'default', time)
 audioSource.playOneShot(objectId, name = 'default', options?)  // 毎回頭から鳴らす単発再生
 audioSource.setVolume(objectId, name = 'default', volume)
-audioSource.setClip(objectId, name = 'default', url)
+audioSource.setClip(objectId, name = 'default', url)  // 既存の volume/loop/playOnAwake 等を保持し url のみ差し替え
 audioSource.syncToAnimation(objectId, name = 'default', { animationClipName?, offset, resyncOnLoop?, driftThreshold? })
 audioSource.unsync(objectId, name = 'default')
 ```

--- a/docs/scene-sync-bgm.md
+++ b/docs/scene-sync-bgm.md
@@ -134,39 +134,110 @@ scene.bgm.volume = volume
 
 最初は `scene.time` を Scene Clock の共通入力として扱い、BGM もアニメーションも同じ時間軸を見る形が自然。
 
-## Object Audio との関係
+## AudioSource component（object-level audio）
 
 BGM は scene-level audio として扱う。
 
-一方で、将来の object-level audio は別物として扱う。
+object-level audio は **AudioSource component** として実装済み。
 
-- BGM: シーン全体に 1 つだけ設定する背景音
-- Object Audio: 特定のオブジェクトに付与する音声 component / extension
+- BGM: シーン全体に 1 つだけ設定する背景音（`scene-bgm`）
+- AudioSource: 特定のオブジェクトに付与する音声再生 component（Unity の Audio Source 相当）
 
-Object Audio は、`asset.type = audio` の独立オブジェクトというより、既存オブジェクトに付く component に近い。
+AudioSource は `asset.type = audio` の独立オブジェクトではなく、既存オブジェクトに付く component。
+1 つのオブジェクトは name をキーにした複数の AudioSource を持てる（`audioSources` map）。
 
-これはアニメーション拡張に近い位置付けになる可能性が高い。
+実装:
 
-現在の Object Audio 実装では、ブラウザの autoplay 制限により remote participant 側で自動再生がブロックされる場合がある。
-BGM と同等の unlock UI は未実装で、ブロック時は toast による通知のみを行う。
+- データモデル: `html/assets/js/scenesync/audio/audio-source.js`
+- 再生エンジン / host API: `html/assets/js/scenesync/audio/audio-source-controller.js`
+- viewer 統合: `html/assets/js/scenesync/scene.js`
 
-将来の payload 例:
+### AudioSource 型
 
-```js
+```ts
+type SceneSyncAudioSource = {
+  type: 'audioSource';
+  name: string;              // default: 'default'
+  url: string;
+  volume: number;            // default: 1
+  loop: boolean;             // default: false
+  playOnAwake: boolean;      // default: false
+  offset: number;            // seconds, default: 0
+  playbackRate: number;      // default: 1
+  spatial: boolean;          // default: true（初期実装では未対応でも可）
+  state?: 'stopped' | 'playing' | 'paused';
+  sync?: AudioSourceSync;    // animation 同期補助
+};
+```
+
+### payload（scene-delta / scene-add）
+
+`audioSources` は map（部分 patch）として流す。値が `null` のキーはその AudioSource を削除する。
+
+```json
 {
-  kind: "scene-delta",
-  objectId: "speaker-1",
-  audio: {
-    url: "https://example.com/se.mp3",
-    mode: "positional",
-    loop: true,
-    volume: 1,
-    playing: true
+  "kind": "scene-delta",
+  "objectId": "speaker-1",
+  "audioSources": {
+    "default": {
+      "type": "audioSource",
+      "name": "default",
+      "url": "https://example.com/sound.mp3",
+      "volume": 1,
+      "loop": true,
+      "playOnAwake": true,
+      "offset": 0,
+      "playbackRate": 1,
+      "spatial": true
+    }
   }
 }
 ```
 
-ただし、object-level audio はまだ実装しない。
+`scene-state` / scene-request 応答にも各オブジェクトの `audioSources` を含めるため、後から参加したクライアントにも復元される。
+
+### D&D / ペースト
+
+- オブジェクト上に音声 URL を D&D / ペースト → そのオブジェクトに `default` という名前の AudioSource を追加/更新する（初期値 `playOnAwake: true`, `loop: true`）。
+- 空間/床/背景的な場所の場合 → 従来通り `scene-bgm` fallback。
+
+### host API（Loomlet 連携の受け皿）
+
+再生条件・演出ロジック（ボタンSE・衝突音・キャラクター音声切替・MusicVideo 的演出）は Scene Sync 本体に組み込まず、Loomlet 側がこの低レベル API を呼んで実装する。
+
+`window.sceneSyncAudioSource`（および `loomIntegration` 経由の audioSource effect）で公開:
+
+```ts
+audioSource.play(objectId, name = 'default')
+audioSource.pause(objectId, name = 'default')
+audioSource.stop(objectId, name = 'default')
+audioSource.seek(objectId, name = 'default', time)
+audioSource.playOneShot(objectId, name = 'default', options?)  // 毎回頭から鳴らす単発再生
+audioSource.setVolume(objectId, name = 'default', volume)
+audioSource.setClip(objectId, name = 'default', url)
+audioSource.syncToAnimation(objectId, name = 'default', { animationClipName?, offset, resyncOnLoop?, driftThreshold? })
+audioSource.unsync(objectId, name = 'default')
+```
+
+Loomlet runtime からは `audioSource.*` 種別の scene effect として届き、host 側 API へ委譲される。
+
+### Animation 同期補助
+
+```ts
+type AudioSourceSync = {
+  mode: 'none' | 'animation';
+  animationClipName?: string;
+  offset: number;           // seconds
+  resyncOnLoop: boolean;    // default: true
+  driftThreshold?: number;  // seconds
+};
+```
+
+- Animation time を master にし、audio currentTime を `animationTime + offset` に合わせる。
+- ドリフトが `driftThreshold`（既定 0.05s）を超えたら再同期する。Animation が loop すると大きなドリフトとして検出され、自動的に loop 先頭 + offset へ再同期される。
+
+現在の AudioSource 実装では、ブラウザの autoplay 制限により remote participant 側で自動再生がブロックされる場合がある。
+ブロック時は toast による通知を行う。
 
 ## glTF export / import
 
@@ -218,8 +289,8 @@ BGM の glTF export / import はまだ実装しない。
 4. サーバー時間同期 / Scene Clock
 5. Loomlet からの BGM 操作
 6. glTF export / import
-7. Object Audio
-8. Positional Audio
+7. ~~Object Audio~~（AudioSource component として実装済み）
+8. Positional Audio（AudioSource.spatial の実再生）
 9. Audio Reactive / FFT / 波形解析
 
 必要になるまで、同期や高度な再生制御は入れない。まずは「URLを落とすとBGMが鳴る」という軽い体験を保つ。

--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -1,0 +1,407 @@
+/**
+ * Scene Sync AudioSource playback controller / host API.
+ *
+ * オブジェクトに付いた AudioSource component（audioSources map）を実際の音声再生に反映し、
+ * Loomlet から呼ばれる低レベル操作（play/pause/stop/seek/playOneShot/setVolume/setClip）と
+ * Animation 同期補助（syncToAnimation/unsync）を提供する。
+ *
+ * 再生条件や演出ロジック（ボタンSE・衝突音・キャラクター音声切替など）はここには含めない。
+ * それらは Loomlet 側がこの host API を呼んで実装する。
+ *
+ * DOM 依存（Audio 要素生成）は createAudio 経由で注入できるためテスト可能。
+ */
+
+import {
+  normalizeAudioSource,
+  normalizeAudioSourcesMap,
+  normalizeAudioSourceSync,
+  DEFAULT_AUDIO_SOURCE_NAME,
+} from './audio-source.js';
+
+function defaultNow() {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+function defaultCreateAudio(url) {
+  const audio = new Audio();
+  audio.src = url;
+  audio.preload = 'auto';
+  return audio;
+}
+
+function safePause(audio) {
+  try { audio?.pause?.(); } catch { /* noop */ }
+}
+
+function safeSeek(audio, time) {
+  if (!audio) return;
+  if (!Number.isFinite(time) || time < 0) return;
+  try { audio.currentTime = time; } catch { /* noop */ }
+}
+
+export function createAudioSourceController(deps = {}) {
+  const {
+    createAudio = defaultCreateAudio,
+    getObjectRuntimeTime = () => 0,
+    getAnimationSample = null,
+    isObjectBeingEdited = () => false,
+    showToast = null,
+    now = defaultNow,
+  } = deps;
+
+  // objectId -> Map<name, entry>
+  // entry: { config, audio, desiredState, started, autoplayBlocked, lastSampleTime }
+  const objects = new Map();
+  const oneShots = new Set();
+
+  function getEntryMap(objectId, create = false) {
+    let map = objects.get(objectId);
+    if (!map && create) {
+      map = new Map();
+      objects.set(objectId, map);
+    }
+    return map || null;
+  }
+
+  function getEntry(objectId, name = DEFAULT_AUDIO_SOURCE_NAME) {
+    return getEntryMap(objectId)?.get(name) || null;
+  }
+
+  function applyAudioElementConfig(audio, config) {
+    if (!audio) return;
+    audio.loop = config.loop === true;
+    audio.volume = typeof config.volume === 'number' ? Math.max(0, Math.min(1, config.volume)) : 1;
+    if (typeof config.playbackRate === 'number' && config.playbackRate > 0) {
+      try { audio.playbackRate = config.playbackRate; } catch { /* noop */ }
+    }
+  }
+
+  function disposeEntry(entry) {
+    if (!entry?.audio) return;
+    safePause(entry.audio);
+    try {
+      entry.audio.src = '';
+      entry.audio.load?.();
+    } catch { /* noop */ }
+    entry.audio = null;
+  }
+
+  function desiredStateForConfig(config, fallback) {
+    if (config.state === 'playing' || config.state === 'paused' || config.state === 'stopped') {
+      return config.state;
+    }
+    if (config.playOnAwake) return 'playing';
+    return fallback || 'stopped';
+  }
+
+  /**
+   * オブジェクトの audioSources 全体を再生エンジンへ反映する（reconcile）。
+   * @param {string} objectId
+   * @param {Record<string, object>} sourcesMap
+   */
+  function setObjectAudioSources(objectId, sourcesMap) {
+    if (!objectId) return;
+    const normalized = normalizeAudioSourcesMap(sourcesMap);
+    const map = getEntryMap(objectId, true);
+
+    // remove entries no longer present
+    for (const name of Array.from(map.keys())) {
+      if (!normalized[name]) {
+        disposeEntry(map.get(name));
+        map.delete(name);
+      }
+    }
+
+    for (const [name, config] of Object.entries(normalized)) {
+      let entry = map.get(name);
+      if (!entry) {
+        entry = {
+          config,
+          audio: null,
+          desiredState: desiredStateForConfig(config, 'stopped'),
+          started: false,
+          autoplayBlocked: false,
+          lastSampleTime: null,
+        };
+        map.set(name, entry);
+      } else {
+        const urlChanged = entry.config?.url !== config.url;
+        entry.config = config;
+        if (urlChanged) {
+          disposeEntry(entry);
+          entry.started = false;
+        }
+        // explicit state in payload overrides current desired state
+        if (config.state === 'playing' || config.state === 'paused' || config.state === 'stopped') {
+          entry.desiredState = config.state;
+        }
+      }
+    }
+
+    if (map.size === 0) {
+      objects.delete(objectId);
+    }
+  }
+
+  function ensureAudio(entry) {
+    if (entry.audio) return entry.audio;
+    if (!entry.config?.url) return null;
+    const audio = createAudio(entry.config.url);
+    applyAudioElementConfig(audio, entry.config);
+    entry.audio = audio;
+    entry.autoplayBlocked = false;
+    return audio;
+  }
+
+  function tryPlay(entry, objectId, name) {
+    const audio = ensureAudio(entry);
+    if (!audio) return;
+    if (!audio.paused) return;
+    const result = audio.play?.();
+    if (result && typeof result.then === 'function') {
+      result.then(() => {
+        entry.autoplayBlocked = false;
+      }).catch((err) => {
+        if (!entry.autoplayBlocked) {
+          entry.autoplayBlocked = true;
+          console.warn('[SceneSync] AudioSource autoplay blocked:', err?.message);
+          showToast?.({
+            type: 'warning',
+            message: 'オブジェクト音声の自動再生がブロックされました',
+          });
+        }
+      });
+    }
+  }
+
+  // ── Host API ──────────────────────────────────────────
+
+  function play(objectId, name = DEFAULT_AUDIO_SOURCE_NAME) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    entry.desiredState = 'playing';
+    entry.started = true;
+    tryPlay(entry, objectId, name);
+    return true;
+  }
+
+  function pause(objectId, name = DEFAULT_AUDIO_SOURCE_NAME) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    entry.desiredState = 'paused';
+    safePause(entry.audio);
+    return true;
+  }
+
+  function stop(objectId, name = DEFAULT_AUDIO_SOURCE_NAME) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    entry.desiredState = 'stopped';
+    safePause(entry.audio);
+    safeSeek(entry.audio, 0);
+    return true;
+  }
+
+  function seek(objectId, name = DEFAULT_AUDIO_SOURCE_NAME, time = 0) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    safeSeek(ensureAudio(entry), time);
+    return true;
+  }
+
+  function setVolume(objectId, name = DEFAULT_AUDIO_SOURCE_NAME, volume = 1) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    const clamped = Math.max(0, Math.min(1, Number.isFinite(volume) ? volume : 1));
+    entry.config = { ...entry.config, volume: clamped };
+    if (entry.audio) entry.audio.volume = clamped;
+    return true;
+  }
+
+  /**
+   * AudioSource の clip(url) を差し替える。再生中なら新しい clip を読み込む。
+   * 注意: component（audioSources map）への永続反映は呼び出し側（scene.js）が broadcast で行う。
+   */
+  function setClip(objectId, name = DEFAULT_AUDIO_SOURCE_NAME, url) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    const source = normalizeAudioSource({ ...entry.config, url, name }, { name });
+    if (!source) return false;
+    const wasPlaying = entry.desiredState === 'playing';
+    entry.config = source;
+    disposeEntry(entry);
+    entry.started = false;
+    if (wasPlaying) tryPlay(entry, objectId, name);
+    return true;
+  }
+
+  /**
+   * 毎回頭から鳴らす単発再生（ボタンSE・衝突音用）。
+   * component の再生状態には影響しない。
+   */
+  function playOneShot(objectId, name = DEFAULT_AUDIO_SOURCE_NAME, options = {}) {
+    const entry = getEntry(objectId, name);
+    const url = options.url || entry?.config?.url;
+    if (!url) return false;
+    const audio = createAudio(url);
+    audio.loop = false;
+    audio.volume = typeof options.volume === 'number'
+      ? Math.max(0, Math.min(1, options.volume))
+      : (entry?.config?.volume ?? 1);
+    if (typeof options.playbackRate === 'number' && options.playbackRate > 0) {
+      try { audio.playbackRate = options.playbackRate; } catch { /* noop */ }
+    }
+    const cleanup = () => {
+      oneShots.delete(audio);
+      try { audio.src = ''; audio.load?.(); } catch { /* noop */ }
+    };
+    audio.addEventListener?.('ended', cleanup, { once: true });
+    oneShots.add(audio);
+    safeSeek(audio, Number.isFinite(options.offset) ? options.offset : 0);
+    const result = audio.play?.();
+    if (result && typeof result.then === 'function') {
+      result.catch(() => cleanup());
+    }
+    return true;
+  }
+
+  function syncToAnimation(objectId, name = DEFAULT_AUDIO_SOURCE_NAME, options = {}) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    const sync = normalizeAudioSourceSync({ mode: 'animation', ...options });
+    entry.config = { ...entry.config, sync };
+    entry.lastSampleTime = null;
+    return true;
+  }
+
+  function unsync(objectId, name = DEFAULT_AUDIO_SOURCE_NAME) {
+    const entry = getEntry(objectId, name);
+    if (!entry) return false;
+    const next = { ...entry.config };
+    delete next.sync;
+    entry.config = next;
+    entry.lastSampleTime = null;
+    return true;
+  }
+
+  // ── tick ──────────────────────────────────────────────
+
+  function tickEntry(objectId, name, entry, nowMs) {
+    const config = entry.config;
+    if (!config?.url) return;
+
+    // while edited, freeze playback to start (matches inspector editing UX)
+    if (isObjectBeingEdited(objectId)) {
+      if (entry.audio) {
+        safePause(entry.audio);
+        safeSeek(entry.audio, config.offset || 0);
+      }
+      return;
+    }
+
+    // initial autoplay
+    if (!entry.started && config.playOnAwake && entry.desiredState !== 'stopped') {
+      entry.started = true;
+      entry.desiredState = 'playing';
+      const audio = ensureAudio(entry);
+      const runtimeTime = getObjectRuntimeTime(objectId, nowMs);
+      const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
+      if (duration) {
+        const base = (config.offset || 0) + runtimeTime;
+        safeSeek(audio, config.loop ? base % duration : Math.min(base, duration));
+      }
+    }
+
+    if (entry.desiredState === 'stopped') {
+      if (entry.audio && !entry.audio.paused) safePause(entry.audio);
+      return;
+    }
+    if (entry.desiredState === 'paused') {
+      if (entry.audio && !entry.audio.paused) safePause(entry.audio);
+      return;
+    }
+
+    // desiredState === 'playing'
+    const audio = ensureAudio(entry);
+    if (!audio) return;
+
+    const sync = config.sync;
+    if (sync?.mode === 'animation' && typeof getAnimationSample === 'function') {
+      const sample = getAnimationSample(objectId, sync.animationClipName);
+      if (sample && Number.isFinite(sample.time)) {
+        const driftThreshold = Number.isFinite(sync.driftThreshold) ? sync.driftThreshold : 0.05;
+        const offset = (sync.offset || 0) + (config.offset || 0);
+        const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
+        let target = sample.time + offset;
+        if (duration) {
+          target = config.loop ? ((target % duration) + duration) % duration : Math.min(Math.max(0, target), duration);
+        } else if (target < 0) {
+          target = 0;
+        }
+        const looped = entry.lastSampleTime != null && sample.time < entry.lastSampleTime;
+        entry.lastSampleTime = sample.time;
+        const drift = Math.abs((audio.currentTime || 0) - target);
+        if (drift > driftThreshold && (sync.resyncOnLoop !== false || !looped)) {
+          safeSeek(audio, target);
+        }
+      }
+    }
+
+    tryPlay(entry, objectId, name);
+  }
+
+  function tick(nowMs = now()) {
+    for (const [objectId, map] of objects) {
+      for (const [name, entry] of map) {
+        tickEntry(objectId, name, entry, nowMs);
+      }
+    }
+  }
+
+  // ── serialization / lifecycle ─────────────────────────
+
+  function getObjectAudioSources(objectId) {
+    const map = getEntryMap(objectId);
+    if (!map) return {};
+    const result = {};
+    for (const [name, entry] of map) {
+      result[name] = { ...entry.config, name };
+    }
+    return result;
+  }
+
+  function disposeObject(objectId) {
+    const map = getEntryMap(objectId);
+    if (!map) return;
+    for (const entry of map.values()) disposeEntry(entry);
+    objects.delete(objectId);
+  }
+
+  function dispose() {
+    for (const objectId of Array.from(objects.keys())) disposeObject(objectId);
+    for (const audio of oneShots) {
+      safePause(audio);
+      try { audio.src = ''; audio.load?.(); } catch { /* noop */ }
+    }
+    oneShots.clear();
+  }
+
+  return {
+    setObjectAudioSources,
+    getObjectAudioSources,
+    play,
+    pause,
+    stop,
+    seek,
+    setVolume,
+    setClip,
+    playOneShot,
+    syncToAnimation,
+    unsync,
+    tick,
+    disposeObject,
+    dispose,
+  };
+}

--- a/html/assets/js/scenesync/audio/audio-source.js
+++ b/html/assets/js/scenesync/audio/audio-source.js
@@ -1,0 +1,189 @@
+/**
+ * Scene Sync AudioSource component model.
+ *
+ * AudioSource は「オブジェクトに付く音声再生コンポーネント」（Unity の Audio Source 相当）。
+ * 1つのオブジェクトは name をキーにした複数の AudioSource を持てる（audioSources map）。
+ *
+ * このモジュールは DOM / Three.js に依存しない純粋なデータモデルで、
+ * ビューア（scene.js）・サーバ schema・テストから共通利用できる。
+ */
+
+export const DEFAULT_AUDIO_SOURCE_NAME = 'default';
+
+export const AUDIO_SOURCE_DEFAULTS = Object.freeze({
+  volume: 1,
+  loop: false,
+  playOnAwake: false,
+  offset: 0,
+  playbackRate: 1,
+  spatial: true,
+  state: 'stopped',
+});
+
+export const AUDIO_SOURCE_STATES = Object.freeze(['stopped', 'playing', 'paused']);
+
+export function isHttpUrl(url) {
+  return typeof url === 'string' && /^https?:\/\//i.test(url.trim());
+}
+
+function clampVolume(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return AUDIO_SOURCE_DEFAULTS.volume;
+  return Math.max(0, Math.min(1, value));
+}
+
+function positiveOrDefault(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function nonNegativeOrDefault(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function resolveName(input, options) {
+  const fromInput = typeof input?.name === 'string' ? input.name.trim() : '';
+  if (fromInput) return fromInput;
+  const fromOptions = typeof options?.name === 'string' ? options.name.trim() : '';
+  if (fromOptions) return fromOptions;
+  return DEFAULT_AUDIO_SOURCE_NAME;
+}
+
+/**
+ * Animation 同期補助設定を正規化する。
+ * @param {object|null} sync
+ * @returns {object|null}
+ */
+export function normalizeAudioSourceSync(sync) {
+  if (!sync || typeof sync !== 'object') return null;
+  const mode = sync.mode === 'animation' ? 'animation' : 'none';
+  const result = {
+    mode,
+    offset: Number.isFinite(sync.offset) ? sync.offset : 0,
+    resyncOnLoop: sync.resyncOnLoop !== false,
+  };
+  if (typeof sync.animationClipName === 'string' && sync.animationClipName.trim()) {
+    result.animationClipName = sync.animationClipName.trim();
+  }
+  if (Number.isFinite(sync.driftThreshold) && sync.driftThreshold >= 0) {
+    result.driftThreshold = sync.driftThreshold;
+  }
+  return result;
+}
+
+/**
+ * 単一の AudioSource を正規化する。url が無ければ null。
+ * @param {object} input
+ * @param {{ name?: string }} [options]
+ * @returns {object|null} normalized SceneSyncAudioSource
+ */
+export function normalizeAudioSource(input, options = {}) {
+  if (!input || typeof input !== 'object') return null;
+  const url = typeof input.url === 'string' ? input.url.trim() : '';
+  if (!url) return null;
+
+  const source = {
+    type: 'audioSource',
+    name: resolveName(input, options),
+    url,
+    volume: clampVolume(input.volume),
+    loop: input.loop === true,
+    playOnAwake: input.playOnAwake === true,
+    offset: nonNegativeOrDefault(input.offset, AUDIO_SOURCE_DEFAULTS.offset),
+    playbackRate: positiveOrDefault(input.playbackRate, AUDIO_SOURCE_DEFAULTS.playbackRate),
+    spatial: input.spatial !== false,
+  };
+
+  if (AUDIO_SOURCE_STATES.includes(input.state)) {
+    source.state = input.state;
+  }
+
+  const sync = normalizeAudioSourceSync(input.sync);
+  if (sync) source.sync = sync;
+
+  return source;
+}
+
+/**
+ * audioSources map 全体を正規化する（null 値は除外）。
+ * @param {object} map
+ * @returns {Record<string, object>}
+ */
+export function normalizeAudioSourcesMap(map) {
+  if (!map || typeof map !== 'object' || Array.isArray(map)) return {};
+  const result = {};
+  for (const [key, value] of Object.entries(map)) {
+    if (value === null) continue;
+    const source = normalizeAudioSource(value, { name: key });
+    if (source) result[source.name] = source;
+  }
+  return result;
+}
+
+/**
+ * 既存の audioSources に部分 map（patch）を適用する。
+ * value が null のキーは削除を意味する。
+ * @param {object} existing
+ * @param {object} patch
+ * @returns {Record<string, object>}
+ */
+export function mergeAudioSourcesPatch(existing, patch) {
+  const base = existing && typeof existing === 'object' && !Array.isArray(existing)
+    ? { ...existing }
+    : {};
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) return base;
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete base[key];
+      continue;
+    }
+    const source = normalizeAudioSource(value, { name: key });
+    if (source) {
+      base[source.name] = source;
+    }
+  }
+  return base;
+}
+
+/**
+ * audioSources map / patch のバリデーション（schema 用）。
+ * @param {*} map
+ * @param {{ maxStringLength?: number, maxUrlLength?: number }} [options]
+ * @returns {{ ok: boolean, reason?: string }}
+ */
+export function validateAudioSourcesMap(map, options = {}) {
+  const { maxStringLength = 128, maxUrlLength = 2048 } = options;
+  if (map === null) return { ok: true };
+  if (typeof map !== 'object' || Array.isArray(map)) {
+    return { ok: false, reason: 'audioSources must be an object map or null' };
+  }
+  for (const [name, source] of Object.entries(map)) {
+    if (typeof name !== 'string' || name.length === 0 || name.length > maxStringLength) {
+      return { ok: false, reason: 'audioSources keys must be reasonable strings' };
+    }
+    if (source === null) continue;
+    if (typeof source !== 'object' || Array.isArray(source)) {
+      return { ok: false, reason: `audioSources.${name} must be an object or null` };
+    }
+    if (typeof source.url !== 'string' || source.url.length === 0 || source.url.length > maxUrlLength) {
+      return { ok: false, reason: `audioSources.${name}.url must be a reasonable string` };
+    }
+    if (source.volume !== undefined && (typeof source.volume !== 'number' || !Number.isFinite(source.volume))) {
+      return { ok: false, reason: `audioSources.${name}.volume must be a finite number` };
+    }
+    if (source.loop !== undefined && typeof source.loop !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.loop must be a boolean` };
+    }
+    if (source.playOnAwake !== undefined && typeof source.playOnAwake !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.playOnAwake must be a boolean` };
+    }
+    if (source.offset !== undefined && (typeof source.offset !== 'number' || !Number.isFinite(source.offset))) {
+      return { ok: false, reason: `audioSources.${name}.offset must be a finite number` };
+    }
+    if (source.playbackRate !== undefined && (typeof source.playbackRate !== 'number' || !Number.isFinite(source.playbackRate))) {
+      return { ok: false, reason: `audioSources.${name}.playbackRate must be a finite number` };
+    }
+    if (source.spatial !== undefined && typeof source.spatial !== 'boolean') {
+      return { ok: false, reason: `audioSources.${name}.spatial must be a boolean` };
+    }
+  }
+  return { ok: true };
+}

--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -182,6 +182,7 @@ export class HistoryManager {
         ...(after.asset !== undefined ? { asset: after.asset } : {}),
         ...(after.metadata !== undefined ? { metadata: after.metadata } : {}),
         ...(after.visible !== undefined ? { visible: after.visible } : {}),
+        ...(after.audioSources !== undefined ? { audioSources: after.audioSources } : {}),
       },
       backward: {
         kind: 'scene-delta',
@@ -193,6 +194,7 @@ export class HistoryManager {
         ...(before.asset !== undefined ? { asset: before.asset } : {}),
         ...(before.metadata !== undefined ? { metadata: before.metadata } : {}),
         ...(before.visible !== undefined ? { visible: before.visible } : {}),
+        ...(before.audioSources !== undefined ? { audioSources: before.audioSources } : {}),
       },
     };
   }

--- a/html/assets/js/scenesync/loaders/url-importers/audio.js
+++ b/html/assets/js/scenesync/loaders/url-importers/audio.js
@@ -1,8 +1,10 @@
 /**
- * URL から BGM をロードし、scene-bgm を broadcast してローカルに適用。
+ * URL から音声をロードする。
+ * - オブジェクト上に D&D/ペーストされた場合: そのオブジェクトに AudioSource component を追加/更新する。
+ * - 空間/床/背景的な場所の場合: 従来通り scene-bgm として broadcast / 適用する。
  * @param {string} url - 分類済みのオーディオ URL（確定済み）
- * @param {object} ctx - { applySceneBgm, broadcastSceneBgm, showToast }
- * @returns {Promise<{ payload }>}
+ * @param {object} ctx - { addOrUpdateAudioSource, resolveObjectAudioTarget, applySceneBgm, broadcastSceneBgm, showToast }
+ * @returns {Promise<{ objectId?, payload }>}
  */
 export async function importAudioUrl(url, ctx) {
   function requireFn(name) {
@@ -18,9 +20,11 @@ export async function importAudioUrl(url, ctx) {
       : null;
 
     if (objectId) {
-      const setObjectAudioComponent = requireFn('setObjectAudioComponent');
+      const addOrUpdateAudioSource = requireFn('addOrUpdateAudioSource');
       const showToast = requireFn('showToast');
-      const payload = setObjectAudioComponent(objectId, {
+      // D&D/ペースト初期値: default という名前で playOnAwake/loop を有効化。
+      const payload = addOrUpdateAudioSource(objectId, {
+        name: 'default',
         url,
         playOnAwake: true,
         loop: true,

--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -34,14 +34,26 @@ const OBJECT_TARGET_NODE_TYPES = new Set([
   'sceneSetScale',
   'sceneSetColor',
   'sceneSetVisible',
-  'sceneSetAudio',
   'scene.setPosition',
   'scene.offsetPosition',
   'scene.setRotation',
   'scene.setScale',
   'scene.setColor',
   'scene.setVisible',
-  'scene.setAudio',
+]);
+
+// Loomlet が emit する AudioSource 操作 effect。
+// 実際の再生は host 側の AudioSource API（audioSource）へ委譲する。
+const AUDIO_SOURCE_EFFECT_TYPES = new Set([
+  'audioSource.play',
+  'audioSource.pause',
+  'audioSource.stop',
+  'audioSource.seek',
+  'audioSource.playOneShot',
+  'audioSource.setVolume',
+  'audioSource.setClip',
+  'audioSource.syncToAnimation',
+  'audioSource.unsync',
 ]);
 
 function graphForRuntime(graph, scopeObjectId) {
@@ -108,11 +120,30 @@ function createRuntimeManager({
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
-  applyObjectAudioEffect,
+  audioSource,
 }) {
   const runtimes = new Map();
   const definitions = new Map();
   const behaviorBases = new Map();
+
+  function routeAudioSourceEffect(effect) {
+    if (!audioSource) return;
+    const objectId = effect.objectId || effect.target;
+    if (!objectId) return;
+    const name = effect.name || 'default';
+    switch (effect.type) {
+      case 'audioSource.play': audioSource.play?.(objectId, name); break;
+      case 'audioSource.pause': audioSource.pause?.(objectId, name); break;
+      case 'audioSource.stop': audioSource.stop?.(objectId, name); break;
+      case 'audioSource.seek': audioSource.seek?.(objectId, name, effect.time ?? 0); break;
+      case 'audioSource.playOneShot': audioSource.playOneShot?.(objectId, name, effect.options || {}); break;
+      case 'audioSource.setVolume': audioSource.setVolume?.(objectId, name, effect.volume ?? 1); break;
+      case 'audioSource.setClip': audioSource.setClip?.(objectId, name, effect.url); break;
+      case 'audioSource.syncToAnimation': audioSource.syncToAnimation?.(objectId, name, effect.sync || effect.options || {}); break;
+      case 'audioSource.unsync': audioSource.unsync?.(objectId, name); break;
+      default: break;
+    }
+  }
 
   function makeBaseKey(key, target) {
     return `${key}:${target}`;
@@ -250,13 +281,8 @@ function createRuntimeManager({
   function applySceneEffect(effect, key) {
     const objectId = effect?.objectId;
 
-    if (effect?.type === 'scene.setAudio') {
-      if (!objectId) return;
-      if (isObjectBeingEdited?.(objectId)) {
-        applyObjectAudioEffect?.({ ...effect, pausedAtStart: true });
-        return;
-      }
-      applyObjectAudioEffect?.(effect);
+    if (effect?.type && AUDIO_SOURCE_EFFECT_TYPES.has(effect.type)) {
+      routeAudioSourceEffect(effect);
       return;
     }
 
@@ -466,7 +492,7 @@ export function createSceneSyncLoomIntegration({
   clearLoomletHostEvents,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
-  applyObjectAudioEffect,
+  audioSource,
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
@@ -482,7 +508,7 @@ export function createSceneSyncLoomIntegration({
     clearLoomletHostEvents,
     getSceneClockStateForLoomlet,
     getInputRoutingMode,
-    applyObjectAudioEffect,
+    audioSource,
   });
 
   function isSceneGraphMessage(payload) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -38,6 +38,15 @@ import { createHistoryManager, HistoryManager } from './history/history-manager.
 import { createUserManager } from './user/user-manager.js';
 import { createLinkManager } from './link/link-manager.js';
 import { createSceneSyncLoomIntegration } from './loomlet-runtime-integration.js';
+import {
+  normalizeAudioSource,
+  normalizeAudioSourcesMap,
+  mergeAudioSourcesPatch,
+  validateAudioSourcesMap,
+  isHttpUrl,
+  DEFAULT_AUDIO_SOURCE_NAME,
+} from './audio/audio-source.js';
+import { createAudioSourceController } from './audio/audio-source-controller.js';
 import { computeAssetId } from './assets/asset-id.js';
 import { createSceneAssetCache } from './assets/asset-cache.js';
 import { createSceneSyncFileTransferAdapter } from './assets/file-transfer-adapter.js';
@@ -1360,9 +1369,6 @@ const sceneBgmState = {
   current: null,
   autoplayBlocked: false,
 };
-
-// objectId -> { audio, current, autoplayBlocked }
-const objectAudioStates = new Map();
 
 // ── トランスフォームツイーン（AI/GPT アニメーション） ────────
 
@@ -3959,7 +3965,7 @@ function deleteObjectById(objectId, options = {}) {
   locks.delete(objectId);
 
   disposeObjectGlbAnimation(objectId);
-  disposeObjectAudio(objectId);
+  audioSourceController.disposeObject(objectId);
 
   // 削除前にオブジェクト情報を保存
   const name = attached.userData.name || objectId;
@@ -4337,6 +4343,7 @@ renderer.setAnimationLoop((time, frame) => {
   updateGazeDwellState(now);
   const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
   loomIntegration?.tickObjectGraphs?.(sceneClockStateForTick);
+  audioSourceController.tick(now);
 
   // Update Scene Clock debug UI
   if (!sceneClockPanelEl?.hidden) {
@@ -4630,120 +4637,15 @@ function getSceneClockStateForLoomlet(now = performance.now()) {
   };
 }
 
-// ── Object Audio Component / Loomlet graph helpers ─────────
-
-const OBJECT_AUDIO_NODE_TYPES = new Set(['scene.setAudio', 'sceneSetAudio']);
-
-function normalizeObjectAudioConfig(audio) {
-  if (!audio || typeof audio !== 'object') return null;
-  const url = typeof audio.url === 'string' ? audio.url.trim() : '';
-  if (!url) return null;
-  return {
-    url,
-    playOnAwake: audio.playOnAwake !== false,
-    loop: audio.loop !== false,
-  };
-}
-
-function removeObjectAudioNodes(graph) {
-  const source = graph && typeof graph === 'object' ? graph : {};
-  const removedIds = new Set();
-  const nodes = Array.isArray(source.nodes)
-    ? source.nodes.filter((node) => {
-        if (OBJECT_AUDIO_NODE_TYPES.has(node?.type)) {
-          removedIds.add(node.id);
-          return false;
-        }
-        return true;
-      })
-    : [];
-  const edges = Array.isArray(source.edges)
-    ? source.edges.filter((edge) => {
-        const fromId = String(edge?.from || '').split('.')[0];
-        const toId = String(edge?.to || '').split('.')[0];
-        return !removedIds.has(fromId) && !removedIds.has(toId);
-      })
-    : [];
-  return { nodes, edges };
-}
-
-function makeObjectAudioGraphNode(objectId, audio) {
-  return {
-    id: 'objectAudio',
-    type: 'sceneSetAudio',
-    params: {
-      target: objectId,
-      url: audio.url,
-      playOnAwake: audio.playOnAwake !== false,
-      loop: audio.loop !== false,
-    },
-  };
-}
-
-function upsertObjectAudioGraph(baseGraph, objectId, audio) {
-  const graph = removeObjectAudioNodes(baseGraph);
-  const normalized = normalizeObjectAudioConfig(audio);
-  if (normalized) {
-    graph.nodes.push(makeObjectAudioGraphNode(objectId, normalized));
-  }
-  return graph;
-}
-
-function graphHasExecutableNodes(graph) {
-  return Array.isArray(graph?.nodes) && graph.nodes.length > 0;
-}
-
-function createObjectAudioGraphOperation(objectId, audio) {
-  const current = loomIntegration?.exportState?.()?.objects?.[objectId] || { nodes: [], edges: [] };
-  const graph = upsertObjectAudioGraph(current, objectId, audio);
-  if (!graphHasExecutableNodes(graph)) {
-    return { type: 'scene-graph-clear', scope: { object: objectId } };
-  }
-  return { type: 'scene-graph-set', scope: { object: objectId }, graph };
-}
-
-function getObjectAudioConfigFromGraph(graph) {
-  const node = Array.isArray(graph?.nodes)
-    ? graph.nodes.find((entry) => OBJECT_AUDIO_NODE_TYPES.has(entry?.type))
-    : null;
-  if (!node) return null;
-  return normalizeObjectAudioConfig(node.params || null);
-}
-
-function getObjectAudioConfigFromLoomState(loomState, objectId) {
-  return getObjectAudioConfigFromGraph(loomState?.objects?.[objectId]);
-}
+// ── Loomlet graph operation helpers ─────────
 
 function applySceneGraphOperation(operation) {
   if (!operation || typeof operation.type !== 'string' || !operation.type.startsWith('scene-graph-')) {
     return false;
   }
-  const objectId = operation.scope && typeof operation.scope === 'object' ? operation.scope.object : null;
-  if (objectId && (
-    operation.type === 'scene-graph-clear' ||
-    ((operation.type === 'scene-graph-set' || operation.type === 'scene-graph-patch') && !getObjectAudioConfigFromGraph(operation.graph))
-  )) {
-    disposeObjectAudio(objectId);
-  }
   loomIntegration.handlePayload(operation);
   notifySceneStateChanged('scene-graph-operation-applied');
   return true;
-}
-
-function setObjectAudioComponent(objectId, audio, options = {}) {
-  const normalized = normalizeObjectAudioConfig(audio);
-  if (!objectId) throw new Error('objectId is required');
-  if (normalized && !/^https?:\/\//i.test(normalized.url)) {
-    throw new Error('audio url must start with http(s)');
-  }
-
-  const operation = createObjectAudioGraphOperation(objectId, normalized);
-  applySceneGraphOperation(operation);
-  if (options.broadcast !== false) {
-    broadcast(operation);
-  }
-  notifySelectionChanged('object-audio-updated');
-  return operation;
 }
 
 function setSceneClockMode(mode, now = performance.now()) {
@@ -4807,31 +4709,116 @@ function followHostClock(now = performance.now()) {
 }
 
 // ── Loom 統合初期化 ──────────────────────────────────
+function isObjectBeingEditedNow(objectId) {
+  if (!objectId) return false;
+
+  if (selectedObjectIds.has(objectId)) return true;
+
+  const transformObjectId = transformCtrl.object?.userData?.objectId;
+  if (transformObjectId === objectId) return true;
+
+  if (xrState.twoHand?.active && xrState.twoHand.object?.userData?.objectId === objectId) {
+    return true;
+  }
+
+  for (const grabber of xrState.grabbers || []) {
+    if (grabber.active && grabber.object?.userData?.objectId === objectId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// 指定 GLB clip の現在再生位置を返す（AudioSource の animation 同期補助に使用）。
+function getObjectAnimationSampleForAudio(objectId, clipName) {
+  const entry = glbAnimationMixers.get(objectId);
+  if (!entry || !entry.action) return null;
+  const clip = entry.clips?.[entry.clipIndex] || entry.clips?.[0];
+  if (!clip) return null;
+  if (clipName && clip.name && clip.name !== clipName) return null;
+  return { time: entry.action.time || 0, duration: clip.duration || 0 };
+}
+
+// ── AudioSource component / playback controller ─────────
+const audioSourceController = createAudioSourceController({
+  getObjectRuntimeTime: (objectId, nowMs) => getObjectRuntimeTime(objectId, nowMs),
+  getAnimationSample: getObjectAnimationSampleForAudio,
+  isObjectBeingEdited: isObjectBeingEditedNow,
+  showToast,
+});
+
+// 既存の audioSources に部分 patch を適用し、再生エンジンへ反映する。
+function applyObjectAudioSourcesPatch(objectId, patch) {
+  const obj = managedObjects.get(objectId);
+  if (!obj) return null;
+  const merged = mergeAudioSourcesPatch(obj.userData.audioSources, patch);
+  obj.userData.audioSources = merged;
+  audioSourceController.setObjectAudioSources(objectId, merged);
+  notifySceneStateChanged('object-audio-sources-updated');
+  return merged;
+}
+
+// オブジェクトの audioSources を完全置換する（scene-add / scene-state 復元用）。
+function setObjectAudioSourcesFull(objectId, map) {
+  const obj = managedObjects.get(objectId);
+  if (!obj) return null;
+  const normalized = normalizeAudioSourcesMap(map);
+  obj.userData.audioSources = normalized;
+  audioSourceController.setObjectAudioSources(objectId, normalized);
+  return normalized;
+}
+
+function getObjectAudioSourcesForSerialize(obj) {
+  const map = obj?.userData?.audioSources;
+  if (!map || typeof map !== 'object') return null;
+  const normalized = normalizeAudioSourcesMap(map);
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+// 音声 URL をオブジェクトの AudioSource component として追加/更新し broadcast する。
+// audioInput が url を持たない場合は、その name の AudioSource を削除する。
+function addOrUpdateAudioSource(objectId, audioInput, options = {}) {
+  if (!objectId) throw new Error('objectId is required');
+  const name = options.name || audioInput?.name || DEFAULT_AUDIO_SOURCE_NAME;
+  const source = normalizeAudioSource({ ...audioInput, name }, { name });
+  if (source && !isHttpUrl(source.url)) {
+    throw new Error('audio url must start with http(s)');
+  }
+  const patch = { [name]: source }; // source が null なら削除
+  applyObjectAudioSourcesPatch(objectId, patch);
+  const payload = { kind: 'scene-delta', objectId, audioSources: patch };
+  if (options.broadcast !== false) {
+    broadcast(payload);
+  }
+  notifySelectionChanged('object-audio-updated');
+  return payload;
+}
+
+// Loomlet から呼ばれる低レベル AudioSource 操作 API（host 側の受け皿）。
+// 再生条件・演出ロジックは Loomlet 側で実装する。
+const audioSourceHostApi = {
+  play: (objectId, name) => audioSourceController.play(objectId, name),
+  pause: (objectId, name) => audioSourceController.pause(objectId, name),
+  stop: (objectId, name) => audioSourceController.stop(objectId, name),
+  seek: (objectId, name, time) => audioSourceController.seek(objectId, name, time),
+  playOneShot: (objectId, name, opts) => audioSourceController.playOneShot(objectId, name, opts),
+  setVolume: (objectId, name, volume) => audioSourceController.setVolume(objectId, name, volume),
+  setClip: (objectId, name, url) => {
+    audioSourceController.setClip(objectId, name, url);
+    // component（audioSources）へも反映し、他クライアントへ broadcast する。
+    return addOrUpdateAudioSource(objectId, { url }, { name });
+  },
+  syncToAnimation: (objectId, name, opts) => audioSourceController.syncToAnimation(objectId, name, opts),
+  unsync: (objectId, name) => audioSourceController.unsync(objectId, name),
+};
+
 const loomIntegration = createSceneSyncLoomIntegration({
   getObjectById: (objectId) => managedObjects.get(objectId) || null,
   send: (payload) => broadcast(payload),
   getHostTime: () => Date.now() / 1000,
   getObjectRuntimeTime,
-  isObjectBeingEdited: (objectId) => {
-    if (!objectId) return false;
-
-    if (selectedObjectIds.has(objectId)) return true;
-
-    const transformObjectId = transformCtrl.object?.userData?.objectId;
-    if (transformObjectId === objectId) return true;
-
-    if (xrState.twoHand?.active && xrState.twoHand.object?.userData?.objectId === objectId) {
-      return true;
-    }
-
-    for (const grabber of xrState.grabbers || []) {
-      if (grabber.active && grabber.object?.userData?.objectId === objectId) {
-        return true;
-      }
-    }
-
-    return false;
-  },
+  isObjectBeingEdited: isObjectBeingEditedNow,
   showToast,
   // Host input providers for Loomlet behavior evaluation
   getViewerPosition: getViewerPositionForLoomlet,
@@ -4843,7 +4830,7 @@ const loomIntegration = createSceneSyncLoomIntegration({
   clearLoomletHostEvents: clearLoomletHostEventsForObject,
   getSceneClockStateForLoomlet,
   getInputRoutingMode,
-  applyObjectAudioEffect,
+  audioSource: audioSourceHostApi,
 });
 
 // ── Scene Clock Debug UI 制御 ────────────────────────────
@@ -5417,6 +5404,11 @@ async function respondToSceneRequest(from) {
       );
     }
 
+    const audioSources = getObjectAudioSourcesForSerialize(obj);
+    if (audioSources) {
+      entry.audioSources = audioSources;
+    }
+
     objects[objectId] = entry;
   }
 
@@ -5608,6 +5600,8 @@ function handleHandoff(data) {
             metadata: hasPayloadMetadata
               ? cloneJsonSafe(payload.metadata)
               : obj.userData?.metadata,
+            // コンテンツ差し替え時も既存の AudioSource component を保持する。
+            audioSources: payload.audioSources ?? obj.userData?.audioSources,
           };
           addOrUpdateObject(payload.objectId, mergedInfo);
 
@@ -5643,6 +5637,13 @@ function handleHandoff(data) {
         console.debug('[scene-delta] animation applied', {
           objectId: payload.objectId,
           animation: payload.animation,
+        });
+      }
+      if (payload.audioSources && typeof payload.audioSources === 'object') {
+        applyObjectAudioSourcesPatch(payload.objectId, payload.audioSources);
+        console.debug('[scene-delta] audioSources applied', {
+          objectId: payload.objectId,
+          audioSources: payload.audioSources,
         });
       }
 
@@ -6251,7 +6252,7 @@ function createSceneUrlImportContext(options = {}) {
     broadcastSceneAdd: broadcast,
     applySceneBgm,
     broadcastSceneBgm: broadcast,
-    setObjectAudioComponent,
+    addOrUpdateAudioSource,
     resolveObjectAudioTarget: () => {
       const explicitObjectId = extraImporterContext?.objectId;
       if (explicitObjectId && managedObjects.has(explicitObjectId)) return explicitObjectId;
@@ -6438,9 +6439,9 @@ function serializeSceneObjectForExternalUse(objectId, obj) {
     result.animationClips = animationClips;
   }
 
-  const audio = getObjectAudioConfigFromLoomState(loomIntegration.exportState(), objectId);
-  if (audio) {
-    result.audio = audio;
+  const audioSources = getObjectAudioSourcesForSerialize(obj);
+  if (audioSources) {
+    result.audioSources = audioSources;
   }
 
   return result;
@@ -6895,6 +6896,9 @@ function addOrUpdateObject(objectId, info, options = {}) {
   applyObjectName(existing, info.name);
   applyTransform(existing, info);
   applyObjectVisibility(existing, info.visible);
+  if (info.audioSources !== undefined) {
+    setObjectAudioSourcesFull(objectId, info.audioSources);
+  }
   notifySceneStateChanged('managed-object-updated');
 }
 
@@ -7859,6 +7863,10 @@ function replaceManagedObject(objectId, nextObject, info) {
 
   setupObjectGlbAnimation(objectId, nextObject);
 
+  if (info.audioSources !== undefined) {
+    setObjectAudioSourcesFull(objectId, info.audioSources);
+  }
+
   console.debug('[scene-add] applied transform', {
     objectId: nextObject.userData?.objectId || null,
     position: nextObject.position.toArray(),
@@ -8109,119 +8117,6 @@ function updateBgmControls() {
   const clearButton = dom.clearBgmButton;
   if (!clearButton) return;
   clearButton.style.display = sceneBgmState.current ? 'block' : 'none';
-}
-
-function disposeObjectAudio(objectId) {
-  const state = objectAudioStates.get(objectId);
-  if (!state) return;
-  state.audio?.pause?.();
-  if (state.audio) {
-    state.audio.src = '';
-    state.audio.load?.();
-  }
-  objectAudioStates.delete(objectId);
-}
-
-function getOrCreateObjectAudioState(objectId) {
-  let state = objectAudioStates.get(objectId);
-  if (!state) {
-    state = {
-      audio: null,
-      current: null,
-      autoplayBlocked: false,
-    };
-    objectAudioStates.set(objectId, state);
-  }
-  return state;
-}
-
-function shouldRecreateObjectAudio(state, config) {
-  return !state.audio ||
-    state.current?.url !== config.url ||
-    state.current?.loop !== config.loop ||
-    state.current?.playOnAwake !== config.playOnAwake;
-}
-
-function seekAudioElement(audio, targetTime) {
-  if (!Number.isFinite(targetTime) || targetTime < 0) return;
-  if (!Number.isFinite(audio.duration) && targetTime > 0) return;
-  if (Math.abs((audio.currentTime || 0) - targetTime) < 0.25) return;
-  try {
-    audio.currentTime = targetTime;
-  } catch {}
-}
-
-function syncObjectAudioPlayback(objectId, state) {
-  const audio = state?.audio;
-  const config = state?.current;
-  if (!audio || !config) return;
-
-  if (state.pausedAtStart) {
-    audio.pause();
-    seekAudioElement(audio, 0);
-    return;
-  }
-
-  const objectTime = getObjectRuntimeTime(objectId, performance.now());
-  const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
-  const targetTime = duration
-    ? config.loop
-      ? objectTime % duration
-      : Math.min(objectTime, duration)
-    : 0;
-
-  seekAudioElement(audio, targetTime);
-
-  if (!config.playOnAwake || (duration && !config.loop && objectTime >= duration)) {
-    audio.pause();
-    return;
-  }
-
-  if (audio.paused) {
-    audio.play().then(() => {
-      state.autoplayBlocked = false;
-    }).catch((err) => {
-      if (!state.autoplayBlocked) {
-        console.warn('[SceneSync] object audio autoplay blocked:', err?.message);
-        showToast?.({
-          type: 'warning',
-          message: 'オブジェクト音声の自動再生がブロックされました',
-        });
-      }
-      state.autoplayBlocked = true;
-    });
-  }
-}
-
-function applyObjectAudioEffect(effect) {
-  const objectId = effect?.objectId;
-  if (!objectId || !managedObjects.has(objectId)) return;
-
-  const config = normalizeObjectAudioConfig(effect);
-  if (!config) {
-    disposeObjectAudio(objectId);
-    return;
-  }
-
-  const state = getOrCreateObjectAudioState(objectId);
-  state.pausedAtStart = effect.pausedAtStart === true;
-
-  if (shouldRecreateObjectAudio(state, config)) {
-    if (state.audio) {
-      state.audio.pause();
-      state.audio.src = '';
-      state.audio.load?.();
-    }
-    const audio = new Audio();
-    audio.src = config.url;
-    audio.loop = config.loop;
-    audio.preload = 'auto';
-    state.audio = audio;
-    state.current = config;
-    state.autoplayBlocked = false;
-  }
-
-  syncObjectAudioPlayback(objectId, state);
 }
 
 // ── Undo/Redo 処理 ──────────────────────────────────────
@@ -9402,7 +9297,11 @@ window.__sceneSyncDebug = {
   dragDropManager,
   getSelection: getCurrentSelectionPayload,
   getActiveTransformTweenCount: () => activeTransformTweens.size,
+  audioSource: audioSourceHostApi,
 };
+
+// Loomlet host 連携用の AudioSource 操作 API（play/pause/stop/seek/playOneShot/setVolume/setClip/syncToAnimation/unsync）。
+window.sceneSyncAudioSource = audioSourceHostApi;
 
 function isMobileUi() {
   return isSceneSyncMobileDevice();
@@ -9852,7 +9751,7 @@ const EDITABLE_SCENE_OBJECT_FIELDS = new Set([
   'scale',
   'visible',
   'asset',
-  'audio',
+  'audioSources',
 ]);
 
 const EDITABLE_TEXT_ASSET_FIELDS = new Set([
@@ -9906,22 +9805,10 @@ function validateColorValue(value, path, errors) {
   return valid;
 }
 
-function validateInspectorAudioValue(value, path, errors) {
-  if (value === null) return true;
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    errors.push(`${path} must be an object or null.`);
-    return false;
-  }
-  if (typeof value.url !== 'string' || !/^https?:\/\//i.test(value.url.trim())) {
-    errors.push(`${path}.url must be an http(s) URL.`);
-    return false;
-  }
-  if (value.playOnAwake !== undefined && typeof value.playOnAwake !== 'boolean') {
-    errors.push(`${path}.playOnAwake must be a boolean.`);
-    return false;
-  }
-  if (value.loop !== undefined && typeof value.loop !== 'boolean') {
-    errors.push(`${path}.loop must be a boolean.`);
+function validateInspectorAudioSourcesValue(value, path, errors) {
+  const result = validateAudioSourcesMap(value, { maxStringLength: 128 });
+  if (!result.ok) {
+    errors.push(`${path}: ${result.reason}.`);
     return false;
   }
   return true;
@@ -10238,10 +10125,10 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       }
     }
 
-    if (!valuesEqual(baseObject.audio ?? null, editedObject.audio ?? null)) {
-      if (validateInspectorAudioValue(editedObject.audio ?? null, `objects.${objectId}.audio`, errors)) {
-        graphActions.push(createObjectAudioGraphOperation(objectId, editedObject.audio ?? null));
-        changedFields.push('audio');
+    if (!valuesEqual(baseObject.audioSources ?? null, editedObject.audioSources ?? null)) {
+      if (validateInspectorAudioSourcesValue(editedObject.audioSources ?? null, `objects.${objectId}.audioSources`, errors)) {
+        objectDelta.audioSources = editedObject.audioSources ?? {};
+        changedFields.push('audioSources');
       }
     }
 
@@ -10968,9 +10855,9 @@ function buildSceneInspectorSnapshot() {
       entry.animationClips = getObjectAnimationClipSummaries(obj);
     }
 
-    const audio = getObjectAudioConfigFromLoomState(loomGraphState, objectId);
-    if (audio) {
-      entry.audio = audio;
+    const audioSources = getObjectAudioSourcesForSerialize(obj);
+    if (audioSources) {
+      entry.audioSources = audioSources;
     }
 
     objects[objectId] = entry;

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4759,6 +4759,20 @@ function applyObjectAudioSourcesPatch(objectId, patch) {
   return merged;
 }
 
+// 受信した scene-delta の audioSources を適用する。
+// - object（map）: 部分 patch（キー値 null はそのキーを削除）
+// - null: 全 AudioSource を削除（clear-all）
+function applyIncomingAudioSources(objectId, value) {
+  if (value === undefined) return;
+  if (value === null) {
+    setObjectAudioSourcesFull(objectId, {});
+    return;
+  }
+  if (typeof value === 'object') {
+    applyObjectAudioSourcesPatch(objectId, value);
+  }
+}
+
 // オブジェクトの audioSources を完全置換する（scene-add / scene-state 復元用）。
 function setObjectAudioSourcesFull(objectId, map) {
   const obj = managedObjects.get(objectId);
@@ -4807,7 +4821,10 @@ const audioSourceHostApi = {
   setClip: (objectId, name, url) => {
     audioSourceController.setClip(objectId, name, url);
     // component（audioSources）へも反映し、他クライアントへ broadcast する。
-    return addOrUpdateAudioSource(objectId, { url }, { name });
+    // 既存の volume/loop/playOnAwake/offset/playbackRate/spatial/sync を保持し url だけ差し替える。
+    const resolvedName = name || DEFAULT_AUDIO_SOURCE_NAME;
+    const current = managedObjects.get(objectId)?.userData?.audioSources?.[resolvedName] || {};
+    return addOrUpdateAudioSource(objectId, { ...current, url }, { name: resolvedName });
   },
   syncToAnimation: (objectId, name, opts) => audioSourceController.syncToAnimation(objectId, name, opts),
   unsync: (objectId, name) => audioSourceController.unsync(objectId, name),
@@ -5615,6 +5632,7 @@ function handleHandoff(data) {
               visible: mergedInfo.visible ?? true,
               asset: cloneJsonSafe(mergedInfo.asset),
               metadata: cloneJsonSafe(mergedInfo.metadata || null),
+              audioSources: cloneJsonSafe(getObjectAudioSourcesForSerialize(managedObjects.get(payload.objectId)) || {}),
             };
 
             presenceState.historyManager?.push(
@@ -5639,8 +5657,8 @@ function handleHandoff(data) {
           animation: payload.animation,
         });
       }
-      if (payload.audioSources && typeof payload.audioSources === 'object') {
-        applyObjectAudioSourcesPatch(payload.objectId, payload.audioSources);
+      if (payload.audioSources !== undefined) {
+        applyIncomingAudioSources(payload.objectId, payload.audioSources);
         console.debug('[scene-delta] audioSources applied', {
           objectId: payload.objectId,
           audioSources: payload.audioSources,
@@ -7622,6 +7640,7 @@ function createContentReplaceSnapshot(obj, fallbackObjectId = null) {
     visible: obj.visible !== false,
     asset: cloneJsonSafe(obj.userData?.asset || null),
     metadata: cloneJsonSafe(obj.userData?.metadata || null),
+    audioSources: cloneJsonSafe(getObjectAudioSourcesForSerialize(obj) || {}),
   };
 }
 
@@ -7697,12 +7716,16 @@ async function replaceObjectContent(objectId, input, options = {}) {
       ? input.name.trim()
       : existing.userData?.name || objectId;
 
+  // コンテンツ差し替えではオブジェクトを作り直すため、既存の AudioSource component を保持する。
+  const preservedAudioSources = getObjectAudioSourcesForSerialize(existing) || {};
+
   const deltaPayload = {
     kind: 'scene-delta',
     objectId,
     ...(input.name ? { name: nextName } : {}),
     asset: newAsset,
     metadata: newMetadata,
+    audioSources: preservedAudioSources,
   };
 
   broadcast(deltaPayload);
@@ -7716,6 +7739,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
     visible: existing.visible !== false,
     asset: newAsset,
     metadata: newMetadata,
+    audioSources: preservedAudioSources,
   };
   addOrUpdateObject(objectId, mergedInfo, { ...options, pushHistory: false });
 
@@ -7729,6 +7753,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
       visible: existing.visible !== false,
       asset: cloneJsonSafe(newAsset),
       metadata: cloneJsonSafe(newMetadata),
+      audioSources: cloneJsonSafe(preservedAudioSources),
     };
 
     presenceState.historyManager?.push(
@@ -8196,6 +8221,9 @@ function applyOperationToScene(operation) {
             metadata: hasMetadata
               ? cloneJsonSafe(operation.metadata)
               : cloneJsonSafe(obj.userData?.metadata || null),
+            audioSources: Object.prototype.hasOwnProperty.call(operation, 'audioSources')
+              ? cloneJsonSafe(operation.audioSources)
+              : cloneJsonSafe(getObjectAudioSourcesForSerialize(obj) || {}),
           };
 
           addOrUpdateObject(operation.objectId, mergedInfo, {
@@ -8215,6 +8243,9 @@ function applyOperationToScene(operation) {
         }
         if (operation.animation && typeof operation.animation === 'object') {
           applyObjectAnimationDelta(obj, operation.animation);
+        }
+        if (operation.audioSources !== undefined) {
+          applyIncomingAudioSources(operation.objectId, operation.audioSources);
         }
       }
       notifySceneStateChanged('undo-redo-scene-delta');


### PR DESCRIPTION
オブジェクト音声を Loomlet graph の scene.setAudio ノードではなく、
オブジェクトに付く AudioSource component（audioSources map）として扱うように変更。

- 新規: audio/audio-source.js（純粋なデータモデル: normalize / merge / validate）
- 新規: audio/audio-source-controller.js（再生エンジン + host API、DI でテスト可能）
- audioSources は scene-delta / scene-add / scene-state で流す（null 値で削除 patch）
- D&D/ペースト: オブジェクト上は AudioSource 追加、それ以外は scene-bgm fallback を維持
- host API: play / pause / stop / seek / playOneShot / setVolume / setClip /
  syncToAnimation / unsync（window.sceneSyncAudioSource と Loomlet effect 経由で公開）
- Animation 同期補助（animationTime + offset、ドリフト/ループ再同期）
- SetAudio / scene.setAudio / 旧 object-audio playback を削除
- message-schema に audioSources バリデーションを追加
- ボタンSE・衝突音・キャラクター音声切替・MusicVideo 演出は組み込まず Loomlet 実装に委譲
- export/inspector の object audio を audioSources へ移行
- Unity package は audioSources を無視（asset/metadata のみ処理、受け皿として変更不要）
- docs/scene-sync-bgm.md を AudioSource 仕様で更新
- tests: model / controller / schema / importer / loom 統合

Refs: afjk/afjk.jp#354

https://claude.ai/code/session_011vSVVkBgmt2GaYsyBEesS8