### PR TITLE
Add Scene Sync Player Shell for Scene Clock transport control

### DIFF
--- a/docs/scene-sync-scene-clock.md
+++ b/docs/scene-sync-scene-clock.md
@@ -231,6 +231,17 @@ To enable debug panel in developer console:
 document.getElementById('scene-clock-panel').removeAttribute('hidden')
 ```
 
+## Player Shell
+
+Player Shell is a UI surface for local Scene Clock transport control.
+
+- URL: `/scenesync/?shell=player`
+- Controls: Play / Pause / Stop / Seek / Rate
+- Calls `core.commands.playSceneClock()` / `pauseSceneClock()` / `stopSceneClock()` / `seekSceneClock(t)` / `setSceneClockRate(r)`
+- Reads state via `core.getSceneClockState()` (side-effect-free, safe to call every frame)
+- GLB animations and Loomlet behaviors follow Scene Clock
+- AudioSource full transport sync is future work
+
 ## Related Docs
 
 - [Scene Sync Runtime Time Model](./scene-sync-runtime-time-model.md) - per-object time and selection behavior

--- a/docs/scene-sync-shells.md
+++ b/docs/scene-sync-shells.md
@@ -180,3 +180,53 @@ The Add button trigger is now exposed as `core.commands.openAddMenu()`:
 - Editor Shell / Minimal Shell can call `core.commands.openAddMenu()` safely without recursion
 - `#add-btn` click listener in scene.js delegates to `openAddMenu()` (mobile path only; DragDropManager handles the desktop click path)
 - Actual file import and mobile add sheet internals remain in scene.js
+
+## Player Shell
+
+Player Shell is an experimental shell for Scene Clock transport controls.
+
+- URL: `/scenesync/?shell=player`
+- Purpose: operate Scene Clock with Play / Pause / Stop / Seek / Rate
+- It does not directly edit scene objects
+- It does not directly control AudioSource yet
+- GLB animations and Loomlet behaviors can follow Scene Clock
+- AudioSource full transport sync is future work
+
+### Directory structure
+
+```text
+html/assets/js/scenesync/shells/player/
+├─ player-shell.js    (main shell entry, mounts transport UI)
+├─ player-actions.js  (thin wrapper over core.commands)
+└─ player-shell.css   (transport panel styles, hides editor chrome)
+```
+
+### Scene Clock commands
+
+Player Shell calls these commands via `core.commands`:
+
+| Command | Behaviour |
+|---|---|
+| `playSceneClock()` | Resume if paused; switch to local mode if host-follow |
+| `pauseSceneClock()` | Freeze time |
+| `stopSceneClock()` | Seek to 0 then pause |
+| `seekSceneClock(t)` | Jump to `t` seconds in local mode |
+| `setSceneClockRate(r)` | Set playback rate (0.25 / 0.5 / 1 / 2) |
+| `resetSceneClock()` | Seek to 0 and continue playing |
+
+State is read via `core.getSceneClockState()`:
+
+```js
+{
+  time: number,    // current time in seconds
+  isPaused: boolean,
+  playing: boolean,
+  mode: 'local' | 'host-follow',
+  rate: number,
+  duration: number,
+}
+```
+
+### UI update loop
+
+Player Shell runs a `requestAnimationFrame` loop for smooth time display. The loop is started on `mount()` and cancelled on `unmount()`.

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4620,9 +4620,11 @@ function getSceneClockDelta(now = performance.now()) {
   }
 
   if (sceneClockState.mode === 'local') {
-    const elapsed = (now - sceneClockState.lastUpdateNow) / 1000;
-    const delta = Math.max(0, elapsed * sceneClockState.rate);
-    sceneClockState.lastUpdateNow = now;  // Update for next frame
+    const elapsed = Math.max(0, (now - sceneClockState.lastUpdateNow) / 1000);
+    const delta = elapsed * sceneClockState.rate;
+    // Accumulate localTime so getSceneClockTime() sees continuous progression
+    sceneClockState.localTime = Math.max(0, sceneClockState.localTime + delta);
+    sceneClockState.lastUpdateNow = now;
     return delta;
   }
 
