### PR TITLE
feat(editor): Player UI open/close で inputRoutingMode を interact/edit に切替

### DIFF
--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.js
@@ -61,6 +61,7 @@ export function createEditorPlayerTransport() {
   let mobileButton = null;
   let mountedCore = null;
   let opened = false;
+  let inputRoutingModeBeforePlayerUi = null;
   const disposers = [];
 
   function renderToggleState() {
@@ -74,6 +75,9 @@ export function createEditorPlayerTransport() {
   function open(core) {
     if (opened) return;
     opened = true;
+    const state = core?.getEditorState?.();
+    inputRoutingModeBeforePlayerUi = state?.inputRoutingMode ?? 'edit';
+    core?.commands?.setInputRoutingMode?.('interact');
     core?.commands?.activateSceneClockTransport?.();
     transport?.setHidden(false);
     renderToggleState();
@@ -84,6 +88,9 @@ export function createEditorPlayerTransport() {
     opened = false;
     transport?.setHidden(true);
     core?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
+    const restoreMode = inputRoutingModeBeforePlayerUi ?? 'edit';
+    inputRoutingModeBeforePlayerUi = null;
+    core?.commands?.setInputRoutingMode?.(restoreMode);
     renderToggleState();
   }
 
@@ -128,6 +135,9 @@ export function createEditorPlayerTransport() {
     unmount() {
       if (opened) {
         mountedCore?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
+        const restoreMode = inputRoutingModeBeforePlayerUi ?? 'edit';
+        inputRoutingModeBeforePlayerUi = null;
+        mountedCore?.commands?.setInputRoutingMode?.(restoreMode);
       }
       opened = false;
       for (const dispose of disposers.splice(0)) dispose();


### PR DESCRIPTION
Player UI を開いたときに現在の inputRoutingMode を保存して interact に切り替え、
閉じたときに保存した mode に戻す。これにより Player UI 表示中はオブジェクトをタップ
しても edit selection/transform toolbar に入らず、Loomlet interaction に届く。

- open(): getEditorState() で現在のモードを保存し setInputRoutingMode('interact') を呼ぶ
- close(): 保存した mode (なければ 'edit') に復元
- unmount(): opened のまま unmount された場合も同様に復元

https://claude.ai/code/session_01Xcx5SUFDTUHZCMaFBVgdvS