### PR TITLE
Scene Sync shell architecture scaffold

### DIFF
--- a/docs/scene-sync-shells.md
+++ b/docs/scene-sync-shells.md
@@ -1,0 +1,72 @@
+# Scene Sync Shell Architecture
+
+Scene Sync UI should be replaceable without changing the scene/runtime implementation.
+
+This document defines the first in-repository architecture for swappable UI. It is intentionally lightweight: shells are normal JavaScript modules in this repository, not an external plugin system yet.
+
+## Terms
+
+```text
+Shell = purpose / operation model
+Layout = surface-specific presentation
+Input Adapter = input method
+```
+
+A shell decides what kind of experience Scene Sync is providing. A layout decides how that shell is presented on a specific surface. An input adapter decides how user input is translated into shared shell actions.
+
+## Architecture
+
+```text
+Scene Sync Core
+├─ scene runtime
+├─ network sync
+├─ object registry
+├─ command API
+├─ selection
+├─ history
+└─ Loomlet binding
+
+Shells
+├─ Editor Shell
+│  ├─ Desktop Layout
+│  ├─ Mobile Layout
+│  └─ XR Layout
+├─ Viewer Shell
+│  ├─ Desktop Layout
+│  ├─ Mobile Layout
+│  └─ XR Layout
+├─ Controller Shell
+└─ Game / VJ / Character Shells
+```
+
+The current Scene Sync UI is the default `editor` shell. Exported static viewers already follow a similar split: viewer entry/UI is separate from viewer core. The live Scene Sync app should move in the same direction.
+
+## Desktop, mobile, and WebXR
+
+Desktop and mobile editing should not be separate shells by default. They are layouts inside the same `Editor Shell` because they share the same purpose: editing the scene.
+
+WebXR is not just responsive CSS. It should be treated as an immersive layout with an XR input adapter. The purpose still determines the shell:
+
+- `Editor Shell + XR Layout`: edit inside the scene.
+- `Viewer Shell + XR Layout`: view or experience the exported/live scene.
+- `Game Shell + XR Layout`: use game-like controls and HUD.
+- `Controller Shell`: use a phone or another surface as an operation panel.
+
+## Initial implementation rules
+
+- Keep the existing UI behavior unchanged when no shell is specified.
+- Use `?shell=editor` as the explicit default.
+- Add experimental shells in `html/assets/js/scenesync/shells/`.
+- Keep shell loading in a small registry.
+- Use simple DOM modules first; do not introduce React or external UI plugin loading yet.
+- Shell UI should call shared commands instead of mutating scene internals directly.
+
+## Current v0 status
+
+The first implementation adds:
+
+- `shell-registry.js` for selecting an in-repository shell.
+- `editor` shell that preserves the current built-in UI.
+- `minimal` shell that hides the built-in editor chrome and mounts a small overlay for quick swap testing.
+
+This is a scaffold, not the final split. Future work should move current editor UI event wiring out of `scene.js` and into `shells/editor/`, while gradually exposing stable scene commands from core.

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -22,7 +22,7 @@ import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
 import { resolveDroppedUrl } from './loaders/url-resolver.js';
 import { normalizeTextAsset, renderTextPanelCanvas, DEFAULT_TEXT_LAYOUT, DEFAULT_TEXT_SCROLL, estimateTextPanelLayout } from './components/text-panel-renderer.js';
 import { dispatchUrlImport } from './loaders/url-importers/index.js';
-import { getSceneSyncDom } from './ui/dom.js';
+import { getSceneSyncDom, mountSceneSyncShellFromDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { createWelcomeDialog } from './ui/welcome-dialog.js';
 import { focusTextInputIfSafe, blurActiveEditableElement } from './ui/input-focus-guard.js';
@@ -6508,6 +6508,28 @@ function getCurrentSelectionPayload() {
   };
 }
 
