### PR TITLE
[codex] Remove editor input mode toggle

### DIFF
--- a/docs/scene-sync-shells.md
+++ b/docs/scene-sync-shells.md
@@ -233,7 +233,7 @@ Player Shell runs a `requestAnimationFrame` loop for smooth time display. The lo
 
 ## Editor Shell v4: Edit command + state API and chrome wiring migration
 
-The Editor Shell shell-ization is completed by exposing the remaining edit operations as commands and by moving the editor chrome (mode toggle + transform toolbar) click wiring out of `scene.js` into the layouts.
+The Editor Shell shell-ization is completed by exposing the remaining edit operations as commands and by moving editor chrome wiring out of `scene.js` into the layouts. The standard Editor Shell no longer exposes Edit/Interact switching; it mounts in `edit` input routing mode.
 
 ### New edit commands (`core.commands`)
 
@@ -242,10 +242,10 @@ The Editor Shell shell-ization is completed by exposing the remaining edit opera
 | `setTransformMode(mode)` | Switch gizmo mode: `'translate' \| 'rotate' \| 'scale'` |
 | `duplicateSelected()` | Duplicate the selected object |
 | `deselect()` | Clear the current selection |
-| `setInputRoutingMode(mode)` | Set `'edit' \| 'interact'` |
-| `toggleInputRoutingMode()` | Toggle Edit/Interact (shows a toast) |
 
 These join the existing commands (`openAddMenu`, `undo`, `redo`, `deleteSelected`, `exportScene`, `openHelp`, `startAiLink`, `open/close/toggleSceneInspector`, `closeMobileActionSheet`, scene-clock transport).
+
+Input routing remains a core capability for shell-specific controls: `setInputRoutingMode(mode)` is still exposed by core for Viewer / Studio / future shells that intentionally switch between `'edit'` and `'interact'`. It is not wrapped as a standard Editor action, and the standard Editor does not expose an input-routing mode switch.
 
 ### Edit state snapshot (`core.getEditorState()`)
 
@@ -268,11 +268,12 @@ Any shell can read a unified edit-state snapshot and re-render on `core.onStateC
 
 ### Chrome wiring migration
 
-- `desktop-editor-layout.js` now wires `#mode` → `actions.toggleInputRoutingMode()` (the button is desktop-only; hidden on mobile).
+- The standard Editor has no mode button and does not wire Edit/Interact switching.
+- `editor-shell.js` resets input routing to `'edit'` when the standard Editor mounts so state from Viewer / Studio does not leak back into editing.
 - `mobile-editor-layout.js` now wires the transform toolbar (`#btn-move/rotate/scale/copy/delete/deselect`) → editor actions.
 - The corresponding `addEventListener` calls were removed from `scene.js` to avoid double-firing.
 
-**Remaining in core (`scene.js`)**: transform gizmo, raycast selection, the toolbar's *visual* state writes (`showToolbar`/`hideToolbar`/`updateToolbarActive`/`updateInputRoutingModeUI`, enable/disable on selection), drag & drop, Inspector internal editing, AI Link pairing, presence/history implementation. The W/E/R keyboard shortcuts also remain in `scene.js` (input-adapter migration is future work).
+**Remaining in core (`scene.js`)**: transform gizmo, raycast selection, toolbar state notifications (`showToolbar`/`hideToolbar`/`updateToolbarActive`, enable/disable on selection), input routing state for shell-specific controls, drag & drop, Inspector internal editing, AI Link pairing, presence/history implementation. The W/E/R keyboard shortcuts also remain in `scene.js` (input-adapter migration is future work).
 
 > Dev note: editor shell modules are loaded via dynamic `import()`. After editing them, a normal reload may serve a cached module; use a hard reload (Cmd/Ctrl+Shift+R) during development.
 
