### PR TITLE
クリップボード fallback 失敗時の誤った error toast を抑止

### DIFF
--- a/apps/presence-server/package.json
+++ b/apps/presence-server/package.json
@@ -6,8 +6,9 @@
   "license": "MIT",
   "scripts": {
     "start": "node src/server.mjs",
-    "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs tests/scenesync-guards.test.mjs tests/loomlet-graph-clipboard.test.mjs",
+    "test": "node --test tests/api.test.mjs tests/inferred-room.test.mjs tests/scenesync-guards.test.mjs tests/loomlet-graph-clipboard.test.mjs tests/clipboard-import-manager.test.mjs",
     "test:loomlet-graph-clipboard": "node --test tests/loomlet-graph-clipboard.test.mjs",
+    "test:clipboard-import-manager": "node --test tests/clipboard-import-manager.test.mjs",
     "scenesync:cleanup-backups": "node scripts/cleanup-backups.mjs",
     "scenesync:load-test": "node ../../tools/scenesync/load-test-presence.mjs"
   },

--- a/apps/presence-server/tests/clipboard-import-manager.test.mjs
+++ b/apps/presence-server/tests/clipboard-import-manager.test.mjs
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+
+import { ClipboardImportManager } from '../../../html/assets/js/scenesync/components/clipboard-import-manager.js';
+
+// paste listener 登録のみに使われる軽量な container モック
+function makeContainer() {
+  return {
+    listeners: [],
+    addEventListener(type, fn) { this.listeners.push([type, fn]); },
+    removeEventListener() {},
+  };
+}
+
+function makeManager(overrides = {}) {
+  const toasts = [];
+  const manager = new ClipboardImportManager({
+    container: makeContainer(),
+    showToast: (msg) => toasts.push(msg),
+    handleFile: async () => ({ objectId: 'file-1' }),
+    handleUrl: async () => ({ objectId: 'url-1' }),
+    handleText: async () => ({ objectId: 'txt-1' }),
+    ...overrides,
+  });
+  return { manager, toasts };
+}
+
+test('importPayload returns { ok: true } on successful text import', async () => {
+  const { manager, toasts } = makeManager();
+  const result = await manager.importPayload({ kind: 'text', text: 'hello' }, null);
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.kind, 'text');
+  assert.deepStrictEqual(result.result, { objectId: 'txt-1' });
+  assert.ok(toasts.includes('クリップボードからテキストを追加しました'));
+});
+
+test('importPayload suppresses generic toast when handler returns suppressToast', async () => {
+  const { manager, toasts } = makeManager({
+    handleText: async () => ({ suppressToast: true }),
+  });
+  const result = await manager.importPayload({ kind: 'text', text: '{"nodes":[],"edges":[]}' }, null);
+  // 成功扱い（Loomlet graph として consume されたケース）
+  assert.strictEqual(result.ok, true);
+  assert.ok(!toasts.includes('クリップボードからテキストを追加しました'));
+});
+
+test('importPayload returns { ok: true } for file and url', async () => {
+  const { manager } = makeManager();
+  const fileResult = await manager.importPayload({ kind: 'file', file: {} }, null);
+  assert.strictEqual(fileResult.ok, true);
+  assert.strictEqual(fileResult.kind, 'file');
+
+  const urlResult = await manager.importPayload({ kind: 'url', url: 'https://example.com' }, null);
+  assert.strictEqual(urlResult.ok, true);
+  assert.strictEqual(urlResult.kind, 'url');
+});
+
+test('importPayload returns { ok: false } when handler throws', async () => {
+  const { manager, toasts } = makeManager({
+    handleText: async () => { throw new Error('boom'); },
+  });
+  const result = await manager.importPayload({ kind: 'text', text: 'x' }, null);
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(result.kind, 'text');
+  assert.ok(toasts.includes('boom'));
+});
+
+test('importPayload returns { ok: false } for unsupported payload', async () => {
+  const { manager, toasts } = makeManager();
+  const result = await manager.importPayload({ kind: 'empty' }, null);
+  assert.strictEqual(result.ok, false);
+  assert.ok(toasts.includes('このクリップボード内容は読み込めません'));
+});
+
+test('pasteFromNavigatorClipboard with silent does not show error toast when clipboard unavailable', async () => {
+  // Node 環境では navigator.clipboard が undefined のため fallback は全てスキップされる
+  const { manager, toasts } = makeManager();
+  const result = await manager.pasteFromNavigatorClipboard(null, { silent: true });
+  assert.strictEqual(result, null);
+  assert.ok(!toasts.includes('クリップボードを読み取れません'));
+});
+
+test('pasteFromNavigatorClipboard without silent shows error toast when clipboard unavailable', async () => {
+  const { manager, toasts } = makeManager();
+  const result = await manager.pasteFromNavigatorClipboard(null);
+  assert.strictEqual(result, null);
+  assert.ok(toasts.includes('クリップボードを読み取れません'));
+});

