### PR TITLE
[codex] Preserve editor player clock timeline

### DIFF
--- a/html/assets/js/scenesync/runtime/scene-clock-transport.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.js
@@ -7,5 +7,24 @@ export function normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions = {
   return {
     now,
     preserveLocalTimeline: options?.preserveLocalTimeline === true,
+    resumeLocalTimeline: options?.resumeLocalTimeline === true,
   };
+}
+
+export function preserveLocalSceneClockTimeline(state, {
+  now,
+  getSceneClockTime,
+  resume = false,
+} = {}) {
+  if (!state || state.mode !== 'local' || typeof getSceneClockTime !== 'function') return false;
+
+  state.localTime = getSceneClockTime(now);
+  state.lastUpdateNow = now;
+
+  if (resume) {
+    state.paused = false;
+    state.pausedAt = null;
+  }
+
+  return true;
 }

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.js
@@ -1,0 +1,11 @@
+export function normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions = {}, getNow = () => performance.now()) {
+  const now = typeof nowOrOptions === 'number' ? nowOrOptions : getNow();
+  const options = nowOrOptions && typeof nowOrOptions === 'object'
+    ? nowOrOptions
+    : maybeOptions;
+
+  return {
+    now,
+    preserveLocalTimeline: options?.preserveLocalTimeline === true,
+  };
+}

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeSceneClockDeactivateArgs } from './scene-clock-transport.js';
+
+test('deactivate scene clock args preserve existing numeric now calls', () => {
+  const result = normalizeSceneClockDeactivateArgs(1234, undefined, () => 9999);
+
+  assert.deepEqual(result, {
+    now: 1234,
+    preserveLocalTimeline: false,
+  });
+});
+
+test('deactivate scene clock args accept options-only calls', () => {
+  const result = normalizeSceneClockDeactivateArgs(
+    { preserveLocalTimeline: true },
+    undefined,
+    () => 4321
+  );
+
+  assert.deepEqual(result, {
+    now: 4321,
+    preserveLocalTimeline: true,
+  });
+});
+
+test('deactivate scene clock args accept numeric now with options', () => {
+  const result = normalizeSceneClockDeactivateArgs(
+    2468,
+    { preserveLocalTimeline: true },
+    () => 9999
+  );
+
+  assert.deepEqual(result, {
+    now: 2468,
+    preserveLocalTimeline: true,
+  });
+});

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { normalizeSceneClockDeactivateArgs } from './scene-clock-transport.js';
+import {
+  normalizeSceneClockDeactivateArgs,
+  preserveLocalSceneClockTimeline,
+} from './scene-clock-transport.js';
 
 test('deactivate scene clock args preserve existing numeric now calls', () => {
   const result = normalizeSceneClockDeactivateArgs(1234, undefined, () => 9999);
@@ -9,6 +12,7 @@ test('deactivate scene clock args preserve existing numeric now calls', () => {
   assert.deepEqual(result, {
     now: 1234,
     preserveLocalTimeline: false,
+    resumeLocalTimeline: false,
   });
 });
 
@@ -22,6 +26,7 @@ test('deactivate scene clock args accept options-only calls', () => {
   assert.deepEqual(result, {
     now: 4321,
     preserveLocalTimeline: true,
+    resumeLocalTimeline: false,
   });
 });
 
@@ -35,5 +40,62 @@ test('deactivate scene clock args accept numeric now with options', () => {
   assert.deepEqual(result, {
     now: 2468,
     preserveLocalTimeline: true,
+    resumeLocalTimeline: false,
   });
+});
+
+test('deactivate scene clock args accept resume local timeline option', () => {
+  const result = normalizeSceneClockDeactivateArgs(
+    { preserveLocalTimeline: true, resumeLocalTimeline: true },
+    undefined,
+    () => 1357
+  );
+
+  assert.deepEqual(result, {
+    now: 1357,
+    preserveLocalTimeline: true,
+    resumeLocalTimeline: true,
+  });
+});
+
+test('preserved local timeline resumes from paused time when requested', () => {
+  const state = {
+    mode: 'local',
+    paused: true,
+    pausedAt: 12.5,
+    localTime: 0,
+    lastUpdateNow: 100,
+  };
+
+  assert.equal(preserveLocalSceneClockTimeline(state, {
+    now: 200,
+    getSceneClockTime: () => state.pausedAt,
+    resume: true,
+  }), true);
+
+  assert.equal(state.localTime, 12.5);
+  assert.equal(state.lastUpdateNow, 200);
+  assert.equal(state.paused, false);
+  assert.equal(state.pausedAt, null);
+});
+
+test('preserved local timeline can keep paused state when not requested', () => {
+  const state = {
+    mode: 'local',
+    paused: true,
+    pausedAt: 4,
+    localTime: 0,
+    lastUpdateNow: 100,
+  };
+
+  assert.equal(preserveLocalSceneClockTimeline(state, {
+    now: 300,
+    getSceneClockTime: () => state.pausedAt,
+    resume: false,
+  }), true);
+
+  assert.equal(state.localTime, 4);
+  assert.equal(state.lastUpdateNow, 300);
+  assert.equal(state.paused, true);
+  assert.equal(state.pausedAt, 4);
 });

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -58,6 +58,7 @@ import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './uti
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
 import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
 import { calculateScenePlaybackDuration } from './runtime/playback-duration.js';
+import { normalizeSceneClockDeactivateArgs } from './runtime/scene-clock-transport.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
@@ -4685,10 +4686,19 @@ function activateSceneClockTransport(now = performance.now()) {
   notifySceneSyncShellStateChanged('scene-clock-transport-activated');
 }
 
-function deactivateSceneClockTransport(now = performance.now()) {
+function deactivateSceneClockTransport(nowOrOptions = performance.now(), maybeOptions = {}) {
+  const { now, preserveLocalTimeline } = normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions);
+
   setSceneClockRate(1, now);
   sceneClockState.transportActive = false;
-  followHostClock(now);
+  if (preserveLocalTimeline) {
+    if (sceneClockState.mode === 'local') {
+      sceneClockState.localTime = getSceneClockTime(now);
+      sceneClockState.lastUpdateNow = now;
+    }
+  } else {
+    followHostClock(now);
+  }
   notifySceneSyncShellStateChanged('scene-clock-transport-deactivated');
 }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -58,7 +58,10 @@ import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './uti
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
 import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
 import { calculateScenePlaybackDuration } from './runtime/playback-duration.js';
-import { normalizeSceneClockDeactivateArgs } from './runtime/scene-clock-transport.js';
+import {
+  normalizeSceneClockDeactivateArgs,
+  preserveLocalSceneClockTimeline,
+} from './runtime/scene-clock-transport.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
@@ -4687,15 +4690,17 @@ function activateSceneClockTransport(now = performance.now()) {
 }
 
 function deactivateSceneClockTransport(nowOrOptions = performance.now(), maybeOptions = {}) {
-  const { now, preserveLocalTimeline } = normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions);
+  const { now, preserveLocalTimeline, resumeLocalTimeline } =
+    normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions);
 
   setSceneClockRate(1, now);
   sceneClockState.transportActive = false;
   if (preserveLocalTimeline) {
-    if (sceneClockState.mode === 'local') {
-      sceneClockState.localTime = getSceneClockTime(now);
-      sceneClockState.lastUpdateNow = now;
-    }
+    preserveLocalSceneClockTimeline(sceneClockState, {
+      now,
+      getSceneClockTime,
+      resume: resumeLocalTimeline,
+    });
   } else {
     followHostClock(now);
   }

--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.js
@@ -1,5 +1,12 @@
 import { createPlayerTransportPanel } from '../player/player-transport.js';
 
+export function getEditorPlayerDeactivateSceneClockOptions() {
+  return {
+    preserveLocalTimeline: true,
+    resumeLocalTimeline: true,
+  };
+}
+
 function addListener(target, type, handler, options) {
   if (!target) return () => {};
   target.addEventListener(type, handler, options);
@@ -76,7 +83,7 @@ export function createEditorPlayerTransport() {
     if (!opened) return;
     opened = false;
     transport?.setHidden(true);
-    core?.commands?.deactivateSceneClockTransport?.({ preserveLocalTimeline: true });
+    core?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
     renderToggleState();
   }
 
@@ -120,7 +127,7 @@ export function createEditorPlayerTransport() {
 
     unmount() {
       if (opened) {
-        mountedCore?.commands?.deactivateSceneClockTransport?.({ preserveLocalTimeline: true });
+        mountedCore?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
       }
       opened = false;
       for (const dispose of disposers.splice(0)) dispose();

--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.js
@@ -76,7 +76,7 @@ export function createEditorPlayerTransport() {
     if (!opened) return;
     opened = false;
     transport?.setHidden(true);
-    core?.commands?.deactivateSceneClockTransport?.();
+    core?.commands?.deactivateSceneClockTransport?.({ preserveLocalTimeline: true });
     renderToggleState();
   }
 
@@ -120,7 +120,7 @@ export function createEditorPlayerTransport() {
 
     unmount() {
       if (opened) {
-        mountedCore?.commands?.deactivateSceneClockTransport?.();
+        mountedCore?.commands?.deactivateSceneClockTransport?.({ preserveLocalTimeline: true });
       }
       opened = false;
       for (const dispose of disposers.splice(0)) dispose();

--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.test.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getEditorPlayerDeactivateSceneClockOptions } from './editor-player-transport.js';
+
+test('editor player close preserves and resumes the local timeline', () => {
+  assert.deepEqual(getEditorPlayerDeactivateSceneClockOptions(), {
+    preserveLocalTimeline: true,
+    resumeLocalTimeline: true,
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the Editor Player's local Scene Clock timeline when the player panel is closed.
- Add an explicit `preserveLocalTimeline` option to `deactivateSceneClockTransport` so existing deactivate calls can continue returning to `host-follow` by default.
- Route only the Editor Player close/unmount path through the preserve-local option.
- Add a small runtime helper and tests for deactivate argument compatibility.

## Why

Animation/audio offset tuning happens against the Player UI's local timeline. Closing the Editor Player previously switched the Scene Clock back to `host-follow`, changing the time basis from local seconds to wall-clock seconds. For object AudioSources, that can make timeline playback fall back to animation-sample timing and appear offset from what was tuned in the Player UI.

Keeping the local timeline after closing the Editor Player lets the editor preview continue using the same time basis the user just adjusted against, while preserving the selected-object freeze behavior when `transportActive` is no longer true.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/editor/editor-player-transport.js`
- `node --check html/assets/js/scenesync/runtime/scene-clock-transport.js`
- `node --test html/assets/js/scenesync/shells/editor/editor-player-transport.test.js html/assets/js/scenesync/runtime/scene-clock-transport.test.js html/assets/js/scenesync/audio/audio-source-controller.test.js html/assets/js/scenesync/runtime/editing-state.test.js`
- `npm run test:audio-source-controller`
- `npm run test:editing-state`
- `npm run test:playback-duration`
- `node --test html/assets/js/scenesync/runtime/scene-clock-transport.test.js apps/presence-server/tests/audio-source-controller.test.mjs`