@@ -322,7 +323,7 @@ Scene Sync Core (`scene.js`) exposes a stable surface to shells via `mountSceneS
 | `duplicateSelected()` | Duplicate the selected object |
 | `deselect()` | Clear the selection |
 | `setTransformMode(mode)` | `'translate' \| 'rotate' \| 'scale'` |
-| `setInputRoutingMode(mode)` / `toggleInputRoutingMode()` | `'edit' \| 'interact'` |
+| `setInputRoutingMode(mode)` | `'edit' \| 'interact'`; for Viewer / Studio / shell-specific controls, not exposed by the standard Editor |
 | `setEnvironment(envId)` | Change & broadcast HDRI environment |
 | `resetView()` | Reset orbit camera to default |
 | `exportScene()` / `openHelp()` / `startAiLink()` | Misc editor actions |
@@ -370,7 +371,7 @@ html/assets/js/scenesync/shells/editor/inputs/
 
 ## Editor chrome fully shell-owned (v4 follow-up)
 
-`scene.js` no longer writes editor DOM. `shells/editor/editor-chrome.js` renders `#mode`, `#mobile-toolbar` and `#history-toolbar` (label / visibility / active / disabled) from `getEditorState()` and wires undo/redo clicks. Both desktop and mobile editor layouts mount it. Core keeps only the *state* (`editorToolbarVisible` + notifications), not the DOM.
+`scene.js` no longer writes editor DOM. `shells/editor/editor-chrome.js` renders `#mobile-toolbar` and `#history-toolbar` (visibility / active / disabled) from `getEditorState()` and wires undo/redo clicks. Both desktop and mobile editor layouts mount it. Core keeps only the *state* (`editorToolbarVisible` + notifications), not the DOM.
 
 ## Viewer Shell
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -228,12 +228,11 @@ dom.clearBgmButton?.addEventListener('click', () => {
   notifySceneStateChanged('bgm-cleared');
 });
 
-// Input routing mode toggle。#mode の DOM 反映は editor shell（editor-chrome.js）が担う。
+// Input routing mode is local-only shell state. Standard Editor stays in edit mode,
+// while Viewer/Studio can set interact mode through commands.
 function updateInputRoutingModeUI() {
   notifySceneSyncShellStateChanged('input-routing-mode-changed');
 }