--- a/html/assets/js/scenesync/components/clipboard-import-manager.js
+++ b/html/assets/js/scenesync/components/clipboard-import-manager.js
@@ -91,21 +91,23 @@ export class ClipboardImportManager {
       case 'file':
         try {
           await this.handleFile(payload.file, placement);
+          return { ok: true, kind: 'file' };
         } catch (err) {
           console.warn('[clipboard] file import failed:', err);
           this.showToast?.(err?.message || 'ファイルの読み込みに失敗しました');
+          return { ok: false, kind: 'file' };
         }
-        break;
 
       case 'url':
         try {
           this.showToast?.('クリップボードからURLを読み込みます');
           await this.handleUrl(payload.url, position, placement);
+          return { ok: true, kind: 'url' };
         } catch (err) {
           console.warn('[clipboard] url import failed:', err);
           this.showToast?.(err?.message || 'URLの追加に失敗しました');
+          return { ok: false, kind: 'url' };
         }
-        break;
 
       case 'text':
         try {
@@ -115,19 +117,23 @@ export class ClipboardImportManager {
           if (!result?.suppressToast) {
             this.showToast?.('クリップボードからテキストを追加しました');
           }
+          return { ok: true, kind: 'text', result };
         } catch (err) {
           console.warn('[clipboard] text import failed:', err);
           this.showToast?.(err?.message || 'テキストの読み込みに失敗しました');
+          return { ok: false, kind: 'text' };
         }
-        break;
 
       default:
         this.showToast?.('このクリップボード内容は読み込めません');
+        return { ok: false, kind: payload?.kind || 'unknown' };
     }
   }
 
   // navigator.clipboard fallback (for future context menu)
-  async pasteFromNavigatorClipboard(position) {
+  // silent=true の場合、read/readText が両方失敗しても強いエラー toast を出さない。
+  // （通常の paste event 側で既に処理できているケースで誤った失敗表示を避けるため）
+  async pasteFromNavigatorClipboard(position, { silent = false } = {}) {
     if (navigator.clipboard?.read) {
       try {
         const items = await navigator.clipboard.read();
@@ -151,7 +157,9 @@ export class ClipboardImportManager {
       }
     }
 
-    this.showToast?.('クリップボードを読み取れません');
+    if (!silent) {
+      this.showToast?.('クリップボードを読み取れません');
+    }
     return null;
   }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -9702,18 +9702,27 @@ function openPasteSheet() {
 
 async function pasteFromClipboardAtDefaultPosition() {
   showToast('クリップボードを読み込みます…');
-  const result = await clipboardImportManager.pasteFromNavigatorClipboard(getClipboardPlacementContext())
+  // silent: true — read/readText が失敗しても manager 側で強い error toast を出さない。
+  // 成功時は importPayload が { ok: true } を返すので、それを成否判定に使う。
+  const result = await clipboardImportManager.pasteFromNavigatorClipboard(getClipboardPlacementContext(), { silent: true })
     .catch((error) => {
       console.warn('[clipboard] navigator clipboard paste failed:', error);
       return null;
     });
 
-  if (result) {
+  if (result?.ok) {
     return result;
   }
 
-  showToast('クリップボードを読み取れません');
-  return null;
+  // ここで強いエラー toast は出さない。
+  // - result?.ok === false: importPayload 側が既に適切な失敗 toast を出している。
+  // - result == null: navigator.clipboard.read/readText が使えない/失敗したケース。
+  //   この場合でも、実際の paste event 側で処理が成功していることがある（iOS Safari 等）ため、
+  //   誤った失敗表示を避け console.warn に留める。
+  if (result == null) {
+    console.warn('[clipboard] navigator clipboard unavailable or read failed');
+  }
+  return result ?? null;
 }
 
 pasteBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## 概要

iPhone Safari で Loomlet graph paste（および通常の paste）が**成功しているのに**、最後に「クリップボードを読み取れません」toast が表示され、成功した操作が失敗に見える問題を修正します。

## 原因

1. `ClipboardImportManager.importPayload()` が成功時も `undefined` を返していたため、呼び出し側 `pasteFromClipboardAtDefaultPosition()` が成功を失敗と誤判定し、error toast を出していた。
2. `pasteFromNavigatorClipboard()` は `navigator.clipboard.read/readText` が失敗した場合に**無条件で**強い error toast を出していた。実際には別ルート（document の `paste` event）で処理が成功しているケースがある。

## 修正

- **`importPayload()`**: 成否を `{ ok, kind }` で返すように変更。成功を正しく検出できるようにした（success path が undefined を返す根本原因の解消）。
- **`pasteFromNavigatorClipboard(position, { silent })`**: `silent` option を追加。`read`/`readText` が両方失敗しても `silent: true` のときは toast を出さず `null` を返す。
- **`pasteFromClipboardAtDefaultPosition()`**: `silent: true` で呼び、`result.ok` で成否判定。失敗/未取得時は強い toast を出さず `console.warn` に留める（iOS Safari 等で実 paste event 側が成功しているケースの誤表示を防止）。

## 要件との対応

- [x] 通常 paste event で処理できた場合、失敗 toast が出ない
- [x] `navigator.clipboard.read/readText` が失敗しても強いエラー表示にしない
- [x] `silent` option を追加
- [x] Loomlet の成功 toast「Loomletの振る舞いを適用しました」は維持
- [x] 既存の file/url/text paste 成功 toast は壊さない

## テスト

`apps/presence-server/tests/clipboard-import-manager.test.mjs` を新規追加（7 ケース、全パス）。

- `importPayload` が成功時に `{ ok: true }`、失敗/未対応時に `{ ok: false }` を返す
- `suppressToast` 指定時に汎用 toast を抑止しつつ成功扱いになる
- `pasteFromNavigatorClipboard` の `silent` option で error toast の有無が切り替わる

`package.json` の `test` スクリプトと専用 `test:clipboard-import-manager` スクリプトに登録済み。

https://claude.ai/code/session_01Dph7PKYGRPqSQriVM9vRRp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dph7PKYGRPqSQriVM9vRRp)_