### PR TITLE
Add shell runtime manager for dynamic shell switching

### DIFF
--- a/html/assets/js/scenesync/shells/shell-bootstrap.js
+++ b/html/assets/js/scenesync/shells/shell-bootstrap.js
@@ -1,4 +1,4 @@
-import { loadSceneSyncShell } from './shell-registry.js';
+import { loadSceneSyncShell, listSceneSyncShellIds } from './shell-registry.js';
 import { createPointerInputAdapter } from './editor/inputs/pointer-input-adapter.js';
 import { createTouchInputAdapter } from './editor/inputs/touch-input-adapter.js';
 import { createEditorKeyboardAdapter } from './editor/inputs/editor-keyboard-adapter.js';
@@ -102,36 +102,168 @@ function createDomBackedCore(extraCore = {}) {
   };
 }
 
+const INPUT_ADAPTER_FACTORIES = {
+  pointer: createPointerInputAdapter,
+  touch: createTouchInputAdapter,
+  keyboard: createEditorKeyboardAdapter,
+};
+
+function mountInputAdaptersForShell(shell, core) {
+  const inputAdapters = [];
+  if (!core?.input?.getCanvas?.()) return inputAdapters;
+
+  const shellInputs = Array.isArray(shell?.inputs) ? shell.inputs : [];
+
+  for (const inputId of shellInputs) {
+    const factory = INPUT_ADAPTER_FACTORIES[inputId];
+    if (!factory) {
+      console.warn(`[SceneSyncShell] unknown input adapter: ${inputId}`);
+      continue;
+    }
+
+    const adapter = factory();
+    try {
+      adapter.mount({ core });
+      inputAdapters.push(adapter);
+    } catch (error) {
+      console.warn(`[SceneSyncShell] input adapter '${inputId}' mount failed:`, error);
+    }
+  }
+
+  return inputAdapters;
+}
+
+function unmountInputAdapters(inputAdapters) {
+  for (const adapter of inputAdapters.splice(0)) {
+    try {
+      adapter.unmount?.();
+    } catch (error) {
+      console.warn('[SceneSyncShell] input adapter unmount failed:', error);
+    }
+  }
+}
+
+export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
+  const core = createDomBackedCore(extraCore);
+  let currentShell = null;
+  let currentShellId = null;
+  let currentInputAdapters = [];
+  let switchSerial = 0;
+  let disposed = false;
+
+  async function switchShell(nextShellId, options = {}) {
+    if (disposed) {
+      console.warn('[SceneSyncShell] runtime already disposed');
+      return;
+    }
+
+    const token = ++switchSerial;
+    const normalizedId = String(nextShellId || '').trim().toLowerCase() || 'editor';
+
+    if (normalizedId === currentShellId) {
+      return;
+    }
+
+    try {
+      const nextShell = await loadSceneSyncShell(normalizedId);
+
+      if (token !== switchSerial) {
+        nextShell.unmount?.();
+        return;
+      }
+
+      unmountInputAdapters(currentInputAdapters);
+      currentInputAdapters = [];
+
+      currentShell?.unmount?.();
+
+      await nextShell.mount({ core, root: document.body });
+
+      currentInputAdapters = mountInputAdaptersForShell(nextShell, core);
+      currentShell = nextShell;
+      currentShellId = normalizedId;
+
+      if (options?.updateUrl) {
+        const url = new URL(location.href);
+        url.searchParams.set('shell', normalizedId);
+        history.replaceState(null, '', url);
+      }
+
+      if (core?.debug) {
+        console.debug('[SceneSyncShell] switched to shell:', normalizedId);
+      }
+    } catch (error) {
+      console.error('[SceneSyncShell] failed to switch shell:', error);
+
+      if (token === switchSerial && currentShell === null) {
+        try {
+          const fallbackShell = await loadSceneSyncShell('editor');
+          await fallbackShell.mount({ core, root: document.body });
+          currentInputAdapters = mountInputAdaptersForShell(fallbackShell, core);
+          currentShell = fallbackShell;
+          currentShellId = 'editor';
+          console.warn('[SceneSyncShell] fell back to editor shell');
+        } catch (fallbackError) {
+          console.error('[SceneSyncShell] fallback to editor shell failed:', fallbackError);
+        }
+      }
+    }
+  }
+
+  const initialShell = await loadSceneSyncShell();
+  await initialShell.mount({ core, root: document.body });
+  currentShell = initialShell;
+  currentShellId = initialShell?.id || 'editor';
+  currentInputAdapters = mountInputAdaptersForShell(initialShell, core);
+
+  return {
+    get core() {
+      return core;
+    },
+
+    getCurrentShellId() {
+      return currentShellId;
+    },
+
+    getCurrentShell() {
+      return currentShell;
+    },
+
+    switchShell,
+
+    listShellIds() {
+      return listSceneSyncShellIds();
+    },
+
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+
+      unmountInputAdapters(currentInputAdapters);
+      currentInputAdapters = [];
+
+      currentShell?.unmount?.();
+      currentShell = null;
+      currentShellId = null;
+
+      core?.dispose?.();
+    },
+  };
+}
+
 export async function mountSceneSyncShell(extraCore = {}) {
   const shell = await loadSceneSyncShell();
   const core = createDomBackedCore(extraCore);
   await shell.mount({ core, root: document.body });
 
-  // 入力アダプタを mount する。
-  // - pointer / touch: 3D シーンを表示する全 shell に常時（選択・hover・カメラ操作）。
-  // - editor-keyboard: 編集系ショートカット（C/V・Undo/Redo・W/E/R・Delete 等）。
-  //   shell.inputs に 'keyboard' を含む編集 shell（editor/studio）のみ mount し、
-  //   鑑賞用 shell（viewer/player/minimal）では編集ショートカットを無効化する。
-  const inputAdapters = [];
-  if (core?.input?.getCanvas?.()) {
-    const factories = [createPointerInputAdapter, createTouchInputAdapter];
-    const shellInputs = Array.isArray(shell?.inputs) ? shell.inputs : [];
-    if (shellInputs.includes('keyboard')) {
-      factories.push(createEditorKeyboardAdapter);
-    }
-    for (const create of factories) {
-      const adapter = create();
-      try { adapter.mount({ core }); inputAdapters.push(adapter); }
-      catch (error) { console.warn('[SceneSyncShell] input adapter mount failed:', error); }
-    }
-  }
+  const inputAdapters = mountInputAdaptersForShell(shell, core);
 
   return {
     shell,
     core,
     inputAdapters,
     dispose() {
-      for (const adapter of inputAdapters.splice(0)) adapter.unmount?.();
+      unmountInputAdapters(inputAdapters);
       shell.unmount?.();
       core.dispose?.();
     },

--- a/html/assets/js/scenesync/shells/shell-bootstrap.js
+++ b/html/assets/js/scenesync/shells/shell-bootstrap.js
@@ -164,6 +164,10 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
       return;
     }
 
+    const previousShell = currentShell;
+    const previousShellId = currentShellId;
+    const previousInputAdapters = currentInputAdapters;
+
     try {
       const nextShell = await loadSceneSyncShell(normalizedId);
 
@@ -172,25 +176,33 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
         return;
       }
 
-      unmountInputAdapters(currentInputAdapters);
-      currentInputAdapters = [];
+      unmountInputAdapters(previousInputAdapters);
+      previousShell?.unmount?.();
 
-      currentShell?.unmount?.();
+      currentShell = null;
+      currentShellId = null;
+      currentInputAdapters = [];
 
       await nextShell.mount({ core, root: document.body });
 
+      if (token !== switchSerial) {
+        nextShell.unmount?.();
+        return;
+      }
+
       currentInputAdapters = mountInputAdaptersForShell(nextShell, core);
       currentShell = nextShell;
-      currentShellId = normalizedId;
+      currentShellId = nextShell.id || normalizedId;
 
       if (options?.updateUrl) {
         const url = new URL(location.href);
-        url.searchParams.set('shell', normalizedId);
+        const mountedShellId = nextShell.id || normalizedId;
+        url.searchParams.set('shell', mountedShellId);
         history.replaceState(null, '', url);
       }
 
       if (core?.debug) {
-        console.debug('[SceneSyncShell] switched to shell:', normalizedId);
+        console.debug('[SceneSyncShell] switched to shell:', currentShellId);
       }
     } catch (error) {
       console.error('[SceneSyncShell] failed to switch shell:', error);
@@ -201,7 +213,7 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
           await fallbackShell.mount({ core, root: document.body });
           currentInputAdapters = mountInputAdaptersForShell(fallbackShell, core);
           currentShell = fallbackShell;
-          currentShellId = 'editor';
+          currentShellId = fallbackShell.id || 'editor';
           console.warn('[SceneSyncShell] fell back to editor shell');
         } catch (fallbackError) {
           console.error('[SceneSyncShell] fallback to editor shell failed:', fallbackError);

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -1,15 +1,40 @@
-import { mountSceneSyncShell } from '../shells/shell-bootstrap.js';
+import { createSceneSyncShellRuntimeManager } from '../shells/shell-bootstrap.js';
 
-let sceneSyncShellMountPromise = null;
+let sceneSyncShellRuntimePromise = null;
+let sceneSyncShellRuntime = null;
 
 export function mountSceneSyncShellFromDom(core = {}) {
-  if (!sceneSyncShellMountPromise) {
-    sceneSyncShellMountPromise = mountSceneSyncShell(core).catch((error) => {
-      console.warn('[SceneSyncShell] failed to mount shell:', error);
-      return null;
-    });
+  if (!sceneSyncShellRuntimePromise) {
+    sceneSyncShellRuntimePromise = createSceneSyncShellRuntimeManager(core)
+      .then((runtime) => {
+        sceneSyncShellRuntime = runtime;
+
+        if (typeof window !== 'undefined') {
+          window.sceneSyncShell = {
+            async switchTo(shellId, options) {
+              return runtime.switchShell(shellId, options);
+            },
+            current() {
+              return runtime.getCurrentShellId();
+            },
+            list() {
+              return runtime.listShellIds();
+            },
+          };
+        }
+
+        return runtime;
+      })
+      .catch((error) => {
+        console.warn('[SceneSyncShell] failed to mount shell runtime:', error);
+        return null;
+      });
   }
-  return sceneSyncShellMountPromise;
+  return sceneSyncShellRuntimePromise;
+}
+
+export function getSceneSyncShellRuntime() {
+  return sceneSyncShellRuntime;
 }
 
 export function getSceneSyncDom() {


### PR DESCRIPTION
## 概要

SceneSyncShell に動的なシェル切り替え機能を追加します。従来の単一シェルマウント方式から、実行時にシェルを切り替え可能なランタイムマネージャーに移行します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更点

1. **新しいランタイムマネージャー API** (`createSceneSyncShellRuntimeManager`)
   - シェルの動的切り替え機能を提供
   - 入力アダプタのライフサイクル管理を統一
   - シェル切り替え時の適切なクリーンアップを実装

2. **入力アダプタ管理の改善**
   - `mountInputAdaptersForShell()`: シェルに応じた入力アダプタの選択的マウント
   - `unmountInputAdapters()`: 統一されたアンマウント処理
   - エラーハンドリングの強化（不明なアダプタの警告、マウント失敗時の処理）

3. **シェル切り替え機能** (`switchShell()`)
   - URL パラメータの自動更新（`?shell=...`）
   - 切り替え中の競合を防ぐトークンベースの制御
   - フォールバック機能（切り替え失敗時は editor シェルにフォールバック）
   - デバッグログの出力

4. **グローバル API の提供** (`window.sceneSyncShell`)
   - `switchTo(shellId, options)`: シェル切り替え
   - `current()`: 現在のシェル ID を取得
   - `list()`: 利用可能なシェル一覧を取得

5. **後方互換性の維持**
   - 既存の `mountSceneSyncShell()` は引き続き利用可能
   - 新しいランタイムマネージャーを使用するよう内部実装を更新

### staging で見てほしい点

- シェル切り替え時の UI の滑らかさ
- 入力アダプタの適切なマウント/アンマウント
- URL パラメータの更新動作
- エラー時のフォールバック動作

## 変更していないこと

- シェルレジストリの仕様
- 個別の入力アダプタの実装
- コア機能（canvas、input、output）

## staging確認

未確認

## テスト/チェック

- 既存の `mountSceneSyncShell()` の動作確認
- 新しいランタイムマネージャーの基本動作確認
- 入力アダプタのマウント/アンマウント処理の確認

## リスク

- シェル切り替え中の状態遷移が複雑なため、エッジケースでの動作確認が必要
- 既存コードが `mountSceneSyncShell()` に依存している場合、動作確認が必要

## follow-up tasks

- シェル切り替え時のアニメーション/トランジション効果の追加
- より詳細なエラーレポーティング機能
- シェル切り替え履歴の記録機能

## merge方針

- squash merge
- merge 後に remote branch を削除

https://claude.ai/code/session_01CvLatbeBz6DVrES1LLJuZF