### PR TITLE
Loomlet graph を通常ペースト導線に統合

### DIFF
--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "start": "node src/server.mjs",
-    "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs tests/scenesync-guards.test.mjs",
+    "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs tests/scenesync-guards.test.mjs tests/loomlet-graph-clipboard.test.mjs",
+    "test:loomlet-graph-clipboard": "node --test tests/loomlet-graph-clipboard.test.mjs",
     "scenesync:cleanup-backups": "node scripts/cleanup-backups.mjs",
     "scenesync:load-test": "node ../../tools/scenesync/load-test-presence.mjs"
   },

--- a/apps/presence-server/tests/loomlet-graph-clipboard.test.mjs
+++ b/apps/presence-server/tests/loomlet-graph-clipboard.test.mjs
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+
+import {
+  parseLoomletGraphClipboardText,
+  isGraph,
+  isEmptyGraph,
+  normalizeScope,
+} from '../../../html/assets/js/scenesync/components/loomlet-graph-clipboard.js';
+
+test('raw graph is parsed as set', () => {
+  const text = JSON.stringify({
+    nodes: [{ id: 'clock', type: 'clock' }],
+    edges: [],
+  });
+  const result = parseLoomletGraphClipboardText(text);
+  assert.ok(result);
+  assert.strictEqual(result.kind, 'set');
+  assert.deepStrictEqual(result.scope, { object: 'selected' });
+  assert.strictEqual(result.graph.nodes.length, 1);
+});
+
+test('empty graph is parsed as clear', () => {
+  const text = JSON.stringify({ nodes: [], edges: [] });
+  const result = parseLoomletGraphClipboardText(text);
+  assert.ok(result);
+  assert.strictEqual(result.kind, 'clear');
+  assert.deepStrictEqual(result.scope, { object: 'selected' });
+});
+
+test('scene-graph-set message is parsed', () => {
+  const text = JSON.stringify({
+    type: 'scene-graph-set',
+    scope: { object: 'selected' },
+    graph: { nodes: [{ id: 'a', type: 'clock' }], edges: [] },
+  });
+  const result = parseLoomletGraphClipboardText(text);
+  assert.ok(result);
+  assert.strictEqual(result.kind, 'set');
+  assert.deepStrictEqual(result.scope, { object: 'selected' });
+  assert.strictEqual(result.graph.nodes.length, 1);
+});
+
+test('scene-graph-set with empty graph is parsed as clear', () => {
+  const text = JSON.stringify({
+    type: 'scene-graph-set',
+    scope: { object: 'selected' },
+    graph: { nodes: [], edges: [] },
+  });
+  const result = parseLoomletGraphClipboardText(text);
+  assert.ok(result);
+  assert.strictEqual(result.kind, 'clear');
+});
+
+test('scene-graph-clear message is parsed', () => {
+  const text = JSON.stringify({
+    type: 'scene-graph-clear',
+    scope: { object: 'selected' },
+  });
+  const result = parseLoomletGraphClipboardText(text);
+  assert.ok(result);
+  assert.strictEqual(result.kind, 'clear');
+  assert.deepStrictEqual(result.scope, { object: 'selected' });
+});
+
+test('plain text returns null', () => {
+  assert.strictEqual(parseLoomletGraphClipboardText('こんにちは、世界'), null);
+});
+
+test('invalid JSON returns null', () => {
+  assert.strictEqual(parseLoomletGraphClipboardText('{ nodes: ['), null);
+});
+
+test('nodes that are not an array returns null', () => {
+  const text = JSON.stringify({ nodes: {}, edges: [] });
+  assert.strictEqual(parseLoomletGraphClipboardText(text), null);
+});
+
+test('edges that are not an array returns null', () => {
+  const text = JSON.stringify({ nodes: [], edges: {} });
+  assert.strictEqual(parseLoomletGraphClipboardText(text), null);
+});
+
+test('array JSON returns null', () => {
+  assert.strictEqual(parseLoomletGraphClipboardText('[]'), null);
+  assert.strictEqual(parseLoomletGraphClipboardText('[{"nodes":[],"edges":[]}]'), null);
+});
+
+test('non-string input returns null', () => {
+  assert.strictEqual(parseLoomletGraphClipboardText(null), null);
+  assert.strictEqual(parseLoomletGraphClipboardText(undefined), null);
+  assert.strictEqual(parseLoomletGraphClipboardText({ nodes: [], edges: [] }), null);
+});
+
+test('isGraph guards', () => {
+  assert.strictEqual(isGraph({ nodes: [], edges: [] }), true);
+  assert.strictEqual(isGraph({ nodes: {}, edges: [] }), false);
+  assert.strictEqual(isGraph([]), false);
+  assert.strictEqual(isGraph(null), false);
+});
+
+test('isEmptyGraph', () => {
+  assert.strictEqual(isEmptyGraph({ nodes: [], edges: [] }), true);
+  assert.strictEqual(isEmptyGraph({ nodes: [{ id: 'a' }], edges: [] }), false);
+  assert.strictEqual(isEmptyGraph({ nodes: [], edges: [{ from: 'a', to: 'b' }] }), false);
+});
+
+test('normalizeScope variations', () => {
+  assert.deepStrictEqual(normalizeScope(undefined), { object: 'selected' });
+  assert.deepStrictEqual(normalizeScope(null), { object: 'selected' });
+  assert.strictEqual(normalizeScope('scene'), 'scene');
+  assert.strictEqual(normalizeScope({ scene: true }), 'scene');
+  assert.deepStrictEqual(normalizeScope({ object: 'selected' }), { object: 'selected' });
+  assert.deepStrictEqual(normalizeScope({ object: 'box-1' }), { object: 'box-1' });
+  assert.deepStrictEqual(normalizeScope({}), { object: 'selected' });
+});

