### PR TITLE
[codex] Retry mesh blob fetches

### DIFF
--- a/html/assets/js/scenesync/assets/expired-glb-recovery.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.js
@@ -72,7 +72,7 @@ export function createExpiredGlbRecovery({
           console.warn('[ExpiredGlbRecovery] Error in recovery failed callback:', err);
         }
       });
-      return;
+      return { started: false, requestId, reason: 'no-peers' };
     }
 
     const request = {
@@ -132,6 +132,8 @@ export function createExpiredGlbRecovery({
         });
       }
     }, RECOVERY_TIMEOUT_MS);
+
+    return { started: true, requestId, peerCount: peers.length };
   }
 
   async function handleSceneAssetRequest({ payload, from }) {

--- a/html/assets/js/scenesync/assets/expired-glb-recovery.test.js
+++ b/html/assets/js/scenesync/assets/expired-glb-recovery.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createExpiredGlbRecovery } from './expired-glb-recovery.js';
+
+test('reports recovery unavailable when no peers can provide the missing GLB', async () => {
+  const recovery = createExpiredGlbRecovery({
+    assetCache: {},
+    fileTransfer: {},
+    presenceState: {
+      id: 'local-peer',
+      peers: [],
+    },
+    sendHandoff() {
+      throw new Error('sendHandoff should not be called without peers');
+    },
+    async loadGlbBlobForObject() {},
+  });
+
+  let failure = null;
+  recovery.onRecoveryFailed((event) => {
+    failure = event;
+  });
+
+  const result = await recovery.handleMissingGlb(
+    'object-1',
+    'mesh-1',
+    1024,
+    'asset-1',
+    { name: 'Model' }
+  );
+
+  assert.equal(result.started, false);
+  assert.equal(result.reason, 'no-peers');
+  assert.equal(typeof result.requestId, 'string');
+  assert.equal(failure.objectId, 'object-1');
+  assert.equal(failure.reason, 'no-peers');
+  assert.deepEqual(failure.info, { name: 'Model' });
+});

--- a/html/assets/js/scenesync/assets/mesh-blob-fetch.js
+++ b/html/assets/js/scenesync/assets/mesh-blob-fetch.js
@@ -1,0 +1,107 @@
+const DEFAULT_MESH_BLOB_FETCH_RETRY_DELAYS_MS = [750];
+
+function waitForMeshRetry(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function readContentLength(headers) {
+  const contentEncoding = headers?.get?.('content-encoding');
+  if (contentEncoding && contentEncoding.toLowerCase() !== 'identity') {
+    return null;
+  }
+
+  const raw = headers?.get?.('content-length');
+  if (!raw) return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+export function decorateMeshFetchError(error, fields = {}) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  Object.assign(err, fields);
+  return err;
+}
+
+export function shouldRetryMeshFetchError(error) {
+  const status = Number(error?.status || 0);
+  if (status === 404) return false;
+  if (error?.retryable === false) return false;
+  if (!status) return true;
+  return status >= 500 || status === 408 || status === 429;
+}
+
+export async function fetchMeshBlobWithRetry(url, options = {}) {
+  const {
+    objectId = null,
+    meshPath = null,
+    retryDelaysMs = DEFAULT_MESH_BLOB_FETCH_RETRY_DELAYS_MS,
+    fetchImpl = globalThis.fetch,
+    logger = console,
+  } = options;
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetchMeshBlobWithRetry requires fetch');
+  }
+
+  let lastError = null;
+  const maxAttemptIndex = retryDelaysMs.length;
+
+  for (let attemptIndex = 0; attemptIndex <= maxAttemptIndex; attemptIndex++) {
+    if (attemptIndex > 0) {
+      await waitForMeshRetry(retryDelaysMs[attemptIndex - 1]);
+    }
+
+    try {
+      const response = await fetchImpl(url, { cache: 'no-store' });
+      const expectedSize = readContentLength(response.headers);
+
+      if (!response.ok) {
+        throw decorateMeshFetchError(
+          new Error(`HTTP ${response.status} loading mesh`),
+          {
+            status: response.status,
+            expectedSize,
+            retryable: shouldRetryMeshFetchError({ status: response.status }),
+          }
+        );
+      }
+
+      try {
+        const blob = await response.blob();
+        if (expectedSize !== null && blob.size !== expectedSize) {
+          throw decorateMeshFetchError(
+            new Error(`Mesh blob size mismatch: expected ${expectedSize}, got ${blob.size}`),
+            {
+              expectedSize,
+              actualSize: blob.size,
+              retryable: true,
+            }
+          );
+        }
+        return { blob, expectedSize };
+      } catch (blobErr) {
+        throw decorateMeshFetchError(blobErr, {
+          expectedSize,
+          retryable: true,
+        });
+      }
+    } catch (err) {
+      lastError = err;
+      if (!shouldRetryMeshFetchError(err) || attemptIndex >= maxAttemptIndex) {
+        throw err;
+      }
+
+      logger?.warn?.('[SceneSync] Mesh fetch failed; retrying', {
+        objectId,
+        meshPath,
+        attempt: attemptIndex + 1,
+        maxAttempts: maxAttemptIndex + 1,
+        status: err?.status || null,
+        expectedSize: err?.expectedSize || null,
+        error: err?.message || String(err),
+      });
+    }
+  }
+
+  throw lastError || new Error('Mesh fetch failed');
+}

