### PR TITLE
[codex] Export static scene assets

### DIFF
--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -76,10 +76,15 @@ test('export package construction', async (t) => {
     const expectedViewerFiles = [
       'viewer/viewer.js',
       'viewer/create-viewer-core.js',
+      'viewer/object-audio-controller.js',
       'viewer/static-asset-resolver.js',
       'viewer/scene-document.js',
       'viewer/viewer.css',
     ];
+    const destPaths = VIEWER_SOURCES.map(s => s.dest);
+    for (const f of expectedViewerFiles) {
+      assert.ok(destPaths.includes(f), `VIEWER_SOURCES should contain ${f}`);
+    }
     // All expected paths start with viewer/
     for (const f of expectedViewerFiles) {
       assert.ok(f.startsWith('viewer/'));

--- a/apps/presence-server/tests/collect-export-assets.test.mjs
+++ b/apps/presence-server/tests/collect-export-assets.test.mjs
@@ -150,6 +150,88 @@ test('collectExportAssets', async (t) => {
     }
   });
 
+  await t.test('collects object audioSource assets and rewrites audio path', async () => {
+    const audioBuf = new ArrayBuffer(6);
+    const restore = mockFetch({
+      'https://example.com/audio/speaker.mp3': audioBuf,
+    });
+
+    try {
+      const doc = makeSceneDoc([{
+        id: 'speaker-1',
+        asset: { type: 'primitive', primitive: 'box', color: '#ff0000' },
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        audioSources: {
+          default: {
+            type: 'audioSource',
+            name: 'default',
+            url: 'https://example.com/audio/speaker.mp3',
+            volume: 0.7,
+            loop: true,
+            playOnAwake: true,
+          },
+        },
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: null,
+        envOrigin: null,
+      });
+
+      const obj = result.document.objects[0];
+      const audioPath = obj.audioSources.default.asset.path;
+      assert.ok(audioPath.startsWith('assets/'), `audio path should be in assets/, got: ${audioPath}`);
+      assert.ok(audioPath.endsWith('.mp3'));
+      assert.ok(result.files[audioPath], 'audio file should be included in ZIP files');
+      assert.equal(result.missingAssets.length, 0);
+      assert.equal(result.assetManifest[0].kind, 'audioSource');
+      assert.equal(result.assetManifest[0].objectId, 'speaker-1');
+      assert.equal(result.assetManifest[0].name, 'default');
+    } finally {
+      restore();
+    }
+  });
+
+  await t.test('records missing object audioSource asset when fetch fails', async () => {
+    const restore = mockFetch({});
+
+    try {
+      const doc = makeSceneDoc([{
+        id: 'speaker-missing',
+        asset: { type: 'primitive', primitive: 'box', color: '#ff0000' },
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        audioSources: {
+          default: {
+            type: 'audioSource',
+            name: 'default',
+            url: 'https://example.com/missing.wav',
+          },
+        },
+      }]);
+
+      const result = await collectExportAssets({
+        sceneDocument: doc,
+        blobBase: null,
+        envOrigin: null,
+      });
+
+      const missing = result.missingAssets[0];
+      assert.equal(missing.id, 'speaker-missing:default');
+      assert.equal(missing.kind, 'audioSource');
+      assert.equal(missing.reason, 'fetch-failed');
+      assert.equal(result.document.objects[0].audioSources.default.asset.path, null);
+    } finally {
+      restore();
+    }
+  });
+
   await t.test('rewrites remote asset path to /presence/blob → assets/', async () => {
     const buf = new ArrayBuffer(4);
     const restore = mockFetch({

--- a/apps/presence-server/tests/export-scene-document.test.mjs
+++ b/apps/presence-server/tests/export-scene-document.test.mjs
@@ -14,6 +14,9 @@ function makeMockObject(objectId, overrides = {}) {
       asset: overrides.asset || null,
       meshPath: overrides.meshPath || null,
       animationState: overrides.animationState || null,
+      metadata: overrides.metadata || undefined,
+      audioSources: overrides.audioSources || undefined,
+      scenesync: overrides.scenesync || undefined,
       role: overrides.role || undefined,
       nonSerializable: overrides.nonSerializable || false,
       _temporary: overrides._temporary || false,
@@ -91,6 +94,85 @@ test('createSceneDocumentFromSceneSyncState', async (t) => {
     assert.equal(obj.animation.enabled, true);
     assert.equal(obj.animation.clip, 1);
     assert.equal(obj.animation.speed, 1.5);
+  });
+
+  await t.test('includes animation clipName and offset when present', () => {
+    const managedObjects = new Map();
+    managedObjects.set('model-anim', makeMockObject('model-anim', {
+      asset: { type: 'mesh', meshPath: 'anim-path' },
+      animationState: { enabled: true, clip: 1, clipName: 'Run', mode: 'once', speed: 0.75, offset: 2.25 },
+    }));
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const obj = doc.objects.find(o => o.id === 'model-anim');
+    assert.equal(obj.animation.clipName, 'Run');
+    assert.equal(obj.animation.offset, 2.25);
+    assert.equal(obj.animation.mode, 'once');
+  });
+
+  await t.test('includes metadata and normalized object audio sources', () => {
+    const managedObjects = new Map();
+    managedObjects.set('speaker-1', makeMockObject('speaker-1', {
+      asset: { type: 'primitive', primitive: 'box', color: '#fff' },
+      metadata: { role: 'speaker', accepts: ['audio'] },
+      audioSources: {
+        default: {
+          url: 'https://example.com/sound.mp3',
+          volume: 0.4,
+          loop: true,
+          playOnAwake: true,
+          offset: 1.5,
+          playbackRate: 1.25,
+          spatial: false,
+        },
+        empty: { url: '' },
+      },
+    }));
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const obj = doc.objects.find(o => o.id === 'speaker-1');
+    assert.deepEqual(obj.metadata, { role: 'speaker', accepts: ['audio'] });
+    assert.equal(Object.keys(obj.audioSources).length, 1);
+    assert.equal(obj.audioSources.default.url, 'https://example.com/sound.mp3');
+    assert.equal(obj.audioSources.default.volume, 0.4);
+    assert.equal(obj.audioSources.default.loop, true);
+    assert.equal(obj.audioSources.default.playOnAwake, true);
+    assert.equal(obj.audioSources.default.offset, 1.5);
+    assert.equal(obj.audioSources.default.playbackRate, 1.25);
+    assert.equal(obj.audioSources.default.spatial, false);
+  });
+
+  await t.test('includes text layout and scroll state', () => {
+    const managedObjects = new Map();
+    managedObjects.set('text-1', makeMockObject('text-1', {
+      asset: {
+        type: 'text',
+        source: 'inline',
+        text: 'hello',
+        layout: { width: 3.2, height: 1.1, padding: 0.2, lineHeight: 1.4, mode: 'scroll' },
+        scroll: { y: 0.5 },
+      },
+    }));
+
+    const doc = createSceneDocumentFromSceneSyncState({
+      managedObjects,
+      bgmState: null,
+      envId: null,
+    });
+
+    const obj = doc.objects.find(o => o.id === 'text-1');
+    assert.deepEqual(obj.asset.layout, { width: 3.2, height: 1.1, padding: 0.2, lineHeight: 1.4, mode: 'scroll' });
+    assert.deepEqual(obj.asset.scroll, { y: 0.5 });
   });
 
   await t.test('excludes nonSerializable objects', () => {

--- a/apps/presence-server/tests/object-audio-controller.test.mjs
+++ b/apps/presence-server/tests/object-audio-controller.test.mjs
@@ -1,0 +1,166 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createObjectAudioController } from '../../../html/assets/js/scenesync-export/viewer/object-audio-controller.js';
+
+class FakeAudio {
+  constructor(url) {
+    this.src = url;
+    this.preload = '';
+    this.loop = false;
+    this.volume = 1;
+    this.playbackRate = 1;
+    this.currentTime = 0;
+    this.duration = 10;
+    this.paused = true;
+    this.playCalls = 0;
+    this.pauseCalls = 0;
+    this.loadCalls = 0;
+  }
+
+  play() {
+    this.playCalls += 1;
+    this.paused = false;
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.pauseCalls += 1;
+    this.paused = true;
+  }
+
+  load() {
+    this.loadCalls += 1;
+  }
+
+  addEventListener() {}
+
+  removeAttribute(name) {
+    if (name === 'src') this.src = '';
+  }
+}
+
+function makeController({ audioSources, getAnimationSample = null } = {}) {
+  const created = [];
+  const resolver = {
+    resolveAsset: (asset) => asset?.path || null,
+  };
+
+  const controller = createObjectAudioController({
+    sceneDoc: {
+      objects: [
+        {
+          id: 'speaker-1',
+          audioSources,
+        },
+      ],
+    },
+    resolver,
+    getAnimationSample,
+    createAudio: (url) => {
+      const audio = new FakeAudio(url);
+      created.push(audio);
+      return audio;
+    },
+    now: () => 0,
+  });
+
+  return { controller, created };
+}
+
+test('static object AudioSource controller', async (t) => {
+  await t.test('plays only sources whose desired state is playing', async () => {
+    const { controller, created } = makeController({
+      audioSources: {
+        ambience: { name: 'ambience', url: 'ambience.mp3', playOnAwake: true },
+        narration: { name: 'narration', url: 'narration.mp3', state: 'playing' },
+        click: { name: 'click', url: 'click.mp3' },
+      },
+    });
+
+    assert.equal(controller.elements.length, 3);
+    assert.deepEqual(controller.getPlaybackTargetElements().map((audio) => audio.src), [
+      'ambience.mp3',
+      'narration.mp3',
+    ]);
+
+    controller.tick(0);
+    assert.equal(created[0].playCalls, 1);
+    assert.equal(created[1].playCalls, 1);
+    assert.equal(created[2].playCalls, 0);
+
+    controller.pausePlaybackTargets();
+    assert.equal(created[0].paused, true);
+    assert.equal(created[1].paused, true);
+    assert.equal(created[2].playCalls, 0);
+
+    await controller.playPlaybackTargets();
+    assert.equal(created[0].playCalls, 2);
+    assert.equal(created[1].playCalls, 2);
+    assert.equal(created[2].playCalls, 0);
+  });
+
+  await t.test('syncs playing audio sources to animation samples', () => {
+    let sampleTime = 2;
+    const { controller, created } = makeController({
+      audioSources: {
+        default: {
+          name: 'default',
+          url: 'music.mp3',
+          state: 'playing',
+          loop: true,
+          offset: 0.5,
+          sync: {
+            mode: 'animation',
+            animationClipName: 'Run',
+            offset: 1,
+            driftThreshold: 0,
+          },
+        },
+      },
+      getAnimationSample: (_objectId, clipName) => (
+        clipName === 'Run' ? { time: sampleTime, duration: 10 } : null
+      ),
+    });
+
+    controller.tick(0);
+    assert.ok(Math.abs(created[0].currentTime - 3.5) < 0.001);
+
+    sampleTime = 9.8;
+    controller.tick(16);
+    assert.ok(Math.abs(created[0].currentTime - 1.3) < 0.001);
+  });
+
+  await t.test('routes syncToAnimation and unsync effects', () => {
+    let sampleTime = 4;
+    const { controller, created } = makeController({
+      audioSources: {
+        default: {
+          name: 'default',
+          url: 'voice.mp3',
+          state: 'playing',
+          sync: null,
+        },
+      },
+      getAnimationSample: () => ({ time: sampleTime, duration: 10 }),
+    });
+
+    controller.applyEffect({
+      type: 'audioSource.syncToAnimation',
+      objectId: 'speaker-1',
+      name: 'default',
+      sync: { offset: 0.25 },
+    });
+    controller.tick(0);
+    assert.ok(Math.abs(created[0].currentTime - 4.25) < 0.001);
+
+    controller.applyEffect({
+      type: 'audioSource.unsync',
+      objectId: 'speaker-1',
+      name: 'default',
+    });
+    created[0].currentTime = 1;
+    sampleTime = 7;
+    controller.tick(16);
+    assert.equal(created[0].currentTime, 1);
+  });
+});

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -7,6 +7,7 @@ import { generateReadme, generateReadmeHtml } from './export-readme.js';
 export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync-export/viewer/static-viewer-entry.js', dest: 'viewer/viewer.js' },
   { src: '/assets/js/scenesync-export/viewer/create-viewer-core.js', dest: 'viewer/create-viewer-core.js' },
+  { src: '/assets/js/scenesync-export/viewer/object-audio-controller.js', dest: 'viewer/object-audio-controller.js' },
   { src: '/assets/js/scenesync-export/viewer/static-asset-resolver.js', dest: 'viewer/static-asset-resolver.js' },
   { src: '/assets/js/scenesync-export/viewer/scene-document.js', dest: 'viewer/scene-document.js' },
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },

--- a/html/assets/js/scenesync-export/export/collect-export-assets.js
+++ b/html/assets/js/scenesync-export/export/collect-export-assets.js
@@ -19,6 +19,16 @@ function extensionFor(mime, fallback = 'bin') {
   return fallback;
 }
 
+function audioExtForUrl(url) {
+  if (typeof url !== 'string') return 'mp3';
+  const clean = url.split(/[?#]/)[0].toLowerCase();
+  if (clean.endsWith('.ogg') || clean.endsWith('.oga')) return 'ogg';
+  if (clean.endsWith('.wav')) return 'wav';
+  if (clean.endsWith('.m4a') || clean.endsWith('.mp4')) return 'm4a';
+  if (clean.endsWith('.webm')) return 'webm';
+  return 'mp3';
+}
+
 async function tryFetch(url) {
   if (!url) return null;
   try {
@@ -96,17 +106,86 @@ export async function collectExportAssets({
     return 'mp4';
   }
 
+  async function withCollectedAudioSources(obj) {
+    if (!obj?.audioSources || typeof obj.audioSources !== 'object' || Array.isArray(obj.audioSources)) {
+      return obj;
+    }
+
+    const updatedAudioSources = {};
+    let changed = false;
+
+    for (const [name, source] of Object.entries(obj.audioSources)) {
+      if (!source || typeof source !== 'object') {
+        updatedAudioSources[name] = source;
+        continue;
+      }
+
+      const existingPath = source.asset?.path;
+      if (existingPath) {
+        updatedAudioSources[name] = source;
+        continue;
+      }
+
+      const audioUrl = source.url;
+      if (!audioUrl) {
+        updatedAudioSources[name] = source;
+        continue;
+      }
+
+      const zipPath = uniquePath(sanitizeFilename(`${obj.id}-${name || 'audio'}`), audioExtForUrl(audioUrl));
+      const buffer = await tryFetch(audioUrl);
+      changed = true;
+
+      if (buffer) {
+        files[zipPath] = buffer;
+        assetManifest.push({
+          id: `${obj.id}:${name}`,
+          objectId: obj.id,
+          kind: 'audioSource',
+          name,
+          path: zipPath,
+          status: 'included',
+        });
+        updatedAudioSources[name] = {
+          ...source,
+          asset: {
+            ...(source.asset || {}),
+            path: zipPath,
+          },
+        };
+      } else {
+        missingAssets.push({
+          id: `${obj.id}:${name}`,
+          objectId: obj.id,
+          kind: 'audioSource',
+          name,
+          url: audioUrl,
+          reason: 'fetch-failed',
+        });
+        updatedAudioSources[name] = {
+          ...source,
+          asset: {
+            ...(source.asset || {}),
+            path: null,
+          },
+        };
+      }
+    }
+
+    return changed ? { ...obj, audioSources: updatedAudioSources } : obj;
+  }
+
   // Collect mesh / image / video / text assets
   const updatedObjects = [];
   for (const obj of sceneDocument.objects) {
     if (!obj.asset || obj.asset.type === 'primitive') {
-      updatedObjects.push(obj);
+      updatedObjects.push(await withCollectedAudioSources(obj));
       continue;
     }
 
     if (obj.asset.type === 'image') {
       const imageUrl = obj.asset.url;
-      if (!imageUrl) { updatedObjects.push(obj); continue; }
+      if (!imageUrl) { updatedObjects.push(await withCollectedAudioSources(obj)); continue; }
 
       const ext = extensionFor(obj.asset.mime || 'image/jpeg', 'jpg');
       const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
@@ -114,17 +193,17 @@ export async function collectExportAssets({
       if (buffer) {
         files[zipPath] = buffer;
         assetManifest.push({ id: obj.id, kind: 'image', path: zipPath, status: 'included' });
-        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, path: zipPath } }));
       } else {
         missingAssets.push({ id: obj.id, kind: 'image', url: imageUrl, reason: 'fetch-failed' });
-        updatedObjects.push(obj); // keep url as fallback for static-asset-resolver
+        updatedObjects.push(await withCollectedAudioSources(obj)); // keep url as fallback for static-asset-resolver
       }
       continue;
     }
 
     if (obj.asset.type === 'video') {
       const videoUrl = obj.asset.url;
-      if (!videoUrl) { updatedObjects.push(obj); continue; }
+      if (!videoUrl) { updatedObjects.push(await withCollectedAudioSources(obj)); continue; }
 
       const ext = videoExtFor(obj.asset.mime);
       const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
@@ -132,11 +211,11 @@ export async function collectExportAssets({
       if (buffer) {
         files[zipPath] = buffer;
         assetManifest.push({ id: obj.id, kind: 'video', path: zipPath, status: 'included' });
-        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, path: zipPath } }));
       } else {
         // Videos often have CORS restrictions; keep url so static viewer can stream
         missingAssets.push({ id: obj.id, kind: 'video', url: videoUrl, reason: 'fetch-failed' });
-        updatedObjects.push(obj);
+        updatedObjects.push(await withCollectedAudioSources(obj));
       }
       continue;
     }
@@ -144,21 +223,21 @@ export async function collectExportAssets({
     if (obj.asset.type === 'text') {
       if (obj.asset.source === 'inline') {
         // Text is embedded in scene.json — no file needed
-        updatedObjects.push(obj);
+        updatedObjects.push(await withCollectedAudioSources(obj));
         continue;
       }
       const textUrl = obj.asset.url;
-      if (!textUrl) { updatedObjects.push(obj); continue; }
+      if (!textUrl) { updatedObjects.push(await withCollectedAudioSources(obj)); continue; }
 
       const zipPath = uniquePath(sanitizeFilename(obj.id), 'txt');
       const buffer = await tryFetch(textUrl);
       if (buffer) {
         files[zipPath] = buffer;
         assetManifest.push({ id: obj.id, kind: 'text', path: zipPath, status: 'included' });
-        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: zipPath } });
+        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, path: zipPath } }));
       } else {
         missingAssets.push({ id: obj.id, kind: 'text', url: textUrl, reason: 'fetch-failed' });
-        updatedObjects.push(obj);
+        updatedObjects.push(await withCollectedAudioSources(obj));
       }
       continue;
     }
@@ -180,10 +259,10 @@ export async function collectExportAssets({
     if (blobBuffer) {
       files[zipPath] = blobBuffer;
       assetManifest.push({ id: obj.id, kind: 'mesh', path: zipPath, status: 'included', source: 'blob' });
-      updatedObjects.push({
+      updatedObjects.push(await withCollectedAudioSources({
         ...obj,
         asset: { ...obj.asset, path: zipPath, meshPath: undefined, assetId: undefined },
-      });
+      }));
     } else {
       // Try IndexedDB cache as fallback
       const cachedAsset = await tryGetCachedAssetBuffer({ assetCache, assetId, meshPath });
@@ -197,10 +276,10 @@ export async function collectExportAssets({
           status: 'included',
           source: 'indexeddb',
         });
-        updatedObjects.push({
+        updatedObjects.push(await withCollectedAudioSources({
           ...obj,
           asset: { ...obj.asset, path: zipPath, meshPath: undefined, assetId: undefined },
-        });
+        }));
       } else {
         missingAssets.push({
           id: obj.id,
@@ -209,7 +288,10 @@ export async function collectExportAssets({
           meshPath: meshPath || null,
           reason: cachedAsset.hasError ? 'blob-fetch-and-cache-error' : 'blob-fetch-and-cache-miss',
         });
-        updatedObjects.push({ ...obj, asset: { ...obj.asset, path: null, meshPath: undefined, assetId: undefined } });
+        updatedObjects.push(await withCollectedAudioSources({
+          ...obj,
+          asset: { ...obj.asset, path: null, meshPath: undefined, assetId: undefined },
+        }));
       }
     }
   }

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -1,11 +1,30 @@
 import { SCENE_DOCUMENT_FORMAT, SCENE_DOCUMENT_VERSION } from '../viewer/scene-document.js';
 import { LOOMLET_RUNTIME_METADATA } from '../../scenesync/loomlet-runtime-integration.js';
+import { normalizeAudioSourcesMap } from '../../scenesync/audio/audio-source.js';
 
 const SKIP_ROLES = new Set([
   'multi-transform-pivot',
   'paste-preview',
   'placement-floor',
 ]);
+
+function cloneJson(value) {
+  if (value == null) return null;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function clonePlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return cloneJson(value);
+}
+
+function copyStringField(target, source, key) {
+  if (typeof source?.[key] === 'string') target[key] = source[key];
+}
+
+function copyFiniteNumberField(target, source, key) {
+  if (Number.isFinite(source?.[key])) target[key] = source[key];
+}
 
 function getAnimationState(obj) {
   const raw =
@@ -19,13 +38,25 @@ function getAnimationState(obj) {
   const clipIndex = Number.isInteger(raw.clip) ? raw.clip : 0;
   // Only clamp if we actually know the clip count
   const safeClip = clipCount > 0 ? Math.max(0, Math.min(clipIndex, clipCount - 1)) : Math.max(0, clipIndex);
+  const clipName = typeof raw.clipName === 'string' && raw.clipName.trim()
+    ? raw.clipName.trim()
+    : clips?.[safeClip]?.name || null;
 
-  return {
+  const state = {
     enabled: raw.enabled !== false,
     clip: safeClip,
     mode: raw.mode === 'once' ? 'once' : 'loop',
     speed: Number.isFinite(raw.speed) ? raw.speed : 1,
   };
+
+  if (clipName) {
+    state.clipName = clipName;
+  }
+  if (Number.isFinite(raw.offset)) {
+    state.offset = raw.offset;
+  }
+
+  return state;
 }
 
 function buildAssetEntry(obj) {
@@ -41,23 +72,33 @@ function buildAssetEntry(obj) {
   }
 
   if (asset.type === 'image') {
-    return {
+    const entry = {
       type: 'image',
       source: asset.source || 'url',
       url: asset.url || null,
       path: null, // filled by collect-export-assets.js
       mime: asset.mime || 'image/jpeg',
     };
+    copyFiniteNumberField(entry, asset, 'width');
+    copyFiniteNumberField(entry, asset, 'height');
+    copyStringField(entry, asset, 'assetId');
+    copyStringField(entry, asset, 'originalName');
+    return entry;
   }
 
   if (asset.type === 'video') {
-    return {
+    const entry = {
       type: 'video',
       source: asset.source || 'url',
       url: asset.url || null,
       path: null, // filled by collect-export-assets.js
       mime: asset.mime || 'video/mp4',
     };
+    copyFiniteNumberField(entry, asset, 'width');
+    copyFiniteNumberField(entry, asset, 'height');
+    copyStringField(entry, asset, 'assetId');
+    copyStringField(entry, asset, 'originalName');
+    return entry;
   }
 
   if (asset.type === 'text') {
@@ -73,6 +114,10 @@ function buildAssetEntry(obj) {
       backgroundColor: asset.backgroundColor || 'rgba(0,0,0,0.65)',
       align: asset.align || 'center',
     };
+    const layout = clonePlainObject(asset.layout);
+    if (layout) entry.layout = layout;
+    const scroll = clonePlainObject(asset.scroll);
+    if (scroll) entry.scroll = scroll;
     if (asset.source === 'inline') {
       entry.text = asset.text || '';
     } else {
@@ -154,9 +199,19 @@ export function createSceneDocumentFromSceneSyncState({
       visible: obj.visible !== false,
     };
 
+    const metadata = clonePlainObject(obj.userData?.metadata);
+    if (metadata) {
+      docObj.metadata = metadata;
+    }
+
     const animation = getAnimationState(obj);
     if (animation) {
       docObj.animation = animation;
+    }
+
+    const audioSources = normalizeAudioSourcesMap(obj.userData?.audioSources);
+    if (Object.keys(audioSources).length > 0) {
+      docObj.audioSources = audioSources;
     }
 
     objects.push(docObj);

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -8,6 +8,23 @@ import { createSceneSyncRuntime } from './loomlet/loomlet-scenesync-runtime.brow
 
 const DRACO_DECODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/libs/draco/gltf/';
 
+const AUDIO_SOURCE_EFFECT_TYPES = new Set([
+  'audioSource.play',
+  'audioSource.pause',
+  'audioSource.stop',
+  'audioSource.seek',
+  'audioSource.playOneShot',
+  'audioSource.setVolume',
+  'audioSource.setClip',
+]);
+
+const TEXT_LAYOUT_DEFAULTS = Object.freeze({
+  width: 2.4,
+  height: 1.6,
+  padding: 0.12,
+  lineHeight: 1.35,
+});
+
 function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
@@ -45,6 +62,19 @@ function clonePosition(position) {
   };
 }
 
+function finiteNumber(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function positiveNumber(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function clamp01(value, fallback = 1) {
+  const n = Number.isFinite(value) ? value : fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
 const OBJECT_TARGET_NODE_TYPES = new Set([
   'sceneSetPosition',
   'sceneOffsetPosition',
@@ -77,11 +107,16 @@ function graphForRuntime(graph, scopeObjectId) {
   };
 }
 
-function createExportBehaviorRuntime(behaviorState, objectMap) {
+function createExportBehaviorRuntime(behaviorState, objectMap, audioController = null) {
   const runtimes = [];
   const behaviorBases = new Map();
 
   function applySceneEffect(effect, scopeKey) {
+    if (effect?.type && AUDIO_SOURCE_EFFECT_TYPES.has(effect.type)) {
+      audioController?.applyEffect(effect);
+      return;
+    }
+
     const objectId = effect?.objectId;
     if (!objectId) return;
 
@@ -196,14 +231,24 @@ function applyTransform(obj, entry) {
   }
 }
 
+function resolveAnimationClip(clips, animState) {
+  const clipName = typeof animState?.clipName === 'string' ? animState.clipName.trim() : '';
+  if (clipName) {
+    const byName = clips.find((clip) => clip.name === clipName);
+    if (byName) return byName;
+  }
+
+  const clipIndex = Number.isInteger(animState?.clip) ? animState.clip : 0;
+  const safeIndex = Math.max(0, Math.min(clipIndex, clips.length - 1));
+  return clips[safeIndex];
+}
+
 function setupAnimation(mixer, gltf, animState) {
   const clips = gltf.animations;
   if (!Array.isArray(clips) || clips.length === 0) return null;
   if (animState && animState.enabled === false) return null;
 
-  const clipIndex = Number.isInteger(animState?.clip) ? animState.clip : 0;
-  const safeIndex = Math.max(0, Math.min(clipIndex, clips.length - 1));
-  const clip = clips[safeIndex];
+  const clip = resolveAnimationClip(clips, animState);
 
   const action = mixer.clipAction(clip);
   action.reset();
@@ -215,8 +260,182 @@ function setupAnimation(mixer, gltf, animState) {
   const speed = Number.isFinite(animState?.speed) ? animState.speed : 1;
   action.timeScale = speed;
 
+  const offset = Number.isFinite(animState?.offset) ? animState.offset : 0;
+  if (offset !== 0 && Number.isFinite(clip.duration) && clip.duration > 0) {
+    action.time = mode === THREE.LoopRepeat
+      ? ((offset % clip.duration) + clip.duration) % clip.duration
+      : Math.max(0, Math.min(offset, clip.duration));
+  }
+
   action.play();
   return action;
+}
+
+function resolveAudioPath(source, resolver) {
+  return resolver.resolveAsset(source?.asset) || source?.url || null;
+}
+
+function createObjectAudioController(sceneDoc, resolver, onMissingAsset) {
+  const entries = [];
+  const byKey = new Map();
+
+  function findEntry(objectId, name = 'default') {
+    return byKey.get(`${objectId}:${name || 'default'}`);
+  }
+
+  for (const objectEntry of sceneDoc.objects || []) {
+    const audioSources = objectEntry.audioSources;
+    if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) continue;
+
+    for (const [name, source] of Object.entries(audioSources)) {
+      if (!source || typeof source !== 'object') continue;
+      const audioPath = resolveAudioPath(source, resolver);
+      if (!audioPath) {
+        onMissingAsset?.({
+          id: `${objectEntry.id}:${name}`,
+          objectId: objectEntry.id,
+          kind: 'audioSource',
+          name,
+          reason: 'no path or url',
+        });
+        continue;
+      }
+
+      const audio = new Audio(audioPath);
+      audio.preload = 'auto';
+      audio.loop = source.loop === true;
+      audio.volume = clamp01(source.volume, 1);
+      audio.playbackRate = positiveNumber(source.playbackRate, 1);
+
+      const offset = Math.max(0, finiteNumber(source.offset, 0));
+      if (offset > 0) {
+        const applyOffset = () => {
+          try {
+            audio.currentTime = Number.isFinite(audio.duration)
+              ? Math.min(offset, audio.duration)
+              : offset;
+          } catch {}
+        };
+        audio.addEventListener('loadedmetadata', applyOffset, { once: true });
+      }
+
+      const entry = {
+        objectId: objectEntry.id,
+        name: source.name || name || 'default',
+        source,
+        audio,
+      };
+      entries.push(entry);
+      byKey.set(`${entry.objectId}:${entry.name}`, entry);
+
+      if (source.playOnAwake === true || source.state === 'playing') {
+        audio.play().catch(() => {});
+      }
+    }
+  }
+
+  return {
+    elements: entries.map((entry) => entry.audio),
+    applyEffect(effect) {
+      const objectId = effect.objectId || effect.target;
+      const name = effect.name || 'default';
+      const entry = findEntry(objectId, name);
+      if (!entry) return;
+
+      if (effect.type === 'audioSource.play') {
+        entry.audio.play().catch(() => {});
+      } else if (effect.type === 'audioSource.pause') {
+        entry.audio.pause();
+      } else if (effect.type === 'audioSource.stop') {
+        entry.audio.pause();
+        try { entry.audio.currentTime = 0; } catch {}
+      } else if (effect.type === 'audioSource.seek') {
+        const time = Math.max(0, finiteNumber(effect.time, 0));
+        try { entry.audio.currentTime = time; } catch {}
+      } else if (effect.type === 'audioSource.playOneShot') {
+        try { entry.audio.currentTime = 0; } catch {}
+        entry.audio.play().catch(() => {});
+      } else if (effect.type === 'audioSource.setVolume') {
+        entry.audio.volume = clamp01(effect.volume, entry.audio.volume);
+      } else if (effect.type === 'audioSource.setClip' && typeof effect.url === 'string') {
+        entry.audio.src = effect.url;
+        entry.audio.load?.();
+      }
+    },
+    dispose() {
+      for (const entry of entries) {
+        entry.audio.pause();
+        entry.audio.removeAttribute?.('src');
+        entry.audio.load?.();
+      }
+      entries.length = 0;
+      byKey.clear();
+    },
+  };
+}
+
+function getTextLayout(assetDef) {
+  const layout = assetDef?.layout && typeof assetDef.layout === 'object'
+    ? assetDef.layout
+    : {};
+
+  return {
+    width: positiveNumber(layout.width, TEXT_LAYOUT_DEFAULTS.width),
+    height: positiveNumber(layout.height, TEXT_LAYOUT_DEFAULTS.height),
+    padding: Math.max(0, finiteNumber(layout.padding, TEXT_LAYOUT_DEFAULTS.padding)),
+    lineHeight: positiveNumber(layout.lineHeight, TEXT_LAYOUT_DEFAULTS.lineHeight),
+  };
+}
+
+function renderTextPanelTexture(assetDef, text) {
+  const FONT_PRESETS = {
+    'system-sans':    'system-ui, -apple-system, "Segoe UI", sans-serif',
+    'serif':          'Georgia, "Times New Roman", serif',
+    'monospace':      '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
+    'japanese-sans':  'system-ui, -apple-system, "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif',
+    'japanese-serif': '"Hiragino Mincho ProN", "Yu Mincho", serif',
+  };
+
+  const layout = getTextLayout(assetDef);
+  const pixelsPerUnit = 512;
+  const cw = Math.max(256, Math.round(layout.width * pixelsPerUnit));
+  const ch = Math.max(256, Math.round(layout.height * pixelsPerUnit));
+  const canvas = document.createElement('canvas');
+  canvas.width = cw;
+  canvas.height = ch;
+
+  const ctx2d = canvas.getContext('2d');
+  ctx2d.clearRect(0, 0, cw, ch);
+  ctx2d.fillStyle = assetDef.backgroundColor || 'rgba(0,0,0,0.65)';
+  ctx2d.fillRect(0, 0, cw, ch);
+
+  const fontSize = positiveNumber(assetDef.fontSize, 32);
+  const fontFamily = FONT_PRESETS[assetDef.fontFamily] || FONT_PRESETS['system-sans'];
+  const fontWeight = assetDef.fontWeight || 'normal';
+  const fontStyle = assetDef.fontStyle || 'normal';
+  ctx2d.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+  ctx2d.fillStyle = assetDef.color || '#ffffff';
+  ctx2d.textAlign = assetDef.align === 'left' ? 'left' : assetDef.align === 'right' ? 'right' : 'center';
+  ctx2d.textBaseline = 'top';
+
+  const paddingPx = layout.padding * pixelsPerUnit;
+  const lineHeight = fontSize * layout.lineHeight;
+  const scrollY = Math.max(0, finiteNumber(assetDef.scroll?.y, 0)) * pixelsPerUnit;
+  const x = assetDef.align === 'left'
+    ? paddingPx
+    : assetDef.align === 'right'
+      ? cw - paddingPx
+      : cw / 2;
+
+  let y = paddingPx - scrollY;
+  for (const line of String(text || '').split(/\r?\n/)) {
+    ctx2d.fillText(line, x, y, Math.max(1, cw - paddingPx * 2));
+    y += lineHeight;
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return { texture, width: layout.width, height: layout.height };
 }
 
 export async function createViewerCore({
@@ -365,14 +584,6 @@ export async function createViewerCore({
         onMissingAsset?.({ id: entry.id, kind: 'video', path: assetPath });
       }
     } else if (assetDef.type === 'text') {
-      const FONT_PRESETS = {
-        'system-sans':    'system-ui, -apple-system, "Segoe UI", sans-serif',
-        'serif':          'Georgia, "Times New Roman", serif',
-        'monospace':      '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
-        'japanese-sans':  'system-ui, -apple-system, "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif',
-        'japanese-serif': '"Hiragino Mincho ProN", "Yu Mincho", serif',
-      };
-
       let text = '';
       if (assetDef.source === 'inline') {
         text = assetDef.text || '';
@@ -386,42 +597,11 @@ export async function createViewerCore({
         }
       }
 
-      const fontSize = assetDef.fontSize || 32;
-      const fontFamily = FONT_PRESETS[assetDef.fontFamily] || FONT_PRESETS['system-sans'];
-      const fontWeight = assetDef.fontWeight || 'normal';
-      const fontStyle = assetDef.fontStyle || 'normal';
-      const color = assetDef.color || '#ffffff';
-      const bgColor = assetDef.backgroundColor || 'rgba(0,0,0,0.65)';
-      const align = assetDef.align || 'center';
-
-      const cw = 1024, ch = 256;
-      const canvas = document.createElement('canvas');
-      canvas.width = cw;
-      canvas.height = ch;
-      const ctx2d = canvas.getContext('2d');
-
-      ctx2d.clearRect(0, 0, cw, ch);
-      ctx2d.fillStyle = bgColor;
-      ctx2d.fillRect(0, 0, cw, ch);
-
-      ctx2d.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
-      ctx2d.fillStyle = color;
-      ctx2d.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
-      ctx2d.textBaseline = 'middle';
-
-      const lines = text.split('\n');
-      const lineHeight = fontSize * 1.2;
-      const startY = (ch - lines.length * lineHeight) / 2 + lineHeight / 2;
-      const x = align === 'left' ? 20 : align === 'right' ? cw - 20 : cw / 2;
-      for (let i = 0; i < lines.length; i++) {
-        ctx2d.fillText(lines[i], x, startY + i * lineHeight);
-      }
-
-      const texture = new THREE.CanvasTexture(canvas);
-      const geo = new THREE.PlaneGeometry(2, 0.5); // 4:1 canvas aspect (1024×256)
+      const { texture, width, height } = renderTextPanelTexture(assetDef, text);
+      const geo = new THREE.PlaneGeometry(width, height);
       const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide, transparent: true });
       const mesh = new THREE.Mesh(geo, mat);
-      mesh.position.y = 0.5 / 2; // align origin to bottom edge, matching web runtime
+      mesh.position.y = height / 2; // align origin to bottom edge, matching web runtime
 
       const group = new THREE.Group();
       group.add(mesh);
@@ -466,6 +646,8 @@ export async function createViewerCore({
     onProgress?.(loaded / total);
   }
 
+  const objectAudioController = createObjectAudioController(sceneDoc, resolver, onMissingAsset);
+
   // BGM setup - returns control object
   let bgmAudio = null;
   let bgmReady = false;
@@ -483,7 +665,7 @@ export async function createViewerCore({
   // Loomlet behavior graph runtime
   let loomAdapter = null;
   if (sceneDoc.behaviors) {
-    loomAdapter = createExportBehaviorRuntime(sceneDoc.behaviors, objectMap);
+    loomAdapter = createExportBehaviorRuntime(sceneDoc.behaviors, objectMap, objectAudioController);
   }
 
   const api = {
@@ -500,9 +682,14 @@ export async function createViewerCore({
       return bgmReady ? bgmAudio : null;
     },
 
+    getObjectAudioElements() {
+      return objectAudioController.elements;
+    },
+
     dispose() {
       dracoLoader.dispose();
       bgmAudio?.pause();
+      objectAudioController.dispose();
       loomAdapter?.dispose?.();
     },
   };

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -5,6 +5,7 @@ import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 import { isValidSceneDocument } from './scene-document.js';
 import { createStaticAssetResolver } from './static-asset-resolver.js';
 import { createSceneSyncRuntime } from './loomlet/loomlet-scenesync-runtime.browser.js';
+import { createObjectAudioController } from './object-audio-controller.js';
 
 const DRACO_DECODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/libs/draco/gltf/';
 
@@ -16,6 +17,8 @@ const AUDIO_SOURCE_EFFECT_TYPES = new Set([
   'audioSource.playOneShot',
   'audioSource.setVolume',
   'audioSource.setClip',
+  'audioSource.syncToAnimation',
+  'audioSource.unsync',
 ]);
 
 const TEXT_LAYOUT_DEFAULTS = Object.freeze({
@@ -68,11 +71,6 @@ function finiteNumber(value, fallback) {
 
 function positiveNumber(value, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
-}
-
-function clamp01(value, fallback = 1) {
-  const n = Number.isFinite(value) ? value : fallback;
-  return Math.max(0, Math.min(1, n));
 }
 
 const OBJECT_TARGET_NODE_TYPES = new Set([
@@ -268,108 +266,16 @@ function setupAnimation(mixer, gltf, animState) {
   }
 
   action.play();
-  return action;
-}
-
-function resolveAudioPath(source, resolver) {
-  return resolver.resolveAsset(source?.asset) || source?.url || null;
-}
-
-function createObjectAudioController(sceneDoc, resolver, onMissingAsset) {
-  const entries = [];
-  const byKey = new Map();
-
-  function findEntry(objectId, name = 'default') {
-    return byKey.get(`${objectId}:${name || 'default'}`);
-  }
-
-  for (const objectEntry of sceneDoc.objects || []) {
-    const audioSources = objectEntry.audioSources;
-    if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) continue;
-
-    for (const [name, source] of Object.entries(audioSources)) {
-      if (!source || typeof source !== 'object') continue;
-      const audioPath = resolveAudioPath(source, resolver);
-      if (!audioPath) {
-        onMissingAsset?.({
-          id: `${objectEntry.id}:${name}`,
-          objectId: objectEntry.id,
-          kind: 'audioSource',
-          name,
-          reason: 'no path or url',
-        });
-        continue;
-      }
-
-      const audio = new Audio(audioPath);
-      audio.preload = 'auto';
-      audio.loop = source.loop === true;
-      audio.volume = clamp01(source.volume, 1);
-      audio.playbackRate = positiveNumber(source.playbackRate, 1);
-
-      const offset = Math.max(0, finiteNumber(source.offset, 0));
-      if (offset > 0) {
-        const applyOffset = () => {
-          try {
-            audio.currentTime = Number.isFinite(audio.duration)
-              ? Math.min(offset, audio.duration)
-              : offset;
-          } catch {}
-        };
-        audio.addEventListener('loadedmetadata', applyOffset, { once: true });
-      }
-
-      const entry = {
-        objectId: objectEntry.id,
-        name: source.name || name || 'default',
-        source,
-        audio,
-      };
-      entries.push(entry);
-      byKey.set(`${entry.objectId}:${entry.name}`, entry);
-
-      if (source.playOnAwake === true || source.state === 'playing') {
-        audio.play().catch(() => {});
-      }
-    }
-  }
-
   return {
-    elements: entries.map((entry) => entry.audio),
-    applyEffect(effect) {
-      const objectId = effect.objectId || effect.target;
-      const name = effect.name || 'default';
-      const entry = findEntry(objectId, name);
-      if (!entry) return;
-
-      if (effect.type === 'audioSource.play') {
-        entry.audio.play().catch(() => {});
-      } else if (effect.type === 'audioSource.pause') {
-        entry.audio.pause();
-      } else if (effect.type === 'audioSource.stop') {
-        entry.audio.pause();
-        try { entry.audio.currentTime = 0; } catch {}
-      } else if (effect.type === 'audioSource.seek') {
-        const time = Math.max(0, finiteNumber(effect.time, 0));
-        try { entry.audio.currentTime = time; } catch {}
-      } else if (effect.type === 'audioSource.playOneShot') {
-        try { entry.audio.currentTime = 0; } catch {}
-        entry.audio.play().catch(() => {});
-      } else if (effect.type === 'audioSource.setVolume') {
-        entry.audio.volume = clamp01(effect.volume, entry.audio.volume);
-      } else if (effect.type === 'audioSource.setClip' && typeof effect.url === 'string') {
-        entry.audio.src = effect.url;
-        entry.audio.load?.();
-      }
-    },
-    dispose() {
-      for (const entry of entries) {
-        entry.audio.pause();
-        entry.audio.removeAttribute?.('src');
-        entry.audio.load?.();
-      }
-      entries.length = 0;
-      byKey.clear();
+    action,
+    clip,
+    getSample(requestedClipName = null) {
+      const name = typeof requestedClipName === 'string' ? requestedClipName.trim() : '';
+      if (name && clip.name && name !== clip.name) return null;
+      return {
+        time: Number.isFinite(action.time) ? action.time : 0,
+        duration: Number.isFinite(clip.duration) ? clip.duration : null,
+      };
     },
   };
 }
@@ -454,6 +360,7 @@ export async function createViewerCore({
   const mixers = [];
   const clock = new THREE.Clock();
   const objectMap = new Map();
+  const animationSamples = new Map();
 
   // Ambient + directional lights as fallback
   const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
@@ -634,8 +541,11 @@ export async function createViewerCore({
 
         if (Array.isArray(gltf.animations) && gltf.animations.length > 0) {
           const mixer = new THREE.AnimationMixer(wrapper);
-          setupAnimation(mixer, gltf, entry.animation);
-          mixers.push(mixer);
+          const animationRuntime = setupAnimation(mixer, gltf, entry.animation);
+          if (animationRuntime) {
+            mixers.push(mixer);
+            animationSamples.set(entry.id, animationRuntime);
+          }
         }
       } catch {
         onMissingAsset?.({ id: entry.id, kind: 'mesh', path: assetPath });
@@ -646,7 +556,12 @@ export async function createViewerCore({
     onProgress?.(loaded / total);
   }
 
-  const objectAudioController = createObjectAudioController(sceneDoc, resolver, onMissingAsset);
+  const objectAudioController = createObjectAudioController({
+    sceneDoc,
+    resolver,
+    onMissingAsset,
+    getAnimationSample: (objectId, clipName) => animationSamples.get(objectId)?.getSample(clipName) || null,
+  });
 
   // BGM setup - returns control object
   let bgmAudio = null;
@@ -673,9 +588,11 @@ export async function createViewerCore({
       const delta = clock.getDelta();
       for (const m of mixers) m.update(delta);
 
+      const now = performance.now();
       if (loomAdapter) {
-        loomAdapter.tick(performance.now());
+        loomAdapter.tick(now);
       }
+      objectAudioController.tick(now);
     },
 
     getBgmAudio() {
@@ -684,6 +601,18 @@ export async function createViewerCore({
 
     getObjectAudioElements() {
       return objectAudioController.elements;
+    },
+
+    getObjectAudioPlaybackElements() {
+      return objectAudioController.getPlaybackTargetElements();
+    },
+
+    playObjectAudioPlaybackTargets() {
+      return objectAudioController.playPlaybackTargets();
+    },
+
+    pauseObjectAudioPlaybackTargets() {
+      objectAudioController.pausePlaybackTargets();
     },
 
     dispose() {

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -1,0 +1,371 @@
+const AUDIO_SOURCE_STATES = new Set(['stopped', 'playing', 'paused']);
+
+function defaultNow() {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+function defaultCreateAudio(url) {
+  const audio = new Audio(url);
+  audio.preload = 'auto';
+  return audio;
+}
+
+function finiteNumber(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function positiveNumber(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function clamp01(value, fallback = 1) {
+  const n = Number.isFinite(value) ? value : fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
+function safePause(audio) {
+  try { audio?.pause?.(); } catch {}
+}
+
+function safeSeek(audio, time) {
+  if (!audio || !Number.isFinite(time) || time < 0) return;
+  try { audio.currentTime = time; } catch {}
+}
+
+function safeLoad(audio) {
+  try { audio?.load?.(); } catch {}
+}
+
+function resolveAudioPath(source, resolver) {
+  return resolver.resolveAsset(source?.asset) || source?.url || null;
+}
+
+function desiredStateForSource(source) {
+  if (AUDIO_SOURCE_STATES.has(source?.state)) return source.state;
+  if (source?.playOnAwake === true) return 'playing';
+  return 'stopped';
+}
+
+function normalizeAnimationSync(sync) {
+  if (!sync || typeof sync !== 'object' || sync.mode !== 'animation') return null;
+
+  const result = {
+    mode: 'animation',
+    offset: finiteNumber(sync.offset, 0),
+    resyncOnLoop: sync.resyncOnLoop !== false,
+  };
+
+  if (typeof sync.animationClipName === 'string' && sync.animationClipName.trim()) {
+    result.animationClipName = sync.animationClipName.trim();
+  }
+  if (Number.isFinite(sync.driftThreshold) && sync.driftThreshold >= 0) {
+    result.driftThreshold = sync.driftThreshold;
+  }
+
+  return result;
+}
+
+function audioDuration(audio) {
+  return Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
+}
+
+function animationTargetTime(audio, sampleTime, offset, loop) {
+  const duration = audioDuration(audio);
+  let target = sampleTime + offset;
+  if (duration) {
+    target = loop ? ((target % duration) + duration) % duration : Math.min(Math.max(0, target), duration);
+  } else if (target < 0) {
+    target = 0;
+  }
+  return target;
+}
+
+function applyAudioElementConfig(audio, source) {
+  if (!audio) return;
+  audio.loop = source.loop === true;
+  audio.volume = clamp01(source.volume, 1);
+  try { audio.playbackRate = positiveNumber(source.playbackRate, 1); } catch {}
+  if ('preload' in audio) audio.preload = 'auto';
+}
+
+export function createObjectAudioController({
+  sceneDoc,
+  resolver,
+  onMissingAsset = null,
+  getAnimationSample = null,
+  createAudio = defaultCreateAudio,
+  now = defaultNow,
+}) {
+  const entries = [];
+  const byKey = new Map();
+  const oneShots = new Set();
+  const startMs = now();
+
+  function keyFor(objectId, name = 'default') {
+    return `${objectId}:${name || 'default'}`;
+  }
+
+  function findEntry(objectId, name = 'default') {
+    return byKey.get(keyFor(objectId, name));
+  }
+
+  function getPlaybackTargetEntries() {
+    return entries.filter((entry) => entry.desiredState === 'playing');
+  }
+
+  function tryPlay(entry, { force = false } = {}) {
+    if (!entry?.audio) return Promise.resolve(false);
+    if (entry.audio.paused === false) return Promise.resolve(true);
+    if (entry.autoplayBlocked && !force) return Promise.resolve(false);
+    if (force) entry.autoplayBlocked = false;
+
+    try {
+      const result = entry.audio.play?.();
+      if (result && typeof result.then === 'function') {
+        return result.then(() => {
+          entry.autoplayBlocked = false;
+          return true;
+        }).catch((err) => {
+          entry.autoplayBlocked = true;
+          if (!entry.warnedAutoplayBlocked) {
+            entry.warnedAutoplayBlocked = true;
+            console.warn('[viewer] AudioSource playback blocked:', err?.message || err);
+          }
+          return false;
+        });
+      }
+      entry.autoplayBlocked = false;
+      return Promise.resolve(true);
+    } catch (err) {
+      entry.autoplayBlocked = true;
+      if (!entry.warnedAutoplayBlocked) {
+        entry.warnedAutoplayBlocked = true;
+        console.warn('[viewer] AudioSource playback failed:', err?.message || err);
+      }
+      return Promise.resolve(false);
+    }
+  }
+
+  function seekToConfiguredOffset(entry) {
+    const offset = Math.max(0, finiteNumber(entry.source.offset, 0));
+    if (offset <= 0) return;
+    const duration = audioDuration(entry.audio);
+    safeSeek(entry.audio, duration ? Math.min(offset, duration) : offset);
+  }
+
+  function syncAnimationEntry(entry) {
+    const sync = entry.sync;
+    if (!sync || sync.mode !== 'animation' || typeof getAnimationSample !== 'function') return false;
+
+    const sample = getAnimationSample(entry.objectId, sync.animationClipName);
+    if (!sample || !Number.isFinite(sample.time)) return false;
+
+    const target = animationTargetTime(
+      entry.audio,
+      sample.time,
+      (sync.offset || 0) + (entry.source.offset || 0),
+      entry.source.loop === true
+    );
+    const driftThreshold = Number.isFinite(sync.driftThreshold) ? sync.driftThreshold : 0.05;
+    const looped = entry.lastSampleTime != null && sample.time < entry.lastSampleTime;
+    entry.lastSampleTime = sample.time;
+
+    const drift = Math.abs((entry.audio.currentTime || 0) - target);
+    if (drift > driftThreshold && (sync.resyncOnLoop !== false || !looped)) {
+      safeSeek(entry.audio, target);
+    }
+
+    return true;
+  }
+
+  function tickEntry(entry, nowMs) {
+    if (!entry.audio) return;
+
+    applyAudioElementConfig(entry.audio, entry.source);
+
+    if (entry.desiredState === 'stopped') {
+      if (entry.audio.paused === false) safePause(entry.audio);
+      return;
+    }
+    if (entry.desiredState === 'paused') {
+      if (entry.audio.paused === false) safePause(entry.audio);
+      return;
+    }
+    if (entry.userPaused) return;
+
+    const syncedToAnimation = syncAnimationEntry(entry);
+    if (!syncedToAnimation && !entry.started) {
+      const elapsed = Math.max(0, (nowMs - startMs) / 1000);
+      const target = (entry.source.offset || 0) + elapsed;
+      const duration = audioDuration(entry.audio);
+      safeSeek(entry.audio, duration && entry.source.loop
+        ? ((target % duration) + duration) % duration
+        : target);
+    }
+
+    entry.started = true;
+    tryPlay(entry);
+  }
+
+  function createEntry(objectEntry, name, source) {
+    const audioPath = resolveAudioPath(source, resolver);
+    if (!audioPath) {
+      onMissingAsset?.({
+        id: `${objectEntry.id}:${name}`,
+        objectId: objectEntry.id,
+        kind: 'audioSource',
+        name,
+        reason: 'no path or url',
+      });
+      return null;
+    }
+
+    const audio = createAudio(audioPath);
+    if ('src' in audio && !audio.src) audio.src = audioPath;
+    applyAudioElementConfig(audio, source);
+
+    const entry = {
+      objectId: objectEntry.id,
+      name: source.name || name || 'default',
+      source: { ...source, url: audioPath },
+      sync: normalizeAnimationSync(source.sync),
+      audio,
+      desiredState: desiredStateForSource(source),
+      started: false,
+      userPaused: false,
+      autoplayBlocked: false,
+      warnedAutoplayBlocked: false,
+      lastSampleTime: null,
+    };
+
+    if (typeof audio.addEventListener === 'function') {
+      audio.addEventListener('loadedmetadata', () => seekToConfiguredOffset(entry), { once: true });
+    }
+    seekToConfiguredOffset(entry);
+
+    entries.push(entry);
+    byKey.set(keyFor(entry.objectId, entry.name), entry);
+    return entry;
+  }
+
+  for (const objectEntry of sceneDoc.objects || []) {
+    const audioSources = objectEntry.audioSources;
+    if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) continue;
+
+    for (const [name, source] of Object.entries(audioSources)) {
+      if (!source || typeof source !== 'object') continue;
+      createEntry(objectEntry, name, source);
+    }
+  }
+
+  return {
+    elements: entries.map((entry) => entry.audio),
+
+    getPlaybackTargetElements() {
+      return getPlaybackTargetEntries().map((entry) => entry.audio);
+    },
+
+    playPlaybackTargets() {
+      return Promise.allSettled(getPlaybackTargetEntries().map((entry) => {
+        entry.userPaused = false;
+        return tryPlay(entry, { force: true });
+      }));
+    },
+
+    pausePlaybackTargets() {
+      for (const entry of getPlaybackTargetEntries()) {
+        entry.userPaused = true;
+        safePause(entry.audio);
+      }
+    },
+
+    applyEffect(effect) {
+      const objectId = effect.objectId || effect.target;
+      const name = effect.name || 'default';
+      const entry = findEntry(objectId, name);
+      if (!entry) return;
+
+      if (effect.type === 'audioSource.play') {
+        entry.desiredState = 'playing';
+        entry.userPaused = false;
+        tryPlay(entry, { force: true });
+      } else if (effect.type === 'audioSource.pause') {
+        entry.desiredState = 'paused';
+        entry.userPaused = false;
+        safePause(entry.audio);
+      } else if (effect.type === 'audioSource.stop') {
+        entry.desiredState = 'stopped';
+        entry.userPaused = false;
+        safePause(entry.audio);
+        safeSeek(entry.audio, 0);
+      } else if (effect.type === 'audioSource.seek') {
+        safeSeek(entry.audio, Math.max(0, finiteNumber(effect.time, 0)));
+      } else if (effect.type === 'audioSource.playOneShot') {
+        const options = effect.options || {};
+        const url = typeof options.url === 'string' && options.url ? options.url : entry.source.url;
+        if (!url) return;
+        const oneShot = createAudio(url);
+        oneShot.loop = false;
+        oneShot.volume = clamp01(options.volume, entry.audio.volume);
+        try { oneShot.playbackRate = positiveNumber(options.playbackRate, entry.audio.playbackRate || 1); } catch {}
+        safeSeek(oneShot, Math.max(0, finiteNumber(options.offset, 0)));
+        const cleanup = () => {
+          oneShots.delete(oneShot);
+          try {
+            oneShot.removeAttribute?.('src');
+            oneShot.src = '';
+            oneShot.load?.();
+          } catch {}
+        };
+        oneShot.addEventListener?.('ended', cleanup, { once: true });
+        oneShots.add(oneShot);
+        const result = oneShot.play?.();
+        if (result && typeof result.then === 'function') result.catch(cleanup);
+      } else if (effect.type === 'audioSource.setVolume') {
+        const volume = clamp01(effect.volume, entry.audio.volume);
+        entry.source.volume = volume;
+        entry.audio.volume = volume;
+      } else if (effect.type === 'audioSource.setClip' && typeof effect.url === 'string') {
+        entry.source.url = effect.url;
+        entry.audio.src = effect.url;
+        entry.started = false;
+        entry.autoplayBlocked = false;
+        safeLoad(entry.audio);
+      } else if (effect.type === 'audioSource.syncToAnimation') {
+        entry.sync = normalizeAnimationSync({ mode: 'animation', ...(effect.sync || effect.options || {}) });
+        entry.lastSampleTime = null;
+      } else if (effect.type === 'audioSource.unsync') {
+        entry.sync = null;
+        entry.lastSampleTime = null;
+      }
+    },
+
+    tick(nowMs = now()) {
+      for (const entry of entries) tickEntry(entry, nowMs);
+    },
+
+    dispose() {
+      for (const entry of entries) {
+        safePause(entry.audio);
+        try {
+          entry.audio.removeAttribute?.('src');
+          entry.audio.src = '';
+          entry.audio.load?.();
+        } catch {}
+      }
+      for (const audio of oneShots) {
+        safePause(audio);
+        try {
+          audio.removeAttribute?.('src');
+          audio.src = '';
+          audio.load?.();
+        } catch {}
+      }
+      entries.length = 0;
+      oneShots.clear();
+      byKey.clear();
+    },
+  };
+}

--- a/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
+++ b/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
@@ -103,24 +103,30 @@ async function main() {
   }
 
   const objectAudioElements = viewerCore.getObjectAudioElements?.() || [];
-  if (objectAudioElements.length > 0 && controlsEl) {
+  const initialPlaybackElements = viewerCore.getObjectAudioPlaybackElements?.() || [];
+  if (objectAudioElements.length > 0 && initialPlaybackElements.length > 0 && controlsEl) {
     const audioBtn = document.createElement('button');
     audioBtn.className = 'viewer-btn';
     audioBtn.textContent = '▶ Play Audio';
     let playing = false;
     audioBtn.addEventListener('click', () => {
       if (playing) {
-        for (const audio of objectAudioElements) audio.pause();
+        viewerCore.pauseObjectAudioPlaybackTargets?.();
         audioBtn.textContent = '▶ Play Audio';
         playing = false;
       } else {
-        Promise.allSettled(objectAudioElements.map((audio) => audio.play()))
-          .then((results) => {
-            if (results.some((result) => result.status === 'fulfilled')) {
-              audioBtn.textContent = '⏸ Pause Audio';
-              playing = true;
-            }
-          });
+        const playbackElements = viewerCore.getObjectAudioPlaybackElements?.() || [];
+        if (playbackElements.length > 0) {
+          Promise.resolve(viewerCore.playObjectAudioPlaybackTargets?.())
+            .then((results) => {
+              if (Array.isArray(results) && results.some((result) => (
+                result.status === 'fulfilled' && result.value === true
+              ))) {
+                audioBtn.textContent = '⏸ Pause Audio';
+                playing = true;
+              }
+            });
+        }
       }
     });
     controlsEl.appendChild(audioBtn);

--- a/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
+++ b/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
@@ -102,6 +102,30 @@ async function main() {
     controlsEl.appendChild(bgmBtn);
   }
 
+  const objectAudioElements = viewerCore.getObjectAudioElements?.() || [];
+  if (objectAudioElements.length > 0 && controlsEl) {
+    const audioBtn = document.createElement('button');
+    audioBtn.className = 'viewer-btn';
+    audioBtn.textContent = '▶ Play Audio';
+    let playing = false;
+    audioBtn.addEventListener('click', () => {
+      if (playing) {
+        for (const audio of objectAudioElements) audio.pause();
+        audioBtn.textContent = '▶ Play Audio';
+        playing = false;
+      } else {
+        Promise.allSettled(objectAudioElements.map((audio) => audio.play()))
+          .then((results) => {
+            if (results.some((result) => result.status === 'fulfilled')) {
+              audioBtn.textContent = '⏸ Pause Audio';
+              playing = true;
+            }
+          });
+      }
+    });
+    controlsEl.appendChild(audioBtn);
+  }
+
   // Immersive entry button
   if (navigator.xr && controlsEl) {
     for (const mode of ['immersive-vr', 'immersive-ar']) {
@@ -146,13 +170,17 @@ function rewriteAssetPaths(doc) {
   if (!doc) return doc;
 
   const objects = (doc.objects || []).map(obj => {
-    if (!obj.asset?.path) return obj;
+    const audioSources = rewriteAudioSourcePaths(obj.audioSources);
+    if (!obj.asset?.path) {
+      return audioSources === obj.audioSources ? obj : { ...obj, audioSources };
+    }
     return {
       ...obj,
       asset: {
         ...obj.asset,
         path: resolveFromRoot(obj.asset.path),
       },
+      audioSources,
     };
   });
 
@@ -170,6 +198,30 @@ function rewriteAssetPaths(doc) {
   }
 
   return { ...doc, objects, skybox, bgm };
+}
+
+function rewriteAudioSourcePaths(audioSources) {
+  if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) {
+    return audioSources;
+  }
+
+  let changed = false;
+  const updated = {};
+  for (const [name, source] of Object.entries(audioSources)) {
+    if (source?.asset?.path) {
+      changed = true;
+      updated[name] = {
+        ...source,
+        asset: {
+          ...source.asset,
+          path: resolveFromRoot(source.asset.path),
+        },
+      };
+    } else {
+      updated[name] = source;
+    }
+  }
+  return changed ? updated : audioSources;
 }
 
 main();

--- a/html/assets/js/scenesync/audio/audio-source.js
+++ b/html/assets/js/scenesync/audio/audio-source.js
@@ -35,8 +35,8 @@ function positiveOrDefault(value, fallback) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function finiteOrDefault(value, fallback) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+function nonNegativeOrDefault(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
 function resolveName(input, options) {
@@ -87,7 +87,7 @@ export function normalizeAudioSource(input, options = {}) {
     volume: clampVolume(input.volume),
     loop: input.loop === true,
     playOnAwake: input.playOnAwake === true,
-    offset: finiteOrDefault(input.offset, AUDIO_SOURCE_DEFAULTS.offset),
+    offset: nonNegativeOrDefault(input.offset, AUDIO_SOURCE_DEFAULTS.offset),
     playbackRate: positiveOrDefault(input.playbackRate, AUDIO_SOURCE_DEFAULTS.playbackRate),
     spatial: input.spatial !== false,
   };


### PR DESCRIPTION
## Summary

- Include exportable Scene Sync state that was previously missing from static exports: object audio sources, metadata, animation clip names/offsets, text layout/scroll state, and media dimensions.
- Collect object audio source files into the exported `assets/` directory and rewrite scene references to packaged paths.
- Teach the static viewer to restore object audio playback and handle audio source behavior effects after export.
- Add focused tests for scene document generation, asset collection, and audio source normalization.

## Why

The static export is intended to be a standalone page, while still preserving enough Scene Sync data for future Web Editor import/re-editing. Some synchronized state, especially per-object audio, was present in the editor/runtime but absent from the export package, so exported scenes could lose visible/audible behavior.

## Validation

- `git diff --check HEAD~1..HEAD`
- `node --test apps/presence-server/tests/export-scene-document.test.mjs apps/presence-server/tests/collect-export-assets.test.mjs apps/presence-server/tests/build-export-package.test.mjs apps/presence-server/tests/audio-source-model.test.mjs apps/presence-server/tests/audio-source-controller.test.mjs`

The node test run passed with 103 tests. The IndexedDB warning output is from tests that intentionally exercise cache error handling.