--- a/apps/presence-server/tests/loomlet-graph-clipboard.test.mjs
+++ b/apps/presence-server/tests/loomlet-graph-clipboard.test.mjs
@@ -8,6 +8,12 @@ import {
   normalizeScope,
 } from '../../../html/assets/js/scenesync/components/loomlet-graph-clipboard.js';
 
+// 注意: parser は scope（'scene' / { object: 'box-1' } 等）を保持・正規化するが、
+// これはあくまで parse 結果。実際の paste 適用側（scene.js tryHandleLoomletGraphPaste）
+// では MVP 方針として parsed.scope を尊重せず、常に「選択中オブジェクト」へ
+// 上書きして attach / clear する。以下の scope 関連テストは parser の挙動のみを
+// 検証しており、最終的な貼り付け先を意味しない点に注意。
+
 test('raw graph is parsed as set', () => {
   const text = JSON.stringify({
     nodes: [{ id: 'clock', type: 'clock' }],

--- a/html/assets/js/scenesync/components/clipboard-import-manager.js
+++ b/html/assets/js/scenesync/components/clipboard-import-manager.js
@@ -109,8 +109,12 @@ export class ClipboardImportManager {
 
       case 'text':
         try {
-          await this.handleText(payload.text, position, payload.filename, placement);
-          this.showToast?.('クリップボードからテキストを追加しました');
+          const result = await this.handleText(payload.text, position, payload.filename, placement);
+          // text handler が独自の通知を出した場合は汎用 toast を抑止する
+          // （例: Loomlet graph として consume したケース）
+          if (!result?.suppressToast) {
+            this.showToast?.('クリップボードからテキストを追加しました');
+          }
         } catch (err) {
           console.warn('[clipboard] text import failed:', err);
           this.showToast?.(err?.message || 'テキストの読み込みに失敗しました');

--- a/html/assets/js/scenesync/components/loomlet-graph-clipboard.js
+++ b/html/assets/js/scenesync/components/loomlet-graph-clipboard.js
@@ -1,0 +1,75 @@
+// ── loomlet-graph-clipboard.js ─────────────────────────────
+// 通常ペースト導線に統合する Loomlet graph paste parser。
+//
+// クリップボードの text を JSON parse し、以下を判定する。
+//   - Raw graph JSON       ({ nodes: [], edges: [] })
+//   - scene-graph-set message
+//   - scene-graph-clear message
+//
+// 空 graph は attach せず clear として扱う。
+// Loomlet graph として認識できない場合は null を返し、
+// 呼び出し側は通常の text paste にフォールバックする。
+// ──────────────────────────────────────────────────────────
+
+export function parseLoomletGraphClipboardText(text) {
+  if (typeof text !== 'string') return null;
+
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  if (isGraph(value)) {
+    return {
+      kind: isEmptyGraph(value) ? 'clear' : 'set',
+      scope: { object: 'selected' },
+      graph: value,
+    };
+  }
+
+  if (value.type === 'scene-graph-set' && isGraph(value.graph)) {
+    return {
+      kind: isEmptyGraph(value.graph) ? 'clear' : 'set',
+      scope: normalizeScope(value.scope),
+      graph: value.graph,
+    };
+  }
+
+  if (value.type === 'scene-graph-clear') {
+    return {
+      kind: 'clear',
+      scope: normalizeScope(value.scope),
+    };
+  }
+
+  return null;
+}
+
+export function isGraph(value) {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Array.isArray(value.nodes) &&
+    Array.isArray(value.edges)
+  );
+}
+
+export function isEmptyGraph(graph) {
+  return graph.nodes.length === 0 && graph.edges.length === 0;
+}
+
+export function normalizeScope(scope) {
+  if (!scope) return { object: 'selected' };
+  if (scope === 'scene') return 'scene';
+  if (scope?.scene === true) return 'scene';
+  if (scope?.object === 'selected') return { object: 'selected' };
+  if (typeof scope?.object === 'string') return { object: scope.object };
+  return { object: 'selected' };
+}

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -11,6 +11,7 @@ import { createThreeApp } from './core/three-app.js';
 import { createEnvironmentManager } from './core/environment.js';
 import { DragDropManager, SKY_DROP_UPNESS_THRESHOLD } from './components/drag-drop-manager.js';
 import { ClipboardImportManager } from './components/clipboard-import-manager.js';
+import { parseLoomletGraphClipboardText } from './components/loomlet-graph-clipboard.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
 import { buildPlaneGlbFromImage, planeSizeFromImage } from './loaders/image-to-plane.js';
 import { createImageCanvasForScene } from './loaders/image-optimizer.js';
@@ -4605,6 +4606,55 @@ function applySceneGraphOperation(operation) {
   }
   loomIntegration.handlePayload(operation);
   notifySceneStateChanged('scene-graph-operation-applied');
+  return true;
+}
+
+// 通常ペースト導線に Loomlet graph を統合する。
+// selectedObjectIds から primary selected object を解決する（MVP: 単一対象）。
+function getPrimarySelectedObjectId() {
+  for (const id of selectedObjectIds) {
+    if (managedObjects.has(id)) return id;
+  }
+  return null;
+}
+
+// text paste の特殊ケースとして Loomlet graph を検出・適用する。
+// consume した場合は true を返し、呼び出し側は通常 text paste を行わない。
+function tryHandleLoomletGraphPaste(text) {
+  const parsed = parseLoomletGraphClipboardText(text);
+  if (!parsed) return false;
+
+  // Loomlet graph と認識した以上、text panel 化はしない（必ず consume する）。
+  const selectedObjectId = getPrimarySelectedObjectId();
+  if (!selectedObjectId) {
+    showToast('Loomlet graphを貼るには、先にオブジェクトを選択してください');
+    return true;
+  }
+
+  // MVP: scene scope へは寄せず、常に選択中オブジェクトへ attach / clear する。
+  const scope = { object: selectedObjectId };
+
+  try {
+    if (parsed.kind === 'clear') {
+      // 空 graph は attach せず Loomlet Behavior を外す。
+      const operation = { type: 'scene-graph-clear', scope };
+      applyOperationToScene(operation); // 自分の画面に即時反映
+      broadcast(operation);             // 同ルームの他クライアントへ同期
+      showToast('Loomletの振る舞いを外しました');
+    } else {
+      const operation = { type: 'scene-graph-set', scope, graph: parsed.graph };
+      applyOperationToScene(operation);
+      broadcast(operation);
+      showToast('Loomletの振る舞いを適用しました');
+    }
+  } catch (err) {
+    console.warn('[loomlet] graph paste failed:', err);
+    showToast('Loomlet graphの適用に失敗しました');
+  }
+
+  // TODO(loomlet): graph paste / clear を Undo/Redo 対象にする。
+  // 理想は graph paste = behavior attach、empty graph paste = behavior clear を
+  // historyManager 経由で前後状態に戻せるようにすること。MVP では未対応。
   return true;
 }
 
@@ -9231,6 +9281,13 @@ async function imageImporterCallback(file, position, context = {}) {
 }
 
 async function textImporterCallback(text, position, filename = 'text.md', context = {}) {
+  // 通常ペースト導線の特殊ケース: 貼り付け内容が Loomlet graph なら
+  // text panel 化せず、選択中オブジェクトへ attach / clear する。
+  // 独自 toast を出すため、呼び出し側の汎用 toast は抑止する。
+  if (tryHandleLoomletGraphPaste(text)) {
+    return { suppressToast: true };
+  }
+
   const existingMetadata = (context.metadata && typeof context.metadata === 'object')
     ? context.metadata
     : {};

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4631,19 +4631,22 @@ function tryHandleLoomletGraphPaste(text) {
     return true;
   }
 
-  // MVP: scene scope へは寄せず、常に選択中オブジェクトへ attach / clear する。
+  // MVP: paste 時は parsed.scope（scene / { object: 'box-1' } 等）を尊重せず、
+  // 常に選択中オブジェクトへ上書きして attach / clear する。
+  // parser は scope を保持するが、適用側のこの正規化が最終的な貼り付け先を決める。
   const scope = { object: selectedObjectId };
 
   try {
     if (parsed.kind === 'clear') {
       // 空 graph は attach せず Loomlet Behavior を外す。
+      // applySceneGraphOperation: loomIntegration.handlePayload + notifySceneStateChanged
       const operation = { type: 'scene-graph-clear', scope };
-      applyOperationToScene(operation); // 自分の画面に即時反映
-      broadcast(operation);             // 同ルームの他クライアントへ同期
+      applySceneGraphOperation(operation); // 自分の画面に即時反映
+      broadcast(operation);                // 同ルームの他クライアントへ同期
       showToast('Loomletの振る舞いを外しました');
     } else {
       const operation = { type: 'scene-graph-set', scope, graph: parsed.graph };
-      applyOperationToScene(operation);
+      applySceneGraphOperation(operation);
       broadcast(operation);
       showToast('Loomletの振る舞いを適用しました');
     }


### PR DESCRIPTION
Scene Sync の通常ペースト（text paste）で Loomlet graph JSON を
検出し、選択中オブジェクトに Behavior として attach / clear する。

- components/loomlet-graph-clipboard.js: paste text を JSON parse し
  raw graph / scene-graph-set / scene-graph-clear を判定。空 graph は
  clear 扱い。Loomlet graph でなければ null を返し通常 text paste に
  フォールバックする。
- scene.js: textImporterCallback の冒頭で tryHandleLoomletGraphPaste を
  実行。選択中オブジェクトへ scene-graph-set / scene-graph-clear を
  ローカル適用 + broadcast し、自分と他クライアント双方に反映。
  選択なしの場合は toast で案内し、text panel 化はしない。
- clipboard-import-manager.js: text handler が suppressToast を返した
  場合は汎用 toast を抑止（Loomlet consume 時の二重 toast を防止）。
- tests/loomlet-graph-clipboard.test.mjs: parser の unit test を追加。

専用ペーストボタンは作らず、既存の file / url / text 導線を維持。