### PR TITLE
feat(scenesync): Editor Shell化の完成 & ライト層向け Studio Shell 追加

### DIFF
--- a/docs/scene-sync-shells.md
+++ b/docs/scene-sync-shells.md
@@ -230,3 +230,80 @@ State is read via `core.getSceneClockState()`:
 ### UI update loop
 
 Player Shell runs a `requestAnimationFrame` loop for smooth time display. The loop is started on `mount()` and cancelled on `unmount()`.
+
+## Editor Shell v4: Edit command + state API and chrome wiring migration
+
+The Editor Shell shell-ization is completed by exposing the remaining edit operations as commands and by moving the editor chrome (mode toggle + transform toolbar) click wiring out of `scene.js` into the layouts.
+
+### New edit commands (`core.commands`)
+
+| Command | Behaviour |
+|---|---|
+| `setTransformMode(mode)` | Switch gizmo mode: `'translate' \| 'rotate' \| 'scale'` |
+| `duplicateSelected()` | Duplicate the selected object |
+| `deselect()` | Clear the current selection |
+| `setInputRoutingMode(mode)` | Set `'edit' \| 'interact'` |
+| `toggleInputRoutingMode()` | Toggle Edit/Interact (shows a toast) |
+
+These join the existing commands (`openAddMenu`, `undo`, `redo`, `deleteSelected`, `exportScene`, `openHelp`, `startAiLink`, `open/close/toggleSceneInspector`, `closeMobileActionSheet`, scene-clock transport).
+
+### Edit state snapshot (`core.getEditorState()`)
+
+Any shell can read a unified edit-state snapshot and re-render on `core.onStateChange`:
+
+```js
+{
+  transformMode: 'translate' | 'rotate' | 'scale',
+  inputRoutingMode: 'edit' | 'interact',
+  selectedCount: number,
+  selectedObjectIds: string[],
+  selectionLabel: string,
+  objectCount: number,   // user-visible objects (excludes sample-cube etc.)
+  canUndo: boolean,
+  canRedo: boolean,
+}
+```
+
+`scene.js` fires `notifySceneSyncShellStateChanged(reason)` on transform-mode, input-routing-mode, history, selection and connection changes so subscribers stay in sync.
+
+### Chrome wiring migration
+
+- `desktop-editor-layout.js` now wires `#mode` → `actions.toggleInputRoutingMode()` (the button is desktop-only; hidden on mobile).
+- `mobile-editor-layout.js` now wires the transform toolbar (`#btn-move/rotate/scale/copy/delete/deselect`) → editor actions.
+- The corresponding `addEventListener` calls were removed from `scene.js` to avoid double-firing.
+
+**Remaining in core (`scene.js`)**: transform gizmo, raycast selection, the toolbar's *visual* state writes (`showToolbar`/`hideToolbar`/`updateToolbarActive`/`updateInputRoutingModeUI`, enable/disable on selection), drag & drop, Inspector internal editing, AI Link pairing, presence/history implementation. The W/E/R keyboard shortcuts also remain in `scene.js` (input-adapter migration is future work).
+
+> Dev note: editor shell modules are loaded via dynamic `import()`. After editing them, a normal reload may serve a cached module; use a hard reload (Cmd/Ctrl+Shift+R) during development.
+
+## Studio Shell
+
+Studio Shell is a light-user-oriented Edit shell: intuitive enough to use without a manual, and inviting to touch. It is a self-contained shell (like minimal/player) that builds its own DOM/CSS, hides the built-in editor chrome, and drives everything through the command + state API — it does not touch scene internals.
+
+- URL: `/scenesync/?shell=studio`
+- Target: casual / light users
+- Built entirely on Editor Shell v4's `core.commands` + `core.getEditorState()`
+
+### Directory structure
+
+```text
+html/assets/js/scenesync/shells/studio/
+├─ studio-shell.js    (DOM construction + state subscription)
+├─ studio-actions.js  (thin wrapper over core.commands)
+└─ studio-shell.css   (panel styles, hides editor chrome)
+```
+
+### Design direction
+
+Soft-modern (Apple/Notion-like): dark neutral glass surfaces, a single calm-blue accent, thin line (SVG) icons, restrained motion, single-layer shadows. English labels (kept short) — chosen over hiragana to avoid a childish tone.
+
+### UI
+
+- **Mode pill (top center)**: `✎ Edit | ▷ Play` — always shows the current Edit/Interact mode (`setInputRoutingMode`). Active segment uses a soft accent fill + thin border (not a solid block).
+- **Selection card (appears when something is selected)**: object name, a 3-way tool toggle `Move / Rotate / Scale` with line icons (highlights `transformMode`), `Duplicate` (single-selection only), `Delete` (soft red), `✕` deselect, and `Details ›` → Scene Inspector.
+- **Bottom dock (always visible)**: rounded-square `undo / redo` (disabled per `canUndo/canRedo`), a central calm-blue circular `+` (Add, primary CTA), and a `⋯` menu popover (Properties / Export / AI Link / Help).
+- **Empty-state hint**: when `objectCount === 0`, a subtle neutral chip above the `+` ("Tap + to add") fades in to invite the first action (no bounce/pulse).
+
+Icons are inline line SVGs defined in an `ICON` map in `studio-shell.js`. State is read via `core.getEditorState()` and the panel re-renders on `core.onStateChange`. All actions go through `core.commands` (no direct scene mutation).
+
+> Status: experimental design prototype. Visual direction and labels may change based on feedback.

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -239,11 +239,7 @@ function updateInputRoutingModeUI() {
   }
 }
 
