### PR TITLE
Pass clockState to updateObjectGlbAnimations for sync

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2484,7 +2484,7 @@ function registerLoadedGlbAnimation(objectId, model, reason = 'unknown') {
   }
 }
 
-function updateObjectGlbAnimations(now = performance.now()) {
+function updateObjectGlbAnimations(now = performance.now(), clockState = null) {
   for (const [objectId, entry] of glbAnimationMixers) {
     const obj = managedObjects.get(objectId);
     if (!obj) {
@@ -2503,7 +2503,7 @@ function updateObjectGlbAnimations(now = performance.now()) {
     const clip = entry.clips[entry.clipIndex] || entry.clips[0];
     if (!clip || !entry.action) continue;
 
-    const baseTime = getObjectRuntimeTime(objectId, now);
+    const baseTime = getObjectRuntimeTime(objectId, now, clockState);
     const animationSpeed = Number.isFinite(state.speed) ? state.speed : 1;
     const t = baseTime * animationSpeed;
     const duration = clip.duration || 1;
@@ -4338,10 +4338,10 @@ renderer.setAnimationLoop((time, frame) => {
   }
 
   const now = performance.now();
-  updateObjectGlbAnimations(now);
+  const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
+  updateObjectGlbAnimations(now, sceneClockStateForTick);
   updateGazeStateFromCamera();
   updateGazeDwellState(now);
-  const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
   loomIntegration?.tickObjectGraphs?.(sceneClockStateForTick);
   audioSourceController.tick(now);
 


### PR DESCRIPTION
## 概要

- GLB アニメーション更新時に `clockState` を渡すことで、シーン時刻の同期を改善

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. `updateObjectGlbAnimations()` 関数に `clockState` パラメータを追加
   - デフォルト値は `null` で後方互換性を保持
   - `getObjectRuntimeTime()` 呼び出し時に `clockState` を渡すように修正

2. アニメーションループ内での処理順序を最適化
   - `getSceneClockStateForLoomlet(now)` の呼び出しを `updateObjectGlbAnimations()` より前に移動
   - 取得した `sceneClockStateForTick` を `updateObjectGlbAnimations()` に渡すことで、同一フレーム内で一貫した時刻情報を使用

### staging で見てほしい点

- GLB アニメーションの再生タイミングが Loom グラフの時刻と正確に同期しているか
- マルチクライアント環境でアニメーション再生位置のズレがないか

## 変更していないこと

- `getObjectRuntimeTime()` の内部実装
- `getSceneClockStateForLoomlet()` の実装
- その他のアニメーション関連ロジック

## staging確認

- 未確認（staging 環境での動作確認が必要）

## テスト/チェック

- 既存の GLB アニメーション機能が正常に動作することを確認
- 後方互換性を保持（`clockState` パラメータなしでの呼び出しも機能）

## リスク

- 低リスク：パラメータ追加で後方互換性を保持、既存の呼び出しパターンに影響なし

## follow-up tasks

- なし

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_016y9ibVWzppVJ1VMHUwmNZX