### PR TITLE
[codex] Preserve object audio during cached GLB reloads

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -8290,6 +8290,9 @@ function getObjectById(objectId) {
 async function loadGlbBlobForObject(objectId, blob, options = {}) {
   const obj = managedObjects.get(objectId);
   const info = options.info || null;
+  const preservedAudioSources = Object.prototype.hasOwnProperty.call(info || {}, 'audioSources')
+    ? info.audioSources
+    : obj?.userData?.audioSources;
   if (!obj && !info) {
     console.warn('[SceneSync] Object not found for loading recovered GLB:', objectId);
     return;
@@ -8412,6 +8415,9 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
     }
     scene.add(wrapper);
     registerLoadedGlbAnimation(objectId, wrapper, 'glb-blob-loaded');
+    if (preservedAudioSources !== undefined) {
+      setObjectAudioSourcesFull(objectId, preservedAudioSources);
+    }
     notifySceneStateChanged('glb-blob-loaded');
     markCrashProbe('glb-scene-attach-success', { objectId });
     clearCrashProbe('glb-object-ready');


### PR DESCRIPTION
## Summary

- Preserve object `audioSources` when a GLB is restored from the local asset cache.
- Apply the audio component before `glb-blob-loaded` schedules the next room snapshot save.

## Root Cause

PR #373 added `audioSources` to the room snapshot save/restore payload, but GLBs restored from IndexedDB asset cache use `loadGlbBlobForObject()` instead of the normal `replaceManagedObject()` path. That cached-load path rebuilt the wrapper object and registered it without reapplying `info.audioSources`, so reloads with cached GLBs still dropped the object audio component.

## Impact

Object audio settings should survive reloads both when the GLB is fetched over the network and when it is loaded from the local asset cache.

## Verification

- `npm run test:audio-source-controller`
- `node --check html/assets/js/scenesync/scene.js`
- `git diff --check -- html/assets/js/scenesync/scene.js`