### PR TITLE
fix(scenesync): アニメーションと音声の同期修正 & アニメーション offset 追加

### DIFF
--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -41,6 +41,19 @@ function safeSeek(audio, time) {
   try { audio.currentTime = time; } catch { /* noop */ }
 }
 
+// アニメーション再生位置(sampleTime)を audio の再生時刻へ変換する。
+// offset を加算し、duration が判明していれば loop なら巻き戻し、非 loop ならクランプする。
+function animationTargetTime(audio, sampleTime, offset, loop) {
+  const duration = Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
+  let target = sampleTime + offset;
+  if (duration) {
+    target = loop ? ((target % duration) + duration) % duration : Math.min(Math.max(0, target), duration);
+  } else if (target < 0) {
+    target = 0;
+  }
+  return target;
+}
+
 export function createAudioSourceController(deps = {}) {
   const {
     createAudio = defaultCreateAudio,
@@ -358,13 +371,7 @@ export function createAudioSourceController(deps = {}) {
         syncedToAnimation = true;
         const driftThreshold = Number.isFinite(sync.driftThreshold) ? sync.driftThreshold : 0.05;
         const offset = (sync.offset || 0) + (config.offset || 0);
-        const duration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
-        let target = sample.time + offset;
-        if (duration) {
-          target = config.loop ? ((target % duration) + duration) % duration : Math.min(Math.max(0, target), duration);
-        } else if (target < 0) {
-          target = 0;
-        }
+        const target = animationTargetTime(audio, sample.time, offset, config.loop);
         const looped = entry.lastSampleTime != null && sample.time < entry.lastSampleTime;
         entry.lastSampleTime = sample.time;
         const drift = Math.abs((audio.currentTime || 0) - target);
@@ -386,6 +393,19 @@ export function createAudioSourceController(deps = {}) {
       const driftThreshold = 0.15;
       const target = getTimelineTargetTime(objectId, entry, nowMs, clockState);
       if (!Number.isFinite(target)) {
+        // host-follow mode: fall back to animation position if available so that
+        // audio resumes in sync with animation after deselect (isObjectBeingEdited
+        // forces audio.currentTime=0 while selected, leaving it at 0 on release).
+        if (typeof getAnimationSample === 'function') {
+          const sample = getAnimationSample(objectId, null);
+          if (sample && Number.isFinite(sample.time)) {
+            const animTarget = animationTargetTime(audio, sample.time, config.offset || 0, config.loop);
+            const drift = Math.abs((audio.currentTime || 0) - animTarget);
+            if (drift > driftThreshold) {
+              safeSeek(audio, animTarget);
+            }
+          }
+        }
         tryPlay(entry, objectId, name);
         return;
       }

--- a/html/assets/js/scenesync/audio/audio-source-controller.test.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.test.js
@@ -30,10 +30,12 @@ class FakeAudio {
   load() {}
 }
 
-function createHarness({ audio = new FakeAudio(), offset = 0, loop = true } = {}) {
+function createHarness({ audio = new FakeAudio(), offset = 0, loop = true, getAnimationSample = null, isObjectBeingEdited = () => false } = {}) {
   const controller = createAudioSourceController({
     createAudio: () => audio,
     getObjectRuntimeTime: (_objectId, _nowMs, clockState) => clockState?.t ?? 0,
+    getAnimationSample,
+    isObjectBeingEdited,
   });
 
   controller.setObjectAudioSources('object-1', {
@@ -92,4 +94,35 @@ test('updates paused audio immediately when the player timeline seeks', () => {
   controller.tick(100, { mode: 'local', t: 8, isPaused: true, rate: 1 });
   assert.equal(audio.paused, true);
   assert.equal(audio.currentTime, 8);
+});
+
+test('resyncs audio to animation position after deselect in host-follow mode', () => {
+  // Simulate: object was selected (isObjectBeingEdited=true) which forced audio.currentTime=0,
+  // then deselected. In host-follow mode getTimelineTargetTime returns null (epoch >> 3600),
+  // so audio must fall back to the GLB animation's current time.
+  let editing = true;
+  const animTime = { value: 7.3 };
+  const audio = new FakeAudio({ duration: 10, currentTime: 0 });
+
+  const { controller } = createHarness({
+    audio,
+    loop: true,
+    isObjectBeingEdited: () => editing,
+    getAnimationSample: (_objectId) => ({ time: animTime.value, duration: 10 }),
+  });
+
+  const hostFollowClock = { mode: 'host-follow', t: 1_780_000_000, isPaused: false, rate: 1 };
+
+  // Tick while selected — audio should stay at 0
+  controller.tick(0, hostFollowClock);
+  assert.equal(audio.currentTime, 0);
+
+  // Deselect
+  editing = false;
+  animTime.value = 7.3;
+
+  // First tick after deselect — audio should seek to animation position
+  controller.tick(16, hostFollowClock);
+  assert.ok(Math.abs(audio.currentTime - 7.3) < 0.001, `expected ~7.3, got ${audio.currentTime}`);
+  assert.equal(audio.paused, false);
 });

--- a/html/assets/js/scenesync/audio/audio-source.js
+++ b/html/assets/js/scenesync/audio/audio-source.js
@@ -35,8 +35,8 @@ function positiveOrDefault(value, fallback) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function nonNegativeOrDefault(value, fallback) {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+function finiteOrDefault(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
 function resolveName(input, options) {
@@ -87,7 +87,7 @@ export function normalizeAudioSource(input, options = {}) {
     volume: clampVolume(input.volume),
     loop: input.loop === true,
     playOnAwake: input.playOnAwake === true,
-    offset: nonNegativeOrDefault(input.offset, AUDIO_SOURCE_DEFAULTS.offset),
+    offset: finiteOrDefault(input.offset, AUDIO_SOURCE_DEFAULTS.offset),
     playbackRate: positiveOrDefault(input.playbackRate, AUDIO_SOURCE_DEFAULTS.playbackRate),
     spatial: input.spatial !== false,
   };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2115,6 +2115,7 @@ function setupObjectGlbAnimation(objectId, model) {
     clip: 0,
     mode: 'loop',
     speed: 1,
+    offset: 0,
     ...(model.userData?.scenesync?.animationState || {}),
     ...(model.userData?.animationState || {}),
   };
@@ -2200,6 +2201,7 @@ function getObjectAnimationState(obj) {
     clipName: typeof raw.clipName === 'string' ? raw.clipName : null,
     mode: raw.mode === 'once' ? 'once' : 'loop',
     speed: Number.isFinite(raw.speed) ? raw.speed : 1,
+    offset: Number.isFinite(raw.offset) ? raw.offset : 0,
   };
 }
 
@@ -2394,6 +2396,7 @@ function normalizeObjectAnimationState(current, delta, clipCount = 0) {
     clip: Number.isInteger(current?.clip) ? current.clip : 0,
     mode: current?.mode === 'once' ? 'once' : 'loop',
     speed: Number.isFinite(current?.speed) ? current.speed : 1,
+    offset: Number.isFinite(current?.offset) ? current.offset : 0,
   };
 
   if (typeof delta.enabled === 'boolean') {
@@ -2416,6 +2419,13 @@ function normalizeObjectAnimationState(current, delta, clipCount = 0) {
     const speed = Number(delta.speed);
     if (Number.isFinite(speed) && speed >= 0) {
       next.speed = speed;
+    }
+  }
+
+  if (delta.offset !== undefined) {
+    const offset = Number(delta.offset);
+    if (Number.isFinite(offset)) {
+      next.offset = offset;
     }
   }
 
@@ -2484,6 +2494,15 @@ function registerLoadedGlbAnimation(objectId, model, reason = 'unknown') {
   }
 }
 
+// 再生時刻 t をクリップ内の時刻へ変換する。
+// loop は duration で巻き戻し（負の t も正しく扱う）、非 loop は [0, duration] にクランプする。
+function clipTimeForMode(t, duration, mode) {
+  const safeDuration = duration > 0 ? duration : 1;
+  return mode === 'loop'
+    ? ((t % safeDuration) + safeDuration) % safeDuration
+    : Math.min(Math.max(0, t), safeDuration);
+}
+
 function updateObjectGlbAnimations(now = performance.now(), clockState = null) {
   for (const [objectId, entry] of glbAnimationMixers) {
     const obj = managedObjects.get(objectId);
@@ -2505,15 +2524,13 @@ function updateObjectGlbAnimations(now = performance.now(), clockState = null) {
 
     const baseTime = getObjectRuntimeTime(objectId, now, clockState);
     const animationSpeed = Number.isFinite(state.speed) ? state.speed : 1;
-    const t = baseTime * animationSpeed;
+    const animationOffset = Number.isFinite(state.offset) ? state.offset : 0;
+    const t = baseTime * animationSpeed + animationOffset;
     const duration = clip.duration || 1;
-    const clipTime = state.mode === 'loop'
-      ? t % duration
-      : Math.min(t, duration);
 
     entry.action.enabled = true;
     entry.action.paused = false;
-    entry.action.time = clipTime;
+    entry.action.time = clipTimeForMode(t, duration, state.mode);
 
     for (const companion of entry.companionActions || []) {
       const companionClip = entry.clips[companion.clipIndex];
@@ -2521,9 +2538,7 @@ function updateObjectGlbAnimations(now = performance.now(), clockState = null) {
       const companionDuration = companionClip.duration || duration || 1;
       companion.action.enabled = true;
       companion.action.paused = false;
-      companion.action.time = state.mode === 'loop'
-        ? t % companionDuration
-        : Math.min(t, companionDuration);
+      companion.action.time = clipTimeForMode(t, companionDuration, state.mode);
     }
 
     entry.mixer.update(0);
@@ -4419,6 +4434,7 @@ const sceneInspectorAnimationMetaEl = document.getElementById('scene-inspector-a
 const sceneInspectorAnimationEnabledEl = document.getElementById('scene-inspector-animation-enabled');
 const sceneInspectorAnimationClipEl = document.getElementById('scene-inspector-animation-clip');
 const sceneInspectorAnimationSpeedEl = document.getElementById('scene-inspector-animation-speed');
+const sceneInspectorAnimationOffsetEl = document.getElementById('scene-inspector-animation-offset');
 
 function resolvePresenceUrl() {
   const params = new URLSearchParams(location.search);
@@ -10977,6 +10993,10 @@ function renderSceneInspectorAnimationControls(selectedObject) {
     sceneInspectorAnimationSpeedEl.value = String(Number.isFinite(animation.speed) ? animation.speed : 1);
   }
 
+  if (sceneInspectorAnimationOffsetEl) {
+    sceneInspectorAnimationOffsetEl.value = String(Number.isFinite(animation.offset) ? animation.offset : 0);
+  }
+
   if (sceneInspectorAnimationClipEl) {
     const currentValue = String(animation.clip || 0);
     sceneInspectorAnimationClipEl.innerHTML = '';
@@ -12376,6 +12396,12 @@ sceneInspectorAnimationClipEl?.addEventListener('change', () => {
 sceneInspectorAnimationSpeedEl?.addEventListener('change', () => {
   broadcastSelectedObjectAnimationDelta({
     speed: Number(sceneInspectorAnimationSpeedEl.value),
+  });
+});
+
+sceneInspectorAnimationOffsetEl?.addEventListener('change', () => {
+  broadcastSelectedObjectAnimationDelta({
+    offset: Number(sceneInspectorAnimationOffsetEl.value),
   });
 });
 

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1450,6 +1450,11 @@
             <span>Speed</span>
             <input id="scene-inspector-animation-speed" class="scene-inspector-number-input" type="number" min="0" step="0.1" value="1">
           </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Offset (s)</span>
+            <input id="scene-inspector-animation-offset" class="scene-inspector-number-input" type="number" step="0.1" value="0">
+          </label>
         </div>
         <div id="scene-inspector-object-actions" class="scene-inspector-object-actions" hidden>
           <button id="scene-inspector-object-edit" class="chip primary" type="button">Edit Object</button>


### PR DESCRIPTION
## 概要

SceneSync で AudioSource とアニメーションが同時にセットされたオブジェクトの同期不具合を修正し、タイミング微調整用の **アニメーション offset** を追加しました。

## 背景・不具合

オブジェクトを選択 → 選択解除したとき、**アニメーションは時刻に従った位置から再生される**のに、**音声は最初から再生される**という同期ズレがありました。

### 原因
1. 選択中は `isObjectBeingEdited` が true になり、毎フレーム audio が先頭 (`currentTime=0`) に固定される
2. 選択解除後、`getTimelineTargetTime` は `host-follow` モードではエポック秒（≈17億秒）が `runtimeTime > 3600` ガードに掛かり `null` を返す
3. 結果 audio はシークされず、先頭から再生されてしまう

アニメーション側は `clockState.t % duration` で毎フレーム直接スクラブされるためズレが顕在化していました。

## 変更内容

### 不具合修正
- `host-follow` モードで `getTimelineTargetTime` が `null` の場合、GLB アニメーションの現在位置へ audio をシークするフォールバックを追加（[audio-source-controller.js](../blob/fix/scenesync-audio-anim-sync-offset/html/assets/js/scenesync/audio/audio-source-controller.js)）
  - アニメーションを持たないオブジェクトは従来通り自由再生（回帰なし）

### 機能追加: アニメーション offset
- Scene Inspector の Animation セクションに **Offset (s)** 入力を追加
- `animationState.offset` を導入（負値も許可。loop は巻き戻し、非 loop はクランプ）
- AudioSource の `offset` も負値許容に変更（アニメーションと音のズレ微調整用）

### リファクタ / 副次修正
- audio: アニメーション位置→再生時刻の変換を `animationTargetTime()` に共通化
- scene: clip 時刻計算を `clipTimeForMode()` に共通化し、**companion clip（モーフ）が負の offset で負値時刻になるバグ**を修正

## テスト
- `audio-source-controller.test.js` に「選択解除後に audio がアニメーション位置へ再同期する」テストを追加（全5件パス）
- 構文チェック（`node --check`）OK
- ブラウザ実機で offset 正値(30) / 負値(-15) の反映を確認、コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)