### PR TITLE
[codex] Preserve object audio in room snapshots

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -11756,6 +11756,7 @@ function createCurrentSceneSnapshot() {
     const asset = safeCloneJson(object.userData?.asset || null);
     const metadata = safeCloneJson(object.userData?.metadata || null);
     const animation = serializeObjectAnimationState(object);
+    const audioSources = getObjectAudioSourcesForSerialize(object);
 
     const entry = {
       objectId,
@@ -11771,6 +11772,9 @@ function createCurrentSceneSnapshot() {
 
     if (animation) {
       entry.animation = animation;
+    }
+    if (audioSources) {
+      entry.audioSources = audioSources;
     }
 
     objects.push(entry);
@@ -11945,6 +11949,7 @@ function restoreSnapshotObject(entry, options = {}) {
 
   const asset = safeCloneJson(entry.asset || null);
   const metadata = safeCloneJson(entry.metadata || null) || {};
+  const audioSources = safeCloneJson(entry.audioSources || null);
   const meshPath = entry.meshPath || asset?.meshPath || null;
   const objectId = entry.objectId && !managedObjects.has(entry.objectId)
     ? entry.objectId
@@ -11970,6 +11975,9 @@ function restoreSnapshotObject(entry, options = {}) {
 
   if (entry.animation && typeof entry.animation === 'object') {
     payload.animation = safeCloneJson(entry.animation);
+  }
+  if (audioSources) {
+    payload.audioSources = audioSources;
   }
 
   addOrUpdateObject(objectId, payload, {


### PR DESCRIPTION
## Summary

- Include object `audioSources` when saving local SceneSync room snapshots.
- Restore saved `audioSources` into the `scene-add` payload when rebuilding objects from IndexedDB snapshots.

## Root Cause

Live SceneSync handoff paths already serialized `audioSources`, but the local reload restore path used by `createCurrentSceneSnapshot()` and `restoreSnapshotObject()` omitted it. After reloading a room with no other participants, the scene could be restored from IndexedDB without the object audio component.

## Impact

Object audio settings should now persist across Web SceneSync reloads once a new snapshot is saved after the fix.

## Verification

- `npm run test:audio-source-controller`
- `node --check html/assets/js/scenesync/scene.js`
- `git diff --check --cached`