### PR TITLE
Fix object audio player transport sync

### DIFF
--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -289,12 +289,12 @@ export function createAudioSourceController(deps = {}) {
   // ── tick ──────────────────────────────────────────────
 
   function getTimelineTargetTime(objectId, entry, nowMs, clockState) {
-    const audio = entry.audio;
-    const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
     const runtimeTime = getObjectRuntimeTime(objectId, nowMs, clockState);
-    if (!duration && clockState?.mode === 'host-follow' && runtimeTime > 3600) {
+    if (clockState?.mode === 'host-follow' && runtimeTime > 3600) {
       return null;
     }
+    const audio = entry.audio;
+    const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
     let target = (entry.config.offset || 0) + runtimeTime;
     if (duration) {
       target = entry.config.loop ? ((target % duration) + duration) % duration : Math.min(target, duration);

--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -288,7 +288,32 @@ export function createAudioSourceController(deps = {}) {
 
   // ── tick ──────────────────────────────────────────────
 
-  function tickEntry(objectId, name, entry, nowMs) {
+  function getTimelineTargetTime(objectId, entry, nowMs, clockState) {
+    const audio = entry.audio;
+    const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
+    const runtimeTime = getObjectRuntimeTime(objectId, nowMs, clockState);
+    if (!duration && clockState?.mode === 'host-follow' && runtimeTime > 3600) {
+      return null;
+    }
+    let target = (entry.config.offset || 0) + runtimeTime;
+    if (duration) {
+      target = entry.config.loop ? ((target % duration) + duration) % duration : Math.min(target, duration);
+    }
+    return Math.max(0, target);
+  }
+
+  function applyTransportPlaybackRate(audio, config, clockState) {
+    if (!audio) return;
+    const sourceRate = typeof config.playbackRate === 'number' && config.playbackRate > 0
+      ? config.playbackRate
+      : 1;
+    const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0
+      ? clockState.rate
+      : 1;
+    try { audio.playbackRate = sourceRate * transportRate; } catch { /* noop */ }
+  }
+
+  function tickEntry(objectId, name, entry, nowMs, clockState = null) {
     const config = entry.config;
     if (!config?.url) return;
 
@@ -306,12 +331,8 @@ export function createAudioSourceController(deps = {}) {
       entry.started = true;
       entry.desiredState = 'playing';
       const audio = ensureAudio(entry);
-      const runtimeTime = getObjectRuntimeTime(objectId, nowMs);
-      const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
-      if (duration) {
-        const base = (config.offset || 0) + runtimeTime;
-        safeSeek(audio, config.loop ? base % duration : Math.min(base, duration));
-      }
+      applyTransportPlaybackRate(audio, config, clockState);
+      safeSeek(audio, getTimelineTargetTime(objectId, entry, nowMs, clockState));
     }
 
     if (entry.desiredState === 'stopped') {
@@ -326,11 +347,15 @@ export function createAudioSourceController(deps = {}) {
     // desiredState === 'playing'
     const audio = ensureAudio(entry);
     if (!audio) return;
+    applyTransportPlaybackRate(audio, config, clockState);
 
+    const transportPaused = Boolean(clockState?.isPaused) || clockState?.rate === 0;
     const sync = config.sync;
+    let syncedToAnimation = false;
     if (sync?.mode === 'animation' && typeof getAnimationSample === 'function') {
       const sample = getAnimationSample(objectId, sync.animationClipName);
       if (sample && Number.isFinite(sample.time)) {
+        syncedToAnimation = true;
         const driftThreshold = Number.isFinite(sync.driftThreshold) ? sync.driftThreshold : 0.05;
         const offset = (sync.offset || 0) + (config.offset || 0);
         const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
@@ -349,13 +374,34 @@ export function createAudioSourceController(deps = {}) {
       }
     }
 
+    if (transportPaused) {
+      safePause(audio);
+      if (!syncedToAnimation) {
+        safeSeek(audio, getTimelineTargetTime(objectId, entry, nowMs, clockState));
+      }
+      return;
+    }
+
+    if (!syncedToAnimation) {
+      const driftThreshold = 0.15;
+      const target = getTimelineTargetTime(objectId, entry, nowMs, clockState);
+      if (!Number.isFinite(target)) {
+        tryPlay(entry, objectId, name);
+        return;
+      }
+      const drift = Math.abs((audio.currentTime || 0) - target);
+      if (drift > driftThreshold) {
+        safeSeek(audio, target);
+      }
+    }
+
     tryPlay(entry, objectId, name);
   }
 
-  function tick(nowMs = now()) {
+  function tick(nowMs = now(), clockState = null) {
     for (const [objectId, map] of objects) {
       for (const [name, entry] of map) {
-        tickEntry(objectId, name, entry, nowMs);
+        tickEntry(objectId, name, entry, nowMs, clockState);
       }
     }
   }

--- a/html/assets/js/scenesync/audio/audio-source-controller.test.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createAudioSourceController } from './audio-source-controller.js';
+
+class FakeAudio {
+  constructor({ duration = 10, currentTime = 0 } = {}) {
+    this.currentTime = currentTime;
+    this.duration = duration;
+    this.loop = false;
+    this.paused = true;
+    this.playbackRate = 1;
+    this.volume = 1;
+    this.seekLog = [];
+    this.pauseCount = 0;
+    this.playCount = 0;
+  }
+
+  play() {
+    this.paused = false;
+    this.playCount += 1;
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.paused = true;
+    this.pauseCount += 1;
+  }
+
+  load() {}
+}
+
+function createHarness({ audio = new FakeAudio(), offset = 0, loop = true } = {}) {
+  const controller = createAudioSourceController({
+    createAudio: () => audio,
+    getObjectRuntimeTime: (_objectId, _nowMs, clockState) => clockState?.t ?? 0,
+  });
+
+  controller.setObjectAudioSources('object-1', {
+    default: {
+      url: 'https://example.com/audio.mp3',
+      state: 'playing',
+      loop,
+      offset,
+    },
+  });
+
+  return { audio, controller };
+}
+
+test('pauses and seeks to the local player timeline while transport is paused', () => {
+  const { audio, controller } = createHarness({ offset: 0.5 });
+
+  controller.tick(0, { mode: 'local', t: 4, isPaused: true, rate: 1 });
+
+  assert.equal(audio.paused, true);
+  assert.equal(audio.currentTime, 4.5);
+  assert.equal(audio.pauseCount, 1);
+});
+
+test('treats zero transport rate as paused', () => {
+  const { audio, controller } = createHarness();
+
+  controller.tick(0, { mode: 'local', t: 6, isPaused: false, rate: 0 });
+
+  assert.equal(audio.paused, true);
+  assert.equal(audio.currentTime, 6);
+});
+
+test('does not seek host-follow epoch seconds even after audio duration is known', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 10, currentTime: 1.25 }),
+  });
+
+  controller.tick(0, {
+    mode: 'host-follow',
+    t: 1_780_000_000,
+    isPaused: false,
+    rate: 1,
+  });
+
+  assert.equal(audio.currentTime, 1.25);
+  assert.equal(audio.paused, false);
+});
+
+test('updates paused audio immediately when the player timeline seeks', () => {
+  const { audio, controller } = createHarness();
+
+  controller.tick(0, { mode: 'local', t: 2, isPaused: true, rate: 1 });
+  assert.equal(audio.currentTime, 2);
+
+  controller.tick(100, { mode: 'local', t: 8, isPaused: true, rate: 1 });
+  assert.equal(audio.paused, true);
+  assert.equal(audio.currentTime, 8);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4343,7 +4343,7 @@ renderer.setAnimationLoop((time, frame) => {
   updateGazeStateFromCamera();
   updateGazeDwellState(now);
   loomIntegration?.tickObjectGraphs?.(sceneClockStateForTick);
-  audioSourceController.tick(now);
+  audioSourceController.tick(now, sceneClockStateForTick);
 
   // Update Scene Clock debug UI
   if (!sceneClockPanelEl?.hidden) {
@@ -4813,7 +4813,7 @@ function getObjectAnimationSampleForAudio(objectId, clipName) {
 
 // ── AudioSource component / playback controller ─────────
 const audioSourceController = createAudioSourceController({
-  getObjectRuntimeTime: (objectId, nowMs) => getObjectRuntimeTime(objectId, nowMs),
+  getObjectRuntimeTime: (objectId, nowMs, clockState) => getObjectRuntimeTime(objectId, nowMs, clockState),
   getAnimationSample: getObjectAnimationSampleForAudio,
   isObjectBeingEdited: isObjectBeingEditedNow,
   showToast,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test:audio-source-controller": "node --test html/assets/js/scenesync/audio/audio-source-controller.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pass Scene Clock transport state into the AudioSource controller each frame
- pause object AudioSources when the player is paused or rate is zero
- seek object AudioSources to the current player timeline on pause/seek and resync drift while playing
- preserve animation-sync behavior by using the sampled GLB animation time when configured

## Verification
- node --check html/assets/js/scenesync/audio/audio-source-controller.js
- node --check html/assets/js/scenesync/scene.js
- git diff --check
- fake AudioSource transport smoke test with play, pause, seek, and rate zero
- curl -fsSI http://127.0.0.1:4173/assets/js/scenesync/audio/audio-source-controller.js