### PR TITLE
[codex] Add editor player transport controls

### DIFF
--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -331,7 +331,7 @@ export function createAudioSourceController(deps = {}) {
     if (!config?.url) return;
 
     // while edited, freeze playback to start (matches inspector editing UX)
-    if (isObjectBeingEdited(objectId)) {
+    if (isObjectBeingEdited(objectId, clockState)) {
       if (entry.audio) {
         safePause(entry.audio);
         safeSeek(entry.audio, config.offset || 0);

--- a/html/assets/js/scenesync/audio/audio-source-controller.test.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.test.js
@@ -96,6 +96,29 @@ test('updates paused audio immediately when the player timeline seeks', () => {
   assert.equal(audio.currentTime, 8);
 });
 
+test('does not freeze edited audio while player transport is active', () => {
+  let seenClockState = null;
+  const { audio, controller } = createHarness({
+    isObjectBeingEdited: (_objectId, clockState) => {
+      seenClockState = clockState;
+      return !clockState?.transportActive;
+    },
+  });
+
+  controller.tick(0, {
+    mode: 'local',
+    t: 3,
+    isPaused: false,
+    rate: 1,
+    transportActive: true,
+  });
+
+  assert.equal(seenClockState?.transportActive, true);
+  assert.equal(audio.paused, false);
+  assert.equal(audio.pauseCount, 0);
+  assert.equal(audio.currentTime, 3);
+});
+
 test('resyncs audio to animation position after deselect in host-follow mode', () => {
   // Simulate: object was selected (isObjectBeingEdited=true) which forced audio.currentTime=0,
   // then deselected. In host-follow mode getTimelineTargetTime returns null (epoch >> 3600),

--- a/html/assets/js/scenesync/runtime/editing-state.js
+++ b/html/assets/js/scenesync/runtime/editing-state.js
@@ -1,0 +1,56 @@
+function getSceneObjectId(object) {
+  return object?.userData?.objectId || null;
+}
+
+function collectionHasObjectId(collection, objectId) {
+  if (!collection || !objectId) return false;
+  if (typeof collection.has === 'function') return collection.has(objectId);
+  if (Array.isArray(collection)) return collection.includes(objectId);
+  return false;
+}
+
+export function isObjectActivelyEdited({
+  objectId,
+  transformObject = null,
+  xrTwoHand = null,
+  grabbers = [],
+} = {}) {
+  if (!objectId) return false;
+
+  if (getSceneObjectId(transformObject) === objectId) {
+    return true;
+  }
+
+  if (xrTwoHand?.active && getSceneObjectId(xrTwoHand.object) === objectId) {
+    return true;
+  }
+
+  for (const grabber of grabbers || []) {
+    if (grabber?.active && getSceneObjectId(grabber.object) === objectId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function shouldFreezeObjectForEditorRuntime({
+  objectId,
+  selectedObjectIds = null,
+  transformObject = null,
+  xrTwoHand = null,
+  grabbers = [],
+  transportActive = false,
+} = {}) {
+  if (!objectId) return false;
+
+  if (isObjectActivelyEdited({ objectId, transformObject, xrTwoHand, grabbers })) {
+    return true;
+  }
+
+  if (transportActive) {
+    return false;
+  }
+
+  return collectionHasObjectId(selectedObjectIds, objectId);
+}

--- a/html/assets/js/scenesync/runtime/editing-state.test.js
+++ b/html/assets/js/scenesync/runtime/editing-state.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shouldFreezeObjectForEditorRuntime } from './editing-state.js';
+
+function objectWithId(objectId) {
+  return { userData: { objectId } };
+}
+
+test('transport active disables selection-only freeze', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    selectedObjectIds: new Set(['object-1']),
+    transportActive: true,
+  }), false);
+});
+
+test('transport active keeps transform editing frozen', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    selectedObjectIds: new Set(['object-1']),
+    transformObject: objectWithId('object-1'),
+    transportActive: true,
+  }), true);
+});
+
+test('transport active keeps XR two-hand editing frozen', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    xrTwoHand: {
+      active: true,
+      object: objectWithId('object-1'),
+    },
+    transportActive: true,
+  }), true);
+});
+
+test('transport active keeps XR grabber editing frozen', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    grabbers: [
+      { active: false, object: objectWithId('object-1') },
+      { active: true, object: objectWithId('object-1') },
+    ],
+    transportActive: true,
+  }), true);
+});
+
+test('selection freeze remains when transport is inactive', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    selectedObjectIds: new Set(['object-1']),
+    transportActive: false,
+  }), true);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -55,6 +55,7 @@ import { createExpiredGlbRecovery } from './assets/expired-glb-recovery.js';
 import { createRoomSnapshotCache } from './assets/scene-snapshot-cache.js';
 import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './utils/crash-probe-helper.js';
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
+import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
@@ -1514,9 +1515,15 @@ function ensureObjectRuntime(obj) {
   return obj.userData.runtime;
 }
 