-
-// #mode クリック配線は Editor Shell の desktop layout へ移管（actions.toggleInputRoutingMode）。
 
 setupXrButtons({
   renderer,
@@ -2893,12 +2892,6 @@ function setInputRoutingMode(mode) {
   notifySceneSyncShellStateChanged('input-routing-mode-changed');
 }
 
-function toggleInputRoutingMode() {
-  const nextMode = inputRoutingMode === 'edit' ? 'interact' : 'edit';
-  setInputRoutingMode(nextMode);
-  showToast(`Mode: ${nextMode.toUpperCase()}`);
-}
-
 function enqueueLoomletHostEvent(objectId, eventName) {
   if (!objectId || !eventName) return;
   if (!loomletHostEvents.has(objectId)) {
@@ -4133,7 +4126,7 @@ function deleteSelectedObjects() {
 }
 
 // ── モバイルツールバー（DOM 反映は editor shell 側） ──────────────
-// editor chrome（#mode / #mobile-toolbar / #history-toolbar）の DOM は
+// editor chrome（#mobile-toolbar / #history-toolbar）の DOM は
 // すべて editor shell の editor-chrome.js が getEditorState を見て描画する。
 // core は表示意図（editorToolbarVisible）と状態通知のみを保持する。
 
@@ -12558,7 +12551,6 @@ mountSceneSyncShellFromDom({
     duplicateSelected: duplicateSelectedObject,
     deselect: () => clearSelection({ reason: 'selection-cleared-shell' }),
     setInputRoutingMode,
-    toggleInputRoutingMode,
     // Environment / view
     setEnvironment: (envId) => {
       if (typeof envId !== 'string' || !envId) return;

--- a/html/assets/js/scenesync/shells/editor/editor-actions.js
+++ b/html/assets/js/scenesync/shells/editor/editor-actions.js
@@ -39,12 +39,6 @@ export function createEditorActions(core) {
     deselect() {
       core?.commands?.deselect?.();
     },
-    setInputRoutingMode(mode) {
-      core?.commands?.setInputRoutingMode?.(mode);
-    },
-    toggleInputRoutingMode() {
-      core?.commands?.toggleInputRoutingMode?.();
-    },
   };
 }
 

--- a/html/assets/js/scenesync/shells/editor/editor-chrome.js
+++ b/html/assets/js/scenesync/shells/editor/editor-chrome.js
@@ -1,6 +1,6 @@
 // Editor chrome の DOM 反映を一手に担うモジュール。
 // core は状態（getEditorState）と通知（onStateChange）のみを提供し、
-// #mode / #mobile-toolbar / #history-toolbar の実際の DOM 更新と
+// #mobile-toolbar / #history-toolbar の実際の DOM 更新と
 // undo/redo のクリック配線はここ（editor shell 側）で行う。
 // desktop / mobile どちらの layout からも mount して共有する。
 
@@ -12,7 +12,6 @@ function addListener(target, type, handler, options) {
 
 export function createEditorChrome(core) {
   const els = {
-    mode: document.getElementById('mode'),
     toolbar: document.getElementById('mobile-toolbar'),
     btnMove: document.getElementById('btn-move'),
     btnRotate: document.getElementById('btn-rotate'),
@@ -28,13 +27,6 @@ export function createEditorChrome(core) {
 
   function render() {
     const s = core?.getEditorState?.() || {};
-
-    // #mode（Edit / Interact）
-    if (els.mode) {
-      const interact = s.inputRoutingMode === 'interact';
-      els.mode.textContent = `Mode: ${interact ? 'Interact' : 'Edit'}`;
-      els.mode.classList.toggle('interact', interact);
-    }
 
     // #mobile-toolbar 表示/非表示
     if (els.toolbar) {

--- a/html/assets/js/scenesync/shells/editor/editor-shell.js
+++ b/html/assets/js/scenesync/shells/editor/editor-shell.js
@@ -26,6 +26,7 @@ export function createSceneSyncShell({ id = 'editor', requestedId = 'editor', av
       document.body.dataset.sceneSyncShell = 'editor';
       document.body.classList.add('scene-sync-shell-editor');
       document.body.classList.remove('scene-sync-shell-minimal');
+      core?.commands?.setInputRoutingMode?.('edit');
 
       layout = isMobileSurface()
         ? createMobileEditorLayout()

--- a/html/assets/js/scenesync/shells/editor/layouts/desktop-editor-layout.js
+++ b/html/assets/js/scenesync/shells/editor/layouts/desktop-editor-layout.js
@@ -25,15 +25,13 @@ export function createDesktopEditorLayout() {
       const linkBtn = document.getElementById('link-btn');
       const sceneInspectorToggleBtn = document.getElementById('scene-inspector-toggle');
       const sceneInspectorCloseBtn = document.getElementById('scene-inspector-close');
-      const modeBtn = document.getElementById('mode'); // Edit/Interact 切替（desktop のみ表示）
 
       disposers.push(
         addListener(exportBtn, 'click', () => actions?.exportScene?.()),
         addListener(helpBtn, 'click', () => actions?.openHelp?.()),
         addListener(linkBtn, 'click', () => actions?.startAiLink?.()),
         addListener(sceneInspectorToggleBtn, 'click', () => core?.commands?.toggleSceneInspector?.()),
-        addListener(sceneInspectorCloseBtn, 'click', () => actions?.closeSceneInspector?.()),
-        addListener(modeBtn, 'click', () => actions?.toggleInputRoutingMode?.())
+        addListener(sceneInspectorCloseBtn, 'click', () => actions?.closeSceneInspector?.())
       );
     },
 

--- a/html/assets/js/scenesync/shells/minimal/minimal-shell.css
+++ b/html/assets/js/scenesync/shells/minimal/minimal-shell.css
@@ -5,7 +5,6 @@
 .scene-sync-shell-minimal #add-btn,
 .scene-sync-shell-minimal #history-toolbar,
 .scene-sync-shell-minimal #mobile-toolbar,
-.scene-sync-shell-minimal #mode,
 .scene-sync-shell-minimal #xr-toggle-btn,
 .scene-sync-shell-minimal #xr-calibrate-btn {
   display: none !important;

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -5,8 +5,7 @@
 .scene-sync-shell-player #scene-clock-panel,
 .scene-sync-shell-player #history-toolbar,
 .scene-sync-shell-player #mobile-toolbar,
-.scene-sync-shell-player #add-btn,
-.scene-sync-shell-player #mode {
+.scene-sync-shell-player #add-btn {
   display: none !important;
 }
 

--- a/html/assets/js/scenesync/shells/studio/studio-shell.css
+++ b/html/assets/js/scenesync/shells/studio/studio-shell.css
@@ -4,8 +4,7 @@
 .scene-sync-shell-studio #scene-clock-panel,
 .scene-sync-shell-studio #history-toolbar,
 .scene-sync-shell-studio #mobile-toolbar,
-.scene-sync-shell-studio #add-btn,
-.scene-sync-shell-studio #mode {
+.scene-sync-shell-studio #add-btn {
   display: none !important;
 }
 /* Keep: canvas, #toast, #scene-inspector-panel（Properties）, #xr-button-container */

--- a/html/assets/js/scenesync/shells/viewer/viewer-shell.css
+++ b/html/assets/js/scenesync/shells/viewer/viewer-shell.css
@@ -6,7 +6,6 @@
 .scene-sync-shell-viewer #history-toolbar,
 .scene-sync-shell-viewer #mobile-toolbar,
 .scene-sync-shell-viewer #add-btn,
-.scene-sync-shell-viewer #mode,
 .scene-sync-shell-viewer #status {
   display: none !important;
 }

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -37,10 +37,6 @@
       display: none !important;
     }
 
-    body.scene-sync-device-mobile #mode {
-      display: none !important;
-    }
-
     /* ── 共通 chip スタイル ── */
     .chip {
       display: inline-flex;
@@ -148,33 +144,6 @@
     }
     .room-input:focus { border-color: rgba(68,136,255,0.7); }
 
-    #mode {
-      position: fixed;
-      bottom: 12px;
-      left: 50%;
-      transform: translateX(-50%);
-      padding: 6px 14px;
-      border-radius: 6px;
-      font: 13px/1.4 monospace;
-      color: #fff;
-      background: rgba(0,0,0,0.55);
-      border: none;
-      cursor: pointer;
-      z-index: 10;
-      user-select: none;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-    }
-    #mode:hover {
-      background: rgba(0,0,0,0.75);
-    }
-    #mode.interact {
-      background: rgba(68,136,255,0.55);
-      color: #fff;
-    }
-    #mode.interact:hover {
-      background: rgba(68,136,255,0.8);
-    }
     #add-btn {
       position: fixed;
       bottom: 12px;
@@ -1608,7 +1577,6 @@
       </div>
     </div>
   </div>
-  <button id="mode" type="button" title="W: Move / E: Rotate / R: Scale">Mode: Edit</button>
   <div id="toast"></div>
   <div id="history-toolbar">
     <button id="btn-undo" class="tb-btn" title="取り消す (Ctrl+Z)">↶</button>


### PR DESCRIPTION
## Summary
- Remove the standard Editor `Mode: Edit / Interact` button, styles, and click wiring.
- Remove Editor shell actions for toggling input routing mode.
- Keep the internal input routing command for Viewer/Studio, and force the standard Editor shell back to `edit` mode when mounted.
- Remove stale `#mode` hide rules from shell CSS.

## Impact
The standard Editor no longer exposes the edit/interact switch. Viewer and Studio can still opt into interact mode through their shell-specific controls.

## Validation
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/editor/editor-shell.js`
- `node --check html/assets/js/scenesync/shells/editor/editor-actions.js`
- `node --check html/assets/js/scenesync/shells/editor/editor-chrome.js`
- `node --check html/assets/js/scenesync/shells/editor/layouts/desktop-editor-layout.js`
- `npm run test:editing-state`
- `npm run test:playback-duration`
- `npm run test:audio-source-controller`
- `npm run test:glb-normalizer`