+const sceneSyncShellStateListeners = new Set();
+
+function getSceneSyncShellSelection() {
+  const selection = getCurrentSelectionPayload();
+  return {
+    ...selection,
+    objectIds: selection.selectedObjectIds,
+  };
+}
+
+function notifySceneSyncShellStateChanged(reason) {
+  for (const listener of sceneSyncShellStateListeners) {
+    listener({ reason });
+  }
+}
+
+function onSceneSyncShellStateChange(listener) {
+  if (typeof listener !== 'function') return () => {};
+  sceneSyncShellStateListeners.add(listener);
+  return () => sceneSyncShellStateListeners.delete(listener);
+}
+
 function resolveAiCommandObjectId(params = {}) {
   const explicit = typeof params.objectId === 'string' ? params.objectId.trim() : '';
   if (explicit) return explicit;
@@ -11593,16 +11615,19 @@ function broadcastSelectedObjectAnimationDelta(delta) {
 
 function notifySceneStateChanged(reason) {
   notifyInspectorStateChanged(`scene:${reason}`);
+  notifySceneSyncShellStateChanged(`scene:${reason}`);
   syncSceneUiState();
   scheduleSaveRoomSnapshot(reason);
 }
 
 function notifySelectionChanged(reason) {
   notifyInspectorStateChanged(`selection:${reason}`);
+  notifySceneSyncShellStateChanged(`selection:${reason}`);
 }
 
 function notifyConnectionStateChanged(reason) {
   notifyInspectorStateChanged(`connection:${reason}`);
+  notifySceneSyncShellStateChanged(`connection:${reason}`);
 }
 
 function setSceneInspectorOpen(nextOpen) {
@@ -11972,6 +11997,21 @@ logDiagnosticFlags();
 
 nicknameChip?.addEventListener('click', editNickname);
 document.getElementById('help-btn')?.addEventListener('click', openHelpDialog);
+mountSceneSyncShellFromDom({
+  commands: {
+    openAddMenu: () => dom.addBtn?.click(),
+    undo: () => {
+      if (presenceState.historyManager.canUndo()) performUndo();
+    },
+    redo: () => {
+      if (presenceState.historyManager.canRedo()) performRedo();
+    },
+    deleteSelected: deleteSelectedObjects,
+    exportScene: triggerExport,
+  },
+  getSelection: getSceneSyncShellSelection,
+  onStateChange: onSceneSyncShellStateChange,
+});
 updateNicknameLabel();
 renderRoomSection();
 syncSceneUiState();

--- a/html/assets/js/scenesync/shells/editor/editor-shell.js
+++ b/html/assets/js/scenesync/shells/editor/editor-shell.js
@@ -1,0 +1,30 @@
+export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', availableShellIds = [] } = {}) {
+  return {
+    id,
+    requestedId,
+    name: 'Editor Shell',
+    kind: 'editor',
+    layouts: ['desktop', 'mobile', 'xr'],
+    inputs: ['mouse', 'touch', 'xr'],
+
+    mount({ core } = {}) {
+      document.body.dataset.sceneSyncShell = 'editor';
+      document.body.classList.add('scene-sync-shell-editor');
+      document.body.classList.remove('scene-sync-shell-minimal');
+
+      if (core?.debug) {
+        console.debug('[SceneSyncShell] mounted editor shell', {
+          requestedId,
+          availableShellIds,
+        });
+      }
+    },
+
+    unmount() {
+      document.body.classList.remove('scene-sync-shell-editor');
+      delete document.body.dataset.sceneSyncShell;
+    },
+  };
+}
+
+export default createSceneSyncShell;

--- a/html/assets/js/scenesync/shells/minimal/minimal-shell.css
+++ b/html/assets/js/scenesync/shells/minimal/minimal-shell.css
@@ -1,0 +1,51 @@
+.scene-sync-shell-minimal #settings-panel,
+.scene-sync-shell-minimal #peers-panel,
+.scene-sync-shell-minimal #scene-inspector-panel,
+.scene-sync-shell-minimal #scene-clock-panel,
+.scene-sync-shell-minimal #add-btn,
+.scene-sync-shell-minimal #history-toolbar,
+.scene-sync-shell-minimal #mobile-toolbar,
+.scene-sync-shell-minimal #mode,
+.scene-sync-shell-minimal #xr-toggle-btn,
+.scene-sync-shell-minimal #xr-calibrate-btn {
+  display: none !important;
+}
+
+.scene-sync-minimal-shell-panel {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 220;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(280px, calc(100vw - 24px));
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font: 13px/1.45 monospace;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.scene-sync-minimal-shell-title {
+  font-weight: 700;
+}
+
+.scene-sync-minimal-shell-note {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 12px;
+}
+
+.scene-sync-minimal-shell-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.scene-sync-minimal-shell-actions .chip {
+  justify-content: center;
+}

--- a/html/assets/js/scenesync/shells/minimal/minimal-shell.js
+++ b/html/assets/js/scenesync/shells/minimal/minimal-shell.js
@@ -32,6 +32,8 @@ function getConnectionText(core) {
 function getSelectionText(core) {
   const selection = core?.getSelection?.();
   const ids = Array.isArray(selection?.objectIds) ? selection.objectIds : [];
+  const label = typeof selection?.label === 'string' ? selection.label.trim() : '';
+  if (ids.length === 0 && label && label !== 'No object selected') return `Selection: ${label}`;
   if (ids.length === 0) return 'Selection: none';
   if (ids.length === 1) return `Selection: ${ids[0]}`;
   return `Selection: ${ids.length} objects`;

--- a/html/assets/js/scenesync/shells/minimal/minimal-shell.js
+++ b/html/assets/js/scenesync/shells/minimal/minimal-shell.js
@@ -1,0 +1,110 @@
+const STYLE_ID = 'scene-sync-minimal-shell-style';
+
+async function ensureStylesheet() {
+  if (document.getElementById(STYLE_ID)) return;
+
+  const link = document.createElement('link');
+  link.id = STYLE_ID;
+  link.rel = 'stylesheet';
+  link.href = new URL('./minimal-shell.css', import.meta.url).href;
+  document.head.appendChild(link);
+}
+
+function createButton(label, onClick, className = 'chip') {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.textContent = label;
+  button.addEventListener('click', onClick);
+  return button;
+}
+
+function getConnectionText(core) {
+  const state = core?.getConnectionState?.();
+  if (!state) return 'Connection: starting…';
+  const room = state.room || '—';
+  const peers = Number.isFinite(state.peerCount) ? state.peerCount : 0;
+  return state.connected
+    ? `Connected · ${room} · ${peers} peer${peers === 1 ? '' : 's'}`
+    : 'Connection: reconnecting…';
+}
+
+function getSelectionText(core) {
+  const selection = core?.getSelection?.();
+  const ids = Array.isArray(selection?.objectIds) ? selection.objectIds : [];
+  if (ids.length === 0) return 'Selection: none';
+  if (ids.length === 1) return `Selection: ${ids[0]}`;
+  return `Selection: ${ids.length} objects`;
+}
+
+export function createSceneSyncShell({ id = 'minimal', requestedId = 'minimal', availableShellIds = [] } = {}) {
+  let panel = null;
+  let removeStateListener = null;
+
+  function update(core) {
+    if (!panel) return;
+    const connectionEl = panel.querySelector('[data-minimal-shell-connection]');
+    const selectionEl = panel.querySelector('[data-minimal-shell-selection]');
+    if (connectionEl) connectionEl.textContent = getConnectionText(core);
+    if (selectionEl) selectionEl.textContent = getSelectionText(core);
+  }
+
+  return {
+    id,
+    requestedId,
+    name: 'Minimal Shell',
+    kind: 'editor',
+    layouts: ['desktop', 'mobile'],
+    inputs: ['mouse', 'touch'],
+
+    async mount({ core } = {}) {
+      await ensureStylesheet();
+
+      document.body.dataset.sceneSyncShell = 'minimal';
+      document.body.classList.add('scene-sync-shell-minimal');
+      document.body.classList.remove('scene-sync-shell-editor');
+
+      panel = document.createElement('section');
+      panel.className = 'scene-sync-minimal-shell-panel';
+      panel.setAttribute('aria-label', 'Minimal Scene Sync Shell');
+      panel.innerHTML = `
+        <div class="scene-sync-minimal-shell-title">Scene Sync · Minimal Shell</div>
+        <div class="scene-sync-minimal-shell-note">Experimental UI swap scaffold. Core scene/runtime stays active.</div>
+        <div data-minimal-shell-connection></div>
+        <div data-minimal-shell-selection></div>
+        <div class="scene-sync-minimal-shell-actions" data-minimal-shell-actions></div>
+      `;
+
+      const actions = panel.querySelector('[data-minimal-shell-actions]');
+      actions?.append(
+        createButton('Add', () => core?.commands?.openAddMenu?.()),
+        createButton('Undo', () => core?.commands?.undo?.()),
+        createButton('Redo', () => core?.commands?.redo?.()),
+        createButton('Delete', () => core?.commands?.deleteSelected?.(), 'chip danger'),
+        createButton('Export', () => core?.commands?.exportScene?.(), 'chip primary')
+      );
+
+      document.body.appendChild(panel);
+      removeStateListener = core?.onStateChange?.(() => update(core)) || null;
+      update(core);
+
+      if (core?.debug) {
+        console.debug('[SceneSyncShell] mounted minimal shell', {
+          requestedId,
+          availableShellIds,
+        });
+      }
+    },
+
+    unmount() {
+      removeStateListener?.();
+      removeStateListener = null;
+      panel?.remove();
+      panel = null;
+      document.body.classList.remove('scene-sync-shell-minimal');
+      delete document.body.dataset.sceneSyncShell;
+    },
+  };
+}
+
+export default createSceneSyncShell;

--- a/html/assets/js/scenesync/shells/shell-bootstrap.js
+++ b/html/assets/js/scenesync/shells/shell-bootstrap.js
@@ -1,0 +1,90 @@
+import { loadSceneSyncShell } from './shell-registry.js';
+
+function clickElement(id) {
+  document.getElementById(id)?.click();
+}
+
+function createDomBackedCommands() {
+  return {
+    openAddMenu() {
+      clickElement('add-btn');
+    },
+    undo() {
+      clickElement('btn-undo');
+    },
+    redo() {
+      clickElement('btn-redo');
+    },
+    deleteSelected() {
+      clickElement('btn-delete');
+    },
+    exportScene() {
+      clickElement('export-btn');
+    },
+  };
+}
+
+function createDomBackedCore(extraCore = {}) {
+  const listeners = new Set();
+
+  const notify = (reason) => {
+    for (const listener of listeners) {
+      listener({ reason });
+    }
+  };
+
+  const statusEl = document.getElementById('status');
+  const selectionOutputEl = document.getElementById('scene-inspector-object-meta');
+
+  const observer = new MutationObserver(() => notify('dom-mutated'));
+  if (statusEl) observer.observe(statusEl, { childList: true, subtree: true, characterData: true });
+  if (selectionOutputEl) observer.observe(selectionOutputEl, { childList: true, subtree: true, characterData: true });
+
+  return {
+    ...extraCore,
+    commands: {
+      ...createDomBackedCommands(),
+      ...(extraCore.commands || {}),
+    },
+    getConnectionState() {
+      const statusText = statusEl?.textContent || '';
+      return {
+        connected: statusText.includes('·'),
+        room: statusText.split('·')[1]?.trim() || '',
+        peerCount: Number.parseInt(statusText.match(/(\d+) peer/)?.[1] || '0', 10),
+        label: statusText,
+      };
+    },
+    getSelection() {
+      const label = selectionOutputEl?.textContent?.trim() || '';
+      return {
+        label,
+        objectIds: [],
+      };
+    },
+    onStateChange(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    dispose() {
+      observer.disconnect();
+      listeners.clear();
+      extraCore.dispose?.();
+    },
+  };
+}
+
+export async function mountSceneSyncShell(extraCore = {}) {
+  const shell = await loadSceneSyncShell();
+  const core = createDomBackedCore(extraCore);
+  await shell.mount({ core, root: document.body });
+
+  return {
+    shell,
+    core,
+    dispose() {
+      shell.unmount?.();
+      core.dispose?.();
+    },
+  };
+}

--- a/html/assets/js/scenesync/shells/shell-bootstrap.js
+++ b/html/assets/js/scenesync/shells/shell-bootstrap.js
@@ -26,6 +26,7 @@ function createDomBackedCommands() {
 
 function createDomBackedCore(extraCore = {}) {
   const listeners = new Set();
+  let removeExtraStateListener = null;
 
   const notify = (reason) => {
     for (const listener of listeners) {
@@ -39,6 +40,15 @@ function createDomBackedCore(extraCore = {}) {
   const observer = new MutationObserver(() => notify('dom-mutated'));
   if (statusEl) observer.observe(statusEl, { childList: true, subtree: true, characterData: true });
   if (selectionOutputEl) observer.observe(selectionOutputEl, { childList: true, subtree: true, characterData: true });
+
+  if (typeof extraCore.onStateChange === 'function') {
+    const removeListener = extraCore.onStateChange((event = {}) => {
+      notify(event.reason || 'core-state-changed');
+    });
+    if (typeof removeListener === 'function') {
+      removeExtraStateListener = removeListener;
+    }
+  }
 
   return {
     ...extraCore,
@@ -56,6 +66,19 @@ function createDomBackedCore(extraCore = {}) {
       };
     },
     getSelection() {
+      const coreSelection = extraCore.getSelection?.();
+      if (coreSelection) {
+        const objectIds = Array.isArray(coreSelection.objectIds)
+          ? coreSelection.objectIds
+          : Array.isArray(coreSelection.selectedObjectIds)
+            ? coreSelection.selectedObjectIds
+            : [];
+        return {
+          ...coreSelection,
+          objectIds,
+        };
+      }
+
       const label = selectionOutputEl?.textContent?.trim() || '';
       return {
         label,
@@ -68,6 +91,8 @@ function createDomBackedCore(extraCore = {}) {
     },
     dispose() {
       observer.disconnect();
+      removeExtraStateListener?.();
+      removeExtraStateListener = null;
       listeners.clear();
       extraCore.dispose?.();
     },

--- a/html/assets/js/scenesync/shells/shell-registry.js
+++ b/html/assets/js/scenesync/shells/shell-registry.js
@@ -1,0 +1,38 @@
+const DEFAULT_SHELL_ID = 'editor';
+
+const SHELL_LOADERS = {
+  editor: () => import('./editor/editor-shell.js'),
+  minimal: () => import('./minimal/minimal-shell.js'),
+};
+
+function normalizeShellId(value) {
+  if (typeof value !== 'string') return DEFAULT_SHELL_ID;
+  const id = value.trim().toLowerCase();
+  return id || DEFAULT_SHELL_ID;
+}
+
+export function getRequestedSceneSyncShellId(search = location.search) {
+  const params = new URLSearchParams(search);
+  return normalizeShellId(params.get('shell'));
+}
+
+export function listSceneSyncShellIds() {
+  return Object.keys(SHELL_LOADERS);
+}
+
+export async function loadSceneSyncShell(shellId = getRequestedSceneSyncShellId()) {
+  const requestedId = normalizeShellId(shellId);
+  const loader = SHELL_LOADERS[requestedId] || SHELL_LOADERS[DEFAULT_SHELL_ID];
+  const module = await loader();
+  const createShell = module.createSceneSyncShell || module.default;
+
+  if (typeof createShell !== 'function') {
+    throw new Error(`Scene Sync shell '${requestedId}' does not export createSceneSyncShell().`);
+  }
+
+  return createShell({
+    id: SHELL_LOADERS[requestedId] ? requestedId : DEFAULT_SHELL_ID,
+    requestedId,
+    availableShellIds: listSceneSyncShellIds(),
+  });
+}

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -2,9 +2,9 @@ import { mountSceneSyncShell } from '../shells/shell-bootstrap.js';
 
 let sceneSyncShellMountPromise = null;
 
-export function mountSceneSyncShellFromDom() {
+export function mountSceneSyncShellFromDom(core = {}) {
   if (!sceneSyncShellMountPromise) {
-    sceneSyncShellMountPromise = mountSceneSyncShell().catch((error) => {
+    sceneSyncShellMountPromise = mountSceneSyncShell(core).catch((error) => {
       console.warn('[SceneSyncShell] failed to mount shell:', error);
       return null;
     });
@@ -13,8 +13,6 @@ export function mountSceneSyncShellFromDom() {
 }
 
 export function getSceneSyncDom() {
-  mountSceneSyncShellFromDom();
-
   return {
     envSelect: document.getElementById('env-select'),
     xrButtonContainer: document.getElementById('xr-button-container'),

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -1,4 +1,20 @@
+import { mountSceneSyncShell } from '../shells/shell-bootstrap.js';
+
+let sceneSyncShellMountPromise = null;
+
+export function mountSceneSyncShellFromDom() {
+  if (!sceneSyncShellMountPromise) {
+    sceneSyncShellMountPromise = mountSceneSyncShell().catch((error) => {
+      console.warn('[SceneSyncShell] failed to mount shell:', error);
+      return null;
+    });
+  }
+  return sceneSyncShellMountPromise;
+}
+
 export function getSceneSyncDom() {
+  mountSceneSyncShellFromDom();
+
   return {
     envSelect: document.getElementById('env-select'),
     xrButtonContainer: document.getElementById('xr-button-container'),


### PR DESCRIPTION
## Summary

Adds the first in-repository scaffold for swappable Scene Sync UI shells.

- Adds `docs/scene-sync-shells.md` to define Shell / Layout / Input Adapter.
- Adds a small shell registry with `editor` as the default and `minimal` as an experimental shell.
- Adds a minimal shell overlay for quick UI swap testing via `?shell=minimal`.
- Mounts the shell scaffold from the existing DOM adapter without changing the large `scene.js` runtime flow.

## Design intent

This is intentionally not a full plugin system yet. The goal is to make UI experiments cheap while preserving current behavior by default.

Desktop/mobile remain layouts under the Editor Shell. WebXR is treated as an immersive layout/input path, not just responsive CSS.

## Related

- Closes #356

## Testing

Not run in this environment. Recommended manual checks:

1. Open `/scenesync/` and confirm the current editor UI behaves unchanged.
2. Open `/scenesync/?shell=editor` and confirm behavior is unchanged.
3. Open `/scenesync/?shell=minimal` and confirm the minimal overlay appears while the scene remains active.
4. Confirm Add / Undo / Redo / Delete / Export buttons in the minimal overlay dispatch to the existing DOM-backed controls.