### PR TITLE
[codex] Use animation length for player duration

### DIFF
--- a/html/assets/js/scenesync/runtime/playback-duration.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.js
@@ -1,0 +1,62 @@
+export const DEFAULT_SCENE_PLAYBACK_DURATION = 60;
+
+function isPositiveFiniteNumber(value) {
+  return Number.isFinite(value) && value > 0;
+}
+
+function getClipDuration(clip) {
+  return isPositiveFiniteNumber(clip?.duration) ? clip.duration : 0;
+}
+
+function clampClipIndex(value, clipCount) {
+  const index = Number.parseInt(value, 10);
+  if (!Number.isFinite(index)) return 0;
+  return Math.max(0, Math.min(Math.max(0, clipCount - 1), index));
+}
+
+function normalizeSpeed(value) {
+  return isPositiveFiniteNumber(value) ? value : 1;
+}
+
+function getCompanionClipIndices(entry) {
+  if (Array.isArray(entry?.companionClipIndices)) {
+    return entry.companionClipIndices;
+  }
+  if (Array.isArray(entry?.companionActions)) {
+    return entry.companionActions.map((companion) => companion?.clipIndex);
+  }
+  return [];
+}
+
+export function calculateAnimationEntryPlaybackDuration(entry) {
+  if (!entry || entry.enabled === false) return 0;
+
+  const clips = Array.isArray(entry.clips) ? entry.clips : [];
+  if (clips.length === 0) return 0;
+
+  const clipIndex = clampClipIndex(entry.clipIndex ?? entry.clip, clips.length);
+  let duration = getClipDuration(clips[clipIndex]);
+
+  for (const index of getCompanionClipIndices(entry)) {
+    const companionIndex = clampClipIndex(index, clips.length);
+    duration = Math.max(duration, getClipDuration(clips[companionIndex]));
+  }
+
+  if (duration <= 0) return 0;
+  return duration / normalizeSpeed(entry.speed);
+}
+
+export function calculateScenePlaybackDuration({
+  animationEntries = [],
+  defaultDuration = DEFAULT_SCENE_PLAYBACK_DURATION,
+} = {}) {
+  let duration = isPositiveFiniteNumber(defaultDuration)
+    ? defaultDuration
+    : DEFAULT_SCENE_PLAYBACK_DURATION;
+
+  for (const entry of animationEntries) {
+    duration = Math.max(duration, calculateAnimationEntryPlaybackDuration(entry));
+  }
+
+  return Math.ceil(duration * 100) / 100;
+}