-document.getElementById('mode')?.addEventListener('click', () => {
-  const nextMode = inputRoutingMode === 'edit' ? 'interact' : 'edit';
-  setInputRoutingMode(nextMode);
-  showToast(`Mode: ${nextMode.toUpperCase()}`);
-});
+// #mode クリック配線は Editor Shell の desktop layout へ移管（actions.toggleInputRoutingMode）。
 
 setupXrButtons({
   renderer,
@@ -1351,6 +1347,10 @@ managedObjects.set('sample-cube', sampleCube);
 const selectedObjectIds = new Set();
 const selectionHelpers = new Map();
 const removedObjectIds = new Set();
+
+// Shell 状態変更リスナー集合。早期初期化（updateHistoryButtonState 等が
+// 初期化フェーズで notifySceneSyncShellStateChanged を呼ぶため TDZ を避ける）。
+const sceneSyncShellStateListeners = new Set();
 
 // Local image replacement preview management
 // objectId → { token, objectUrl, overlayObject, cleanup }
@@ -2784,6 +2784,13 @@ function setInputRoutingMode(mode) {
     clearInteractionRoutingState();
   }
   updateInputRoutingModeUI();
+  notifySceneSyncShellStateChanged('input-routing-mode-changed');
+}
+
+function toggleInputRoutingMode() {
+  const nextMode = inputRoutingMode === 'edit' ? 'interact' : 'edit';
+  setInputRoutingMode(nextMode);
+  showToast(`Mode: ${nextMode.toUpperCase()}`);
 }
 
 function enqueueLoomletHostEvent(objectId, eventName) {
@@ -4105,37 +4112,19 @@ function setTransformMode(mode) {
   if (selectedObjectIds.size > 1 && ['translate', 'rotate', 'scale'].includes(mode)) {
     startMultiTransformMode(mode);
     updateToolbarActive(mode);
+    notifySceneSyncShellStateChanged('transform-mode-changed');
     return;
   }
 
   cleanupMultiTransformPivot();
   transformCtrl.setMode(mode);
   updateToolbarActive(mode);
+  notifySceneSyncShellStateChanged('transform-mode-changed');
 }
 
-btnMove?.addEventListener('click', () => {
-  setTransformMode('translate');
-});
-
-btnRotate?.addEventListener('click', () => {
-  setTransformMode('rotate');
-});
-
-btnScale?.addEventListener('click', () => {
-  setTransformMode('scale');
-});
-
-btnCopy?.addEventListener('click', () => {
-  duplicateSelectedObject();
-});
-
-btnDeselect?.addEventListener('click', () => {
-  clearSelection({ reason: 'selection-cleared-button' });
-});
-
-btnDelete?.addEventListener('click', () => {
-  deleteSelectedObjects();
-});
+// transform ツールバー（move/rotate/scale/copy/delete/deselect）のクリック配線は
+// Editor Shell の mobile layout へ移管。表示/活性の DOM 更新は引き続き core が担う
+// （showToolbar/hideToolbar/updateToolbarActive/updateSelectionToolbar）。
 
 updateSelectionToolbar();
 
@@ -4147,6 +4136,8 @@ function updateHistoryButtonState() {
 
   if (btnUndo) btnUndo.disabled = !canUndo;
   if (btnRedo) btnRedo.disabled = !canRedo;
+
+  notifySceneSyncShellStateChanged('history-changed');
 }
 
 btnUndo?.addEventListener('click', () => {
@@ -6585,13 +6576,40 @@ function getCurrentSelectionPayload() {
   };
 }
 
-const sceneSyncShellStateListeners = new Set();
-
 function getSceneSyncShellSelection() {
   const selection = getCurrentSelectionPayload();
   return {
     ...selection,
     objectIds: selection.selectedObjectIds,
+  };
+}
+
+// Shell が編集 UI を組み立てるための統合状態スナップショット。
+// command API のみで完結した shell（studio 等）が購読して描画に使う。
+function getEditorState() {
+  const selectedIds = Array.from(selectedObjectIds || []);
+  let selectionLabel = '';
+  if (selectedIds.length === 1) {
+    const obj = managedObjects.get(selectedIds[0]);
+    selectionLabel = obj?.userData?.name || obj?.name || selectedIds[0];
+  } else if (selectedIds.length > 1) {
+    selectionLabel = `${selectedIds.length} objects`;
+  }
+
+  let objectCount = 0;
+  for (const [objectId, obj] of managedObjects) {
+    if (!isSnapshotExcludedObject(objectId, obj)) objectCount++;
+  }
+
+  return {
+    transformMode: transformCtrl?.mode || 'translate',
+    inputRoutingMode,
+    selectedCount: selectedIds.length,
+    selectedObjectIds: selectedIds,
+    selectionLabel,
+    objectCount,
+    canUndo: presenceState.historyManager?.canUndo?.() === true,
+    canRedo: presenceState.historyManager?.canRedo?.() === true,
   };
 }
 
@@ -12560,6 +12578,12 @@ mountSceneSyncShellFromDom({
     closeSceneInspector: () => setSceneInspectorOpen(false),
     toggleSceneInspector: () => setSceneInspectorOpen(!sceneInspectorState.isOpen),
     closeMobileActionSheet,
+    // Edit operations (Editor / Studio shells)
+    setTransformMode,
+    duplicateSelected: duplicateSelectedObject,
+    deselect: () => clearSelection({ reason: 'selection-cleared-shell' }),
+    setInputRoutingMode,
+    toggleInputRoutingMode,
     // Scene Clock transport (Player Shell)
     playSceneClock,
     pauseSceneClock,
@@ -12569,6 +12593,7 @@ mountSceneSyncShellFromDom({
     resetSceneClock,
   },
   getSelection: getSceneSyncShellSelection,
+  getEditorState,
   getSceneClockState: getSceneClockStateForShell,
   onStateChange: onSceneSyncShellStateChange,
 });

--- a/html/assets/js/scenesync/shells/editor/editor-actions.js
+++ b/html/assets/js/scenesync/shells/editor/editor-actions.js
@@ -27,6 +27,24 @@ export function createEditorActions(core) {
     closeSceneInspector() {
       core?.commands?.closeSceneInspector?.();
     },
+    toggleSceneInspector() {
+      core?.commands?.toggleSceneInspector?.();
+    },
+    setTransformMode(mode) {
+      core?.commands?.setTransformMode?.(mode);
+    },
+    duplicateSelected() {
+      core?.commands?.duplicateSelected?.();
+    },
+    deselect() {
+      core?.commands?.deselect?.();
+    },
+    setInputRoutingMode(mode) {
+      core?.commands?.setInputRoutingMode?.(mode);
+    },
+    toggleInputRoutingMode() {
+      core?.commands?.toggleInputRoutingMode?.();
+    },
   };
 }
 

--- a/html/assets/js/scenesync/shells/editor/layouts/desktop-editor-layout.js
+++ b/html/assets/js/scenesync/shells/editor/layouts/desktop-editor-layout.js
@@ -19,13 +19,15 @@ export function createDesktopEditorLayout() {
       const linkBtn = document.getElementById('link-btn');
       const sceneInspectorToggleBtn = document.getElementById('scene-inspector-toggle');
       const sceneInspectorCloseBtn = document.getElementById('scene-inspector-close');
+      const modeBtn = document.getElementById('mode'); // Edit/Interact 切替（desktop のみ表示）
 
       disposers.push(
         addListener(exportBtn, 'click', () => actions?.exportScene?.()),
         addListener(helpBtn, 'click', () => actions?.openHelp?.()),
         addListener(linkBtn, 'click', () => actions?.startAiLink?.()),
         addListener(sceneInspectorToggleBtn, 'click', () => core?.commands?.toggleSceneInspector?.()),
-        addListener(sceneInspectorCloseBtn, 'click', () => actions?.closeSceneInspector?.())
+        addListener(sceneInspectorCloseBtn, 'click', () => actions?.closeSceneInspector?.()),
+        addListener(modeBtn, 'click', () => actions?.toggleInputRoutingMode?.())
       );
     },
 

--- a/html/assets/js/scenesync/shells/editor/layouts/mobile-editor-layout.js
+++ b/html/assets/js/scenesync/shells/editor/layouts/mobile-editor-layout.js
@@ -19,6 +19,14 @@ export function createMobileEditorLayout() {
       const mobileLinkOpenBtn = document.getElementById('mobile-link-open-btn');
       const mobileDevOpenBtn = document.getElementById('mobile-dev-open-btn');
 
+      // transform ツールバー（mobile-toolbar）。表示/活性の DOM 更新は core 側が担う。
+      const btnMove = document.getElementById('btn-move');
+      const btnRotate = document.getElementById('btn-rotate');
+      const btnScale = document.getElementById('btn-scale');
+      const btnCopy = document.getElementById('btn-copy');
+      const btnDelete = document.getElementById('btn-delete');
+      const btnDeselect = document.getElementById('btn-deselect');
+
       disposers.push(
         addListener(mobileExportBtn, 'click', () => {
           core?.commands?.closeMobileActionSheet?.();
@@ -35,7 +43,13 @@ export function createMobileEditorLayout() {
         addListener(mobileDevOpenBtn, 'click', () => {
           core?.commands?.closeMobileActionSheet?.();
           core?.commands?.toggleSceneInspector?.();
-        })
+        }),
+        addListener(btnMove, 'click', () => actions?.setTransformMode?.('translate')),
+        addListener(btnRotate, 'click', () => actions?.setTransformMode?.('rotate')),
+        addListener(btnScale, 'click', () => actions?.setTransformMode?.('scale')),
+        addListener(btnCopy, 'click', () => actions?.duplicateSelected?.()),
+        addListener(btnDelete, 'click', () => actions?.deleteSelected?.()),
+        addListener(btnDeselect, 'click', () => actions?.deselect?.())
       );
     },
 

--- a/html/assets/js/scenesync/shells/shell-registry.js
+++ b/html/assets/js/scenesync/shells/shell-registry.js
@@ -4,6 +4,7 @@ const SHELL_LOADERS = {
   editor: () => import('./editor/editor-shell.js'),
   minimal: () => import('./minimal/minimal-shell.js'),
   player: () => import('./player/player-shell.js'),
+  studio: () => import('./studio/studio-shell.js'),
 };
 
 function normalizeShellId(value) {

--- a/html/assets/js/scenesync/shells/studio/studio-actions.js
+++ b/html/assets/js/scenesync/shells/studio/studio-actions.js
@@ -1,0 +1,43 @@
+// Studio Shell の command ラッパ（core.commands への薄い委譲、editor-actions.js に倣う）。
+export function createStudioActions(core) {
+  return {
+    add() {
+      core?.commands?.openAddMenu?.();
+    },
+    undo() {
+      core?.commands?.undo?.();
+    },
+    redo() {
+      core?.commands?.redo?.();
+    },
+    setTransformMode(mode) {
+      core?.commands?.setTransformMode?.(mode);
+    },
+    duplicate() {
+      core?.commands?.duplicateSelected?.();
+    },
+    remove() {
+      core?.commands?.deleteSelected?.();
+    },
+    deselect() {
+      core?.commands?.deselect?.();
+    },
+    setInputRoutingMode(mode) {
+      core?.commands?.setInputRoutingMode?.(mode);
+    },
+    openInspector() {
+      core?.commands?.openSceneInspector?.();
+    },
+    exportScene() {
+      core?.commands?.exportScene?.();
+    },
+    openHelp() {
+      core?.commands?.openHelp?.();
+    },
+    startAiLink() {
+      core?.commands?.startAiLink?.();
+    },
+  };
+}
+
+export default createStudioActions;

--- a/html/assets/js/scenesync/shells/studio/studio-shell.css
+++ b/html/assets/js/scenesync/shells/studio/studio-shell.css
@@ -114,7 +114,6 @@
   gap: 11px;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
 }
 .studio-card[data-show="true"] {
   opacity: 1;
@@ -269,7 +268,6 @@
   box-shadow: var(--s-shadow);
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0.2s;
 }
 .studio-hint[data-show="true"] { opacity: 1; visibility: visible; }
 .studio-hint::after {
@@ -306,10 +304,8 @@
   box-shadow: var(--s-shadow);
   opacity: 0;
   visibility: hidden;
-  transform: translateY(6px);
-  transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s;
 }
-.studio-menu[data-open="true"] { opacity: 1; visibility: visible; transform: translateY(0); }
+.studio-menu[data-open="true"] { opacity: 1; visibility: visible; }
 .studio-menu-item {
   display: flex;
   align-items: center;

--- a/html/assets/js/scenesync/shells/studio/studio-shell.css
+++ b/html/assets/js/scenesync/shells/studio/studio-shell.css
@@ -1,0 +1,338 @@
+/* ── Hide editor chrome in Studio Shell ──────────────── */
+.scene-sync-shell-studio #settings-panel,
+.scene-sync-shell-studio #peers-panel,
+.scene-sync-shell-studio #scene-clock-panel,
+.scene-sync-shell-studio #history-toolbar,
+.scene-sync-shell-studio #mobile-toolbar,
+.scene-sync-shell-studio #add-btn,
+.scene-sync-shell-studio #mode {
+  display: none !important;
+}
+/* Keep: canvas, #toast, #scene-inspector-panel（Properties）, #xr-button-container */
+
+/* ── Design tokens（やわらかモダン / ダークニュートラルガラス / 落ち着いたブルー） ── */
+.studio-shell {
+  --s-surface: rgba(24, 26, 32, 0.74);
+  --s-surface-strong: rgba(28, 30, 37, 0.92);
+  --s-raised: rgba(255, 255, 255, 0.055);
+  --s-raised-hover: rgba(255, 255, 255, 0.10);
+  --s-border: rgba(255, 255, 255, 0.10);
+  --s-text: #e8eaee;
+  --s-muted: rgba(232, 234, 238, 0.56);
+  --s-accent: #6b8fc7;
+  --s-accent-strong: #5e82ba;
+  --s-accent-soft: rgba(107, 143, 199, 0.16);
+  --s-accent-border: rgba(107, 143, 199, 0.46);
+  --s-danger: rgba(224, 122, 122, 0.92);
+  --s-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  --s-blur: blur(18px) saturate(1.15);
+
+  position: fixed;
+  inset: 0;
+  z-index: 210;
+  pointer-events: none; /* 子要素のみ操作可。3D 操作を妨げない */
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  color: var(--s-text);
+  -webkit-user-select: none;
+  user-select: none;
+}
+.studio-shell > * { pointer-events: auto; }
+.studio-ic { display: block; flex: none; }
+
+/* 共通アイコンボタン */
+.studio-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--s-border);
+  background: var(--s-raised);
+  color: var(--s-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease, opacity 0.15s ease;
+}
+.studio-icon-btn:hover { background: var(--s-raised-hover); color: var(--s-text); }
+.studio-icon-btn:active { transform: scale(0.94); }
+.studio-icon-btn:disabled { opacity: 0.32; cursor: not-allowed; }
+.studio-icon-btn:focus-visible { outline: 2px solid var(--s-accent-border); outline-offset: 2px; }
+
+/* ── Mode pill（上部中央） ────────────────────────────── */
+.studio-mode-pill {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 12px;
+  background: var(--s-surface);
+  border: 1px solid var(--s-border);
+  backdrop-filter: var(--s-blur);
+  -webkit-backdrop-filter: var(--s-blur);
+  box-shadow: var(--s-shadow);
+}
+.studio-mode-seg {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: none;
+  background: transparent;
+  color: var(--s-muted);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 7px 16px;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.16s ease, color 0.16s ease, transform 0.1s ease;
+  font-family: inherit;
+}
+.studio-mode-seg:active { transform: scale(0.97); }
+.studio-mode-seg[data-active="true"] {
+  background: var(--s-accent-soft);
+  color: var(--s-text);
+  box-shadow: inset 0 0 0 1px var(--s-accent-border);
+}
+.studio-mode-seg[data-active="true"] .studio-ic { color: var(--s-accent); }
+
+/* ── Selection card ──────────────────────────────────── */
+.studio-card {
+  position: fixed;
+  top: 70px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
+  width: clamp(280px, 86vw, 360px);
+  padding: 13px 14px 14px;
+  border-radius: 16px;
+  background: var(--s-surface);
+  border: 1px solid var(--s-border);
+  backdrop-filter: var(--s-blur);
+  -webkit-backdrop-filter: var(--s-blur);
+  box-shadow: var(--s-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
+}
+.studio-card[data-show="true"] {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+.studio-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.studio-card-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.studio-card-x { width: 28px; height: 28px; border-radius: 8px; }
+
+/* transform tools */
+.studio-tools {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.studio-tool {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 11px 4px 9px;
+  border-radius: 11px;
+  border: 1px solid var(--s-border);
+  background: var(--s-raised);
+  color: var(--s-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
+  font-family: inherit;
+}
+.studio-tool:hover { background: var(--s-raised-hover); color: var(--s-text); }
+.studio-tool:active { transform: scale(0.96); }
+.studio-tool[data-active="true"] {
+  background: var(--s-accent-soft);
+  color: var(--s-text);
+  box-shadow: inset 0 0 0 1px var(--s-accent-border);
+}
+.studio-tool[data-active="true"] .studio-ic { color: var(--s-accent); }
+
+/* card secondary actions */
+.studio-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.studio-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--s-border);
+  background: var(--s-raised);
+  color: var(--s-text);
+  border-radius: 9px;
+  padding: 7px 11px;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease, opacity 0.15s ease;
+  font-family: inherit;
+}
+.studio-chip .studio-ic { color: var(--s-muted); }
+.studio-chip:hover { background: var(--s-raised-hover); }
+.studio-chip:active { transform: scale(0.96); }
+.studio-chip:disabled { opacity: 0.34; cursor: not-allowed; }
+.studio-chip-danger { color: var(--s-danger); }
+.studio-chip-danger .studio-ic { color: var(--s-danger); }
+.studio-chip-danger:hover { background: rgba(224, 122, 122, 0.12); }
+.studio-chip-ghost {
+  margin-left: auto;
+  background: transparent;
+  border-color: transparent;
+  color: var(--s-accent);
+  padding: 7px 8px;
+}
+.studio-chip-ghost .studio-ic { color: var(--s-accent); }
+.studio-chip-ghost:hover { background: var(--s-accent-soft); }
+
+/* ── Bottom dock ─────────────────────────────────────── */
+.studio-dock {
+  position: fixed;
+  bottom: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.studio-dock-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--s-surface);
+  backdrop-filter: var(--s-blur);
+  -webkit-backdrop-filter: var(--s-blur);
+  box-shadow: var(--s-shadow);
+}
+
+/* primary add */
+.studio-add-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.studio-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: var(--s-accent-strong);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(94, 130, 186, 0.42);
+  transition: background 0.16s ease, transform 0.12s ease, box-shadow 0.16s ease;
+}
+.studio-add .studio-ic { color: #fff; }
+.studio-add:hover { background: var(--s-accent); box-shadow: 0 8px 22px rgba(94, 130, 186, 0.55); }
+.studio-add:active { transform: scale(0.94); }
+.studio-add:focus-visible { outline: 2px solid var(--s-accent-border); outline-offset: 3px; }
+
+/* 空状態ヒント（控えめ・フェードのみ） */
+.studio-hint {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding: 6px 11px;
+  border-radius: 9px;
+  background: var(--s-surface-strong);
+  border: 1px solid var(--s-border);
+  color: var(--s-text);
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: var(--s-shadow);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s;
+}
+.studio-hint[data-show="true"] { opacity: 1; visibility: visible; }
+.studio-hint::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--s-surface-strong);
+}
+
+/* ── Menu popover ────────────────────────────────────── */
+.studio-menu-wrap { position: relative; }
+.studio-dock-btn[data-active="true"] {
+  background: var(--s-accent-soft);
+  color: var(--s-text);
+  box-shadow: var(--s-shadow), inset 0 0 0 1px var(--s-accent-border);
+}
+.studio-menu {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 184px;
+  padding: 6px;
+  border-radius: 12px;
+  background: var(--s-surface-strong);
+  border: 1px solid var(--s-border);
+  backdrop-filter: var(--s-blur);
+  -webkit-backdrop-filter: var(--s-blur);
+  box-shadow: var(--s-shadow);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(6px);
+  transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s;
+}
+.studio-menu[data-open="true"] { opacity: 1; visibility: visible; transform: translateY(0); }
+.studio-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: none;
+  background: transparent;
+  color: var(--s-text);
+  font-size: 13.5px;
+  font-weight: 500;
+  text-align: left;
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+  font-family: inherit;
+}
+.studio-menu-item .studio-ic { color: var(--s-muted); }
+.studio-menu-item:hover { background: var(--s-raised-hover); }
+
+/* ── Mobile 調整 ─────────────────────────────────────── */
+@media (max-width: 560px) {
+  .studio-dock { gap: 10px; bottom: 18px; }
+  .studio-dock-btn { width: 42px; height: 42px; }
+  .studio-add { width: 54px; height: 54px; }
+  .studio-card { top: 66px; }
+}

--- a/html/assets/js/scenesync/shells/studio/studio-shell.js
+++ b/html/assets/js/scenesync/shells/studio/studio-shell.js
@@ -1,0 +1,217 @@
+import { createStudioActions } from './studio-actions.js';
+
+const STYLE_ID = 'scene-sync-studio-shell-style';
+const BODY_CLASS = 'scene-sync-shell-studio';
+
+async function ensureStylesheet() {
+  if (document.getElementById(STYLE_ID)) return;
+  const link = document.createElement('link');
+  link.id = STYLE_ID;
+  link.rel = 'stylesheet';
+  link.href = new URL('./studio-shell.css', import.meta.url).href;
+  document.head.appendChild(link);
+}
+
+// 細い line アイコン（24x24, currentColor, stroke）。やわらかモダン基調。
+const ICON = {
+  edit: '<path d="M16.5 3.8a2 2 0 0 1 2.8 2.8L7.5 18.4 3.5 19.5l1.1-4Z"/>',
+  play: '<path d="M7 4.5 18.5 12 7 19.5Z" stroke-linejoin="round"/>',
+  move: '<path d="M12 3v18M3 12h18"/><path d="M12 3 9.5 5.5M12 3l2.5 2.5M12 21l-2.5-2.5M12 21l2.5-2.5M3 12l2.5-2.5M3 12l2.5 2.5M21 12l-2.5-2.5M21 12l-2.5 2.5"/>',
+  rotate: '<path d="M20.5 12a8.5 8.5 0 1 1-2.6-6.1"/><path d="M20.5 4.2v4.2h-4.2"/>',
+  scale: '<path d="M14 4h6v6"/><path d="M10 20H4v-6"/><path d="M20 4l-7 7"/><path d="M4 20l7-7"/>',
+  duplicate: '<rect x="9" y="9" width="11" height="11" rx="2.2"/><path d="M5 15H4.5A1.5 1.5 0 0 1 3 13.5V4.5A1.5 1.5 0 0 1 4.5 3h9A1.5 1.5 0 0 1 15 4.5V5"/>',
+  trash: '<path d="M3.5 6h17"/><path d="M8.5 6V4.5A1.5 1.5 0 0 1 10 3h4a1.5 1.5 0 0 1 1.5 1.5V6"/><path d="M18.5 6 17.6 19a1.5 1.5 0 0 1-1.5 1.4H7.9A1.5 1.5 0 0 1 6.4 19L5.5 6"/>',
+  close: '<path d="M17 7 7 17M7 7l10 10"/>',
+  undo: '<path d="M9 14 4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-2"/>',
+  redo: '<path d="m15 14 5-5-5-5"/><path d="M20 9H9a5 5 0 0 0 0 10h2"/>',
+  plus: '<path d="M12 5v14M5 12h14"/>',
+  more: '<circle cx="5" cy="12" r="1.4" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.4" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.4" fill="currentColor" stroke="none"/>',
+  chevron: '<path d="m9 6 6 6-6 6"/>',
+  sliders: '<path d="M4 7h10M18 7h2M4 17h2M10 17h10"/><circle cx="16" cy="7" r="2.2"/><circle cx="8" cy="17" r="2.2"/>',
+  download: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 20h14"/>',
+  link: '<path d="M9.5 14.5 14.5 9.5"/><path d="M10.5 6.8 12 5.3a4 4 0 0 1 5.7 5.7l-1.5 1.5"/><path d="M13.5 17.2 12 18.7a4 4 0 0 1-5.7-5.7l1.5-1.5"/>',
+  help: '<circle cx="12" cy="12" r="9"/><path d="M9.6 9.2a2.4 2.4 0 1 1 3.3 2.2c-.8.4-1.1 1-1.1 1.8"/><path d="M12 16.5h.01"/>',
+};
+
+function icon(name, size = 22) {
+  return `<svg class="studio-ic" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${ICON[name] || ''}</svg>`;
+}
+
+// 英語ラベル・やわらかモダン・ダークニュートラルガラスのライト層向け Edit シェル。
+// core.commands / getEditorState のみで構築（scene 内部に依存しない）。
+export function createSceneSyncShell({ id = 'studio', requestedId = 'studio', availableShellIds = [] } = {}) {
+  let root = null;
+  let actions = null;
+  let removeStateListener = null;
+  let menuOpen = false;
+
+  function getState(core) {
+    return core?.getEditorState?.() ?? {};
+  }
+
+  function render(core) {
+    if (!root) return;
+    const s = getState(core);
+    const selected = (s.selectedCount || 0) > 0;
+    const mode = s.inputRoutingMode === 'interact' ? 'interact' : 'edit';
+
+    root.querySelectorAll('[data-studio-mode]').forEach((btn) => {
+      btn.dataset.active = String(btn.dataset.studioMode === mode);
+    });
+
+    const undoBtn = root.querySelector('[data-studio-undo]');
+    const redoBtn = root.querySelector('[data-studio-redo]');
+    if (undoBtn) undoBtn.disabled = !s.canUndo;
+    if (redoBtn) redoBtn.disabled = !s.canRedo;
+
+    const hint = root.querySelector('[data-studio-hint]');
+    if (hint) hint.dataset.show = String((s.objectCount || 0) === 0);
+
+    const card = root.querySelector('[data-studio-card]');
+    if (card) card.dataset.show = String(selected);
+    if (selected) {
+      const nameEl = card.querySelector('[data-studio-card-name]');
+      if (nameEl) {
+        nameEl.textContent = s.selectedCount > 1
+          ? `${s.selectedCount} selected`
+          : (s.selectionLabel || 'Object');
+      }
+      const tm = s.transformMode || 'translate';
+      card.querySelectorAll('[data-studio-tool]').forEach((btn) => {
+        btn.dataset.active = String(btn.dataset.studioTool === tm);
+      });
+      const dupBtn = card.querySelector('[data-studio-duplicate]');
+      if (dupBtn) dupBtn.disabled = s.selectedCount !== 1;
+    }
+  }
+
+  function setMenuOpen(next) {
+    menuOpen = next;
+    const menu = root?.querySelector('[data-studio-menu]');
+    const menuBtn = root?.querySelector('[data-studio-menu-btn]');
+    if (menu) menu.dataset.open = String(menuOpen);
+    if (menuBtn) menuBtn.dataset.active = String(menuOpen);
+  }
+
+  function bind(core) {
+    const on = (sel, handler, type = 'click') => {
+      root.querySelectorAll(sel).forEach((el) => el.addEventListener(type, handler));
+    };
+
+    on('[data-studio-mode]', (e) => actions.setInputRoutingMode(e.currentTarget.dataset.studioMode));
+    on('[data-studio-add]', () => actions.add());
+    on('[data-studio-undo]', () => actions.undo());
+    on('[data-studio-redo]', () => actions.redo());
+    on('[data-studio-tool]', (e) => actions.setTransformMode(e.currentTarget.dataset.studioTool));
+    on('[data-studio-duplicate]', () => actions.duplicate());
+    on('[data-studio-delete]', () => actions.remove());
+    on('[data-studio-deselect]', () => actions.deselect());
+    on('[data-studio-details]', () => { actions.openInspector(); setMenuOpen(false); });
+    on('[data-studio-menu-btn]', () => setMenuOpen(!menuOpen));
+    on('[data-studio-export]', () => { actions.exportScene(); setMenuOpen(false); });
+    on('[data-studio-help]', () => { actions.openHelp(); setMenuOpen(false); });
+    on('[data-studio-ai]', () => { actions.startAiLink(); setMenuOpen(false); });
+
+    root.addEventListener('pointerdown', (e) => {
+      if (!menuOpen) return;
+      if (e.target.closest('[data-studio-menu]') || e.target.closest('[data-studio-menu-btn]')) return;
+      setMenuOpen(false);
+    });
+  }
+
+  return {
+    id,
+    requestedId,
+    name: 'Studio Shell',
+    kind: 'editor',
+    layouts: ['desktop', 'mobile'],
+    inputs: ['mouse', 'touch'],
+
+    async mount({ core } = {}) {
+      await ensureStylesheet();
+
+      document.body.dataset.sceneSyncShell = 'studio';
+      document.body.classList.add(BODY_CLASS);
+      document.body.classList.remove('scene-sync-shell-editor', 'scene-sync-shell-minimal', 'scene-sync-shell-player');
+
+      actions = createStudioActions(core);
+
+      root = document.createElement('div');
+      root.className = 'studio-shell';
+      root.setAttribute('aria-label', 'Scene Sync Studio');
+      root.innerHTML = `
+        <div class="studio-mode-pill" role="group" aria-label="Mode">
+          <button class="studio-mode-seg" data-studio-mode="edit" data-active="true" type="button">
+            ${icon('edit', 16)}<span>Edit</span>
+          </button>
+          <button class="studio-mode-seg" data-studio-mode="interact" data-active="false" type="button">
+            ${icon('play', 16)}<span>Play</span>
+          </button>
+        </div>
+
+        <div class="studio-card" data-studio-card data-show="false" role="group" aria-label="Selection">
+          <div class="studio-card-head">
+            <span class="studio-card-name" data-studio-card-name>Object</span>
+            <button class="studio-icon-btn studio-card-x" data-studio-deselect type="button" title="Deselect" aria-label="Deselect">${icon('close', 18)}</button>
+          </div>
+          <div class="studio-tools">
+            <button class="studio-tool" data-studio-tool="translate" data-active="true" type="button">
+              ${icon('move', 20)}<span>Move</span>
+            </button>
+            <button class="studio-tool" data-studio-tool="rotate" data-active="false" type="button">
+              ${icon('rotate', 20)}<span>Rotate</span>
+            </button>
+            <button class="studio-tool" data-studio-tool="scale" data-active="false" type="button">
+              ${icon('scale', 20)}<span>Scale</span>
+            </button>
+          </div>
+          <div class="studio-card-actions">
+            <button class="studio-chip" data-studio-duplicate type="button">${icon('duplicate', 16)}<span>Duplicate</span></button>
+            <button class="studio-chip studio-chip-danger" data-studio-delete type="button">${icon('trash', 16)}<span>Delete</span></button>
+            <button class="studio-chip studio-chip-ghost" data-studio-details type="button"><span>Details</span>${icon('chevron', 14)}</button>
+          </div>
+        </div>
+
+        <div class="studio-dock">
+          <button class="studio-icon-btn studio-dock-btn" data-studio-undo type="button" title="Undo" aria-label="Undo">${icon('undo', 20)}</button>
+          <div class="studio-add-wrap">
+            <div class="studio-hint" data-studio-hint data-show="true">Tap + to add</div>
+            <button class="studio-add" data-studio-add type="button" aria-label="Add">${icon('plus', 26)}</button>
+          </div>
+          <button class="studio-icon-btn studio-dock-btn" data-studio-redo type="button" title="Redo" aria-label="Redo">${icon('redo', 20)}</button>
+          <div class="studio-menu-wrap">
+            <button class="studio-icon-btn studio-dock-btn" data-studio-menu-btn type="button" title="Menu" aria-label="Menu">${icon('more', 20)}</button>
+            <div class="studio-menu" data-studio-menu data-open="false" role="menu">
+              <button class="studio-menu-item" data-studio-details type="button">${icon('sliders', 18)}<span>Properties</span></button>
+              <button class="studio-menu-item" data-studio-export type="button">${icon('download', 18)}<span>Export</span></button>
+              <button class="studio-menu-item" data-studio-ai type="button">${icon('link', 18)}<span>AI Link</span></button>
+              <button class="studio-menu-item" data-studio-help type="button">${icon('help', 18)}<span>Help</span></button>
+            </div>
+          </div>
+        </div>
+      `;
+
+      bind(core);
+      document.body.appendChild(root);
+      removeStateListener = core?.onStateChange?.(() => render(core)) ?? null;
+      render(core);
+
+      if (core?.debug) {
+        console.debug('[SceneSyncShell] mounted studio shell', { requestedId, availableShellIds });
+      }
+    },
+
+    unmount() {
+      removeStateListener?.();
+      removeStateListener = null;
+      root?.remove();
+      root = null;
+      actions = null;
+      menuOpen = false;
+      document.body.classList.remove(BODY_CLASS);
+      delete document.body.dataset.sceneSyncShell;
+    },
+  };
+}
+
+export default createSceneSyncShell;

--- a/html/assets/js/scenesync/shells/studio/studio-shell.js
+++ b/html/assets/js/scenesync/shells/studio/studio-shell.js
@@ -44,6 +44,8 @@ export function createSceneSyncShell({ id = 'studio', requestedId = 'studio', av
   let actions = null;
   let removeStateListener = null;
   let menuOpen = false;
+  let onDocPointerDown = null;
+  let onDocKeyDown = null;
 
   function getState(core) {
     return core?.getEditorState?.() ?? {};
@@ -91,6 +93,30 @@ export function createSceneSyncShell({ id = 'studio', requestedId = 'studio', av
     const menuBtn = root?.querySelector('[data-studio-menu-btn]');
     if (menu) menu.dataset.open = String(menuOpen);
     if (menuBtn) menuBtn.dataset.active = String(menuOpen);
+
+    // root は pointer-events:none のため canvas クリックが届かない。
+    // メニュー open 中だけ document に外側クリック / Escape を張る。
+    if (menuOpen) {
+      if (!onDocPointerDown) {
+        onDocPointerDown = (e) => {
+          if (e.target.closest('[data-studio-menu]') || e.target.closest('[data-studio-menu-btn]')) return;
+          setMenuOpen(false);
+        };
+        onDocKeyDown = (e) => { if (e.key === 'Escape') setMenuOpen(false); };
+        // 開いたクリックのイベント列を拾って即閉じしないよう、登録は次ティックへ遅延。
+        // capture phase で canvas が止めても確実に届くようにする。
+        setTimeout(() => {
+          if (!onDocPointerDown) return;
+          document.addEventListener('pointerdown', onDocPointerDown, true);
+          document.addEventListener('keydown', onDocKeyDown, true);
+        }, 0);
+      }
+    } else if (onDocPointerDown) {
+      document.removeEventListener('pointerdown', onDocPointerDown, true);
+      document.removeEventListener('keydown', onDocKeyDown, true);
+      onDocPointerDown = null;
+      onDocKeyDown = null;
+    }
   }
 
   function bind(core) {
@@ -111,12 +137,6 @@ export function createSceneSyncShell({ id = 'studio', requestedId = 'studio', av
     on('[data-studio-export]', () => { actions.exportScene(); setMenuOpen(false); });
     on('[data-studio-help]', () => { actions.openHelp(); setMenuOpen(false); });
     on('[data-studio-ai]', () => { actions.startAiLink(); setMenuOpen(false); });
-
-    root.addEventListener('pointerdown', (e) => {
-      if (!menuOpen) return;
-      if (e.target.closest('[data-studio-menu]') || e.target.closest('[data-studio-menu-btn]')) return;
-      setMenuOpen(false);
-    });
   }
 
   return {
@@ -202,12 +222,12 @@ export function createSceneSyncShell({ id = 'studio', requestedId = 'studio', av
     },
 
     unmount() {
+      setMenuOpen(false); // document リスナを確実に解除
       removeStateListener?.();
       removeStateListener = null;
       root?.remove();
       root = null;
       actions = null;
-      menuOpen = false;
       document.body.classList.remove(BODY_CLASS);
       delete document.body.dataset.sceneSyncShell;
     },

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -1333,51 +1333,53 @@
         <span>ヘルプ</span>
       </button>
     </div>
-    <div id="pairing-dialog" class="pairing-dialog" style="display:none;">
-      <div class="pairing-content">
-        <h3>AI ペアリング</h3>
-        <div id="pairing-step-code">
-          <p>次のコードを AI に入力してください:</p>
-          <button id="pairing-code" class="pairing-code" type="button" title="クリックしてコピー">------</button>
-          <p class="pairing-note">
-            リンク中はScene Syncのページを開いたままにしてください。
-          </p>
-          <div class="pairing-actions">
-            <button id="btn-copy-pairing-code" class="chip" type="button">コードをコピー</button>
-            <a id="scene-sync-operator-link" class="chip" href="#" target="_blank" rel="noopener noreferrer">Scene Sync Operator</a>
-          </div>
-          <div id="pairing-timer">5:00</div>
-        </div>
-        <div id="pairing-step-linked" style="display:none;">
-          <p>✓ リンクしました</p>
-          <p class="pairing-note" id="pairing-auto-close-note">
-            このダイアログは自動で閉じます。
-          </p>
-        </div>
-        <div id="pairing-error" style="display:none;" class="pairing-error"></div>
-        <div class="pairing-buttons">
-          <button id="btn-cancel-pairing" class="chip">キャンセル</button>
-          <button id="btn-revoke-link" class="chip danger" style="display:none;">リンク解除</button>
-        </div>
-      </div>
-    </div>
-    <div id="room-full-dialog" class="pairing-dialog" style="display:none;">
-      <div class="pairing-content">
-        <h3>ルームが満員です</h3>
-        <p style="margin: 16px 0; color: #ccc; text-align: center; line-height: 1.6;">
-          このルームは満員です。<br>
-          <br>
-          少し待つか、新しいルームを作って始めましょう。
-        </p>
-        <div class="pairing-actions">
-          <button id="btn-room-full-retry" class="chip" type="button">もう一度試す</button>
-          <button id="btn-room-full-new" class="chip primary" type="button">新しいルームを作る</button>
-        </div>
-      </div>
-    </div>
     <div class="row mobile-collapsible-row" id="room-section"></div>
     <div class="row meta-link-row mobile-collapsible-row">
       <a class="meta-link" href="/scenesync/privacy/">プライバシーポリシー</a>
+    </div>
+  </div>
+
+  <!-- グローバルモーダル: #settings-panel を隠す shell でも表示できるよう外出し -->
+  <div id="pairing-dialog" class="pairing-dialog" style="display:none;">
+    <div class="pairing-content">
+      <h3>AI ペアリング</h3>
+      <div id="pairing-step-code">
+        <p>次のコードを AI に入力してください:</p>
+        <button id="pairing-code" class="pairing-code" type="button" title="クリックしてコピー">------</button>
+        <p class="pairing-note">
+          リンク中はScene Syncのページを開いたままにしてください。
+        </p>
+        <div class="pairing-actions">
+          <button id="btn-copy-pairing-code" class="chip" type="button">コードをコピー</button>
+          <a id="scene-sync-operator-link" class="chip" href="#" target="_blank" rel="noopener noreferrer">Scene Sync Operator</a>
+        </div>
+        <div id="pairing-timer">5:00</div>
+      </div>
+      <div id="pairing-step-linked" style="display:none;">
+        <p>✓ リンクしました</p>
+        <p class="pairing-note" id="pairing-auto-close-note">
+          このダイアログは自動で閉じます。
+        </p>
+      </div>
+      <div id="pairing-error" style="display:none;" class="pairing-error"></div>
+      <div class="pairing-buttons">
+        <button id="btn-cancel-pairing" class="chip">キャンセル</button>
+        <button id="btn-revoke-link" class="chip danger" style="display:none;">リンク解除</button>
+      </div>
+    </div>
+  </div>
+  <div id="room-full-dialog" class="pairing-dialog" style="display:none;">
+    <div class="pairing-content">
+      <h3>ルームが満員です</h3>
+      <p style="margin: 16px 0; color: #ccc; text-align: center; line-height: 1.6;">
+        このルームは満員です。<br>
+        <br>
+        少し待つか、新しいルームを作って始めましょう。
+      </p>
+      <div class="pairing-actions">
+        <button id="btn-room-full-retry" class="chip" type="button">もう一度試す</button>
+        <button id="btn-room-full-new" class="chip primary" type="button">新しいルームを作る</button>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要

SceneSync の UI 差し替えアーキテクチャ（`shells/`）において、**Editor Shell の shell 化を完成**させ、その上に**ライト層向けの新しい Edit デザイン「Studio Shell」**を独立シェルとして追加しました。既存の `editor` シェルは無変更で並存します。

## Editor Shell v4 — command + state API の公開と chrome 配線の移管

これまで `scene.js` に直書きされていた Edit mode の中核操作を command 化し、編集状態を shell から購読できるようにしました。

**新コマンド (`core.commands`)**
`setTransformMode` / `duplicateSelected` / `deselect` / `setInputRoutingMode` / `toggleInputRoutingMode`

**新状態 getter (`core.getEditorState()`)**
`transformMode` / `inputRoutingMode` / `selectedCount` / `selectionLabel` / `objectCount` / `canUndo` / `canRedo`
（transform mode・routing mode・history 変更時に状態通知を発火）

**配線の移管**
- `#mode`（Edit/Interact 切替）→ desktop layout
- transform ツールバー（move/rotate/scale/copy/delete/deselect）→ mobile layout
- `scene.js` の重複リスナを削除（二重発火防止）

> transform gizmo・raycast 選択・drag&drop・Inspector 内部編集・W/E/R ショートカットは引き続き core 側に残置。

## Studio Shell（`?shell=studio`）

ライト層向けの自己完結型 Edit シェル。**command + state API のみ**で構築し、scene 内部に依存しません（minimal/player と同方式、既存 chrome は body class で隠蔽）。

**デザイン方針**（ユーザーと協議し決定）: やわらかモダン（Apple/Notion 風）/ ダークニュートラルガラス / 落ち着いたブルー / 細い line アイコン / 英語ラベル（Edit・Play）/ 控えめなモーション。

**UI**
- 上部: `✎ Edit | ▷ Play` モードピル（現在モード常時明示）
- 選択カード: `Move / Rotate / Scale` ＋ `Duplicate / Delete / Details ›`
- 下部ドック: undo / redo・中央の Add（＋）・⋯メニュー（Properties / Export / AI Link / Help）
- 空状態ヒント（オブジェクト 0 件時）

## 検証

- `?shell=studio` でモード切替・オブジェクト選択→Move/Rotate/Scale（gizmo 連動）・Duplicate/Delete/Deselect・undo/redo・メニュー・Inspector がすべて command 経由で動作、コンソールエラーなし（ブラウザ実機確認）
- 既定 `?shell=editor` の `#mode`・transform ツールバー配線を cache-bust import で E2E 検証
- 全 JS の `node --check` パス、既存 `audio-source-controller.test.js` パス

> 注: 開発中は editor 系モジュールが動的 import でキャッシュされるため、変更反映にはハードリロード（Cmd/Ctrl+Shift+R）が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)