### PR TITLE
[codex] Add static viewer audio unlock

### DIFF
--- a/apps/presence-server/tests/object-audio-controller.test.mjs
+++ b/apps/presence-server/tests/object-audio-controller.test.mjs
@@ -11,14 +11,17 @@ class FakeAudio {
     this.playbackRate = 1;
     this.currentTime = 0;
     this.duration = 10;
+    this.muted = false;
     this.paused = true;
     this.playCalls = 0;
     this.pauseCalls = 0;
     this.loadCalls = 0;
+    this.mutedDuringPlay = [];
   }
 
   play() {
     this.playCalls += 1;
+    this.mutedDuringPlay.push(this.muted);
     this.paused = false;
     return Promise.resolve();
   }
@@ -78,6 +81,8 @@ test('static object AudioSource controller', async (t) => {
     });
 
     assert.equal(controller.elements.length, 3);
+    assert.equal(controller.hasAudioSources(), true);
+    assert.equal(controller.hasPlaybackTargets(), true);
     assert.deepEqual(controller.getPlaybackTargetElements().map((audio) => audio.src), [
       'ambience.mp3',
       'narration.mp3',
@@ -97,6 +102,32 @@ test('static object AudioSource controller', async (t) => {
     assert.equal(created[0].playCalls, 2);
     assert.equal(created[1].playCalls, 2);
     assert.equal(created[2].playCalls, 0);
+  });
+
+  await t.test('unlocks event-only audio sources without leaving them playing', async () => {
+    const { controller, created } = makeController({
+      audioSources: {
+        click: { name: 'click', url: 'click.mp3' },
+        hit: { name: 'hit', url: 'hit.mp3', state: 'stopped' },
+      },
+    });
+
+    created[0].currentTime = 3;
+
+    assert.equal(controller.hasAudioSources(), true);
+    assert.equal(controller.hasPlaybackTargets(), false);
+    assert.equal(controller.isAudioUnlocked(), false);
+
+    const unlocked = await controller.unlockAudio();
+
+    assert.equal(unlocked, true);
+    assert.equal(controller.isAudioUnlocked(), true);
+    assert.equal(created[0].mutedDuringPlay[0], true);
+    assert.equal(created[1].mutedDuringPlay[0], true);
+    assert.equal(created[0].muted, false);
+    assert.equal(created[0].paused, true);
+    assert.equal(created[0].currentTime, 3);
+    assert.equal(created[1].paused, true);
   });
 
   await t.test('syncs playing audio sources to animation samples', () => {

--- a/apps/presence-server/tests/object-audio-controller.test.mjs
+++ b/apps/presence-server/tests/object-audio-controller.test.mjs
@@ -130,6 +130,54 @@ test('static object AudioSource controller', async (t) => {
     assert.equal(created[1].paused, true);
   });
 
+  await t.test('playOneShot reuses unlocked event-only audio element', async () => {
+    const { controller, created } = makeController({
+      audioSources: {
+        click: { name: 'click', url: 'click.mp3' },
+      },
+    });
+
+    assert.equal(await controller.unlockAudio(), true);
+    assert.equal(created.length, 1);
+
+    controller.applyEffect({
+      type: 'audioSource.playOneShot',
+      objectId: 'speaker-1',
+      name: 'click',
+      options: { offset: 1.25, volume: 0.35 },
+    });
+
+    assert.equal(created.length, 1, 'playOneShot should not create a new Audio after unlock');
+    assert.equal(created[0].playCalls, 2);
+    assert.equal(created[0].mutedDuringPlay[1], false);
+    assert.equal(created[0].volume, 0.35);
+    assert.equal(created[0].currentTime, 1.25);
+    assert.equal(created[0].paused, false);
+
+    controller.tick(16);
+    assert.equal(created[0].paused, false, 'tick should not immediately stop the transient one-shot');
+  });
+
+  await t.test('playOneShot keeps using transient audio for playing sources', async () => {
+    const { controller, created } = makeController({
+      audioSources: {
+        music: { name: 'music', url: 'music.mp3', state: 'playing' },
+      },
+    });
+
+    assert.equal(await controller.unlockAudio(), true);
+    controller.applyEffect({
+      type: 'audioSource.playOneShot',
+      objectId: 'speaker-1',
+      name: 'music',
+    });
+
+    assert.equal(created.length, 2);
+    assert.equal(created[0].src, 'music.mp3');
+    assert.equal(created[1].src, 'music.mp3');
+    assert.equal(created[1].playCalls, 1);
+  });
+
   await t.test('syncs playing audio sources to animation samples', () => {
     let sampleTime = 2;
     const { controller, created } = makeController({

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -603,8 +603,24 @@ export async function createViewerCore({
       return objectAudioController.elements;
     },
 
+    hasObjectAudioSources() {
+      return objectAudioController.hasAudioSources();
+    },
+
+    hasObjectAudioPlaybackTargets() {
+      return objectAudioController.hasPlaybackTargets();
+    },
+
     getObjectAudioPlaybackElements() {
       return objectAudioController.getPlaybackTargetElements();
+    },
+
+    unlockObjectAudio() {
+      return objectAudioController.unlockAudio();
+    },
+
+    isObjectAudioUnlocked() {
+      return objectAudioController.isAudioUnlocked();
     },
 
     playObjectAudioPlaybackTargets() {

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -116,6 +116,12 @@ export function createObjectAudioController({
     return entries.filter((entry) => entry.desiredState === 'playing');
   }
 
+  function cancelEntryOneShot(entry) {
+    if (!entry) return;
+    entry.oneShotToken += 1;
+    entry.oneShotActive = false;
+  }
+
   function restoreAfterUnlockAttempt(entry, snapshot) {
     const audio = entry.audio;
     if (!audio) return;
@@ -224,6 +230,7 @@ export function createObjectAudioController({
 
   function tickEntry(entry, nowMs) {
     if (!entry.audio) return;
+    if (entry.oneShotActive) return;
 
     applyAudioElementConfig(entry.audio, entry.source);
 
@@ -249,6 +256,68 @@ export function createObjectAudioController({
 
     entry.started = true;
     tryPlay(entry);
+  }
+
+  function playUnlockedEntryOneShot(entry, url, options = {}) {
+    const audio = entry?.audio;
+    if (!audio) return Promise.resolve(false);
+
+    const snapshot = {
+      src: audio.src,
+      currentTime: Number.isFinite(audio.currentTime) ? audio.currentTime : 0,
+      muted: audio.muted === true,
+      volume: Number.isFinite(audio.volume) ? audio.volume : 1,
+      playbackRate: Number.isFinite(audio.playbackRate) ? audio.playbackRate : 1,
+      loop: audio.loop === true,
+    };
+    const token = entry.oneShotToken + 1;
+
+    let restored = false;
+    const restore = () => {
+      if (entry.oneShotToken !== token) return;
+      if (restored) return;
+      restored = true;
+      entry.oneShotActive = false;
+      safePause(audio);
+      audio.loop = snapshot.loop;
+      audio.volume = snapshot.volume;
+      audio.muted = snapshot.muted;
+      try { audio.playbackRate = snapshot.playbackRate; } catch {}
+      if (snapshot.src && audio.src !== snapshot.src) {
+        audio.src = snapshot.src;
+        safeLoad(audio);
+      }
+      safeSeek(audio, snapshot.currentTime);
+      applyAudioElementConfig(audio, entry.source);
+    };
+
+    entry.oneShotToken = token;
+    entry.oneShotActive = true;
+    safePause(audio);
+    if (url && audio.src !== url) {
+      audio.src = url;
+      safeLoad(audio);
+    }
+    audio.loop = false;
+    audio.muted = false;
+    audio.volume = clamp01(options.volume, snapshot.volume);
+    try { audio.playbackRate = positiveNumber(options.playbackRate, snapshot.playbackRate); } catch {}
+    safeSeek(audio, Math.max(0, finiteNumber(options.offset, 0)));
+    audio.addEventListener?.('ended', restore, { once: true });
+
+    try {
+      const result = audio.play?.();
+      if (result && typeof result.then === 'function') {
+        return result.then(() => true).catch(() => {
+          restore();
+          return false;
+        });
+      }
+      return Promise.resolve(true);
+    } catch {
+      restore();
+      return Promise.resolve(false);
+    }
   }
 
   function createEntry(objectEntry, name, source) {
@@ -280,6 +349,8 @@ export function createObjectAudioController({
       autoplayBlocked: false,
       warnedAutoplayBlocked: false,
       lastSampleTime: null,
+      oneShotActive: false,
+      oneShotToken: 0,
     };
 
     if (typeof audio.addEventListener === 'function') {
@@ -344,6 +415,7 @@ export function createObjectAudioController({
 
     pausePlaybackTargets() {
       for (const entry of getPlaybackTargetEntries()) {
+        cancelEntryOneShot(entry);
         entry.userPaused = true;
         safePause(entry.audio);
       }
@@ -356,14 +428,17 @@ export function createObjectAudioController({
       if (!entry) return;
 
       if (effect.type === 'audioSource.play') {
+        cancelEntryOneShot(entry);
         entry.desiredState = 'playing';
         entry.userPaused = false;
         tryPlay(entry, { force: true });
       } else if (effect.type === 'audioSource.pause') {
+        cancelEntryOneShot(entry);
         entry.desiredState = 'paused';
         entry.userPaused = false;
         safePause(entry.audio);
       } else if (effect.type === 'audioSource.stop') {
+        cancelEntryOneShot(entry);
         entry.desiredState = 'stopped';
         entry.userPaused = false;
         safePause(entry.audio);
@@ -374,6 +449,12 @@ export function createObjectAudioController({
         const options = effect.options || {};
         const url = typeof options.url === 'string' && options.url ? options.url : entry.source.url;
         if (!url) return;
+
+        if (audioUnlocked && entry.desiredState !== 'playing') {
+          playUnlockedEntryOneShot(entry, url, options);
+          return;
+        }
+
         const oneShot = createAudio(url);
         oneShot.loop = false;
         oneShot.volume = clamp01(options.volume, entry.audio.volume);
@@ -396,6 +477,7 @@ export function createObjectAudioController({
         entry.source.volume = volume;
         entry.audio.volume = volume;
       } else if (effect.type === 'audioSource.setClip' && typeof effect.url === 'string') {
+        cancelEntryOneShot(entry);
         entry.source.url = effect.url;
         entry.audio.src = effect.url;
         entry.started = false;

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -102,6 +102,7 @@ export function createObjectAudioController({
   const byKey = new Map();
   const oneShots = new Set();
   const startMs = now();
+  let audioUnlocked = false;
 
   function keyFor(objectId, name = 'default') {
     return `${objectId}:${name || 'default'}`;
@@ -113,6 +114,47 @@ export function createObjectAudioController({
 
   function getPlaybackTargetEntries() {
     return entries.filter((entry) => entry.desiredState === 'playing');
+  }
+
+  function restoreAfterUnlockAttempt(entry, snapshot) {
+    const audio = entry.audio;
+    if (!audio) return;
+
+    safePause(audio);
+    safeSeek(audio, snapshot.currentTime);
+    audio.muted = snapshot.muted;
+
+    if (!snapshot.paused && entry.desiredState === 'playing' && !entry.userPaused) {
+      tryPlay(entry, { force: true });
+    }
+  }
+
+  function unlockEntryAudio(entry) {
+    const audio = entry?.audio;
+    if (!audio) return Promise.resolve(false);
+
+    const snapshot = {
+      paused: audio.paused !== false,
+      currentTime: Number.isFinite(audio.currentTime) ? audio.currentTime : 0,
+      muted: audio.muted === true,
+    };
+
+    try {
+      audio.muted = true;
+      const result = audio.play?.();
+      return Promise.resolve(result).then(() => {
+        entry.autoplayBlocked = false;
+        entry.warnedAutoplayBlocked = false;
+        restoreAfterUnlockAttempt(entry, snapshot);
+        return true;
+      }).catch(() => {
+        restoreAfterUnlockAttempt(entry, snapshot);
+        return false;
+      });
+    } catch {
+      restoreAfterUnlockAttempt(entry, snapshot);
+      return Promise.resolve(false);
+    }
   }
 
   function tryPlay(entry, { force = false } = {}) {
@@ -263,6 +305,32 @@ export function createObjectAudioController({
   return {
     elements: entries.map((entry) => entry.audio),
 
+    hasAudioSources() {
+      return entries.length > 0;
+    },
+
+    hasPlaybackTargets() {
+      return getPlaybackTargetEntries().length > 0;
+    },
+
+    isAudioUnlocked() {
+      return audioUnlocked;
+    },
+
+    unlockAudio() {
+      if (audioUnlocked) return Promise.resolve(true);
+      if (entries.length === 0) return Promise.resolve(false);
+
+      const attempts = entries.map((entry) => unlockEntryAudio(entry));
+      return Promise.allSettled(attempts).then((results) => {
+        const unlocked = results.some((result) => (
+          result.status === 'fulfilled' && result.value === true
+        ));
+        if (unlocked) audioUnlocked = true;
+        return unlocked;
+      });
+    },
+
     getPlaybackTargetElements() {
       return getPlaybackTargetEntries().map((entry) => entry.audio);
     },
@@ -366,6 +434,7 @@ export function createObjectAudioController({
       entries.length = 0;
       oneShots.clear();
       byKey.clear();
+      audioUnlocked = false;
     },
   };
 }

--- a/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
+++ b/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
@@ -103,13 +103,18 @@ async function main() {
   }
 
   const objectAudioElements = viewerCore.getObjectAudioElements?.() || [];
-  const initialPlaybackElements = viewerCore.getObjectAudioPlaybackElements?.() || [];
-  if (objectAudioElements.length > 0 && initialPlaybackElements.length > 0 && controlsEl) {
+  const hasObjectAudioSources = viewerCore.hasObjectAudioSources?.() ?? objectAudioElements.length > 0;
+  const hasPlaybackTargets = viewerCore.hasObjectAudioPlaybackTargets?.()
+    ?? (viewerCore.getObjectAudioPlaybackElements?.() || []).length > 0;
+
+  if (hasObjectAudioSources && hasPlaybackTargets && controlsEl) {
     const audioBtn = document.createElement('button');
     audioBtn.className = 'viewer-btn';
     audioBtn.textContent = '▶ Play Audio';
     let playing = false;
-    audioBtn.addEventListener('click', () => {
+    let pending = false;
+    audioBtn.addEventListener('click', async () => {
+      if (pending) return;
       if (playing) {
         viewerCore.pauseObjectAudioPlaybackTargets?.();
         audioBtn.textContent = '▶ Play Audio';
@@ -117,19 +122,43 @@ async function main() {
       } else {
         const playbackElements = viewerCore.getObjectAudioPlaybackElements?.() || [];
         if (playbackElements.length > 0) {
-          Promise.resolve(viewerCore.playObjectAudioPlaybackTargets?.())
-            .then((results) => {
-              if (Array.isArray(results) && results.some((result) => (
-                result.status === 'fulfilled' && result.value === true
-              ))) {
-                audioBtn.textContent = '⏸ Pause Audio';
-                playing = true;
-              }
-            });
+          pending = true;
+          audioBtn.disabled = true;
+          await Promise.resolve(viewerCore.unlockObjectAudio?.()).catch(() => false);
+          const results = await Promise.resolve(viewerCore.playObjectAudioPlaybackTargets?.()).catch(() => []);
+          if (Array.isArray(results) && results.some((result) => (
+            result.status === 'fulfilled' && result.value === true
+          ))) {
+            audioBtn.textContent = '⏸ Pause Audio';
+            playing = true;
+          }
+          audioBtn.disabled = false;
+          pending = false;
         }
       }
     });
     controlsEl.appendChild(audioBtn);
+  } else if (hasObjectAudioSources && controlsEl) {
+    const enableBtn = document.createElement('button');
+    enableBtn.className = 'viewer-btn';
+    enableBtn.textContent = 'Enable Audio';
+    let pending = false;
+    enableBtn.addEventListener('click', async () => {
+      if (pending || viewerCore.isObjectAudioUnlocked?.()) return;
+      pending = true;
+      enableBtn.disabled = true;
+      enableBtn.textContent = 'Enabling Audio...';
+
+      const unlocked = await Promise.resolve(viewerCore.unlockObjectAudio?.()).catch(() => false);
+      if (unlocked || viewerCore.isObjectAudioUnlocked?.()) {
+        enableBtn.textContent = 'Audio Enabled';
+      } else {
+        enableBtn.textContent = 'Enable Audio';
+        enableBtn.disabled = false;
+      }
+      pending = false;
+    });
+    controlsEl.appendChild(enableBtn);
   }
 
   // Immersive entry button


### PR DESCRIPTION
## Summary

- Add an object AudioSource unlock API for static exports so event-triggered sounds can be prepared by a user gesture.
- Keep the Static Viewer UI to at most one object-audio button: `Play Audio` when playback targets exist, otherwise `Enable Audio` for event-only AudioSources.
- Make `Play Audio` call the unlock path before starting playback targets.
- Add coverage for event-only AudioSource unlock behavior and state restoration.

## Why

Static exported scenes may contain AudioSources that are only triggered later by Loomlet or scene events, such as click sounds, collision sounds, applause, or short voice lines. Without an explicit user gesture, browsers can block those later playback attempts. `Enable Audio` provides that gesture without playing event sounds immediately.

## Validation

- `git diff --check`
- `node --test apps/presence-server/tests/object-audio-controller.test.mjs apps/presence-server/tests/export-scene-document.test.mjs apps/presence-server/tests/collect-export-assets.test.mjs apps/presence-server/tests/build-export-package.test.mjs apps/presence-server/tests/audio-source-model.test.mjs apps/presence-server/tests/audio-source-controller.test.mjs`

The node test run passed with 108 tests. The IndexedDB warning output is from tests that intentionally exercise cache error handling.