-function isRuntimeFrozenForSelection(objectId) {
-  if (!objectId) return false;
-  return selectedObjectIds.has(objectId);
+function shouldFreezeRuntimeForEditor(objectId, clockState = null) {
+  return shouldFreezeObjectForEditorRuntime({
+    objectId,
+    selectedObjectIds,
+    transformObject: transformCtrl.object,
+    xrTwoHand: xrState.twoHand,
+    grabbers: xrState.grabbers,
+    transportActive: clockState?.transportActive === true,
+  });
 }
 
 function getObjectRuntimeTime(objectId, now = performance.now(), clockState = null) {
@@ -1526,8 +1533,9 @@ function getObjectRuntimeTime(objectId, now = performance.now(), clockState = nu
   const runtime = ensureObjectRuntime(obj);
   if (!runtime?.enabled) return 0;
 
-  // selected/edited object: freeze to t=0
-  if (isRuntimeFrozenForSelection(objectId)) {
+  // Freeze selected/actively edited objects, except selection-only freeze is
+  // disabled while the Player transport explicitly owns scene time.
+  if (shouldFreezeRuntimeForEditor(objectId, clockState)) {
     return runtime.selectedTime ?? 0;
   }
 
@@ -2477,6 +2485,7 @@ function serializeObjectAnimationState(obj) {
     clipName,
     mode: raw.mode === 'once' ? 'once' : 'loop',
     speed: Number.isFinite(raw.speed) ? raw.speed : 1,
+    offset: Number.isFinite(raw.offset) ? raw.offset : 0,
   };
 }
 
@@ -4443,6 +4452,7 @@ const sceneClockState = {
   lastUpdateNow: performance.now(),
   lastHostNow: Date.now() / 1000,    // host-follow mode の delta 計算用
   rate: 1,                       // 再生速度倍率
+  transportActive: false,         // Player transport UI がScene Clockを明示制御中
 };
 
 function getSceneClockTime(now = performance.now()) {
@@ -4491,6 +4501,7 @@ function getSceneClockStateForLoomlet(now = performance.now()) {
     mode: sceneClockState.mode,
     rate: sceneClockState.rate,
     hostNow: Date.now() / 1000,
+    transportActive: sceneClockState.transportActive,
   };
 }
 
@@ -4520,6 +4531,8 @@ function setSceneClockMode(mode, now = performance.now()) {
     sceneClockState.localTime = 0;
     sceneClockState.paused = false;
     sceneClockState.pausedAt = null;
+    sceneClockState.lastHostNow = Date.now() / 1000;
+    sceneClockState.lastUpdateNow = now;
   }
 
   sceneClockState.mode = mode;
@@ -4577,6 +4590,20 @@ function followHostClock(now = performance.now()) {
   setSceneClockMode('host-follow', now);
 }
 
+function activateSceneClockTransport(now = performance.now()) {
+  setSceneClockRate(1, now);
+  stopSceneClock(now);
+  sceneClockState.transportActive = true;
+  notifySceneSyncShellStateChanged('scene-clock-transport-activated');
+}
+
+function deactivateSceneClockTransport(now = performance.now()) {
+  setSceneClockRate(1, now);
+  sceneClockState.transportActive = false;
+  followHostClock(now);
+  notifySceneSyncShellStateChanged('scene-clock-transport-deactivated');
+}
+
 function setSceneClockRate(rate, now = performance.now()) {
   const nextRate = Number(rate);
   if (!Number.isFinite(nextRate) || nextRate < 0) return;
@@ -4618,29 +4645,13 @@ function getSceneClockStateForShell() {
     mode: sceneClockState.mode,
     rate: sceneClockState.rate,
     duration: 60,
+    transportActive: sceneClockState.transportActive,
   };
 }
 
 // ── Loom 統合初期化 ──────────────────────────────────
-function isObjectBeingEditedNow(objectId) {
-  if (!objectId) return false;
-
-  if (selectedObjectIds.has(objectId)) return true;
-
-  const transformObjectId = transformCtrl.object?.userData?.objectId;
-  if (transformObjectId === objectId) return true;
-
-  if (xrState.twoHand?.active && xrState.twoHand.object?.userData?.objectId === objectId) {
-    return true;
-  }
-
-  for (const grabber of xrState.grabbers || []) {
-    if (grabber.active && grabber.object?.userData?.objectId === objectId) {
-      return true;
-    }
-  }
-
-  return false;
+function isObjectBeingEditedNow(objectId, clockState = null) {
+  return shouldFreezeRuntimeForEditor(objectId, clockState);
 }
 
 // 指定 GLB clip の現在再生位置を返す（AudioSource の animation 同期補助に使用）。
@@ -12453,6 +12464,9 @@ mountSceneSyncShellFromDom({
     seekSceneClock,
     setSceneClockRate,
     resetSceneClock,
+    followSceneClock: followHostClock,
+    activateSceneClockTransport,
+    deactivateSceneClockTransport,
   },
   getSelection: getSceneSyncShellSelection,
   getEditorState,

--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.js
@@ -1,0 +1,139 @@
+import { createPlayerTransportPanel } from '../player/player-transport.js';
+
+function addListener(target, type, handler, options) {
+  if (!target) return () => {};
+  target.addEventListener(type, handler, options);
+  return () => target.removeEventListener(type, handler, options);
+}
+
+function createToggleButton(label = 'Player') {
+  const button = document.createElement('button');
+  button.className = 'chip';
+  button.type = 'button';
+  button.title = 'Player controls';
+  button.setAttribute('aria-expanded', 'false');
+  button.innerHTML = '<span>Play</span>';
+  button.querySelector('span').textContent = label;
+  return button;
+}
+
+function insertDesktopToggle(button) {
+  const settingsPanel = document.getElementById('settings-panel');
+  if (!settingsPanel) return null;
+
+  const row = document.createElement('div');
+  row.className = 'row mobile-collapsible-row';
+  row.appendChild(button);
+
+  const devRow = document.getElementById('scene-inspector-toggle')?.closest('.row');
+  if (devRow?.parentElement === settingsPanel) {
+    settingsPanel.insertBefore(row, devRow);
+  } else {
+    settingsPanel.appendChild(row);
+  }
+  return row;
+}
+
+function insertMobileToggle(button) {
+  const actions = document.querySelector('#mobile-action-sheet .mobile-sheet-actions');
+  if (!actions) return null;
+
+  const before = document.getElementById('mobile-export-btn');
+  if (before?.parentElement === actions) {
+    actions.insertBefore(button, before);
+  } else {
+    actions.appendChild(button);
+  }
+  return button;
+}
+
+export function createEditorPlayerTransport() {
+  let transport = null;
+  let desktopRow = null;
+  let desktopButton = null;
+  let mobileButton = null;
+  let mountedCore = null;
+  let opened = false;
+  const disposers = [];
+
+  function renderToggleState() {
+    for (const button of [desktopButton, mobileButton]) {
+      if (!button) continue;
+      button.classList.toggle('active', opened);
+      button.setAttribute('aria-expanded', String(opened));
+    }
+  }
+
+  function open(core) {
+    if (opened) return;
+    opened = true;
+    core?.commands?.activateSceneClockTransport?.();
+    transport?.setHidden(false);
+    renderToggleState();
+  }
+
+  function close(core) {
+    if (!opened) return;
+    opened = false;
+    transport?.setHidden(true);
+    core?.commands?.deactivateSceneClockTransport?.();
+    renderToggleState();
+  }
+
+  function toggle(core) {
+    if (opened) close(core);
+    else open(core);
+  }
+
+  return {
+    async mount({ core, root = document.body } = {}) {
+      mountedCore = core;
+      desktopButton = createToggleButton('Player');
+      mobileButton = createToggleButton('Player');
+      desktopRow = insertDesktopToggle(desktopButton);
+      insertMobileToggle(mobileButton);
+
+      transport = createPlayerTransportPanel({
+        title: 'SCENE SYNC · EDITOR PLAYER',
+        className: 'scene-sync-editor-player-panel',
+        closeable: true,
+        hidden: true,
+        onClose: () => close(core),
+      });
+      await transport.mount({ core, root });
+
+      disposers.push(
+        addListener(desktopButton, 'click', () => toggle(core)),
+        addListener(mobileButton, 'click', () => {
+          core?.commands?.closeMobileActionSheet?.();
+          toggle(core);
+        }),
+        addListener(document, 'keydown', (event) => {
+          if (event.key === 'Escape' && opened) {
+            close(core);
+          }
+        })
+      );
+
+      renderToggleState();
+    },
+
+    unmount() {
+      if (opened) {
+        mountedCore?.commands?.deactivateSceneClockTransport?.();
+      }
+      opened = false;
+      for (const dispose of disposers.splice(0)) dispose();
+      transport?.unmount?.();
+      transport = null;
+      desktopRow?.remove();
+      desktopRow = null;
+      mobileButton?.remove();
+      desktopButton = null;
+      mobileButton = null;
+      mountedCore = null;
+    },
+  };
+}
+
+export default createEditorPlayerTransport;

--- a/html/assets/js/scenesync/shells/editor/editor-shell.js
+++ b/html/assets/js/scenesync/shells/editor/editor-shell.js
@@ -1,4 +1,5 @@
 import { createEditorActions } from './editor-actions.js';
+import { createEditorPlayerTransport } from './editor-player-transport.js';
 import { createDesktopEditorLayout } from './layouts/desktop-editor-layout.js';
 import { createMobileEditorLayout } from './layouts/mobile-editor-layout.js';
 import { createXrEditorLayout } from './layouts/xr-editor-layout.js'; // forward placeholder for WebXR/MR editing
@@ -9,6 +10,7 @@ function isMobileSurface() {
 
 export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', availableShellIds = [] } = {}) {
   let layout = null;
+  let playerTransport = null;
 
   return {
     id,
@@ -18,7 +20,7 @@ export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', av
     layouts: ['desktop', 'mobile', 'xr'],
     inputs: ['pointer', 'touch', 'keyboard', 'xr'],
 
-    mount({ core, root } = {}) {
+    async mount({ core, root } = {}) {
       const actions = createEditorActions(core);
 
       document.body.dataset.sceneSyncShell = 'editor';
@@ -30,6 +32,8 @@ export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', av
         : createDesktopEditorLayout();
 
       layout.mount({ core, actions, root });
+      playerTransport = createEditorPlayerTransport();
+      await playerTransport.mount({ core, root });
 
       if (core?.debug) {
         console.debug('[SceneSyncShell] mounted editor shell', {
@@ -41,6 +45,8 @@ export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', av
     },
 
     unmount() {
+      playerTransport?.unmount?.();
+      playerTransport = null;
       layout?.unmount?.();
       layout = null;
       document.body.classList.remove('scene-sync-shell-editor');

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -41,6 +41,11 @@
   -webkit-user-select: none;
 }
 
+.scene-sync-editor-player-panel {
+  bottom: 72px;
+  width: clamp(320px, 54vw, 560px);
+}
+
 /* ── Header ─────────────────────────────────────────── */
 .player-header {
   display: flex;
@@ -57,6 +62,7 @@
 
 .player-badges {
   display: flex;
+  align-items: center;
   gap: 5px;
 }
 
@@ -91,6 +97,25 @@
   background: rgba(251, 191, 36, 0.11);
   color: rgba(253, 224, 71, 0.82);
   border-color: rgba(251, 191, 36, 0.18);
+}
+
+.player-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(226, 232, 240, 0.82);
+  font: 13px/1 monospace;
+  cursor: pointer;
+}
+
+.player-close-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
 }
 
 /* ── Time display ────────────────────────────────────── */
@@ -261,4 +286,25 @@
   background: rgba(99, 102, 241, 0.22);
   color: rgba(165, 180, 252, 0.95);
   border-color: rgba(99, 102, 241, 0.40);
+}
+
+@media (max-width: 720px) {
+  .scene-sync-player-shell {
+    bottom: calc(18px + var(--mobile-safe-bottom, 0px));
+    width: min(560px, calc(100vw - 24px));
+    padding: 14px 14px 16px;
+    border-radius: 14px;
+  }
+
+  .scene-sync-editor-player-panel {
+    bottom: calc(96px + var(--mobile-safe-bottom, 0px));
+  }
+
+  .player-current-time {
+    font-size: 34px;
+  }
+
+  .player-rate-row {
+    flex-wrap: wrap;
+  }
 }

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -1,103 +1,10 @@
-import { createPlayerActions } from './player-actions.js';
+import { createPlayerTransportPanel } from './player-transport.js';
 
-const STYLE_ID = 'scene-sync-player-shell-style';
 const BODY_CLASS = 'scene-sync-shell-player';
-const DEFAULT_DURATION = 60;
-
-async function ensureStylesheet() {
-  if (document.getElementById(STYLE_ID)) return;
-  const link = document.createElement('link');
-  link.id = STYLE_ID;
-  link.rel = 'stylesheet';
-  link.href = new URL('./player-shell.css', import.meta.url).href;
-  document.head.appendChild(link);
-}
-
-function resolvePlayerDuration(core) {
-  return core?.getSceneClockState?.()?.duration ?? DEFAULT_DURATION;
-}
-
-function formatTime(seconds) {
-  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0;
-  const mins = Math.floor(seconds / 60);
-  const secs = (seconds % 60).toFixed(2).padStart(5, '0');
-  return `${String(mins).padStart(2, '0')}:${secs}`;
-}
 
 export function createSceneSyncShell({ id = 'player', requestedId = 'player', availableShellIds = [] } = {}) {
-  let panel = null;
-  let actions = null;
-  let removeStateListener = null;
-  let rafId = null;
-  let isSeeking = false;
-  let lastSeekValue = null;
-
-  function getClockState(core) {
-    return core?.getSceneClockState?.() ?? {};
-  }
-
-  function startLoop(core) {
-    function tick() {
-      updateDisplay(core);
-      rafId = requestAnimationFrame(tick);
-    }
-    tick();
-  }
-
-  function stopLoop() {
-    if (rafId != null) cancelAnimationFrame(rafId);
-    rafId = null;
-  }
-
-  function updateDisplay(core) {
-    if (!panel) return;
-    const state = getClockState(core);
-    const time = Number.isFinite(state.time) ? state.time : (state.t ?? 0);
-    const isPaused = state.isPaused === true || state.playing === false;
-    const mode = state.mode ?? 'local';
-    const rate = state.rate ?? 1;
-    const duration = resolvePlayerDuration(core);
-
-    const timeEl = panel.querySelector('[data-player-current-time]');
-    if (timeEl) timeEl.textContent = formatTime(time);
-
-    if (!isSeeking) {
-      const seekEl = panel.querySelector('[data-player-seek]');
-      if (seekEl) {
-        if (parseFloat(seekEl.max) !== duration) seekEl.max = duration;
-        seekEl.value = Math.min(time, duration);
-      }
-    }
-
-    const playPauseBtn = panel.querySelector('[data-player-play-pause]');
-    if (playPauseBtn) {
-      const playing = !isPaused;
-      if (playPauseBtn.dataset.playerPlaying !== (playing ? '1' : '0')) {
-        playPauseBtn.dataset.playerPlaying = playing ? '1' : '0';
-        playPauseBtn.title = playing ? 'Pause' : 'Play';
-      }
-    }
-
-    const modeEl = panel.querySelector('[data-player-clock-mode]');
-    if (modeEl && modeEl.textContent !== mode) {
-      modeEl.textContent = mode;
-      modeEl.dataset.mode = mode;
-    }
-
-    const statusEl = panel.querySelector('[data-player-clock-status]');
-    if (statusEl) {
-      const pausedStr = isPaused ? '1' : '0';
-      if (statusEl.dataset.paused !== pausedStr) {
-        statusEl.textContent = isPaused ? 'paused' : 'playing';
-        statusEl.dataset.paused = pausedStr;
-      }
-    }
-
-    panel.querySelectorAll('[data-player-rate]').forEach(btn => {
-      const active = String(parseFloat(btn.dataset.playerRate) === rate);
-      if (btn.dataset.active !== active) btn.dataset.active = active;
-    });
-  }
+  let transport = null;
+  let mountedCore = null;
 
   return {
     id,
@@ -107,112 +14,24 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
     layouts: ['desktop', 'mobile'],
     inputs: [],
 
-    async mount({ core } = {}) {
-      await ensureStylesheet();
-
+    async mount({ core, root } = {}) {
+      mountedCore = core;
       document.body.dataset.sceneSyncShell = 'player';
       document.body.classList.add(BODY_CLASS);
       document.body.classList.remove('scene-sync-shell-editor', 'scene-sync-shell-minimal');
 
-      actions = createPlayerActions(core);
-
-      panel = document.createElement('section');
-      panel.className = 'scene-sync-player-shell';
-      panel.setAttribute('aria-label', 'Scene Sync Player');
-      panel.innerHTML = `
-        <header class="player-header">
-          <span class="player-title">SCENE SYNC · PLAYER</span>
-          <div class="player-badges">
-            <span class="player-badge player-badge-mode" data-player-clock-mode data-mode="local">local</span>
-            <span class="player-badge player-badge-status" data-player-clock-status data-paused="1">paused</span>
-          </div>
-        </header>
-        <div class="player-time-display">
-          <span class="player-current-time" data-player-current-time>00:00.00</span>
-        </div>
-        <div class="player-seek-wrap">
-          <input class="player-seek" data-player-seek type="range" min="0" max="60" step="0.01" value="0" />
-        </div>
-        <div class="player-controls">
-          <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <rect x="3" y="3" width="10" height="10" rx="2"/>
-            </svg>
-          </button>
-          <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
-            <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
-              <polygon points="5,2 16,9 5,16"/>
-            </svg>
-            <svg class="icon-pause" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="14" rx="1.5"/>
-              <rect x="11" y="2" width="4" height="14" rx="1.5"/>
-            </svg>
-          </button>
-        </div>
-        <div class="player-rate-row">
-          <span class="player-rate-label">Rate</span>
-          <button class="player-rate-btn" data-player-rate="0.25" type="button">¼×</button>
-          <button class="player-rate-btn" data-player-rate="0.5" type="button">½×</button>
-          <button class="player-rate-btn" data-player-rate="1" type="button" data-active="true">1×</button>
-          <button class="player-rate-btn" data-player-rate="2" type="button">2×</button>
-        </div>
-      `;
-
-      const seekEl = panel.querySelector('[data-player-seek]');
-      seekEl?.addEventListener('pointerdown', () => { isSeeking = true; });
-      seekEl?.addEventListener('input', (e) => {
-        const value = parseFloat(e.target.value);
-        if (!Number.isFinite(value)) return;
-
-        const timeEl = panel.querySelector('[data-player-current-time]');
-        if (timeEl) timeEl.textContent = formatTime(value);
-
-        if (lastSeekValue !== value) {
-          lastSeekValue = value;
-          actions.seek(value);
-        }
+      transport = createPlayerTransportPanel({
+        title: 'SCENE SYNC · PLAYER',
+        activateOnMount: true,
       });
-      seekEl?.addEventListener('change', (e) => {
-        const value = parseFloat(e.target.value);
-        if (Number.isFinite(value)) {
-          if (lastSeekValue !== value) {
-            lastSeekValue = value;
-            actions.seek(value);
-          }
-        }
-        isSeeking = false;
-      });
-
-      panel.querySelector('[data-player-play-pause]')?.addEventListener('click', () => {
-        const state = getClockState(core);
-        const isPaused = state.isPaused === true || state.playing === false;
-        if (isPaused) actions.play();
-        else actions.pause();
-      });
-
-      panel.querySelector('[data-player-stop]')?.addEventListener('click', () => actions.stop());
-
-      panel.querySelectorAll('[data-player-rate]').forEach(btn => {
-        btn.addEventListener('click', () => {
-          const rate = parseFloat(btn.dataset.playerRate);
-          if (Number.isFinite(rate)) actions.setRate(rate);
-        });
-      });
-
-      document.body.appendChild(panel);
-      removeStateListener = core?.onStateChange?.(() => updateDisplay(core)) ?? null;
-      startLoop(core);
+      await transport.mount({ core, root: root || document.body });
     },
 
     unmount() {
-      stopLoop();
-      removeStateListener?.();
-      removeStateListener = null;
-      panel?.remove();
-      panel = null;
-      actions = null;
-      isSeeking = false;
-      lastSeekValue = null;
+      mountedCore?.commands?.deactivateSceneClockTransport?.();
+      transport?.unmount?.();
+      transport = null;
+      mountedCore = null;
       document.body.classList.remove(BODY_CLASS);
       delete document.body.dataset.sceneSyncShell;
     },

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -1,0 +1,253 @@
+import { createPlayerActions } from './player-actions.js';
+
+const STYLE_ID = 'scene-sync-player-shell-style';
+const DEFAULT_DURATION = 60;
+
+export async function ensurePlayerTransportStylesheet() {
+  if (document.getElementById(STYLE_ID)) return;
+  const link = document.createElement('link');
+  link.id = STYLE_ID;
+  link.rel = 'stylesheet';
+  link.href = new URL('./player-shell.css', import.meta.url).href;
+  document.head.appendChild(link);
+}
+
+function resolvePlayerDuration(core) {
+  return core?.getSceneClockState?.()?.duration ?? DEFAULT_DURATION;
+}
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0;
+  const mins = Math.floor(seconds / 60);
+  const secs = (seconds % 60).toFixed(2).padStart(5, '0');
+  return `${String(mins).padStart(2, '0')}:${secs}`;
+}
+
+function createPanelHtml({ title, closeable }) {
+  return `
+    <header class="player-header">
+      <span class="player-title">${title}</span>
+      <div class="player-badges">
+        <span class="player-badge player-badge-mode" data-player-clock-mode data-mode="local">local</span>
+        <span class="player-badge player-badge-status" data-player-clock-status data-paused="1">paused</span>
+        ${closeable ? '<button class="player-close-btn" data-player-close type="button" title="Close">x</button>' : ''}
+      </div>
+    </header>
+    <div class="player-time-display">
+      <span class="player-current-time" data-player-current-time>00:00.00</span>
+    </div>
+    <div class="player-seek-wrap">
+      <input class="player-seek" data-player-seek type="range" min="0" max="60" step="0.01" value="0" />
+    </div>
+    <div class="player-controls">
+      <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <rect x="3" y="3" width="10" height="10" rx="2"/>
+        </svg>
+      </button>
+      <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
+        <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+          <polygon points="5,2 16,9 5,16"/>
+        </svg>
+        <svg class="icon-pause" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+          <rect x="3" y="2" width="4" height="14" rx="1.5"/>
+          <rect x="11" y="2" width="4" height="14" rx="1.5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="player-rate-row">
+      <span class="player-rate-label">Rate</span>
+      <button class="player-rate-btn" data-player-rate="0.25" type="button">1/4x</button>
+      <button class="player-rate-btn" data-player-rate="0.5" type="button">1/2x</button>
+      <button class="player-rate-btn" data-player-rate="1" type="button" data-active="true">1x</button>
+      <button class="player-rate-btn" data-player-rate="2" type="button">2x</button>
+    </div>
+  `;
+}
+
+export function createPlayerTransportPanel({
+  title = 'SCENE SYNC · PLAYER',
+  className = '',
+  closeable = false,
+  hidden = false,
+  activateOnMount = false,
+  onClose = null,
+} = {}) {
+  let panel = null;
+  let actions = null;
+  let removeStateListener = null;
+  let rafId = null;
+  let isSeeking = false;
+  let lastSeekValue = null;
+  let mountedCore = null;
+  const disposers = [];
+
+  function getClockState(core) {
+    return core?.getSceneClockState?.() ?? {};
+  }
+
+  function updateDisplay(core) {
+    if (!panel) return;
+    const state = getClockState(core);
+    const time = Number.isFinite(state.time) ? state.time : (state.t ?? 0);
+    const isPaused = state.isPaused === true || state.playing === false;
+    const mode = state.mode ?? 'local';
+    const rate = state.rate ?? 1;
+    const duration = resolvePlayerDuration(core);
+
+    const timeEl = panel.querySelector('[data-player-current-time]');
+    if (timeEl) timeEl.textContent = formatTime(time);
+
+    if (!isSeeking) {
+      const seekEl = panel.querySelector('[data-player-seek]');
+      if (seekEl) {
+        if (parseFloat(seekEl.max) !== duration) seekEl.max = duration;
+        seekEl.value = Math.min(time, duration);
+      }
+    }
+
+    const playPauseBtn = panel.querySelector('[data-player-play-pause]');
+    if (playPauseBtn) {
+      const playing = !isPaused;
+      if (playPauseBtn.dataset.playerPlaying !== (playing ? '1' : '0')) {
+        playPauseBtn.dataset.playerPlaying = playing ? '1' : '0';
+        playPauseBtn.title = playing ? 'Pause' : 'Play';
+      }
+    }
+
+    const modeEl = panel.querySelector('[data-player-clock-mode]');
+    if (modeEl && modeEl.textContent !== mode) {
+      modeEl.textContent = mode;
+      modeEl.dataset.mode = mode;
+    }
+
+    const statusEl = panel.querySelector('[data-player-clock-status]');
+    if (statusEl) {
+      const pausedStr = isPaused ? '1' : '0';
+      if (statusEl.dataset.paused !== pausedStr) {
+        statusEl.textContent = isPaused ? 'paused' : 'playing';
+        statusEl.dataset.paused = pausedStr;
+      }
+    }
+
+    panel.querySelectorAll('[data-player-rate]').forEach(btn => {
+      const active = String(parseFloat(btn.dataset.playerRate) === rate);
+      if (btn.dataset.active !== active) btn.dataset.active = active;
+    });
+  }
+
+  function startLoop(core) {
+    function tick() {
+      updateDisplay(core);
+      rafId = requestAnimationFrame(tick);
+    }
+    tick();
+  }
+
+  function stopLoop() {
+    if (rafId != null) cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+
+  return {
+    get element() {
+      return panel;
+    },
+
+    async mount({ core, root = document.body } = {}) {
+      await ensurePlayerTransportStylesheet();
+      mountedCore = core;
+      actions = createPlayerActions(core);
+
+      panel = document.createElement('section');
+      panel.className = ['scene-sync-player-shell', className].filter(Boolean).join(' ');
+      panel.setAttribute('aria-label', title);
+      panel.hidden = hidden;
+      panel.innerHTML = createPanelHtml({ title, closeable });
+
+      const seekEl = panel.querySelector('[data-player-seek]');
+      disposers.push(
+        addListener(seekEl, 'pointerdown', () => { isSeeking = true; }),
+        addListener(seekEl, 'input', (e) => {
+          const value = parseFloat(e.target.value);
+          if (!Number.isFinite(value)) return;
+
+          const timeEl = panel.querySelector('[data-player-current-time]');
+          if (timeEl) timeEl.textContent = formatTime(value);
+
+          if (lastSeekValue !== value) {
+            lastSeekValue = value;
+            actions.seek(value);
+          }
+        }),
+        addListener(seekEl, 'change', (e) => {
+          const value = parseFloat(e.target.value);
+          if (Number.isFinite(value) && lastSeekValue !== value) {
+            lastSeekValue = value;
+            actions.seek(value);
+          }
+          isSeeking = false;
+        }),
+        addListener(panel.querySelector('[data-player-play-pause]'), 'click', () => {
+          const state = getClockState(core);
+          const isPaused = state.isPaused === true || state.playing === false;
+          if (isPaused) actions.play();
+          else actions.pause();
+        }),
+        addListener(panel.querySelector('[data-player-stop]'), 'click', () => actions.stop())
+      );
+
+      panel.querySelectorAll('[data-player-rate]').forEach(btn => {
+        disposers.push(addListener(btn, 'click', () => {
+          const rate = parseFloat(btn.dataset.playerRate);
+          if (Number.isFinite(rate)) actions.setRate(rate);
+        }));
+      });
+
+      if (closeable) {
+        disposers.push(addListener(panel.querySelector('[data-player-close]'), 'click', () => {
+          onClose?.();
+        }));
+      }
+
+      root.appendChild(panel);
+      removeStateListener = core?.onStateChange?.(() => updateDisplay(core)) ?? null;
+      if (activateOnMount) core?.commands?.activateSceneClockTransport?.();
+      if (!hidden) {
+        startLoop(core);
+      }
+    },
+
+    setHidden(nextHidden) {
+      if (!panel) return;
+      const shouldHide = !!nextHidden;
+      if (panel.hidden === shouldHide) return;
+      panel.hidden = shouldHide;
+      if (shouldHide) {
+        stopLoop();
+      } else {
+        updateDisplay(mountedCore);
+        startLoop(mountedCore);
+      }
+    },
+
+    unmount() {
+      stopLoop();
+      removeStateListener?.();
+      removeStateListener = null;
+      for (const dispose of disposers.splice(0)) dispose();
+      panel?.remove();
+      panel = null;
+      actions = null;
+      mountedCore = null;
+      isSeeking = false;
+      lastSeekValue = null;
+    },
+  };
+}
+
+function addListener(target, type, handler, options) {
+  if (!target) return () => {};
+  target.addEventListener(type, handler, options);
+  return () => target.removeEventListener(type, handler, options);
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test:audio-source-controller": "node --test html/assets/js/scenesync/audio/audio-source-controller.test.js",
+    "test:editing-state": "node --test html/assets/js/scenesync/runtime/editing-state.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds Player-style transport controls to the Editor shell. The controls are hidden by default and can be opened from the new `Player` button.

When the Editor Player UI is open, Scene Sync uses the Player transport's local Scene Clock time. Closing the UI returns the scene to the normal `host-follow` clock. While transport is active, selected objects are no longer frozen at `t = 0`, so animation and AudioSource playback can be checked in the Editor against the same timeline used by the Player shell.

## Details

- Extracted the Player transport panel into a shared module used by both Player and Editor shells.
- Added an Editor transport toggle for desktop and mobile editor surfaces.
- Added Scene Clock transport activation/deactivation commands.
- Propagated `transportActive` into runtime/audio timing so selected objects can play in sync while the Editor transport is visible.
- Preserved `animation.offset` in serialized animation state.
- Added AudioSource coverage for transport-active edited objects.

## Validation

- `npm run test:editing-state`
- `node --check html/assets/js/scenesync/audio/audio-source-controller.test.js`
- `node --check html/assets/js/scenesync/audio/audio-source-controller.js`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/player/player-transport.js`
- `node --check html/assets/js/scenesync/shells/editor/editor-player-transport.js`
- `npm run test:audio-source-controller`
- `npm run test:glb-normalizer`
- `git diff --check`