@@ -4718,10 +4720,9 @@ function followHostClock(now = performance.now()) {
   setSceneClockMode('host-follow', now);
 }
 
-function setSceneClockRate(rate) {
-  const now = performance.now();
-  const nextRate = typeof rate === 'number' ? rate : parseFloat(rate) || 1;
-  if (nextRate < 0) return;
+function setSceneClockRate(rate, now = performance.now()) {
+  const nextRate = Number(rate);
+  if (!Number.isFinite(nextRate) || nextRate < 0) return;
   // rate 変更時に time jump を避けるため現在時刻を localTime に焼く
   if (sceneClockState.mode === 'local') {
     sceneClockState.localTime = getSceneClockTime(now);
@@ -4731,10 +4732,13 @@ function setSceneClockRate(rate) {
 }
 
 function playSceneClock(now = performance.now()) {
+  // seekSceneClock(0) ensures we are in local mode starting from a sensible
+  // position rather than baking the host-follow wall-clock epoch into localTime.
+  if (sceneClockState.mode !== 'local') {
+    seekSceneClock(0, now);
+  }
   if (sceneClockState.paused) {
-    resumeSceneClock(now); // resumeSceneClock already switches to local mode
-  } else if (sceneClockState.mode !== 'local') {
-    setSceneClockMode('local', now);
+    resumeSceneClock(now);
   }
 }
 
@@ -4743,13 +4747,17 @@ function stopSceneClock(now = performance.now()) {
   pauseSceneClock(now);
 }
 
-// Side-effect-free getter for shell UI (does not update delta/lastUpdateNow)
+// Side-effect-free getter for shell UI (does not update delta/lastUpdateNow).
+// In host-follow mode, raw time is wall-clock epoch (>1 billion seconds).
+// Player Shell transport always starts from 0, so display 0 until local mode.
 function getSceneClockStateForShell() {
+  const rawTime = getSceneClockTime();
+  const displayTime = sceneClockState.mode === 'host-follow' ? 0 : rawTime;
   return {
-    time: getSceneClockTime(),
-    t: getSceneClockTime(),
+    time: displayTime,
+    t: displayTime,
     isPaused: sceneClockState.paused,
-    playing: !sceneClockState.paused,
+    playing: !sceneClockState.paused && sceneClockState.mode === 'local',
     mode: sceneClockState.mode,
     rate: sceneClockState.rate,
     duration: 60,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4718,6 +4718,44 @@ function followHostClock(now = performance.now()) {
   setSceneClockMode('host-follow', now);
 }
 
+function setSceneClockRate(rate) {
+  const now = performance.now();
+  const nextRate = typeof rate === 'number' ? rate : parseFloat(rate) || 1;
+  if (nextRate < 0) return;
+  // rate 変更時に time jump を避けるため現在時刻を localTime に焼く
+  if (sceneClockState.mode === 'local') {
+    sceneClockState.localTime = getSceneClockTime(now);
+    sceneClockState.lastUpdateNow = now;
+  }
+  sceneClockState.rate = nextRate;
+}
+
+function playSceneClock(now = performance.now()) {
+  if (sceneClockState.paused) {
+    resumeSceneClock(now); // resumeSceneClock already switches to local mode
+  } else if (sceneClockState.mode !== 'local') {
+    setSceneClockMode('local', now);
+  }
+}
+
+function stopSceneClock(now = performance.now()) {
+  seekSceneClock(0, now); // seek clears pause; then we re-pause at t=0
+  pauseSceneClock(now);
+}
+
+// Side-effect-free getter for shell UI (does not update delta/lastUpdateNow)
+function getSceneClockStateForShell() {
+  return {
+    time: getSceneClockTime(),
+    t: getSceneClockTime(),
+    isPaused: sceneClockState.paused,
+    playing: !sceneClockState.paused,
+    mode: sceneClockState.mode,
+    rate: sceneClockState.rate,
+    duration: 60,
+  };
+}
+
 // ── Loom 統合初期化 ──────────────────────────────────
 function isObjectBeingEditedNow(objectId) {
   if (!objectId) return false;
@@ -12001,8 +12039,16 @@ mountSceneSyncShellFromDom({
     closeSceneInspector: () => setSceneInspectorOpen(false),
     toggleSceneInspector: () => setSceneInspectorOpen(!sceneInspectorState.isOpen),
     closeMobileActionSheet,
+    // Scene Clock transport (Player Shell)
+    playSceneClock,
+    pauseSceneClock,
+    stopSceneClock,
+    seekSceneClock,
+    setSceneClockRate,
+    resetSceneClock,
   },
   getSelection: getSceneSyncShellSelection,
+  getSceneClockState: getSceneClockStateForShell,
   onStateChange: onSceneSyncShellStateChange,
 });
 updateNicknameLabel();

--- a/html/assets/js/scenesync/shells/player/player-actions.js
+++ b/html/assets/js/scenesync/shells/player/player-actions.js
@@ -1,0 +1,19 @@
+export function createPlayerActions(core) {
+  return {
+    play() {
+      core?.commands?.playSceneClock?.();
+    },
+    pause() {
+      core?.commands?.pauseSceneClock?.();
+    },
+    stop() {
+      core?.commands?.stopSceneClock?.();
+    },
+    seek(seconds) {
+      core?.commands?.seekSceneClock?.(seconds);
+    },
+    setRate(rate) {
+      core?.commands?.setSceneClockRate?.(rate);
+    },
+  };
+}

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -1,0 +1,264 @@
+/* ── Hide editor chrome in Player Shell ──────────────── */
+.scene-sync-shell-player #settings-panel,
+.scene-sync-shell-player #peers-panel,
+.scene-sync-shell-player #scene-inspector-panel,
+.scene-sync-shell-player #scene-clock-panel,
+.scene-sync-shell-player #history-toolbar,
+.scene-sync-shell-player #mobile-toolbar,
+.scene-sync-shell-player #add-btn,
+.scene-sync-shell-player #mode {
+  display: none !important;
+}
+
+/* Keep: canvas, #toast, #xr-button-container */
+
+/* ── Player panel ──────────────────────────────────── */
+.scene-sync-player-shell {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 220;
+  width: clamp(320px, 70vw, 560px);
+  padding: 16px 20px 18px;
+  border-radius: 18px;
+  background: rgba(8, 8, 20, 0.90);
+  border: 1px solid rgba(99, 102, 241, 0.28);
+  color: #e2e8f0;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', ui-monospace, monospace;
+  font-size: 13px;
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(99, 102, 241, 0.06) inset,
+    0 1px 0 rgba(255, 255, 255, 0.06) inset;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* ── Header ─────────────────────────────────────────── */
+.player-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.player-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: rgba(129, 140, 248, 0.85);
+}
+
+.player-badges {
+  display: flex;
+  gap: 5px;
+}
+
+.player-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 100px;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+}
+
+.player-badge-mode {
+  background: rgba(99, 102, 241, 0.15);
+  color: rgba(165, 180, 252, 0.9);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.player-badge-mode[data-mode="host-follow"] {
+  background: rgba(16, 185, 129, 0.15);
+  color: rgba(110, 231, 183, 0.9);
+  border-color: rgba(16, 185, 129, 0.22);
+}
+
+.player-badge-status {
+  background: rgba(52, 211, 153, 0.13);
+  color: rgba(110, 231, 183, 0.88);
+  border: 1px solid rgba(52, 211, 153, 0.18);
+}
+
+.player-badge-status[data-paused="1"] {
+  background: rgba(251, 191, 36, 0.11);
+  color: rgba(253, 224, 71, 0.82);
+  border-color: rgba(251, 191, 36, 0.18);
+}
+
+/* ── Time display ────────────────────────────────────── */
+.player-time-display {
+  text-align: center;
+  line-height: 1;
+  padding: 4px 0 2px;
+}
+
+.player-current-time {
+  font-size: 42px;
+  font-weight: 200;
+  letter-spacing: 0.03em;
+  color: #f1f5f9;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Seek bar ────────────────────────────────────────── */
+.player-seek-wrap {
+  padding: 0 4px;
+}
+
+.player-seek {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  outline: none;
+  cursor: pointer;
+  transition: height 0.15s ease;
+}
+
+.player-seek:hover,
+.player-seek:focus-visible {
+  height: 6px;
+}
+
+.player-seek::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #6366f1;
+  cursor: pointer;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.28);
+  transition: box-shadow 0.15s ease, transform 0.12s ease;
+}
+
+.player-seek:hover::-webkit-slider-thumb,
+.player-seek:active::-webkit-slider-thumb {
+  box-shadow: 0 0 0 5px rgba(99, 102, 241, 0.38);
+  transform: scale(1.15);
+}
+
+.player-seek::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #6366f1;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.28);
+}
+
+/* ── Transport controls ──────────────────────────────── */
+.player-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+
+.player-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.14s ease, transform 0.1s ease, box-shadow 0.14s ease;
+  outline: none;
+}
+
+.player-btn:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.7);
+  outline-offset: 2px;
+}
+
+.player-btn:active {
+  transform: scale(0.91);
+}
+
+.player-btn-stop {
+  width: 40px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(148, 163, 184, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.player-btn-stop:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #e2e8f0;
+}
+
+.player-btn-play-pause {
+  width: 54px;
+  height: 54px;
+  background: linear-gradient(145deg, #6366f1, #4f46e5);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.42);
+}
+
+.player-btn-play-pause:hover {
+  background: linear-gradient(145deg, #818cf8, #6366f1);
+  box-shadow: 0 6px 22px rgba(99, 102, 241, 0.55);
+}
+
+/* Toggle play/pause SVG icons */
+.player-btn-play-pause .icon-pause { display: none; }
+
+.player-btn-play-pause[data-player-playing="1"] .icon-play  { display: none; }
+.player-btn-play-pause[data-player-playing="1"] .icon-pause { display: block; }
+
+/* ── Rate buttons ────────────────────────────────────── */
+.player-rate-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.player-rate-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.35);
+  margin-right: 2px;
+}
+
+.player-rate-btn {
+  padding: 4px 11px;
+  border-radius: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  outline: none;
+  line-height: 1.5;
+}
+
+.player-rate-btn:hover {
+  background: rgba(255, 255, 255, 0.11);
+  color: rgba(255, 255, 255, 0.82);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.player-rate-btn:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.7);
+  outline-offset: 2px;
+}
+
+.player-rate-btn[data-active="true"] {
+  background: rgba(99, 102, 241, 0.22);
+  color: rgba(165, 180, 252, 0.95);
+  border-color: rgba(99, 102, 241, 0.40);
+}

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -1,0 +1,211 @@
+import { createPlayerActions } from './player-actions.js';
+
+const STYLE_ID = 'scene-sync-player-shell-style';
+const BODY_CLASS = 'scene-sync-shell-player';
+const DEFAULT_DURATION = 60;
+
+async function ensureStylesheet() {
+  if (document.getElementById(STYLE_ID)) return;
+  const link = document.createElement('link');
+  link.id = STYLE_ID;
+  link.rel = 'stylesheet';
+  link.href = new URL('./player-shell.css', import.meta.url).href;
+  document.head.appendChild(link);
+}
+
+function resolvePlayerDuration(core) {
+  return core?.getSceneClockState?.()?.duration ?? DEFAULT_DURATION;
+}
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0;
+  const mins = Math.floor(seconds / 60);
+  const secs = (seconds % 60).toFixed(2).padStart(5, '0');
+  return `${String(mins).padStart(2, '0')}:${secs}`;
+}
+
+export function createSceneSyncShell({ id = 'player', requestedId = 'player', availableShellIds = [] } = {}) {
+  let panel = null;
+  let actions = null;
+  let removeStateListener = null;
+  let rafId = null;
+  let isSeeking = false;
+
+  function getClockState(core) {
+    return core?.getSceneClockState?.() ?? {};
+  }
+
+  function startLoop(core) {
+    function tick() {
+      updateDisplay(core);
+      rafId = requestAnimationFrame(tick);
+    }
+    tick();
+  }
+
+  function stopLoop() {
+    if (rafId != null) cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+
+  function updateDisplay(core) {
+    if (!panel) return;
+    const state = getClockState(core);
+    const time = Number.isFinite(state.time) ? state.time : (state.t ?? 0);
+    const isPaused = state.isPaused === true || state.playing === false;
+    const mode = state.mode ?? 'local';
+    const rate = state.rate ?? 1;
+    const duration = resolvePlayerDuration(core);
+
+    const timeEl = panel.querySelector('[data-player-current-time]');
+    if (timeEl) timeEl.textContent = formatTime(time);
+
+    if (!isSeeking) {
+      const seekEl = panel.querySelector('[data-player-seek]');
+      if (seekEl) {
+        if (parseFloat(seekEl.max) !== duration) seekEl.max = duration;
+        seekEl.value = Math.min(time, duration);
+      }
+    }
+
+    const playPauseBtn = panel.querySelector('[data-player-play-pause]');
+    if (playPauseBtn) {
+      const playing = !isPaused;
+      if (playPauseBtn.dataset.playerPlaying !== (playing ? '1' : '0')) {
+        playPauseBtn.dataset.playerPlaying = playing ? '1' : '0';
+        playPauseBtn.title = playing ? 'Pause' : 'Play';
+      }
+    }
+
+    const modeEl = panel.querySelector('[data-player-clock-mode]');
+    if (modeEl && modeEl.textContent !== mode) {
+      modeEl.textContent = mode;
+      modeEl.dataset.mode = mode;
+    }
+
+    const statusEl = panel.querySelector('[data-player-clock-status]');
+    if (statusEl) {
+      const pausedStr = isPaused ? '1' : '0';
+      if (statusEl.dataset.paused !== pausedStr) {
+        statusEl.textContent = isPaused ? 'paused' : 'playing';
+        statusEl.dataset.paused = pausedStr;
+      }
+    }
+
+    panel.querySelectorAll('[data-player-rate]').forEach(btn => {
+      const active = String(parseFloat(btn.dataset.playerRate) === rate);
+      if (btn.dataset.active !== active) btn.dataset.active = active;
+    });
+  }
+
+  return {
+    id,
+    requestedId,
+    name: 'Player Shell',
+    kind: 'player',
+    layouts: ['desktop', 'mobile'],
+    inputs: [],
+
+    async mount({ core } = {}) {
+      await ensureStylesheet();
+
+      document.body.dataset.sceneSyncShell = 'player';
+      document.body.classList.add(BODY_CLASS);
+      document.body.classList.remove('scene-sync-shell-editor', 'scene-sync-shell-minimal');
+
+      actions = createPlayerActions(core);
+
+      panel = document.createElement('section');
+      panel.className = 'scene-sync-player-shell';
+      panel.setAttribute('aria-label', 'Scene Sync Player');
+      panel.innerHTML = `
+        <header class="player-header">
+          <span class="player-title">SCENE SYNC · PLAYER</span>
+          <div class="player-badges">
+            <span class="player-badge player-badge-mode" data-player-clock-mode data-mode="local">local</span>
+            <span class="player-badge player-badge-status" data-player-clock-status data-paused="1">paused</span>
+          </div>
+        </header>
+        <div class="player-time-display">
+          <span class="player-current-time" data-player-current-time>00:00.00</span>
+        </div>
+        <div class="player-seek-wrap">
+          <input class="player-seek" data-player-seek type="range" min="0" max="60" step="0.01" value="0" />
+        </div>
+        <div class="player-controls">
+          <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <rect x="3" y="3" width="10" height="10" rx="2"/>
+            </svg>
+          </button>
+          <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
+            <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+              <polygon points="5,2 16,9 5,16"/>
+            </svg>
+            <svg class="icon-pause" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="14" rx="1.5"/>
+              <rect x="11" y="2" width="4" height="14" rx="1.5"/>
+            </svg>
+          </button>
+        </div>
+        <div class="player-rate-row">
+          <span class="player-rate-label">Rate</span>
+          <button class="player-rate-btn" data-player-rate="0.25" type="button">¼×</button>
+          <button class="player-rate-btn" data-player-rate="0.5" type="button">½×</button>
+          <button class="player-rate-btn" data-player-rate="1" type="button" data-active="true">1×</button>
+          <button class="player-rate-btn" data-player-rate="2" type="button">2×</button>
+        </div>
+      `;
+
+      const seekEl = panel.querySelector('[data-player-seek]');
+      seekEl?.addEventListener('pointerdown', () => { isSeeking = true; });
+      seekEl?.addEventListener('input', (e) => {
+        // Live preview while dragging (no seek yet)
+        const timeEl = panel.querySelector('[data-player-current-time]');
+        if (timeEl) timeEl.textContent = formatTime(parseFloat(e.target.value));
+      });
+      seekEl?.addEventListener('change', (e) => {
+        actions.seek(parseFloat(e.target.value));
+        isSeeking = false;
+      });
+      seekEl?.addEventListener('pointerup', (e) => {
+        actions.seek(parseFloat(e.target.value));
+        isSeeking = false;
+      });
+
+      panel.querySelector('[data-player-play-pause]')?.addEventListener('click', () => {
+        const state = getClockState(core);
+        const isPaused = state.isPaused === true || state.playing === false;
+        if (isPaused) actions.play();
+        else actions.pause();
+      });
+
+      panel.querySelector('[data-player-stop]')?.addEventListener('click', () => actions.stop());
+
+      panel.querySelectorAll('[data-player-rate]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const rate = parseFloat(btn.dataset.playerRate);
+          if (Number.isFinite(rate)) actions.setRate(rate);
+        });
+      });
+
+      document.body.appendChild(panel);
+      removeStateListener = core?.onStateChange?.(() => updateDisplay(core)) ?? null;
+      startLoop(core);
+    },
+
+    unmount() {
+      stopLoop();
+      removeStateListener?.();
+      removeStateListener = null;
+      panel?.remove();
+      panel = null;
+      actions = null;
+      isSeeking = false;
+      document.body.classList.remove(BODY_CLASS);
+      delete document.body.dataset.sceneSyncShell;
+    },
+  };
+}
+
+export default createSceneSyncShell;

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -160,15 +160,12 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
       const seekEl = panel.querySelector('[data-player-seek]');
       seekEl?.addEventListener('pointerdown', () => { isSeeking = true; });
       seekEl?.addEventListener('input', (e) => {
-        // Live preview while dragging (no seek yet)
+        // Live preview while dragging (does not commit seek)
         const timeEl = panel.querySelector('[data-player-current-time]');
         if (timeEl) timeEl.textContent = formatTime(parseFloat(e.target.value));
       });
       seekEl?.addEventListener('change', (e) => {
-        actions.seek(parseFloat(e.target.value));
-        isSeeking = false;
-      });
-      seekEl?.addEventListener('pointerup', (e) => {
+        // `change` fires once when the thumb is released on both desktop and mobile
         actions.seek(parseFloat(e.target.value));
         isSeeking = false;
       });

--- a/html/assets/js/scenesync/shells/shell-registry.js
+++ b/html/assets/js/scenesync/shells/shell-registry.js
@@ -3,6 +3,7 @@ const DEFAULT_SHELL_ID = 'editor';
 const SHELL_LOADERS = {
   editor: () => import('./editor/editor-shell.js'),
   minimal: () => import('./minimal/minimal-shell.js'),
+  player: () => import('./player/player-shell.js'),
 };
 
 function normalizeShellId(value) {


### PR DESCRIPTION
- New shells/player/ with player-shell.js, player-actions.js, player-shell.css
- Play / Pause / Stop / Seek / Rate transport UI panel (bottom-center)
- Added playSceneClock, stopSceneClock, setSceneClockRate, getSceneClockStateForShell to scene.js
- Added Scene Clock transport commands to mountSceneSyncShellFromDom core object
- Registered ?shell=player in shell-registry.js
- Updated docs/scene-sync-shells.md and docs/scene-sync-scene-clock.md
- AudioSource full transport sync is explicitly out of scope (future work)
- Editor Shell and Minimal Shell are unaffected

https://claude.ai/code/session_01SrCxHpJej4WFyetgJfhxKm