--- a/html/assets/js/scenesync/assets/mesh-blob-fetch.test.js
+++ b/html/assets/js/scenesync/assets/mesh-blob-fetch.test.js
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  fetchMeshBlobWithRetry,
+  shouldRetryMeshFetchError,
+} from './mesh-blob-fetch.js';
+
+function responseWithBlob({
+  status = 200,
+  size = 4,
+  contentLength = size,
+  contentEncoding = null,
+} = {}) {
+  const headers = new Headers();
+  if (contentLength !== null) {
+    headers.set('content-length', String(contentLength));
+  }
+  if (contentEncoding) {
+    headers.set('content-encoding', contentEncoding);
+  }
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    async blob() {
+      return new Blob([new Uint8Array(size)]);
+    },
+  };
+}
+
+test('retries when the response body read fails after a 200', async () => {
+  let calls = 0;
+  const result = await fetchMeshBlobWithRetry('https://example.test/blob/model', {
+    retryDelaysMs: [0],
+    logger: null,
+    fetchImpl: async () => {
+      calls++;
+      if (calls === 1) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-length': '4' }),
+          async blob() {
+            throw new TypeError('network body failed');
+          },
+        };
+      }
+      return responseWithBlob({ size: 4 });
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.blob.size, 4);
+  assert.equal(result.expectedSize, 4);
+});
+
+test('keeps final body read failure metadata after retries are exhausted', async () => {
+  let calls = 0;
+
+  await assert.rejects(
+    fetchMeshBlobWithRetry('https://example.test/blob/model', {
+      retryDelaysMs: [0],
+      logger: null,
+      fetchImpl: async () => {
+        calls++;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-length': '4' }),
+          async blob() {
+            throw new TypeError('network body failed');
+          },
+        };
+      },
+    }),
+    (err) => {
+      assert.equal(err.expectedSize, 4);
+      assert.equal(err.retryable, true);
+      return true;
+    }
+  );
+
+  assert.equal(calls, 2);
+});
+
+test('does not retry expired blobs', async () => {
+  let calls = 0;
+
+  await assert.rejects(
+    fetchMeshBlobWithRetry('https://example.test/blob/missing', {
+      retryDelaysMs: [0],
+      logger: null,
+      fetchImpl: async () => {
+        calls++;
+        return responseWithBlob({ status: 404, size: 0, contentLength: 0 });
+      },
+    }),
+    (err) => err.status === 404
+  );
+
+  assert.equal(calls, 1);
+});
+
+test('retries retryable HTTP failures', async () => {
+  let calls = 0;
+  const result = await fetchMeshBlobWithRetry('https://example.test/blob/model', {
+    retryDelaysMs: [0],
+    logger: null,
+    fetchImpl: async () => {
+      calls++;
+      return calls === 1
+        ? responseWithBlob({ status: 503, size: 0, contentLength: 0 })
+        : responseWithBlob({ size: 8 });
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.blob.size, 8);
+});
+
+test('treats content-length mismatch as retryable', async () => {
+  let calls = 0;
+  const result = await fetchMeshBlobWithRetry('https://example.test/blob/model', {
+    retryDelaysMs: [0],
+    logger: null,
+    fetchImpl: async () => {
+      calls++;
+      return calls === 1
+        ? responseWithBlob({ size: 3, contentLength: 4 })
+        : responseWithBlob({ size: 4, contentLength: 4 });
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.blob.size, 4);
+});
+
+test('allows successful responses without content-length', async () => {
+  let calls = 0;
+  const result = await fetchMeshBlobWithRetry('https://example.test/blob/model', {
+    retryDelaysMs: [0],
+    logger: null,
+    fetchImpl: async () => {
+      calls++;
+      return responseWithBlob({ size: 7, contentLength: null });
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.blob.size, 7);
+  assert.equal(result.expectedSize, null);
+});
+
+test('skips size validation for encoded responses', async () => {
+  let calls = 0;
+  const result = await fetchMeshBlobWithRetry('https://example.test/blob/model', {
+    retryDelaysMs: [0],
+    logger: null,
+    fetchImpl: async () => {
+      calls++;
+      return responseWithBlob({ size: 12, contentLength: 4, contentEncoding: 'gzip' });
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.blob.size, 12);
+  assert.equal(result.expectedSize, null);
+});
+
+test('keeps non-retryable client errors non-retryable', () => {
+  assert.equal(shouldRetryMeshFetchError({ status: 400 }), false);
+  assert.equal(shouldRetryMeshFetchError({ status: 408 }), true);
+  assert.equal(shouldRetryMeshFetchError(new TypeError('network failed')), true);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -52,6 +52,7 @@ import { computeAssetId } from './assets/asset-id.js';
 import { createSceneAssetCache } from './assets/asset-cache.js';
 import { createSceneSyncFileTransferAdapter } from './assets/file-transfer-adapter.js';
 import { createExpiredGlbRecovery } from './assets/expired-glb-recovery.js';
+import { fetchMeshBlobWithRetry } from './assets/mesh-blob-fetch.js';
 import { createRoomSnapshotCache } from './assets/scene-snapshot-cache.js';
 import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './utils/crash-probe-helper.js';
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
@@ -6994,6 +6995,63 @@ function addOrUpdateObject(objectId, info, options = {}) {
   notifySceneStateChanged('managed-object-updated');
 }
 
+async function recoverUnavailableMeshBlob({
+  objectId,
+  info,
+  meshPath,
+  existing,
+  assetId,
+  expectedSize,
+  options,
+  reason,
+}) {
+  removeLoadingOverlay(objectId);
+
+  let cachedBeforeRecovery = null;
+  try {
+    cachedBeforeRecovery = assetId
+      ? await assetCache.getByAssetId(assetId)
+      : await assetCache.getByMeshPath(meshPath);
+  } catch (cacheErr) {
+    console.warn('[asset-cache] recovery pre-check failed:', cacheErr);
+  }
+
+  if (cachedBeforeRecovery?.blob) {
+    await loadGlbBlobForObject(objectId, cachedBeforeRecovery.blob, {
+      info,
+      existing,
+      meshPath,
+      assetId: cachedBeforeRecovery.assetId || assetId || null,
+    });
+    cleanupPreviewForLoadedObject(options);
+    return true;
+  }
+
+  console.warn('[SceneSync] Mesh blob unavailable; requesting recovery', {
+    objectId,
+    meshPath,
+    assetId,
+    expectedSize,
+    reason,
+  });
+
+  addRecoveringOverlay(objectId, info);
+  const recoveryResult = await expiredGlbRecovery.handleMissingGlb(
+    objectId,
+    meshPath,
+    expectedSize,
+    assetId,
+    info
+  );
+  if (recoveryResult?.started === false) {
+    removeRecoveringOverlay(objectId);
+    return false;
+  }
+
+  cleanupPreviewForLoadedObject(options);
+  return true;
+}
+
 function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
   removeFailedOverlay(objectId);
   removeRecoveringOverlay(objectId);
@@ -7066,51 +7124,50 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
         console.warn('[asset-cache] lookup failed, falling back to network fetch:', cacheErr);
       }
 
-      const response = await fetch(url);
-      if (!response.ok) {
-        if (response.status === 404) {
+      let blob = null;
+      try {
+        const result = await fetchMeshBlobWithRetry(url, { objectId, meshPath });
+        blob = result.blob;
+      } catch (fetchErr) {
+        const status = Number(fetchErr?.status || 0);
+        if (status === 404) {
           console.warn('[SceneSync] Mesh blob expired (404):', meshPath);
-          removeLoadingOverlay(objectId);
+        } else {
+          console.warn('[SceneSync] Mesh fetch failed after retry:', {
+            objectId,
+            meshPath,
+            status: status || null,
+            expectedSize: fetchErr?.expectedSize || null,
+            error: fetchErr?.message || String(fetchErr),
+          });
+        }
 
-          const assetId = incomingAssetId;
-          const expectedSize = null;
-          let cachedBeforeRecovery = null;
-
-          try {
-            cachedBeforeRecovery = assetId
-              ? await assetCache.getByAssetId(assetId)
-              : await assetCache.getByMeshPath(meshPath);
-          } catch (cacheErr) {
-            console.warn('[asset-cache] recovery pre-check failed:', cacheErr);
-          }
-
-          if (cachedBeforeRecovery?.blob) {
-            await loadGlbBlobForObject(objectId, cachedBeforeRecovery.blob, {
-              info,
-              existing,
-              meshPath,
-              assetId: cachedBeforeRecovery.assetId || assetId || null,
-            });
+        const recoveryHandled = await recoverUnavailableMeshBlob({
+          objectId,
+          info,
+          meshPath,
+          existing,
+          assetId: incomingAssetId,
+          expectedSize: fetchErr?.expectedSize || null,
+          options,
+          reason: status === 404 ? 'http-404' : 'fetch-failed',
+        });
+        if (!recoveryHandled) {
+          removeFailedOverlay(objectId);
+          if (removedObjectIds.has(objectId)) {
             cleanupPreviewForLoadedObject(options);
             return;
           }
-
-          addRecoveringOverlay(objectId, info);
-          await expiredGlbRecovery.handleMissingGlb(
-            objectId,
-            meshPath,
-            expectedSize,
-            assetId,
-            info
-          );
+          if (!existing && !skipFallbackOnFailure) {
+            replaceManagedObject(objectId, buildDefaultBoxObject(objectId, info, 0xff4444), info);
+          } else if (!suppressSnapshotSaveOnFailure) {
+            notifySceneStateChanged('mesh-load-failed');
+          }
           cleanupPreviewForLoadedObject(options);
-
-          return;
         }
-        throw new Error(`HTTP ${response.status} loading mesh`);
+        return;
       }
 
-      const blob = await response.blob();
       const objectUrl = URL.createObjectURL(blob);
       let loadCompleted = false;
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test:audio-source-controller": "node --test html/assets/js/scenesync/audio/audio-source-controller.test.js",
     "test:editing-state": "node --test html/assets/js/scenesync/runtime/editing-state.test.js",
+    "test:expired-glb-recovery": "node --test html/assets/js/scenesync/assets/expired-glb-recovery.test.js",
+    "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js"
   },


### PR DESCRIPTION
## Summary
- Add a dedicated mesh blob fetch helper with retry support for transient network/body read failures.
- Route Scene Sync mesh loading through the retry helper before falling back to cached assets or peer recovery.
- Return an explicit recovery-start status from expired GLB recovery so no-peer cases fall back to the normal mesh-load failure path instead of staying in recovery state.
- Add tests for 200-after-body-failure retry, retry exhaustion, retryable HTTP failures, content-length handling, encoded responses, and no-peer recovery fallback.

## Why
Unity-published GLB loads can fail in the browser with `net::ERR_FAILED 200 (OK)`, which indicates the response headers arrived but the body did not finish reading. The previous path immediately replaced the model with a red placeholder after that failure. This change retries once and then uses the existing asset recovery path. If recovery cannot start because no peer can provide the asset, the loader returns to the normal failure fallback.

## Validation
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/assets/mesh-blob-fetch.js`
- `node --check html/assets/js/scenesync/assets/expired-glb-recovery.js`
- `npm run test:mesh-blob-fetch`
- `npm run test:expired-glb-recovery`
- `npm run test:audio-source-controller`
- `npm run test:playback-duration`
- `npm run test:glb-normalizer`