--- a/html/assets/js/scenesync/runtime/playback-duration.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.js
@@ -19,13 +19,13 @@ function normalizeSpeed(value) {
 }
 
 function getCompanionClipIndices(entry) {
+  let indices = [];
   if (Array.isArray(entry?.companionClipIndices)) {
-    return entry.companionClipIndices;
+    indices = entry.companionClipIndices;
+  } else if (Array.isArray(entry?.companionActions)) {
+    indices = entry.companionActions.map((companion) => companion?.clipIndex);
   }
-  if (Array.isArray(entry?.companionActions)) {
-    return entry.companionActions.map((companion) => companion?.clipIndex);
-  }
-  return [];
+  return indices.filter((index) => Number.isInteger(index));
 }
 
 export function calculateAnimationEntryPlaybackDuration(entry) {
@@ -43,7 +43,16 @@ export function calculateAnimationEntryPlaybackDuration(entry) {
   }
 
   if (duration <= 0) return 0;
-  return duration / normalizeSpeed(entry.speed);
+  const speed = Number(entry.speed);
+  if (speed === 0) return 0;
+
+  const normalizedSpeed = normalizeSpeed(speed);
+  if (entry.mode === 'once') {
+    const offset = Number.isFinite(entry.offset) ? entry.offset : 0;
+    return Math.max(0, duration - offset) / normalizedSpeed;
+  }
+
+  return duration / normalizedSpeed;
 }
 
 export function calculateScenePlaybackDuration({

--- a/html/assets/js/scenesync/runtime/playback-duration.test.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.test.js
@@ -44,12 +44,46 @@ test('includes companion morph clips for the active animation', () => {
   assert.equal(duration, 96);
 });
 
+test('uses cached companionActions clip indices', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      clips: [{ duration: 48 }, { duration: 96 }],
+      clipIndex: 0,
+      companionActions: [{ clipIndex: 1 }],
+    }],
+  });
+
+  assert.equal(duration, 96);
+});
+
 test('accounts for animation speed', () => {
   assert.equal(calculateAnimationEntryPlaybackDuration({
     clips: [{ duration: 120 }],
     clipIndex: 0,
     speed: 2,
   }), 60);
+});
+
+test('accounts for negative animation offset in once mode', () => {
+  assert.equal(calculateAnimationEntryPlaybackDuration({
+    clips: [{ duration: 120 }],
+    clipIndex: 0,
+    speed: 1,
+    offset: -30,
+    mode: 'once',
+  }), 150);
+});
+
+test('ignores zero-speed animation entries', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      clips: [{ duration: 180 }],
+      clipIndex: 0,
+      speed: 0,
+    }],
+  });
+
+  assert.equal(duration, 60);
 });
 
 test('ignores disabled animation entries', () => {

--- a/html/assets/js/scenesync/runtime/playback-duration.test.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  calculateAnimationEntryPlaybackDuration,
+  calculateScenePlaybackDuration,
+} from './playback-duration.js';
+
+test('keeps the default duration for empty scenes', () => {
+  assert.equal(calculateScenePlaybackDuration(), 60);
+});
+
+test('uses the currently selected animation clip, not the longest clip', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      clips: [{ duration: 24 }, { duration: 120 }],
+      clipIndex: 0,
+    }],
+  });
+
+  assert.equal(duration, 60);
+});
+
+test('extends duration when the selected animation clip is longer than the default', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      clips: [{ duration: 24 }, { duration: 120 }],
+      clipIndex: 1,
+    }],
+  });
+
+  assert.equal(duration, 120);
+});
+
+test('includes companion morph clips for the active animation', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      clips: [{ duration: 48 }, { duration: 96 }, { duration: 8 }],
+      clipIndex: 0,
+      companionClipIndices: [1],
+    }],
+  });
+
+  assert.equal(duration, 96);
+});
+
+test('accounts for animation speed', () => {
+  assert.equal(calculateAnimationEntryPlaybackDuration({
+    clips: [{ duration: 120 }],
+    clipIndex: 0,
+    speed: 2,
+  }), 60);
+});
+
+test('ignores disabled animation entries', () => {
+  const duration = calculateScenePlaybackDuration({
+    animationEntries: [{
+      enabled: false,
+      clips: [{ duration: 180 }],
+      clipIndex: 0,
+    }],
+  });
+
+  assert.equal(duration, 60);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -56,6 +56,7 @@ import { createRoomSnapshotCache } from './assets/scene-snapshot-cache.js';
 import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './utils/crash-probe-helper.js';
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
 import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
+import { calculateScenePlaybackDuration } from './runtime/playback-duration.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
@@ -2616,6 +2617,35 @@ function updateObjectGlbAnimations(now = performance.now(), clockState = null) {
   }
 }
 
+function getSceneAnimationPlaybackEntries() {
+  const entries = [];
+
+  for (const [objectId, entry] of glbAnimationMixers) {
+    const obj = managedObjects.get(objectId);
+    if (!obj || !Array.isArray(entry?.clips) || entry.clips.length === 0) continue;
+
+    const state = getObjectAnimationState(obj);
+    if (!state?.enabled) continue;
+
+    const clipIndex = clampAnimationClipIndex(state.clip, entry.clips.length);
+    entries.push({
+      enabled: state.enabled,
+      clips: entry.clips,
+      clipIndex,
+      companionClipIndices: getCompanionMorphClipIndices(entry.clips, clipIndex),
+      speed: state.speed,
+    });
+  }
+
+  return entries;
+}
+
+function getScenePlaybackDuration() {
+  return calculateScenePlaybackDuration({
+    animationEntries: getSceneAnimationPlaybackEntries(),
+  });
+}
+
 function showTemporaryImagePreview(objectId, file, position, options = {}) {
   if (!objectId || !file) return;
 
@@ -4695,6 +4725,7 @@ function stopSceneClock(now = performance.now()) {
 function getSceneClockStateForShell() {
   const rawTime = getSceneClockTime();
   const displayTime = sceneClockState.mode === 'host-follow' ? 0 : rawTime;
+  const duration = getScenePlaybackDuration();
   return {
     time: displayTime,
     t: displayTime,
@@ -4702,7 +4733,7 @@ function getSceneClockStateForShell() {
     playing: !sceneClockState.paused && sceneClockState.mode === 'local',
     mode: sceneClockState.mode,
     rate: sceneClockState.rate,
-    duration: 60,
+    duration,
     transportActive: sceneClockState.transportActive,
   };
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2244,6 +2244,7 @@ function setupObjectGlbAnimation(objectId, model) {
     clips,
     action,
     clipIndex,
+    companionClipIndices,
     companionActions,
   });
 }
@@ -2430,6 +2431,7 @@ function updateObjectGlbAnimationClip(objectId, nextClipIndex) {
 
   entry.action = action;
   entry.clipIndex = clipIndex;
+  entry.companionClipIndices = companionClipIndices;
   entry.companionActions = companionActions;
 
   const obj = managedObjects.get(objectId);
@@ -2632,8 +2634,12 @@ function getSceneAnimationPlaybackEntries() {
       enabled: state.enabled,
       clips: entry.clips,
       clipIndex,
-      companionClipIndices: getCompanionMorphClipIndices(entry.clips, clipIndex),
+      companionClipIndices: Array.isArray(entry.companionClipIndices)
+        ? entry.companionClipIndices
+        : (entry.companionActions || []).map((companion) => companion?.clipIndex),
       speed: state.speed,
+      offset: state.offset,
+      mode: state.mode,
     });
   }
 

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -12,8 +12,9 @@ export async function ensurePlayerTransportStylesheet() {
   document.head.appendChild(link);
 }
 
-function resolvePlayerDuration(core) {
-  return core?.getSceneClockState?.()?.duration ?? DEFAULT_DURATION;
+function resolvePlayerDuration(core, state = null) {
+  const duration = state?.duration ?? core?.getSceneClockState?.()?.duration;
+  return Number.isFinite(duration) && duration > 0 ? duration : DEFAULT_DURATION;
 }
 
 function formatTime(seconds) {
@@ -93,7 +94,7 @@ export function createPlayerTransportPanel({
     const isPaused = state.isPaused === true || state.playing === false;
     const mode = state.mode ?? 'local';
     const rate = state.rate ?? 1;
-    const duration = resolvePlayerDuration(core);
+    const duration = resolvePlayerDuration(core, state);
 
     const timeEl = panel.querySelector('[data-player-current-time]');
     if (timeEl) timeEl.textContent = formatTime(time);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test:audio-source-controller": "node --test html/assets/js/scenesync/audio/audio-source-controller.test.js",
     "test:editing-state": "node --test html/assets/js/scenesync/runtime/editing-state.test.js",
-    "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js"
+    "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
+    "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",


### PR DESCRIPTION
## Summary
- Replace the fixed 60s Scene Sync player duration with a dynamic duration derived from active GLB animation clips.
- Use each object's currently selected animation clip, include companion morph clips, and account for animation speed while preserving the 60s minimum.
- Avoid an extra `getSceneClockState()` call in the player transport and add focused duration calculation tests.

## Impact
The Player seek range now grows when the selected animation is longer than 60 seconds, without being stretched by unrelated clips on the same GLB.

## Validation
- `npm run test:playback-duration`
- `npm run test:editing-state`
- `npm run test:audio-source-controller`
- `npm run test:glb-normalizer`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/player/player-transport.js`