### PR TITLE
Add deterministic physics engine with lockstep synchronization

### DIFF
--- a/.github/workflows/ci-scene-sync-physics.yml
+++ b/.github/workflows/ci-scene-sync-physics.yml
@@ -1,0 +1,42 @@
+name: CI - Scene Sync Physics
+
+on:
+  pull_request:
+    paths:
+      - "html/assets/js/scenesync/physics/**"
+      - "package.json"
+      - ".github/workflows/ci-scene-sync-physics.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "html/assets/js/scenesync/physics/**"
+      - "package.json"
+      - ".github/workflows/ci-scene-sync-physics.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test Scene Sync Physics
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Syntax check
+        run: |
+          node --check html/assets/js/scenesync/physics/index.js
+          node --check html/assets/js/scenesync/physics/fixed.js
+          node --check html/assets/js/scenesync/physics/world.js
+          node --check html/assets/js/scenesync/physics/lockstep.js
+
+      - name: Run physics tests
+        run: npm run test:physics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,19 @@ curl -s -X POST "http://localhost:8787/api/room/ai-test/broadcast?name=Claude" \
   -d '{"kind":"scene-env","envId":"outdoor_night"}'
 ```
 
+### 決定論的物理エンジン
+
+物理演算をコマンド同期(lockstep + rollback)で共有するためのライブラリ。
+
+- 実装: `html/assets/js/scenesync/physics/`（`fixed.js` 固定小数点数学 / `world.js` 物理ワールド / `lockstep.js` コマンド同期）
+- 仕様: `docs/scene-sync-physics.md`（16.16 固定小数点の移植ルール、broadcast メッセージ案を含む）
+- テスト: `npm run test:physics`
+
 ### テスト実行
 
 ```bash
 cd apps/presence-server && node --test tests/api.test.mjs
+npm run test:physics
 ```
 
 # Scene Sync AI 操作

--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -18,7 +18,9 @@ Scene Sync で物理演算を複数クライアント間で同期するための
 1. **16.16 固定小数点整数演算のみ** — 浮動小数点の実行系差を排除
 2. **固定タイムステップ** — シミュレーションは tick 数のみに依存し、実時間に依存しない
 3. **決定論的な反復順序** — body は挿入順、コマンドは `(tick, peerId, seq)` で全クライアント同一順に適用
-4. **状態ハッシュ(FNV-1a 32bit)** — 分岐検出。不一致時は snapshot で再同期
+4. **プロトコルは raw int** — float→固定小数点変換はコマンド発行クライアントで 1 回だけ行い、wire には固定小数点 raw int を流す。受信側は決定論的なサニタイズ(safe int 化 + クランプ)のみ行う
+5. **コマンドの canonical 化** — 発行・受信時に正規化 + deep freeze してから log に入れる。呼び出し側が保持した参照を後から変更しても log は変わらない
+6. **フルステートハッシュ(FNV-1a 32bit)** — 将来の挙動に影響する全フィールド(world 設定 + tick + 全 body の形状・質量・材質・sleepCounter 含む)を hash。分岐検出時は snapshot で再同期
 
 ## 固定小数点の演算規則(移植ルール)
 
@@ -30,8 +32,11 @@ FP_ONE = 65536 (16.16)
 fmul(a, b) = floor((a * b) / 2^16)      # C#: (a * b) >> 16  (long, 算術シフト)
 fdiv(a, b) = floor((a * 2^16) / b)      # 注意: floor 除算。C# の / は 0 方向切り捨てなので負数は補正が必要
 fsqrt(a)   = floor(sqrt(a * 2^16))      # 64bit 整数 sqrt(Newton 法等)で厳密に
-toFp(x)    = round(x * 65536)           # float→固定小数点は body 定義の取り込み時のみ
+toFp(x)    = floor(x * 2^16 + 0.5)      # IEEE754 double で評価。2 のべき乗倍と floor は厳密なので移植可能
 ```
+
+`toFp` を `Math.round` / C# `Math.Round` で実装してはいけない(0.5 の丸め規則が処理系で異なる)。
+ただし `toFp` が必要になるのはコマンド発行クライアントと world 生成時(`physics-start` の float options)のみで、コマンド payload は raw int で broadcast されるため、通常の同期経路に float 変換は乗らない。
 
 - 乱数は xorshift32(32bit 演算)、状態ハッシュは FNV-1a 32bit。
 - JS 実装は Number(倍精度)の整数演算が 2^53 まで厳密であることを利用する。
@@ -96,6 +101,8 @@ const session = createLockstepSession({
 });
 
 // ローカル操作 → コマンド発行 → broadcast
+// payload の float はここで一度だけ固定小数点 raw int へ変換され、
+// canonical 化 + freeze 済みのコマンドが返る(log にも同じものが入る)
 const command = session.issueCommand('add-body', {
   body: { id: 'ball-1', shape: 'sphere', position: [0, 3, 0] },
 });
@@ -114,10 +121,16 @@ render(session.getBodies());
 // 途中参加 / ハッシュ不一致時の再同期
 const state = session.createResyncState();   // { tick, hash, snapshot, commands }
 newSession.applyResyncState(state);
+// applyResyncState は復元状態を rollback 起点 snapshot として seed し、
+// state 内に自分の peerId のコマンドがあれば seq をその先から再開する
 ```
 
 コマンド種別: `add-body` / `remove-body` / `impulse` / `set-velocity` / `teleport`。
+canonical なコマンド payload は raw int(`body`(raw record) / `impulseFp` / `velocityFp` / `positionFp`)。
 未知の type・不正な payload は **全クライアントで同一に無視** する(前方互換)。
+
+`stateHash()` は world 設定(gravity / timestep / ground)も hash に含めるため、
+`physics-start` の `worldOptions` が一致しないクライアントは即座にハッシュ不一致として検出される。
 
 ## broadcast メッセージ(案)
 
@@ -129,7 +142,7 @@ Scene Sync の broadcast に以下の kind を載せる。シミュレーショ�
 
 { "kind": "physics-command", "sessionId": "phys-1",
   "command": { "tick": 126, "seq": 3, "peerId": "peer-abc", "type": "impulse",
-               "bodyId": "ball-1", "impulse": [2, 4, 0] } }
+               "bodyId": "ball-1", "impulseFp": [131072, 262144, 0] } }
 
 { "kind": "physics-state", "sessionId": "phys-1",
   "tick": 600, "hash": "3fa2c81b", "snapshot": { }, "commands": [] }

--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -1,0 +1,155 @@
+# Scene Sync Deterministic Physics
+
+Scene Sync で物理演算を複数クライアント間で同期するための決定論的物理エンジンライブラリの仕様です。
+
+- 実装: `html/assets/js/scenesync/physics/`
+  - `fixed.js` — 16.16 固定小数点数学(乗除算・平方根・vec3・PRNG・状態ハッシュ)
+  - `world.js` — 決定論的物理ワールド(重力・衝突・スリープ・snapshot)
+  - `lockstep.js` — コマンド同期(tick 固定・順序保証・rollback・再同期)
+  - `index.js` — エントリポイント
+- テスト: `npm run test:physics`
+
+## 設計方針
+
+物理の「状態」をネットワークでストリーミングするのではなく、**コマンド(入力)だけを broadcast** し、各クライアントが同一のシミュレーションを実行する lockstep 方式を採用する。
+
+これが成立する条件は「全クライアントで演算結果がビット単位で一致する」ことであり、本ライブラリは以下で決定論を保証する。
+
+1. **16.16 固定小数点整数演算のみ** — 浮動小数点の実行系差を排除
+2. **固定タイムステップ** — シミュレーションは tick 数のみに依存し、実時間に依存しない
+3. **決定論的な反復順序** — body は挿入順、コマンドは `(tick, peerId, seq)` で全クライアント同一順に適用
+4. **状態ハッシュ(FNV-1a 32bit)** — 分岐検出。不一致時は snapshot で再同期
+
+## 固定小数点の演算規則(移植ルール)
+
+Unity (C#) / Godot (GDScript) に移植する場合、以下の規則を 64bit 整数で厳密に実装すれば JS 実装とビット一致する。
+
+```txt
+FP_ONE = 65536 (16.16)
+
+fmul(a, b) = floor((a * b) / 2^16)      # C#: (a * b) >> 16  (long, 算術シフト)
+fdiv(a, b) = floor((a * 2^16) / b)      # 注意: floor 除算。C# の / は 0 方向切り捨てなので負数は補正が必要
+fsqrt(a)   = floor(sqrt(a * 2^16))      # 64bit 整数 sqrt(Newton 法等)で厳密に
+toFp(x)    = round(x * 65536)           # float→固定小数点は body 定義の取り込み時のみ
+```
+
+- 乱数は xorshift32(32bit 演算)、状態ハッシュは FNV-1a 32bit。
+- JS 実装は Number(倍精度)の整数演算が 2^53 まで厳密であることを利用する。
+  `fmul` は乗数を上位/下位 16bit に分割して計算しており、**絶対値が小さい方のオペランドを第1引数に渡す**規約で厳密性を保つ。
+- world 側で position ±4096m / velocity ±256m/s / mass 0.01〜1000kg / impulse をクランプしているため、すべての中間値が JS の厳密整数範囲(および 64bit 整数範囲)に収まる。
+
+## World API
+
+```js
+import { createWorld } from './html/assets/js/scenesync/physics/index.js';
+
+const world = createWorld({
+  gravity: -9.81,                     // 数値(Y軸) or [x,y,z]
+  ground: { y: 0, restitution: 0.2, friction: 0.5 },  // null で無効化(デフォルトは y=0 に床)
+  timestepFp: 1092,                   // ≈1/60s。省略可
+});
+
+world.addBody({
+  id: 'ball-1',
+  shape: 'sphere',                    // 'sphere' | 'box'
+  radius: 0.5,                        // box の場合は halfExtents: [x,y,z]
+  position: [0, 3, 0],
+  velocity: [0, 0, 0],
+  mass: 1,                            // 0 または static: true で固定
+  restitution: 0.6,
+  friction: 0.5,
+});
+
+world.step();                         // 1 tick 進める
+world.stepTo(120);                    // tick 120 まで進める
+world.applyImpulse('ball-1', [2, 4, 0]);
+world.setVelocity('ball-1', [0, 5, 0]);
+world.teleport('ball-1', [0, 3, 0]);
+world.removeBody('ball-1');
+
+world.getBody('ball-1');              // { position, velocity, sleeping, ... }(float、描画用)
+world.getBodies();
+world.snapshot();                     // 生の固定小数点整数を含む JSON-safe な状態
+world.restore(snapshot);
+world.stateHash();                    // uint32。分岐検出用
+```
+
+挙動:
+
+- 並進運動のみ(回転なし)。dynamic は sphere / AABB box、static は両形状 + 床平面
+- 衝突解決は逐次インパルス(4 iteration)+ 位置補正(Baumgarte 20%, slop 0.01m)
+- restitution は `min(a, b)`、friction は `min(a, b)`、0.5m/s 未満の衝突は反発しない
+- 速度が 0.05m/s 未満の状態が 60 tick 続くと sleep(完全凍結)。接触・インパルス・body 削除で wake
+- 同一 id の `addBody` は置き換え
+
+## Lockstep API
+
+```js
+import { createLockstepSession, tickForElapsedMs } from './html/assets/js/scenesync/physics/index.js';
+
+const session = createLockstepSession({
+  peerId: 'peer-abc',                 // クライアント毎に一意(コマンド順序のタイブレークに使用)
+  worldOptions: { ground: { y: 0 } },
+  commandDelayTicks: 6,               // 発行コマンドは 6 tick 先に予約(伝搬猶予)
+  snapshotIntervalTicks: 30,          // rollback 用 snapshot の間隔
+  maxSnapshots: 8,
+});
+
+// ローカル操作 → コマンド発行 → broadcast
+const command = session.issueCommand('add-body', {
+  body: { id: 'ball-1', shape: 'sphere', position: [0, 3, 0] },
+});
+broadcast({ kind: 'physics-command', command });
+
+// 受信側
+const result = session.receiveCommand(message.command);
+// { applied: true, rolledBack: false }
+// { applied: true, rolledBack: true }   … 遅延到着 → snapshot へ巻き戻して再実行済み
+// { applied: false, reason: 'too-old' } … 巻き戻し限界超過 → 再同期を要求する
+
+// 毎フレーム: 共有開始時刻から目標 tick を計算して進める
+session.advanceTo(tickForElapsedMs(hostNow - startHostTime));
+render(session.getBodies());
+
+// 途中参加 / ハッシュ不一致時の再同期
+const state = session.createResyncState();   // { tick, hash, snapshot, commands }
+newSession.applyResyncState(state);
+```
+
+コマンド種別: `add-body` / `remove-body` / `impulse` / `set-velocity` / `teleport`。
+未知の type・不正な payload は **全クライアントで同一に無視** する(前方互換)。
+
+## broadcast メッセージ(案)
+
+Scene Sync の broadcast に以下の kind を載せる。シミュレーションは tick のみに依存するため、`hostTime` はペーシング(進行速度合わせ)にだけ使い、結果には影響しない。
+
+```json
+{ "kind": "physics-start", "sessionId": "phys-1", "startHostTime": 1770000000000,
+  "worldOptions": { "gravity": -9.81, "ground": { "y": 0 } } }
+
+{ "kind": "physics-command", "sessionId": "phys-1",
+  "command": { "tick": 126, "seq": 3, "peerId": "peer-abc", "type": "impulse",
+               "bodyId": "ball-1", "impulse": [2, 4, 0] } }
+
+{ "kind": "physics-state", "sessionId": "phys-1",
+  "tick": 600, "hash": "3fa2c81b", "snapshot": { }, "commands": [] }
+
+{ "kind": "physics-stop", "sessionId": "phys-1" }
+```
+
+- `physics-state` は途中参加者への配布と定期的なハッシュ照合に使う(`createResyncState()` の出力)
+- ハッシュ不一致を検出したクライアントは host に `physics-state` を要求して `applyResyncState()` する
+- 描画への反映はローカルで行う。物理 body と scene object の対応付けは `objectId == bodyId` を推奨
+
+## 制限事項
+
+- 回転の動力学なし(必要になったら固定小数点 quaternion を拡張)
+- 衝突形状は sphere / AABB / 床平面のみ。ペア総当たり(数十 body 規模を想定)
+- 座標 ±4096m、速度 ±256m/s、質量 0.01〜1000kg にクランプされる
+- `advanceTo` の引数は単調増加を想定(過去 tick への巻き戻しは receiveCommand 内部のみ)
+
+## 関連ドキュメント
+
+- [Scene Sync Spec Index](./scene-sync-spec.md)
+- [Runtime Time Model](./scene-sync-runtime-time-model.md) — `f(t)` モデルとの関係。物理は tick ベースの逐次シミュレーションなのでコマンド同期 + 決定論で扱う
+- [API / Protocol](./scene-sync-api-protocol.md)

--- a/docs/scene-sync-spec.md
+++ b/docs/scene-sync-spec.md
@@ -11,6 +11,7 @@ Scene Sync 仕様の入口です。詳細仕様は以下に分冊します。
 - [Avatar / Presence](./scene-sync-avatar-and-presence.md)
 - [Animation](./scene-sync-animation.md)
 - [Runtime Time Model](./scene-sync-runtime-time-model.md)
+- [Deterministic Physics](./scene-sync-physics.md)
 - [Loom / Behavior Graph Protocol](./scene-sync-loom-protocol.md)
 - [Realtime Streaming Notes](./scene-sync-realtime-streaming.md)
 

--- a/html/assets/js/scenesync/physics/fixed.js
+++ b/html/assets/js/scenesync/physics/fixed.js
@@ -1,0 +1,181 @@
+// Deterministic 16.16 fixed-point math for Scene Sync physics.
+//
+// All simulation state is stored as raw fixed-point integers so that every
+// client (browser / Unity / Godot) can compute bit-identical results.
+// Porting rules (see docs/scene-sync-physics.md):
+//   fmul(a, b)  = floor((a * b) / 2^16)   (= (a * b) >> 16 in 64-bit ints)
+//   fdiv(a, b)  = floor((a * 2^16) / b)   (floored division, not truncated)
+//   fsqrt(a)    = floor(sqrt(a * 2^16))
+//
+// JavaScript numbers represent integers exactly up to 2^53. fmul is exact
+// when the smaller-magnitude operand is passed first (|a| < 2^37) and
+// |a * b| stays below 2^68; the world enforces this through its
+// position / velocity / mass / impulse clamps.
+
+export const FP_SHIFT = 16;
+export const FP_ONE = 65536;
+
+export function toFp(value) {
+  if (!Number.isFinite(value)) return 0;
+  // `+ 0` normalizes -0 so raw state never contains negative zero
+  return Math.round(value * FP_ONE) + 0;
+}
+
+export function fromFp(raw) {
+  return raw / FP_ONE;
+}
+
+export function floorDiv(n, d) {
+  if (d === 0) throw new RangeError('floorDiv: division by zero');
+  let q = Math.floor(n / d);
+  // Float division can round across an integer boundary; correct with exact
+  // integer remainders so the result is always the true floored quotient.
+  let r = n - q * d;
+  if (d > 0) {
+    while (r < 0) { q -= 1; r += d; }
+    while (r >= d) { q += 1; r -= d; }
+  } else {
+    while (r > 0) { q -= 1; r += d; }
+    while (r <= d) { q += 1; r -= d; }
+  }
+  return q + 0;
+}
+
+export function fmul(a, b) {
+  // Split b so that both partial products stay below 2^53.
+  // floor((a*b) / 2^16) = a*bh + floor((a*bl) / 2^16) because a*bh*2^16 is
+  // an exact multiple of 2^16, and dividing by a power of two is exact.
+  const bh = Math.floor(b / FP_ONE);
+  const bl = b - bh * FP_ONE;
+  return a * bh + Math.floor((a * bl) / FP_ONE) + 0;
+}
+
+export function fdiv(a, b) {
+  return floorDiv(a * FP_ONE, b);
+}
+
+export function fclamp(value, min, max) {
+  return value < min ? min : value > max ? max : value;
+}
+
+export function fsqrt(a) {
+  if (a <= 0) return 0;
+  const n = BigInt(a) << 16n;
+  // Newton's method seeded above the true root converges downward; the final
+  // correction loops make the result exact regardless of the float seed.
+  let x = BigInt(Math.floor(Math.sqrt(Number(n)))) + 2n;
+  for (;;) {
+    const next = (x + n / x) >> 1n;
+    if (next >= x) break;
+    x = next;
+  }
+  while (x * x > n) x -= 1n;
+  while ((x + 1n) * (x + 1n) <= n) x += 1n;
+  return Number(x);
+}
+
+// --- vec3 helpers (arrays of raw fixed-point ints) ---
+
+export function toFpVec(v) {
+  return [toFp(v[0]), toFp(v[1]), toFp(v[2])];
+}
+
+export function fromFpVec(v) {
+  return [fromFp(v[0]), fromFp(v[1]), fromFp(v[2])];
+}
+
+export function vadd(a, b) {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+export function vsub(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+export function vneg(v) {
+  return [-v[0], -v[1], -v[2]];
+}
+
+export function vscale(v, s) {
+  return [fmul(v[0], s), fmul(v[1], s), fmul(v[2], s)];
+}
+
+export function vdot(a, b) {
+  return fmul(a[0], b[0]) + fmul(a[1], b[1]) + fmul(a[2], b[2]);
+}
+
+export function vlenSq(v) {
+  return vdot(v, v);
+}
+
+export function vlen(v) {
+  return fsqrt(vdot(v, v));
+}
+
+export function vclampComponents(v, limit) {
+  return [
+    fclamp(v[0], -limit, limit),
+    fclamp(v[1], -limit, limit),
+    fclamp(v[2], -limit, limit),
+  ];
+}
+
+// --- deterministic PRNG (xorshift32) ---
+
+export function createXorShift32(seed = 1) {
+  let state = seed >>> 0;
+  if (state === 0) state = 0x9e3779b9;
+  function nextUint32() {
+    state = (state ^ (state << 13)) >>> 0;
+    state = (state ^ (state >>> 17)) >>> 0;
+    state = (state ^ (state << 5)) >>> 0;
+    return state;
+  }
+  function nextFp() {
+    // [0, FP_ONE)
+    return nextUint32() >>> 16;
+  }
+  function nextFpRange(minFp, maxFp) {
+    return minFp + fmul(maxFp - minFp, nextFp());
+  }
+  return { nextUint32, nextFp, nextFpRange };
+}
+
+// --- FNV-1a 32-bit hash for state divergence checks ---
+
+const FNV_OFFSET = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+export function hashInit() {
+  return FNV_OFFSET;
+}
+
+function hashByte(h, byte) {
+  return Math.imul(h ^ (byte & 0xff), FNV_PRIME) >>> 0;
+}
+
+export function hashUint32(h, value) {
+  const v = value >>> 0;
+  h = hashByte(h, v);
+  h = hashByte(h, v >>> 8);
+  h = hashByte(h, v >>> 16);
+  h = hashByte(h, v >>> 24);
+  return h;
+}
+
+export function hashInt(h, value) {
+  const bits = BigInt.asUintN(64, BigInt(value));
+  h = hashUint32(h, Number(bits & 0xffffffffn));
+  return hashUint32(h, Number(bits >> 32n));
+}
+
+export function hashString(h, str) {
+  for (let i = 0; i < str.length; i += 1) {
+    h = hashUint32(h, str.charCodeAt(i));
+  }
+  return h;
+}
+
+export function hashHex(h) {
+  return (h >>> 0).toString(16).padStart(8, '0');
+}

--- a/html/assets/js/scenesync/physics/fixed.js
+++ b/html/assets/js/scenesync/physics/fixed.js
@@ -17,8 +17,13 @@ export const FP_ONE = 65536;
 
 export function toFp(value) {
   if (!Number.isFinite(value)) return 0;
-  // `+ 0` normalizes -0 so raw state never contains negative zero
-  return Math.round(value * FP_ONE) + 0;
+  // Spec: toFp(x) = floor(x * 2^16 + 0.5) evaluated in IEEE754 doubles.
+  // Multiplying by a power of two and flooring are exact, so this definition
+  // is bit-portable — unlike Math.round / C# Math.Round whose half-way tie
+  // rules differ. Conversion happens only when commands are issued; the wire
+  // protocol carries raw fixed-point ints (see docs/scene-sync-physics.md).
+  // `+ 0` normalizes -0 so raw state never contains negative zero.
+  return Math.floor(value * FP_ONE + 0.5) + 0;
 }
 
 export function fromFp(raw) {
@@ -56,6 +61,21 @@ export function fdiv(a, b) {
 
 export function fclamp(value, min, max) {
   return value < min ? min : value > max ? max : value;
+}
+
+// Deterministic coercion for raw fixed-point values received from the
+// network: anything that is not a safe integer becomes the fallback.
+export function toSafeInt(value, fallback = 0) {
+  return Number.isSafeInteger(value) ? value + 0 : fallback;
+}
+
+export function sanitizeFpVec(value, limit) {
+  const v = Array.isArray(value) && value.length >= 3 ? value : [0, 0, 0];
+  return [
+    fclamp(toSafeInt(v[0]), -limit, limit),
+    fclamp(toSafeInt(v[1]), -limit, limit),
+    fclamp(toSafeInt(v[2]), -limit, limit),
+  ];
 }
 
 export function fsqrt(a) {

--- a/html/assets/js/scenesync/physics/fixed.test.js
+++ b/html/assets/js/scenesync/physics/fixed.test.js
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  FP_ONE,
+  toFp,
+  fromFp,
+  floorDiv,
+  fmul,
+  fdiv,
+  fsqrt,
+  fclamp,
+  vadd,
+  vsub,
+  vscale,
+  vdot,
+  vlen,
+  createXorShift32,
+  hashInit,
+  hashInt,
+  hashString,
+  hashHex,
+} from './fixed.js';
+
+// Independent 64-bit integer references the ports (C# / GDScript) must match.
+function bigFloorDiv(n, d) {
+  let q = n / d;
+  if (q * d !== n && (n < 0n) !== (d < 0n)) q -= 1n;
+  return q;
+}
+
+function bigIsqrt(n) {
+  let remainder = n;
+  let result = 0n;
+  let bit = 1n << 62n;
+  while (bit > remainder) bit >>= 2n;
+  while (bit > 0n) {
+    if (remainder >= result + bit) {
+      remainder -= result + bit;
+      result = (result >> 1n) + bit;
+    } else {
+      result >>= 1n;
+    }
+    bit >>= 2n;
+  }
+  return result;
+}
+
+const SAMPLE_VALUES = [
+  0, 1, -1, 7, -7, 255, -256, 65535, 65536, -65536, 65537,
+  12345, -98765, 1000000, -1000003, 2 ** 20, -(2 ** 20) + 1,
+  2 ** 28, -(2 ** 28), 999999937, -999999937,
+];
+
+test('toFp / fromFp round numbers symmetrically', () => {
+  assert.equal(toFp(1), FP_ONE);
+  assert.equal(toFp(-9.81), -642908); // round(-9.81 * 65536)
+  assert.equal(toFp(Number.NaN), 0);
+  assert.equal(fromFp(FP_ONE), 1);
+  assert.equal(fromFp(toFp(0.5)), 0.5);
+});
+
+test('floorDiv floors toward negative infinity', () => {
+  assert.equal(floorDiv(7, 2), 3);
+  assert.equal(floorDiv(-7, 2), -4);
+  assert.equal(floorDiv(7, -2), -4);
+  assert.equal(floorDiv(-7, -2), 3);
+  assert.equal(floorDiv(6, 3), 2);
+  assert.equal(floorDiv(-6, 3), -2);
+  assert.throws(() => floorDiv(1, 0), RangeError);
+});
+
+test('fmul matches the 64-bit (a*b)>>16 reference', () => {
+  for (const a of SAMPLE_VALUES) {
+    for (const b of SAMPLE_VALUES) {
+      const expected = Number((BigInt(a) * BigInt(b)) >> 16n);
+      assert.equal(fmul(a, b), expected, `fmul(${a}, ${b})`);
+    }
+  }
+});
+
+test('fdiv matches the 64-bit floored division reference', () => {
+  for (const a of SAMPLE_VALUES) {
+    for (const b of SAMPLE_VALUES) {
+      if (b === 0) continue;
+      const expected = Number(bigFloorDiv(BigInt(a) << 16n, BigInt(b)));
+      assert.equal(fdiv(a, b), expected, `fdiv(${a}, ${b})`);
+    }
+  }
+});
+
+test('fsqrt matches the 64-bit integer sqrt reference', () => {
+  const values = [0, 1, 2, 3, 4, 65536, 65537, 164, 5898, 2 ** 30, 2 ** 40, 3 * 2 ** 42];
+  for (const a of values) {
+    const expected = Number(bigIsqrt(BigInt(a) << 16n));
+    assert.equal(fsqrt(a), expected, `fsqrt(${a})`);
+  }
+  assert.equal(fsqrt(-5), 0);
+  // sqrt(4.0) = 2.0, sqrt(2.0) = floor(1.41421... * 65536) = 92681
+  assert.equal(fsqrt(toFp(4)), toFp(2));
+  assert.equal(fsqrt(toFp(2)), 92681);
+});
+
+test('vector helpers operate component-wise in fixed point', () => {
+  const a = [toFp(1), toFp(2), toFp(-3)];
+  const b = [toFp(0.5), toFp(-1), toFp(4)];
+  assert.deepEqual(vadd(a, b), [toFp(1.5), toFp(1), toFp(1)]);
+  assert.deepEqual(vsub(a, b), [toFp(0.5), toFp(3), toFp(-7)]);
+  assert.deepEqual(vscale(a, toFp(2)), [toFp(2), toFp(4), toFp(-6)]);
+  // 1*0.5 + 2*(-1) + (-3)*4 = -13.5
+  assert.equal(vdot(a, b), toFp(-13.5));
+  // |(3,4,0)| = 5
+  assert.equal(vlen([toFp(3), toFp(4), 0]), toFp(5));
+});
+
+test('fclamp limits values to the range', () => {
+  assert.equal(fclamp(5, 0, 10), 5);
+  assert.equal(fclamp(-5, 0, 10), 0);
+  assert.equal(fclamp(15, 0, 10), 10);
+});
+
+test('xorshift32 produces a stable deterministic sequence', () => {
+  const rng = createXorShift32(1);
+  assert.equal(rng.nextUint32(), 270369);
+  const a = createXorShift32(12345);
+  const b = createXorShift32(12345);
+  for (let i = 0; i < 100; i += 1) {
+    assert.equal(a.nextUint32(), b.nextUint32());
+  }
+  const fp = a.nextFp();
+  assert.ok(fp >= 0 && fp < FP_ONE);
+});
+
+test('hash is stable and sensitive to changes', () => {
+  let h1 = hashInit();
+  h1 = hashString(h1, 'ball-1');
+  h1 = hashInt(h1, 65536);
+  h1 = hashInt(h1, -642998);
+
+  let h2 = hashInit();
+  h2 = hashString(h2, 'ball-1');
+  h2 = hashInt(h2, 65536);
+  h2 = hashInt(h2, -642998);
+  assert.equal(h1, h2);
+
+  let h3 = hashInit();
+  h3 = hashString(h3, 'ball-1');
+  h3 = hashInt(h3, 65537);
+  h3 = hashInt(h3, -642998);
+  assert.notEqual(h1, h3);
+
+  assert.match(hashHex(h1), /^[0-9a-f]{8}$/);
+});

--- a/html/assets/js/scenesync/physics/index.js
+++ b/html/assets/js/scenesync/physics/index.js
@@ -1,0 +1,6 @@
+// Scene Sync deterministic physics library entry point.
+// See docs/scene-sync-physics.md for the protocol and porting rules.
+
+export * from './fixed.js';
+export * from './world.js';
+export * from './lockstep.js';

--- a/html/assets/js/scenesync/physics/lockstep.js
+++ b/html/assets/js/scenesync/physics/lockstep.js
@@ -1,0 +1,203 @@
+// Lockstep command synchronization for the deterministic physics world.
+//
+// Clients never exchange physics state during normal play — only commands
+// pinned to a tick. Because the world is deterministic, applying the same
+// sorted command log produces identical states everywhere. Commands that
+// arrive after their tick has already been simulated are handled by rolling
+// back to a periodic snapshot and replaying.
+//
+// Command ordering is (tick, peerId, seq) so all clients apply concurrent
+// commands in the same order regardless of arrival order.
+
+import { FP_ONE } from './fixed.js';
+import { createWorld, DEFAULT_TIMESTEP_FP } from './world.js';
+
+export function compareCommands(a, b) {
+  if (a.tick !== b.tick) return a.tick - b.tick;
+  const peerA = String(a.peerId ?? '');
+  const peerB = String(b.peerId ?? '');
+  if (peerA < peerB) return -1;
+  if (peerA > peerB) return 1;
+  return (a.seq ?? 0) - (b.seq ?? 0);
+}
+
+// Wall-clock pacing only: each client maps a shared start time to a target
+// tick, but simulation results depend solely on tick counts, never on clocks.
+export function tickForElapsedMs(elapsedMs, timestepFp = DEFAULT_TIMESTEP_FP) {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return 0;
+  return Math.floor((elapsedMs * FP_ONE) / (timestepFp * 1000));
+}
+
+export function createLockstepSession({
+  peerId = 'local',
+  worldOptions = {},
+  commandDelayTicks = 6,
+  snapshotIntervalTicks = 30,
+  maxSnapshots = 8,
+} = {}) {
+  const world = createWorld(worldOptions);
+  const commandLog = [];
+  const snapshots = [];
+  let seqCounter = 0;
+
+  function pruneCommandLog() {
+    const oldestTick = snapshots.length > 0 ? snapshots[0].tick : 0;
+    while (commandLog.length > 0 && commandLog[0].tick < oldestTick) {
+      commandLog.shift();
+    }
+  }
+
+  function recordSnapshotIfDue() {
+    if (world.tick % snapshotIntervalTicks !== 0) return;
+    const last = snapshots[snapshots.length - 1];
+    if (last && last.tick === world.tick) return;
+    snapshots.push({ tick: world.tick, snapshot: world.snapshot() });
+    while (snapshots.length > maxSnapshots) snapshots.shift();
+    pruneCommandLog();
+  }
+
+  function applyCommand(command) {
+    try {
+      switch (command.type) {
+        case 'add-body':
+          if (command.body) world.addBody(command.body);
+          break;
+        case 'remove-body':
+          world.removeBody(command.bodyId);
+          break;
+        case 'impulse':
+          if (Array.isArray(command.impulse)) world.applyImpulse(command.bodyId, command.impulse);
+          break;
+        case 'set-velocity':
+          if (Array.isArray(command.velocity)) world.setVelocity(command.bodyId, command.velocity);
+          break;
+        case 'teleport':
+          if (Array.isArray(command.position)) world.teleport(command.bodyId, command.position);
+          break;
+        default:
+          // 未知のコマンドは全クライアントで同一に無視する
+          break;
+      }
+    } catch {
+      // 不正な payload も全クライアントで同一に無視する
+    }
+  }
+
+  function applyCommandsAt(tick) {
+    for (const command of commandLog) {
+      if (command.tick > tick) break;
+      if (command.tick === tick) applyCommand(command);
+    }
+  }
+
+  function advanceTo(targetTick) {
+    if (!Number.isInteger(targetTick)) return;
+    while (world.tick < targetTick) {
+      recordSnapshotIfDue();
+      applyCommandsAt(world.tick);
+      world.step();
+    }
+  }
+
+  function isValidCommand(command) {
+    return command
+      && Number.isInteger(command.tick) && command.tick >= 0
+      && Number.isInteger(command.seq)
+      && typeof command.peerId === 'string'
+      && typeof command.type === 'string';
+  }
+
+  function findDuplicate(command) {
+    return commandLog.some((existing) => existing.tick === command.tick
+      && existing.peerId === command.peerId
+      && existing.seq === command.seq);
+  }
+
+  function insertCommand(command) {
+    let index = commandLog.length;
+    while (index > 0 && compareCommands(commandLog[index - 1], command) > 0) {
+      index -= 1;
+    }
+    commandLog.splice(index, 0, command);
+  }
+
+  function issueCommand(type, payload = {}) {
+    const command = {
+      ...payload,
+      tick: world.tick + commandDelayTicks,
+      seq: seqCounter,
+      peerId,
+      type,
+    };
+    seqCounter += 1;
+    insertCommand(command);
+    return command;
+  }
+
+  function receiveCommand(command) {
+    if (!isValidCommand(command)) {
+      return { applied: false, reason: 'invalid' };
+    }
+    if (findDuplicate(command)) {
+      return { applied: false, reason: 'duplicate' };
+    }
+    if (command.tick >= world.tick) {
+      insertCommand(command);
+      return { applied: true, rolledBack: false };
+    }
+    // Late command: roll back to the newest snapshot at or before its tick
+    // (snapshots hold the state before that tick's commands are applied),
+    // then replay with the command inserted.
+    let snapshotIndex = -1;
+    for (let i = snapshots.length - 1; i >= 0; i -= 1) {
+      if (snapshots[i].tick <= command.tick) {
+        snapshotIndex = i;
+        break;
+      }
+    }
+    if (snapshotIndex < 0) {
+      return { applied: false, reason: 'too-old' };
+    }
+    const resumeTick = world.tick;
+    world.restore(snapshots[snapshotIndex].snapshot);
+    snapshots.length = snapshotIndex + 1;
+    insertCommand(command);
+    advanceTo(resumeTick);
+    return { applied: true, rolledBack: true };
+  }
+
+  // 途中参加・ハッシュ不一致時の再同期用フルステート
+  function createResyncState() {
+    return {
+      tick: world.tick,
+      hash: world.stateHash(),
+      snapshot: world.snapshot(),
+      commands: commandLog.filter((command) => command.tick >= world.tick),
+    };
+  }
+
+  function applyResyncState(state) {
+    if (!state || typeof state !== 'object' || !state.snapshot) return false;
+    world.restore(state.snapshot);
+    snapshots.length = 0;
+    commandLog.length = 0;
+    for (const command of state.commands ?? []) {
+      if (isValidCommand(command) && !findDuplicate(command)) insertCommand(command);
+    }
+    return true;
+  }
+
+  return {
+    peerId,
+    world,
+    get tick() { return world.tick; },
+    commandDelayTicks,
+    issueCommand,
+    receiveCommand,
+    advanceTo,
+    createResyncState,
+    applyResyncState,
+    stateHash: () => world.stateHash(),
+    getBodies: () => world.getBodies(),
+  };
+}

--- a/html/assets/js/scenesync/physics/lockstep.js
+++ b/html/assets/js/scenesync/physics/lockstep.js
@@ -9,8 +9,71 @@
 // Command ordering is (tick, peerId, seq) so all clients apply concurrent
 // commands in the same order regardless of arrival order.
 
-import { FP_ONE } from './fixed.js';
-import { createWorld, DEFAULT_TIMESTEP_FP } from './world.js';
+import { FP_ONE, toFp, toSafeInt, sanitizeFpVec } from './fixed.js';
+import {
+  createWorld,
+  DEFAULT_TIMESTEP_FP,
+  normalizeBodyDef,
+  sanitizeBodyRecord,
+  MAX_POSITION_FP,
+  MAX_VELOCITY_FP,
+  MAX_IMPULSE_FP,
+} from './world.js';
+
+function toFpVecLoose(value) {
+  const v = Array.isArray(value) && value.length >= 3 ? value : [0, 0, 0];
+  return [toFp(Number(v[0])), toFp(Number(v[1])), toFp(Number(v[2]))];
+}
+
+function deepFreeze(object) {
+  for (const value of Object.values(object)) {
+    if (value && typeof value === 'object') deepFreeze(value);
+  }
+  return Object.freeze(object);
+}
+
+// Builds the canonical, JSON-safe, frozen command that goes into the log.
+// Payloads are raw fixed-point ints; every peer runs the same coercion, so a
+// command observed anywhere is byte-identical everywhere, and callers cannot
+// mutate logged commands through retained references.
+export function canonicalizeCommand(command) {
+  const canonical = {
+    tick: toSafeInt(command.tick, -1),
+    seq: toSafeInt(command.seq, -1),
+    peerId: String(command.peerId ?? ''),
+    type: String(command.type ?? ''),
+  };
+  switch (canonical.type) {
+    case 'add-body': {
+      const body = sanitizeBodyRecord(command.body);
+      if (body) {
+        body.sleepCounter = 0;
+        body.sleeping = false;
+        canonical.body = body;
+      }
+      break;
+    }
+    case 'remove-body':
+      canonical.bodyId = String(command.bodyId ?? '');
+      break;
+    case 'impulse':
+      canonical.bodyId = String(command.bodyId ?? '');
+      canonical.impulseFp = sanitizeFpVec(command.impulseFp, MAX_IMPULSE_FP);
+      break;
+    case 'set-velocity':
+      canonical.bodyId = String(command.bodyId ?? '');
+      canonical.velocityFp = sanitizeFpVec(command.velocityFp, MAX_VELOCITY_FP);
+      break;
+    case 'teleport':
+      canonical.bodyId = String(command.bodyId ?? '');
+      canonical.positionFp = sanitizeFpVec(command.positionFp, MAX_POSITION_FP);
+      break;
+    default:
+      // 未知 type は payload を持たない inert なコマンドとして残す
+      break;
+  }
+  return deepFreeze(canonical);
+}
 
 export function compareCommands(a, b) {
   if (a.tick !== b.tick) return a.tick - b.tick;
@@ -57,29 +120,25 @@ export function createLockstepSession({
   }
 
   function applyCommand(command) {
-    try {
-      switch (command.type) {
-        case 'add-body':
-          if (command.body) world.addBody(command.body);
-          break;
-        case 'remove-body':
-          world.removeBody(command.bodyId);
-          break;
-        case 'impulse':
-          if (Array.isArray(command.impulse)) world.applyImpulse(command.bodyId, command.impulse);
-          break;
-        case 'set-velocity':
-          if (Array.isArray(command.velocity)) world.setVelocity(command.bodyId, command.velocity);
-          break;
-        case 'teleport':
-          if (Array.isArray(command.position)) world.teleport(command.bodyId, command.position);
-          break;
-        default:
-          // 未知のコマンドは全クライアントで同一に無視する
-          break;
-      }
-    } catch {
-      // 不正な payload も全クライアントで同一に無視する
+    switch (command.type) {
+      case 'add-body':
+        if (command.body) world.addBodyRecord(command.body);
+        break;
+      case 'remove-body':
+        world.removeBody(command.bodyId);
+        break;
+      case 'impulse':
+        world.applyImpulseFp(command.bodyId, command.impulseFp);
+        break;
+      case 'set-velocity':
+        world.setVelocityFp(command.bodyId, command.velocityFp);
+        break;
+      case 'teleport':
+        world.teleportFp(command.bodyId, command.positionFp);
+        break;
+      default:
+        // 未知のコマンドは全クライアントで同一に無視する
+        break;
     }
   }
 
@@ -121,23 +180,52 @@ export function createLockstepSession({
     commandLog.splice(index, 0, command);
   }
 
+  // Accepts ergonomic float payloads ({ body }, { impulse }, { velocity },
+  // { position }) or pre-converted raw payloads ({ impulseFp }, ...). Floats
+  // are converted to fixed point here, once, on the issuing client — the
+  // canonical raw-int command is what gets logged and broadcast.
   function issueCommand(type, payload = {}) {
-    const command = {
-      ...payload,
+    const draft = {
       tick: world.tick + commandDelayTicks,
       seq: seqCounter,
       peerId,
       type,
     };
+    switch (type) {
+      case 'add-body':
+        draft.body = payload.body && !Array.isArray(payload.body)
+          ? (payload.body.positionFp ? payload.body : normalizeBodyDef(payload.body))
+          : null;
+        break;
+      case 'remove-body':
+        draft.bodyId = payload.bodyId;
+        break;
+      case 'impulse':
+        draft.bodyId = payload.bodyId;
+        draft.impulseFp = payload.impulseFp ?? toFpVecLoose(payload.impulse);
+        break;
+      case 'set-velocity':
+        draft.bodyId = payload.bodyId;
+        draft.velocityFp = payload.velocityFp ?? toFpVecLoose(payload.velocity);
+        break;
+      case 'teleport':
+        draft.bodyId = payload.bodyId;
+        draft.positionFp = payload.positionFp ?? toFpVecLoose(payload.position);
+        break;
+      default:
+        break;
+    }
+    const command = canonicalizeCommand(draft);
     seqCounter += 1;
     insertCommand(command);
     return command;
   }
 
-  function receiveCommand(command) {
-    if (!isValidCommand(command)) {
+  function receiveCommand(message) {
+    if (!isValidCommand(message)) {
       return { applied: false, reason: 'invalid' };
     }
+    const command = canonicalizeCommand(message);
     if (findDuplicate(command)) {
       return { applied: false, reason: 'duplicate' };
     }
@@ -180,9 +268,22 @@ export function createLockstepSession({
     if (!state || typeof state !== 'object' || !state.snapshot) return false;
     world.restore(state.snapshot);
     snapshots.length = 0;
+    // Seed the restored state as a rollback anchor so slightly-late commands
+    // arriving before the next snapshot interval can still be replayed
+    // instead of being rejected as too-old.
+    snapshots.push({ tick: world.tick, snapshot: world.snapshot() });
     commandLog.length = 0;
-    for (const command of state.commands ?? []) {
-      if (isValidCommand(command) && !findDuplicate(command)) insertCommand(command);
+    for (const message of state.commands ?? []) {
+      if (!isValidCommand(message)) continue;
+      const command = canonicalizeCommand(message);
+      if (!findDuplicate(command)) insertCommand(command);
+    }
+    // Never reuse a (peerId, seq) pair that may already exist in the room:
+    // resume our sequence after the highest seq attributed to us.
+    for (const command of commandLog) {
+      if (command.peerId === peerId && command.seq >= seqCounter) {
+        seqCounter = command.seq + 1;
+      }
     }
     return true;
   }

--- a/html/assets/js/scenesync/physics/lockstep.test.js
+++ b/html/assets/js/scenesync/physics/lockstep.test.js
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createLockstepSession, compareCommands, tickForElapsedMs } from './lockstep.js';
+
+const WORLD_OPTIONS = { ground: { y: 0, restitution: 0.4, friction: 0.5 } };
+
+function exchange(from, to, command) {
+  // Simulate the broadcast round trip through JSON
+  return to.receiveCommand(JSON.parse(JSON.stringify(command)));
+}
+
+test('compareCommands orders by tick, then peerId, then seq', () => {
+  assert.ok(compareCommands({ tick: 1, peerId: 'b', seq: 0 }, { tick: 2, peerId: 'a', seq: 0 }) < 0);
+  assert.ok(compareCommands({ tick: 1, peerId: 'a', seq: 5 }, { tick: 1, peerId: 'b', seq: 0 }) < 0);
+  assert.ok(compareCommands({ tick: 1, peerId: 'a', seq: 1 }, { tick: 1, peerId: 'a', seq: 0 }) > 0);
+});
+
+test('tickForElapsedMs maps wall time to ticks', () => {
+  assert.equal(tickForElapsedMs(0), 0);
+  assert.equal(tickForElapsedMs(-100), 0);
+  assert.equal(tickForElapsedMs(1000), 60);
+  assert.equal(tickForElapsedMs(10000), 600);
+});
+
+test('two sessions exchanging commands stay bit-identical', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const b = createLockstepSession({ peerId: 'peer-b', worldOptions: WORLD_OPTIONS });
+
+  const cmd1 = a.issueCommand('add-body', {
+    body: { id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 3, 0], restitution: 0.6 },
+  });
+  exchange(a, b, cmd1);
+  const cmd2 = b.issueCommand('add-body', {
+    body: { id: 'crate', shape: 'box', position: [0.4, 6, 0], mass: 5 },
+  });
+  exchange(b, a, cmd2);
+
+  a.advanceTo(120);
+  b.advanceTo(120);
+
+  const cmd3 = a.issueCommand('impulse', { bodyId: 'ball', impulse: [2, 3, 0] });
+  exchange(a, b, cmd3);
+
+  a.advanceTo(300);
+  b.advanceTo(300);
+
+  assert.equal(a.stateHash(), b.stateHash());
+  assert.deepEqual(a.getBodies(), b.getBodies());
+});
+
+test('a late command triggers rollback and the sessions re-converge', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS, snapshotIntervalTicks: 10 });
+  const b = createLockstepSession({ peerId: 'peer-b', worldOptions: WORLD_OPTIONS, snapshotIntervalTicks: 10 });
+
+  const spawn = a.issueCommand('add-body', {
+    body: { id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 2, 0] },
+  });
+  exchange(a, b, spawn);
+  a.advanceTo(30);
+  b.advanceTo(30);
+
+  const late = a.issueCommand('impulse', { bodyId: 'ball', impulse: [5, 8, 0] });
+  a.advanceTo(60);
+  b.advanceTo(80); // b has already simulated past the command's tick
+
+  const result = exchange(a, b, late);
+  assert.equal(result.applied, true);
+  assert.equal(result.rolledBack, true);
+
+  a.advanceTo(150);
+  b.advanceTo(150);
+  assert.equal(a.stateHash(), b.stateHash());
+});
+
+test('commands older than the oldest snapshot are rejected', () => {
+  const session = createLockstepSession({
+    peerId: 'peer-a',
+    worldOptions: WORLD_OPTIONS,
+    snapshotIntervalTicks: 10,
+    maxSnapshots: 2,
+  });
+  session.advanceTo(100);
+  const result = session.receiveCommand({
+    tick: 5, seq: 0, peerId: 'peer-b', type: 'impulse', bodyId: 'x', impulse: [1, 0, 0],
+  });
+  assert.deepEqual(result, { applied: false, reason: 'too-old' });
+});
+
+test('duplicate and invalid commands are ignored', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const b = createLockstepSession({ peerId: 'peer-b', worldOptions: WORLD_OPTIONS });
+  const cmd = a.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 1, 0] } });
+
+  assert.equal(exchange(a, b, cmd).applied, true);
+  assert.deepEqual(exchange(a, b, cmd), { applied: false, reason: 'duplicate' });
+  assert.deepEqual(b.receiveCommand({ type: 'impulse' }), { applied: false, reason: 'invalid' });
+  assert.deepEqual(b.receiveCommand(null), { applied: false, reason: 'invalid' });
+});
+
+test('unknown command types are ignored identically on all peers', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const b = createLockstepSession({ peerId: 'peer-b', worldOptions: WORLD_OPTIONS });
+  const spawn = a.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 2, 0] } });
+  exchange(a, b, spawn);
+  const unknown = a.issueCommand('explode', { bodyId: 'ball', power: 100 });
+  exchange(a, b, unknown);
+  a.advanceTo(120);
+  b.advanceTo(120);
+  assert.equal(a.stateHash(), b.stateHash());
+});
+
+test('a late joiner resyncs from a state snapshot and stays in sync', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const spawn = a.issueCommand('add-body', {
+    body: { id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 4, 0], restitution: 0.5 },
+  });
+  a.advanceTo(90);
+  const pending = a.issueCommand('impulse', { bodyId: 'ball', impulse: [1, 6, 0] });
+
+  const c = createLockstepSession({ peerId: 'peer-c', worldOptions: WORLD_OPTIONS });
+  const state = JSON.parse(JSON.stringify(a.createResyncState()));
+  assert.equal(c.applyResyncState(state), true);
+  assert.equal(c.tick, a.tick);
+  assert.equal(c.stateHash(), state.hash);
+
+  a.advanceTo(240);
+  c.advanceTo(240);
+  assert.equal(a.stateHash(), c.stateHash());
+
+  // unused but documents intent: spawn / pending travelled inside the resync state
+  void spawn;
+  void pending;
+});
+
+test('issued commands are scheduled commandDelayTicks ahead', () => {
+  const session = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS, commandDelayTicks: 6 });
+  session.advanceTo(10);
+  const cmd = session.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 1, 0] } });
+  assert.equal(cmd.tick, 16);
+  assert.equal(cmd.peerId, 'peer-a');
+  // the body does not exist until its tick has been simulated
+  session.advanceTo(16);
+  assert.equal(session.world.hasBody('ball'), false);
+  session.advanceTo(17);
+  assert.equal(session.world.hasBody('ball'), true);
+});

--- a/html/assets/js/scenesync/physics/lockstep.test.js
+++ b/html/assets/js/scenesync/physics/lockstep.test.js
@@ -133,6 +133,73 @@ test('a late joiner resyncs from a state snapshot and stays in sync', () => {
   void pending;
 });
 
+test('issued commands are canonical raw-int payloads and frozen', () => {
+  const session = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  session.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 2, 0] } });
+  const cmd = session.issueCommand('impulse', { bodyId: 'ball', impulse: [1, 2, 3] });
+
+  assert.deepEqual(cmd.impulseFp, [65536, 131072, 196608]);
+  assert.equal('impulse' in cmd, false);
+  assert.ok(Object.isFrozen(cmd));
+  assert.throws(() => { cmd.tick = 999; }, TypeError);
+  assert.throws(() => { cmd.impulseFp[0] = 12345; }, TypeError);
+});
+
+test('mutating a received message after the fact cannot diverge the log', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const b = createLockstepSession({ peerId: 'peer-b', worldOptions: WORLD_OPTIONS });
+  const spawn = a.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 2, 0] } });
+  exchange(a, b, spawn);
+
+  const message = JSON.parse(JSON.stringify(
+    a.issueCommand('impulse', { bodyId: 'ball', impulse: [2, 0, 0] }),
+  ));
+  b.receiveCommand(message);
+  // sender-side tampering with the retained message object must not matter
+  message.impulseFp[0] = 999999;
+  message.tick = 1;
+
+  a.advanceTo(120);
+  b.advanceTo(120);
+  assert.equal(a.stateHash(), b.stateHash());
+});
+
+test('after a resync, slightly-late commands are replayed instead of rejected', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const spawn = a.issueCommand('add-body', {
+    body: { id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 2, 0] },
+  });
+  a.advanceTo(95);
+
+  const c = createLockstepSession({ peerId: 'peer-c', worldOptions: WORLD_OPTIONS });
+  assert.equal(c.applyResyncState(JSON.parse(JSON.stringify(a.createResyncState()))), true);
+
+  const late = a.issueCommand('impulse', { bodyId: 'ball', impulse: [3, 5, 0] }); // tick 101
+  a.advanceTo(150);
+  c.advanceTo(110); // c has passed tick 101 with no snapshot interval boundary since 95
+
+  const result = exchange(a, c, late);
+  assert.equal(result.applied, true);
+  assert.equal(result.rolledBack, true);
+
+  c.advanceTo(150);
+  assert.equal(a.stateHash(), c.stateHash());
+  void spawn;
+});
+
+test('seqCounter resumes after own pending commands found in a resync state', () => {
+  const a = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS });
+  const c = createLockstepSession({ peerId: 'peer-c', worldOptions: WORLD_OPTIONS });
+  exchange(c, a, c.issueCommand('add-body', { body: { id: 'ball', shape: 'sphere', position: [0, 2, 0] } }));
+  exchange(c, a, c.issueCommand('impulse', { bodyId: 'ball', impulse: [1, 0, 0] }));
+
+  // peer-c rejoins from a's state, which still holds peer-c's pending commands
+  const rejoined = createLockstepSession({ peerId: 'peer-c', worldOptions: WORLD_OPTIONS });
+  assert.equal(rejoined.applyResyncState(JSON.parse(JSON.stringify(a.createResyncState()))), true);
+  const next = rejoined.issueCommand('remove-body', { bodyId: 'ball' });
+  assert.equal(next.seq, 2);
+});
+
 test('issued commands are scheduled commandDelayTicks ahead', () => {
   const session = createLockstepSession({ peerId: 'peer-a', worldOptions: WORLD_OPTIONS, commandDelayTicks: 6 });
   session.advanceTo(10);

--- a/html/assets/js/scenesync/physics/world.js
+++ b/html/assets/js/scenesync/physics/world.js
@@ -16,6 +16,8 @@ import {
   fdiv,
   fsqrt,
   fclamp,
+  toSafeInt,
+  sanitizeFpVec,
   vadd,
   vsub,
   vneg,
@@ -32,8 +34,8 @@ export const DEFAULT_GRAVITY_FP = -642908; // -9.81 m/s²
 
 export const MAX_POSITION_FP = 1 << 28; // ±4096 m
 export const MAX_VELOCITY_FP = 1 << 24; // ±256 m/s
-const MAX_EXTENT_FP = 1 << 24;
-const MAX_IMPULSE_FP = 2 ** 36;
+export const MAX_EXTENT_FP = 1 << 24;
+export const MAX_IMPULSE_FP = 2 ** 36;
 
 const MIN_MASS = 0.01;
 const MAX_MASS = 1000;
@@ -72,6 +74,69 @@ function normalizeGround(ground) {
     yFp: fclamp(toFp(Number.isFinite(def.y) ? def.y : 0), -MAX_POSITION_FP, MAX_POSITION_FP),
     restitutionFp: fclamp(toFp(Number.isFinite(def.restitution) ? def.restitution : 0.2), 0, FP_ONE),
     frictionFp: fclamp(toFp(Number.isFinite(def.friction) ? def.friction : 0.5), 0, FP_ONE),
+  };
+}
+
+const MAX_INV_MASS_FP = 6553600; // fdiv(FP_ONE, toFp(MIN_MASS))
+
+// Converts a float body definition into a raw fixed-point body record.
+// Conversion happens once on the issuing client; the record (not the float
+// def) is what travels over the wire and feeds the simulation.
+export function normalizeBodyDef(def) {
+  if (!def || typeof def.id !== 'string' || def.id.length === 0) {
+    throw new TypeError('normalizeBodyDef: body def requires a non-empty string id');
+  }
+  const shape = def.shape === 'box' ? 'box' : 'sphere';
+  const halfSource = Array.isArray(def.halfExtents) && def.halfExtents.length >= 3
+    ? def.halfExtents
+    : [0.5, 0.5, 0.5];
+  const mass = Number.isFinite(def.mass) ? def.mass : 1;
+  const isStatic = def.static === true || mass <= 0;
+  return {
+    id: def.id,
+    shape,
+    radiusFp: shape === 'sphere'
+      ? fclamp(toFp(Number.isFinite(def.radius) ? def.radius : 0.5), 1, MAX_EXTENT_FP)
+      : 0,
+    halfFp: shape === 'box'
+      ? [
+        fclamp(toFp(Number(halfSource[0])), 1, MAX_EXTENT_FP),
+        fclamp(toFp(Number(halfSource[1])), 1, MAX_EXTENT_FP),
+        fclamp(toFp(Number(halfSource[2])), 1, MAX_EXTENT_FP),
+      ]
+      : [0, 0, 0],
+    positionFp: sanitizeFpVec(toFpVecSafe(def.position), MAX_POSITION_FP),
+    velocityFp: sanitizeFpVec(toFpVecSafe(def.velocity), MAX_VELOCITY_FP),
+    invMassFp: isStatic ? 0 : fdiv(FP_ONE, toFp(clampNumber(mass, MIN_MASS, MAX_MASS))),
+    restitutionFp: fclamp(toFp(Number.isFinite(def.restitution) ? def.restitution : 0.2), 0, FP_ONE),
+    frictionFp: fclamp(toFp(Number.isFinite(def.friction) ? def.friction : 0.5), 0, FP_ONE),
+    sleepCounter: 0,
+    sleeping: false,
+  };
+}
+
+// Deterministically coerces a raw body record received from the network
+// (command payload or snapshot) back into safe bounds. Returns null when the
+// record has no usable id, which every client treats the same way.
+export function sanitizeBodyRecord(record) {
+  if (!record || typeof record.id !== 'string' || record.id.length === 0) return null;
+  const shape = record.shape === 'box' ? 'box' : 'sphere';
+  return {
+    id: record.id,
+    shape,
+    radiusFp: shape === 'sphere'
+      ? fclamp(toSafeInt(record.radiusFp, FP_ONE >> 1), 1, MAX_EXTENT_FP)
+      : 0,
+    halfFp: shape === 'box'
+      ? sanitizeFpVec(record.halfFp, MAX_EXTENT_FP).map((v) => fclamp(v, 1, MAX_EXTENT_FP))
+      : [0, 0, 0],
+    positionFp: sanitizeFpVec(record.positionFp, MAX_POSITION_FP),
+    velocityFp: sanitizeFpVec(record.velocityFp, MAX_VELOCITY_FP),
+    invMassFp: fclamp(toSafeInt(record.invMassFp, FP_ONE), 0, MAX_INV_MASS_FP),
+    restitutionFp: fclamp(toSafeInt(record.restitutionFp), 0, FP_ONE),
+    frictionFp: fclamp(toSafeInt(record.frictionFp), 0, FP_ONE),
+    sleepCounter: fclamp(toSafeInt(record.sleepCounter), 0, SLEEP_TICKS),
+    sleeping: record.sleeping === true,
   };
 }
 
@@ -131,42 +196,14 @@ export function createWorld(options = {}) {
     return vclampComponents(v, MAX_VELOCITY_FP);
   }
 
-  function normalizeBodyDef(def) {
-    if (!def || typeof def.id !== 'string' || def.id.length === 0) {
-      throw new TypeError('addBody: body def requires a non-empty string id');
-    }
-    const shape = def.shape === 'box' ? 'box' : 'sphere';
-    const halfSource = Array.isArray(def.halfExtents) && def.halfExtents.length >= 3
-      ? def.halfExtents
-      : [0.5, 0.5, 0.5];
-    const body = {
-      id: def.id,
-      shape,
-      radiusFp: shape === 'sphere'
-        ? fclamp(toFp(Number.isFinite(def.radius) ? def.radius : 0.5), 1, MAX_EXTENT_FP)
-        : 0,
-      halfFp: shape === 'box'
-        ? [
-          fclamp(toFp(Number(halfSource[0])), 1, MAX_EXTENT_FP),
-          fclamp(toFp(Number(halfSource[1])), 1, MAX_EXTENT_FP),
-          fclamp(toFp(Number(halfSource[2])), 1, MAX_EXTENT_FP),
-        ]
-        : [0, 0, 0],
-      positionFp: clampPosition(toFpVecSafe(def.position)),
-      velocityFp: clampVelocity(toFpVecSafe(def.velocity)),
-      restitutionFp: fclamp(toFp(Number.isFinite(def.restitution) ? def.restitution : 0.2), 0, FP_ONE),
-      frictionFp: fclamp(toFp(Number.isFinite(def.friction) ? def.friction : 0.5), 0, FP_ONE),
-      sleepCounter: 0,
-      sleeping: false,
-    };
-    const mass = Number.isFinite(def.mass) ? def.mass : 1;
-    const isStatic = def.static === true || mass <= 0;
-    body.invMassFp = isStatic ? 0 : fdiv(FP_ONE, toFp(clampNumber(mass, MIN_MASS, MAX_MASS)));
-    return body;
+  function addBody(def) {
+    return addBodyRecord(normalizeBodyDef(def));
   }
 
-  function addBody(def) {
-    const body = normalizeBodyDef(def);
+  // Raw fixed-point entry point used by the lockstep command log.
+  function addBodyRecord(record) {
+    const body = sanitizeBodyRecord(record);
+    if (!body) return null;
     if (bodyIndex.has(body.id)) removeBody(body.id);
     bodyIndex.set(body.id, bodies.length);
     bodies.push(body);
@@ -187,11 +224,11 @@ export function createWorld(options = {}) {
     return bodyIndex.has(id);
   }
 
-  function applyImpulse(id, impulse) {
+  function applyImpulseFp(id, impulseFpInput) {
     const body = getRecord(id);
     if (!body || body.invMassFp === 0) return false;
     wake(body);
-    const impulseFp = vclampComponents(toFpVecSafe(impulse), MAX_IMPULSE_FP);
+    const impulseFp = sanitizeFpVec(impulseFpInput, MAX_IMPULSE_FP);
     body.velocityFp = clampVelocity([
       body.velocityFp[0] + fmul(body.invMassFp, impulseFp[0]),
       body.velocityFp[1] + fmul(body.invMassFp, impulseFp[1]),
@@ -200,20 +237,32 @@ export function createWorld(options = {}) {
     return true;
   }
 
-  function setVelocity(id, velocity) {
+  function applyImpulse(id, impulse) {
+    return applyImpulseFp(id, toFpVecSafe(impulse));
+  }
+
+  function setVelocityFp(id, velocityFpInput) {
     const body = getRecord(id);
     if (!body || body.invMassFp === 0) return false;
     wake(body);
-    body.velocityFp = clampVelocity(toFpVecSafe(velocity));
+    body.velocityFp = sanitizeFpVec(velocityFpInput, MAX_VELOCITY_FP);
+    return true;
+  }
+
+  function setVelocity(id, velocity) {
+    return setVelocityFp(id, toFpVecSafe(velocity));
+  }
+
+  function teleportFp(id, positionFpInput) {
+    const body = getRecord(id);
+    if (!body) return false;
+    if (body.invMassFp !== 0) wake(body);
+    body.positionFp = sanitizeFpVec(positionFpInput, MAX_POSITION_FP);
     return true;
   }
 
   function teleport(id, position) {
-    const body = getRecord(id);
-    if (!body) return false;
-    if (body.invMassFp !== 0) wake(body);
-    body.positionFp = clampPosition(toFpVecSafe(position));
-    return true;
+    return teleportFp(id, toFpVecSafe(position));
   }
 
   // --- contact generation ---
@@ -475,28 +524,42 @@ export function createWorld(options = {}) {
   }
 
   function restore(snap) {
-    tick = Number.isInteger(snap?.tick) ? snap.tick : 0;
+    tick = Number.isInteger(snap?.tick) && snap.tick >= 0 ? snap.tick : 0;
     bodies.length = 0;
     bodyIndex.clear();
     for (const record of snap?.bodies ?? []) {
-      const body = {
-        ...record,
-        halfFp: [...record.halfFp],
-        positionFp: [...record.positionFp],
-        velocityFp: [...record.velocityFp],
-      };
+      const body = sanitizeBodyRecord(record);
+      if (!body || bodyIndex.has(body.id)) continue;
       bodyIndex.set(body.id, bodies.length);
       bodies.push(body);
     }
   }
 
+  // Hashes every value that can influence future simulation steps — the same
+  // set of fields a snapshot carries, plus the world configuration. Two
+  // worlds must only compare hashes when they agree on all of this.
   function stateHash() {
     let h = hashInit();
+    h = hashInt(h, timestepFp);
+    for (const component of gravityFp) h = hashInt(h, component);
+    h = hashInt(h, ground ? 1 : 0);
+    if (ground) {
+      h = hashInt(h, ground.yFp);
+      h = hashInt(h, ground.restitutionFp);
+      h = hashInt(h, ground.frictionFp);
+    }
     h = hashInt(h, tick);
     for (const body of bodies) {
       h = hashString(h, body.id);
+      h = hashString(h, body.shape);
+      h = hashInt(h, body.radiusFp);
+      for (const component of body.halfFp) h = hashInt(h, component);
       for (const component of body.positionFp) h = hashInt(h, component);
       for (const component of body.velocityFp) h = hashInt(h, component);
+      h = hashInt(h, body.invMassFp);
+      h = hashInt(h, body.restitutionFp);
+      h = hashInt(h, body.frictionFp);
+      h = hashInt(h, body.sleepCounter);
       h = hashInt(h, body.sleeping ? 1 : 0);
     }
     return h >>> 0;
@@ -506,11 +569,15 @@ export function createWorld(options = {}) {
     get tick() { return tick; },
     timestepFp,
     addBody,
+    addBodyRecord,
     removeBody,
     hasBody,
     applyImpulse,
+    applyImpulseFp,
     setVelocity,
+    setVelocityFp,
     teleport,
+    teleportFp,
     step,
     stepTo,
     getBody,

--- a/html/assets/js/scenesync/physics/world.js
+++ b/html/assets/js/scenesync/physics/world.js
@@ -1,0 +1,522 @@
+// Deterministic rigid-body world for Scene Sync physics.
+//
+// Linear dynamics only (no rotation): dynamic spheres and axis-aligned boxes
+// against each other, static bodies, and an optional ground plane. Every
+// computation uses 16.16 fixed-point integer math (see fixed.js) with a fixed
+// timestep, so identical command sequences yield bit-identical states on all
+// clients. Iteration order is the body insertion order; clients must apply
+// world mutations in the same order (the lockstep layer guarantees this).
+
+import {
+  FP_ONE,
+  toFp,
+  fromFp,
+  fromFpVec,
+  fmul,
+  fdiv,
+  fsqrt,
+  fclamp,
+  vadd,
+  vsub,
+  vneg,
+  vscale,
+  vdot,
+  vclampComponents,
+  hashInit,
+  hashInt,
+  hashString,
+} from './fixed.js';
+
+export const DEFAULT_TIMESTEP_FP = 1092; // ≈ 1/60 s
+export const DEFAULT_GRAVITY_FP = -642908; // -9.81 m/s²
+
+export const MAX_POSITION_FP = 1 << 28; // ±4096 m
+export const MAX_VELOCITY_FP = 1 << 24; // ±256 m/s
+const MAX_EXTENT_FP = 1 << 24;
+const MAX_IMPULSE_FP = 2 ** 36;
+
+const MIN_MASS = 0.01;
+const MAX_MASS = 1000;
+
+const SOLVER_ITERATIONS = 4;
+const PENETRATION_SLOP_FP = 655; // 0.01 m
+const CORRECTION_PERCENT_FP = 13107; // 0.2
+const RESTITUTION_MIN_SPEED_FP = 32768; // bounces below 0.5 m/s are absorbed
+const FRICTION_MIN_TANGENT_SQ_FP = 16;
+const SLEEP_SPEED_SQ_FP = 164; // ≈ (0.05 m/s)²
+const SLEEP_TICKS = 60;
+
+function clampNumber(value, min, max) {
+  return value < min ? min : value > max ? max : value;
+}
+
+function toFpVecSafe(value) {
+  const v = Array.isArray(value) && value.length >= 3 ? value : [0, 0, 0];
+  return [toFp(Number(v[0])), toFp(Number(v[1])), toFp(Number(v[2]))];
+}
+
+function normalizeGravity(gravity) {
+  if (Array.isArray(gravity)) {
+    return vclampComponents(toFpVecSafe(gravity), MAX_VELOCITY_FP);
+  }
+  if (Number.isFinite(gravity)) {
+    return [0, fclamp(toFp(gravity), -MAX_VELOCITY_FP, MAX_VELOCITY_FP), 0];
+  }
+  return [0, DEFAULT_GRAVITY_FP, 0];
+}
+
+function normalizeGround(ground) {
+  if (ground === null || ground === false) return null;
+  const def = typeof ground === 'object' && ground !== null ? ground : {};
+  return {
+    yFp: fclamp(toFp(Number.isFinite(def.y) ? def.y : 0), -MAX_POSITION_FP, MAX_POSITION_FP),
+    restitutionFp: fclamp(toFp(Number.isFinite(def.restitution) ? def.restitution : 0.2), 0, FP_ONE),
+    frictionFp: fclamp(toFp(Number.isFinite(def.friction) ? def.friction : 0.5), 0, FP_ONE),
+  };
+}
+
+export function createWorld(options = {}) {
+  const gravityFp = normalizeGravity(options.gravity);
+  const timestepFp = Number.isInteger(options.timestepFp) && options.timestepFp > 0
+    ? options.timestepFp
+    : DEFAULT_TIMESTEP_FP;
+  const ground = normalizeGround(options.ground);
+  const groundBody = ground
+    ? {
+      id: '__ground__',
+      invMassFp: 0,
+      velocityFp: [0, 0, 0],
+      restitutionFp: ground.restitutionFp,
+      frictionFp: ground.frictionFp,
+      sleeping: false,
+    }
+    : null;
+
+  const bodies = [];
+  const bodyIndex = new Map();
+  let tick = 0;
+
+  function rebuildIndex() {
+    bodyIndex.clear();
+    for (let i = 0; i < bodies.length; i += 1) {
+      bodyIndex.set(bodies[i].id, i);
+    }
+  }
+
+  function getRecord(id) {
+    const index = bodyIndex.get(id);
+    return index === undefined ? null : bodies[index];
+  }
+
+  function wake(body) {
+    body.sleeping = false;
+    body.sleepCounter = 0;
+  }
+
+  function wakeAll() {
+    for (const body of bodies) {
+      if (body.invMassFp !== 0) wake(body);
+    }
+  }
+
+  function isAwakeDynamic(body) {
+    return body.invMassFp !== 0 && !body.sleeping;
+  }
+
+  function clampPosition(v) {
+    return vclampComponents(v, MAX_POSITION_FP);
+  }
+
+  function clampVelocity(v) {
+    return vclampComponents(v, MAX_VELOCITY_FP);
+  }
+
+  function normalizeBodyDef(def) {
+    if (!def || typeof def.id !== 'string' || def.id.length === 0) {
+      throw new TypeError('addBody: body def requires a non-empty string id');
+    }
+    const shape = def.shape === 'box' ? 'box' : 'sphere';
+    const halfSource = Array.isArray(def.halfExtents) && def.halfExtents.length >= 3
+      ? def.halfExtents
+      : [0.5, 0.5, 0.5];
+    const body = {
+      id: def.id,
+      shape,
+      radiusFp: shape === 'sphere'
+        ? fclamp(toFp(Number.isFinite(def.radius) ? def.radius : 0.5), 1, MAX_EXTENT_FP)
+        : 0,
+      halfFp: shape === 'box'
+        ? [
+          fclamp(toFp(Number(halfSource[0])), 1, MAX_EXTENT_FP),
+          fclamp(toFp(Number(halfSource[1])), 1, MAX_EXTENT_FP),
+          fclamp(toFp(Number(halfSource[2])), 1, MAX_EXTENT_FP),
+        ]
+        : [0, 0, 0],
+      positionFp: clampPosition(toFpVecSafe(def.position)),
+      velocityFp: clampVelocity(toFpVecSafe(def.velocity)),
+      restitutionFp: fclamp(toFp(Number.isFinite(def.restitution) ? def.restitution : 0.2), 0, FP_ONE),
+      frictionFp: fclamp(toFp(Number.isFinite(def.friction) ? def.friction : 0.5), 0, FP_ONE),
+      sleepCounter: 0,
+      sleeping: false,
+    };
+    const mass = Number.isFinite(def.mass) ? def.mass : 1;
+    const isStatic = def.static === true || mass <= 0;
+    body.invMassFp = isStatic ? 0 : fdiv(FP_ONE, toFp(clampNumber(mass, MIN_MASS, MAX_MASS)));
+    return body;
+  }
+
+  function addBody(def) {
+    const body = normalizeBodyDef(def);
+    if (bodyIndex.has(body.id)) removeBody(body.id);
+    bodyIndex.set(body.id, bodies.length);
+    bodies.push(body);
+    return exportBody(body);
+  }
+
+  function removeBody(id) {
+    const index = bodyIndex.get(id);
+    if (index === undefined) return false;
+    bodies.splice(index, 1);
+    rebuildIndex();
+    // 支えを失った body が眠ったまま浮かないように全員起こす
+    wakeAll();
+    return true;
+  }
+
+  function hasBody(id) {
+    return bodyIndex.has(id);
+  }
+
+  function applyImpulse(id, impulse) {
+    const body = getRecord(id);
+    if (!body || body.invMassFp === 0) return false;
+    wake(body);
+    const impulseFp = vclampComponents(toFpVecSafe(impulse), MAX_IMPULSE_FP);
+    body.velocityFp = clampVelocity([
+      body.velocityFp[0] + fmul(body.invMassFp, impulseFp[0]),
+      body.velocityFp[1] + fmul(body.invMassFp, impulseFp[1]),
+      body.velocityFp[2] + fmul(body.invMassFp, impulseFp[2]),
+    ]);
+    return true;
+  }
+
+  function setVelocity(id, velocity) {
+    const body = getRecord(id);
+    if (!body || body.invMassFp === 0) return false;
+    wake(body);
+    body.velocityFp = clampVelocity(toFpVecSafe(velocity));
+    return true;
+  }
+
+  function teleport(id, position) {
+    const body = getRecord(id);
+    if (!body) return false;
+    if (body.invMassFp !== 0) wake(body);
+    body.positionFp = clampPosition(toFpVecSafe(position));
+    return true;
+  }
+
+  // --- contact generation ---
+  // Contacts store { a, b, normalFp, penetrationFp } with the unit normal
+  // pointing from a toward b.
+
+  function sphereSphere(a, b) {
+    const delta = vsub(b.positionFp, a.positionFp);
+    const distSq = vdot(delta, delta);
+    const radiusSum = a.radiusFp + b.radiusFp;
+    if (distSq >= fmul(radiusSum, radiusSum)) return null;
+    const dist = fsqrt(distSq);
+    const normalFp = dist === 0
+      ? [0, FP_ONE, 0]
+      : [fdiv(delta[0], dist), fdiv(delta[1], dist), fdiv(delta[2], dist)];
+    return { a, b, normalFp, penetrationFp: radiusSum - dist };
+  }
+
+  function sphereBox(sphere, box, flipped) {
+    const minB = vsub(box.positionFp, box.halfFp);
+    const maxB = vadd(box.positionFp, box.halfFp);
+    const closest = [
+      fclamp(sphere.positionFp[0], minB[0], maxB[0]),
+      fclamp(sphere.positionFp[1], minB[1], maxB[1]),
+      fclamp(sphere.positionFp[2], minB[2], maxB[2]),
+    ];
+    const delta = vsub(closest, sphere.positionFp);
+    const distSq = vdot(delta, delta);
+    let normalFp;
+    let penetrationFp;
+    if (distSq > 0) {
+      if (distSq >= fmul(sphere.radiusFp, sphere.radiusFp)) return null;
+      const dist = fsqrt(distSq);
+      if (dist === 0) return null;
+      normalFp = [fdiv(delta[0], dist), fdiv(delta[1], dist), fdiv(delta[2], dist)];
+      penetrationFp = sphere.radiusFp - dist;
+    } else {
+      // Sphere center inside the box: push out through the nearest face.
+      // Deterministic tie-break: -x, +x, -y, +y, -z, +z with strict <.
+      let bestAxis = 0;
+      let bestSign = -1;
+      let bestDepth = Number.MAX_SAFE_INTEGER;
+      for (let axis = 0; axis < 3; axis += 1) {
+        const toMin = sphere.positionFp[axis] - minB[axis];
+        if (toMin < bestDepth) {
+          bestDepth = toMin;
+          bestAxis = axis;
+          bestSign = -1;
+        }
+        const toMax = maxB[axis] - sphere.positionFp[axis];
+        if (toMax < bestDepth) {
+          bestDepth = toMax;
+          bestAxis = axis;
+          bestSign = 1;
+        }
+      }
+      normalFp = [0, 0, 0];
+      // normal は a(sphere)→b(box) 向きなので、押し出し方向の逆を指す
+      normalFp[bestAxis] = -bestSign * FP_ONE;
+      penetrationFp = bestDepth + sphere.radiusFp;
+    }
+    if (flipped) {
+      return { a: box, b: sphere, normalFp: vneg(normalFp), penetrationFp };
+    }
+    return { a: sphere, b: box, normalFp, penetrationFp };
+  }
+
+  function boxBox(a, b) {
+    const delta = vsub(b.positionFp, a.positionFp);
+    let bestAxis = -1;
+    let bestOverlap = Number.MAX_SAFE_INTEGER;
+    for (let axis = 0; axis < 3; axis += 1) {
+      const overlap = a.halfFp[axis] + b.halfFp[axis] - Math.abs(delta[axis]);
+      if (overlap <= 0) return null;
+      if (overlap < bestOverlap) {
+        bestOverlap = overlap;
+        bestAxis = axis;
+      }
+    }
+    const normalFp = [0, 0, 0];
+    normalFp[bestAxis] = delta[bestAxis] >= 0 ? FP_ONE : -FP_ONE;
+    return { a, b, normalFp, penetrationFp: bestOverlap };
+  }
+
+  function detectContact(a, b) {
+    if (a.shape === 'sphere' && b.shape === 'sphere') return sphereSphere(a, b);
+    if (a.shape === 'sphere' && b.shape === 'box') return sphereBox(a, b, false);
+    if (a.shape === 'box' && b.shape === 'sphere') return sphereBox(b, a, true);
+    return boxBox(a, b);
+  }
+
+  function detectGroundContact(body) {
+    const bottom = body.shape === 'sphere'
+      ? body.positionFp[1] - body.radiusFp
+      : body.positionFp[1] - body.halfFp[1];
+    const penetrationFp = ground.yFp - bottom;
+    if (penetrationFp <= 0) return null;
+    return { a: groundBody, b: body, normalFp: [0, FP_ONE, 0], penetrationFp };
+  }
+
+  // --- contact solving ---
+
+  function applyBodyImpulse(body, impulseFp) {
+    if (body.invMassFp === 0) return;
+    body.velocityFp = clampVelocity([
+      body.velocityFp[0] + fmul(body.invMassFp, impulseFp[0]),
+      body.velocityFp[1] + fmul(body.invMassFp, impulseFp[1]),
+      body.velocityFp[2] + fmul(body.invMassFp, impulseFp[2]),
+    ]);
+  }
+
+  function resolveContactVelocity(contact) {
+    const { a, b, normalFp: n } = contact;
+    const invMassSum = a.invMassFp + b.invMassFp;
+    if (invMassSum === 0) return;
+    let relVel = vsub(b.velocityFp, a.velocityFp);
+    const vn = vdot(relVel, n);
+    if (vn >= 0) return;
+    const restitution = -vn > RESTITUTION_MIN_SPEED_FP
+      ? Math.min(a.restitutionFp, b.restitutionFp)
+      : 0;
+    const jn = fclamp(
+      fdiv(fmul(-(FP_ONE + restitution), vn), invMassSum),
+      0,
+      MAX_IMPULSE_FP,
+    );
+    applyBodyImpulse(a, vscale(n, -jn));
+    applyBodyImpulse(b, vscale(n, jn));
+
+    // Coulomb friction clamped by the normal impulse
+    relVel = vsub(b.velocityFp, a.velocityFp);
+    const tangent = vsub(relVel, vscale(n, vdot(relVel, n)));
+    const tangentLenSq = vdot(tangent, tangent);
+    if (tangentLenSq <= FRICTION_MIN_TANGENT_SQ_FP) return;
+    const tangentLen = fsqrt(tangentLenSq);
+    if (tangentLen === 0) return;
+    const t = [
+      fdiv(tangent[0], tangentLen),
+      fdiv(tangent[1], tangentLen),
+      fdiv(tangent[2], tangentLen),
+    ];
+    const friction = Math.min(a.frictionFp, b.frictionFp);
+    const maxFriction = fmul(friction, jn);
+    const jt = fclamp(fdiv(-vdot(relVel, t), invMassSum), -maxFriction, maxFriction);
+    applyBodyImpulse(a, vscale(t, -jt));
+    applyBodyImpulse(b, vscale(t, jt));
+  }
+
+  function correctPositions(contact) {
+    const { a, b, normalFp: n, penetrationFp } = contact;
+    const invMassSum = a.invMassFp + b.invMassFp;
+    if (invMassSum === 0) return;
+    const depth = penetrationFp - PENETRATION_SLOP_FP;
+    if (depth <= 0) return;
+    const correction = fdiv(fmul(depth, CORRECTION_PERCENT_FP), invMassSum);
+    if (a.invMassFp !== 0) {
+      a.positionFp = clampPosition(vsub(a.positionFp, vscale(n, fmul(a.invMassFp, correction))));
+    }
+    if (b.invMassFp !== 0) {
+      b.positionFp = clampPosition(vadd(b.positionFp, vscale(n, fmul(b.invMassFp, correction))));
+    }
+  }
+
+  function step() {
+    for (const body of bodies) {
+      if (!isAwakeDynamic(body)) continue;
+      body.velocityFp = clampVelocity(vadd(body.velocityFp, vscale(gravityFp, timestepFp)));
+      body.positionFp = clampPosition(vadd(body.positionFp, vscale(body.velocityFp, timestepFp)));
+    }
+
+    const contacts = [];
+    for (let i = 0; i < bodies.length; i += 1) {
+      const a = bodies[i];
+      for (let j = i + 1; j < bodies.length; j += 1) {
+        const b = bodies[j];
+        if (!isAwakeDynamic(a) && !isAwakeDynamic(b)) continue;
+        const contact = detectContact(a, b);
+        if (!contact) continue;
+        if (a.sleeping) wake(a);
+        if (b.sleeping) wake(b);
+        contacts.push(contact);
+      }
+    }
+    if (groundBody) {
+      for (const body of bodies) {
+        if (!isAwakeDynamic(body)) continue;
+        const contact = detectGroundContact(body);
+        if (contact) contacts.push(contact);
+      }
+    }
+
+    for (let iteration = 0; iteration < SOLVER_ITERATIONS; iteration += 1) {
+      for (const contact of contacts) resolveContactVelocity(contact);
+    }
+    for (const contact of contacts) correctPositions(contact);
+
+    for (const body of bodies) {
+      if (!isAwakeDynamic(body)) continue;
+      if (vdot(body.velocityFp, body.velocityFp) < SLEEP_SPEED_SQ_FP) {
+        body.sleepCounter += 1;
+        if (body.sleepCounter >= SLEEP_TICKS) {
+          body.sleeping = true;
+          body.velocityFp = [0, 0, 0];
+        }
+      } else {
+        body.sleepCounter = 0;
+      }
+    }
+
+    tick += 1;
+  }
+
+  function stepTo(targetTick) {
+    while (Number.isInteger(targetTick) && tick < targetTick) step();
+  }
+
+  // --- state access ---
+
+  function exportBody(body) {
+    const result = {
+      id: body.id,
+      shape: body.shape,
+      position: fromFpVec(body.positionFp),
+      velocity: fromFpVec(body.velocityFp),
+      static: body.invMassFp === 0,
+      sleeping: body.sleeping,
+    };
+    if (body.shape === 'sphere') result.radius = fromFp(body.radiusFp);
+    else result.halfExtents = fromFpVec(body.halfFp);
+    return result;
+  }
+
+  function getBody(id) {
+    const body = getRecord(id);
+    return body ? exportBody(body) : null;
+  }
+
+  function getBodies() {
+    return bodies.map(exportBody);
+  }
+
+  function snapshot() {
+    return {
+      tick,
+      bodies: bodies.map((body) => ({
+        id: body.id,
+        shape: body.shape,
+        radiusFp: body.radiusFp,
+        halfFp: [...body.halfFp],
+        positionFp: [...body.positionFp],
+        velocityFp: [...body.velocityFp],
+        invMassFp: body.invMassFp,
+        restitutionFp: body.restitutionFp,
+        frictionFp: body.frictionFp,
+        sleepCounter: body.sleepCounter,
+        sleeping: body.sleeping,
+      })),
+    };
+  }
+
+  function restore(snap) {
+    tick = Number.isInteger(snap?.tick) ? snap.tick : 0;
+    bodies.length = 0;
+    bodyIndex.clear();
+    for (const record of snap?.bodies ?? []) {
+      const body = {
+        ...record,
+        halfFp: [...record.halfFp],
+        positionFp: [...record.positionFp],
+        velocityFp: [...record.velocityFp],
+      };
+      bodyIndex.set(body.id, bodies.length);
+      bodies.push(body);
+    }
+  }
+
+  function stateHash() {
+    let h = hashInit();
+    h = hashInt(h, tick);
+    for (const body of bodies) {
+      h = hashString(h, body.id);
+      for (const component of body.positionFp) h = hashInt(h, component);
+      for (const component of body.velocityFp) h = hashInt(h, component);
+      h = hashInt(h, body.sleeping ? 1 : 0);
+    }
+    return h >>> 0;
+  }
+
+  return {
+    get tick() { return tick; },
+    timestepFp,
+    addBody,
+    removeBody,
+    hasBody,
+    applyImpulse,
+    setVelocity,
+    teleport,
+    step,
+    stepTo,
+    getBody,
+    getBodies,
+    snapshot,
+    restore,
+    stateHash,
+  };
+}

--- a/html/assets/js/scenesync/physics/world.test.js
+++ b/html/assets/js/scenesync/physics/world.test.js
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorld } from './world.js';
+
+function buildWorld() {
+  const world = createWorld({ ground: { y: 0, restitution: 0.4, friction: 0.5 } });
+  world.addBody({ id: 'ball-1', shape: 'sphere', radius: 0.5, position: [0, 3, 0], mass: 1, restitution: 0.6 });
+  world.addBody({ id: 'ball-2', shape: 'sphere', radius: 0.5, position: [0.4, 5, 0.2], mass: 2 });
+  world.addBody({ id: 'crate', shape: 'box', halfExtents: [0.5, 0.5, 0.5], position: [2, 4, 0], mass: 5 });
+  world.addBody({ id: 'plinth', shape: 'box', halfExtents: [3, 0.5, 3], position: [0, 0.5, 0], static: true });
+  return world;
+}
+
+test('gravity pulls a free body down', () => {
+  const world = createWorld({ ground: null });
+  world.addBody({ id: 'ball', shape: 'sphere', position: [0, 10, 0] });
+  for (let i = 0; i < 60; i += 1) world.step();
+  const body = world.getBody('ball');
+  assert.ok(body.position[1] < 10);
+  assert.ok(body.velocity[1] < -5);
+});
+
+test('a sphere settles on the ground plane and falls asleep', () => {
+  const world = createWorld({ ground: { y: 0 } });
+  world.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 2, 0] });
+  for (let i = 0; i < 600; i += 1) world.step();
+  const body = world.getBody('ball');
+  assert.ok(Math.abs(body.position[1] - 0.5) < 0.05, `rest height was ${body.position[1]}`);
+  assert.equal(body.sleeping, true);
+
+  // Sleeping bodies stay frozen exactly
+  const before = world.snapshot();
+  for (let i = 0; i < 100; i += 1) world.step();
+  const ball = world.snapshot().bodies.find((b) => b.id === 'ball');
+  const ballBefore = before.bodies.find((b) => b.id === 'ball');
+  assert.deepEqual(ball.positionFp, ballBefore.positionFp);
+});
+
+test('restitution makes a sphere bounce back up', () => {
+  const world = createWorld({ ground: { y: 0, restitution: 0.9 } });
+  world.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 3, 0], restitution: 0.9 });
+  let bounced = false;
+  for (let i = 0; i < 120; i += 1) {
+    world.step();
+    if (world.getBody('ball').velocity[1] > 1) {
+      bounced = true;
+      break;
+    }
+  }
+  assert.equal(bounced, true);
+});
+
+test('a moving sphere transfers momentum to a resting sphere', () => {
+  const world = createWorld({ ground: { y: 0, friction: 0 } });
+  world.addBody({ id: 'cue', shape: 'sphere', radius: 0.5, position: [-2, 0.5, 0], velocity: [4, 0, 0], friction: 0 });
+  world.addBody({ id: 'target', shape: 'sphere', radius: 0.5, position: [0, 0.5, 0], friction: 0 });
+  for (let i = 0; i < 120; i += 1) world.step();
+  const target = world.getBody('target');
+  assert.ok(target.velocity[0] > 0.5 || target.position[0] > 0.2,
+    `target did not move: v=${target.velocity[0]} x=${target.position[0]}`);
+});
+
+test('a dynamic box rests on top of a static box', () => {
+  const world = createWorld({ ground: { y: 0 } });
+  world.addBody({ id: 'base', shape: 'box', halfExtents: [2, 0.5, 2], position: [0, 0.5, 0], static: true });
+  world.addBody({ id: 'crate', shape: 'box', halfExtents: [0.5, 0.5, 0.5], position: [0, 3, 0] });
+  for (let i = 0; i < 600; i += 1) world.step();
+  const crate = world.getBody('crate');
+  assert.ok(Math.abs(crate.position[1] - 1.5) < 0.05, `rest height was ${crate.position[1]}`);
+  assert.equal(crate.sleeping, true);
+});
+
+test('a sphere starting inside a box is pushed out and settles on top', () => {
+  const world = createWorld({ ground: { y: 0 } });
+  world.addBody({ id: 'block', shape: 'box', halfExtents: [1, 1, 1], position: [0, 1, 0], static: true });
+  world.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 1.9, 0] });
+  for (let i = 0; i < 600; i += 1) world.step();
+  const ball = world.getBody('ball');
+  assert.ok(Number.isFinite(ball.position[1]));
+  assert.ok(Math.abs(ball.position[1] - 2.5) < 0.1, `rest height was ${ball.position[1]}`);
+});
+
+test('applyImpulse changes velocity by impulse / mass and wakes the body', () => {
+  const world = createWorld({ ground: { y: 0 } });
+  world.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 0.5, 0], mass: 2 });
+  for (let i = 0; i < 600; i += 1) world.step();
+  assert.equal(world.getBody('ball').sleeping, true);
+
+  assert.equal(world.applyImpulse('ball', [4, 0, 0]), true);
+  const body = world.getBody('ball');
+  assert.equal(body.sleeping, false);
+  assert.equal(body.velocity[0], 2);
+
+  assert.equal(world.applyImpulse('missing', [1, 0, 0]), false);
+});
+
+test('velocities and positions are clamped to safe bounds', () => {
+  const world = createWorld({ ground: null });
+  world.addBody({ id: 'fast', shape: 'sphere', position: [0, 9999999, 0], velocity: [99999, 0, 0] });
+  const body = world.getBody('fast');
+  assert.equal(body.velocity[0], 256);
+  assert.equal(body.position[1], 4096);
+});
+
+test('identical operations on two worlds stay bit-identical', () => {
+  const a = buildWorld();
+  const b = buildWorld();
+  for (let i = 0; i < 600; i += 1) {
+    if (i === 120) {
+      a.applyImpulse('ball-1', [3, 4, 0]);
+      b.applyImpulse('ball-1', [3, 4, 0]);
+    }
+    if (i === 200) {
+      a.removeBody('crate');
+      b.removeBody('crate');
+    }
+    a.step();
+    b.step();
+  }
+  assert.equal(a.stateHash(), b.stateHash());
+  assert.deepEqual(a.snapshot(), b.snapshot());
+});
+
+test('snapshot / restore reproduces the exact same future', () => {
+  const a = buildWorld();
+  for (let i = 0; i < 100; i += 1) a.step();
+  const snap = JSON.parse(JSON.stringify(a.snapshot()));
+  for (let i = 0; i < 100; i += 1) a.step();
+  const expectedHash = a.stateHash();
+
+  const b = createWorld({ ground: { y: 0, restitution: 0.4, friction: 0.5 } });
+  b.restore(snap);
+  assert.equal(b.tick, 100);
+  for (let i = 0; i < 100; i += 1) b.step();
+  assert.equal(b.stateHash(), expectedHash);
+});
+
+test('adding a body with an existing id replaces it', () => {
+  const world = createWorld({});
+  world.addBody({ id: 'thing', shape: 'sphere', position: [0, 1, 0] });
+  world.addBody({ id: 'thing', shape: 'box', position: [5, 1, 0] });
+  assert.equal(world.getBodies().length, 1);
+  const body = world.getBody('thing');
+  assert.equal(body.shape, 'box');
+  assert.equal(body.position[0], 5);
+});
+
+test('teleport and setVelocity update state and report missing bodies', () => {
+  const world = createWorld({ ground: null });
+  world.addBody({ id: 'ball', shape: 'sphere', position: [0, 1, 0] });
+  assert.equal(world.teleport('ball', [1, 2, 3]), true);
+  assert.deepEqual(world.getBody('ball').position, [1, 2, 3]);
+  assert.equal(world.setVelocity('ball', [0, 5, 0]), true);
+  assert.deepEqual(world.getBody('ball').velocity, [0, 5, 0]);
+  assert.equal(world.teleport('missing', [0, 0, 0]), false);
+  assert.equal(world.setVelocity('missing', [0, 0, 0]), false);
+});
+
+test('stateHash changes when the simulation state changes', () => {
+  const world = buildWorld();
+  const h0 = world.stateHash();
+  world.step();
+  assert.notEqual(world.stateHash(), h0);
+});

--- a/html/assets/js/scenesync/physics/world.test.js
+++ b/html/assets/js/scenesync/physics/world.test.js
@@ -163,3 +163,69 @@ test('stateHash changes when the simulation state changes', () => {
   world.step();
   assert.notEqual(world.stateHash(), h0);
 });
+
+test('stateHash covers material parameters, not just position and velocity', () => {
+  const make = (overrides) => {
+    const world = createWorld({ ground: null });
+    world.addBody({ id: 'ball', shape: 'sphere', position: [0, 1, 0], ...overrides });
+    return world.stateHash();
+  };
+  const base = make({});
+  assert.notEqual(make({ restitution: 0.9 }), base);
+  assert.notEqual(make({ friction: 0.1 }), base);
+  assert.notEqual(make({ mass: 5 }), base);
+  assert.notEqual(make({ radius: 0.7 }), base);
+  assert.notEqual(make({ shape: 'box' }), base);
+});
+
+test('stateHash covers world configuration', () => {
+  const hashFor = (options) => {
+    const world = createWorld(options);
+    world.addBody({ id: 'ball', shape: 'sphere', position: [0, 1, 0] });
+    return world.stateHash();
+  };
+  const base = hashFor({ ground: { y: 0 } });
+  assert.notEqual(hashFor({ ground: null }), base);
+  assert.notEqual(hashFor({ ground: { y: 1 } }), base);
+  assert.notEqual(hashFor({ ground: { y: 0 }, gravity: -5 }), base);
+  assert.notEqual(hashFor({ ground: { y: 0 }, timestepFp: 2184 }), base);
+});
+
+test('stateHash covers sleepCounter progress', () => {
+  const a = createWorld({ ground: { y: 0 } });
+  a.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 0.5, 0] });
+  const b = createWorld({ ground: { y: 0 } });
+  b.addBody({ id: 'ball', shape: 'sphere', radius: 0.5, position: [0, 0.5, 0] });
+  for (let i = 0; i < 10; i += 1) { a.step(); b.step(); }
+  assert.equal(a.stateHash(), b.stateHash());
+  const snapA = a.snapshot();
+  const snapB = b.snapshot();
+  assert.equal(snapA.bodies[0].sleepCounter, snapB.bodies[0].sleepCounter);
+  // Worlds whose only difference is sleep progress must not hash-collide
+  snapB.bodies[0].sleepCounter += 1;
+  b.restore(snapB);
+  assert.notEqual(a.stateHash(), b.stateHash());
+});
+
+test('addBodyRecord and raw mutators sanitize network input deterministically', () => {
+  const world = createWorld({ ground: null });
+  assert.equal(world.addBodyRecord(null), null);
+  assert.equal(world.addBodyRecord({ id: '' }), null);
+  const added = world.addBodyRecord({
+    id: 'ball',
+    shape: 'sphere',
+    radiusFp: 32768,
+    positionFp: [0, 65536, 0],
+    velocityFp: ['bogus', 1.5, 2 ** 60],
+    invMassFp: 65536,
+    restitutionFp: 99999999,
+    frictionFp: -5,
+  });
+  assert.deepEqual(added.velocity, [0, 0, 0]);
+  assert.equal(world.applyImpulseFp('ball', [65536, 0, 0]), true);
+  assert.equal(world.getBody('ball').velocity[0], 1);
+  assert.equal(world.setVelocityFp('ball', [0, 131072, 0]), true);
+  assert.equal(world.getBody('ball').velocity[1], 2);
+  assert.equal(world.teleportFp('ball', [196608, 0, 0]), true);
+  assert.equal(world.getBody('ball').position[0], 3);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:expired-glb-recovery": "node --test html/assets/js/scenesync/assets/expired-glb-recovery.test.js",
     "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
-    "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js"
+    "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
+    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",


### PR DESCRIPTION
## 概要

Scene Sync に決定論的物理エンジンを追加しました。複数クライアント間でコマンド同期(lockstep + rollback)により、ビット単位で一致する物理シミュレーション結果を実現します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 新規ファイル

1. **`html/assets/js/scenesync/physics/fixed.js`** (181行)
   - 16.16 固定小数点整数演算の実装
   - `fmul`, `fdiv`, `fsqrt` など基本演算
   - vec3 ヘルパー関数
   - xorshift32 決定論的 PRNG
   - FNV-1a 32bit 状態ハッシュ
   - Unity/Godot への移植ルール対応

2. **`html/assets/js/scenesync/physics/world.js`** (522行)
   - 決定論的物理ワールドの実装
   - 並進運動のみ対応（回転なし）
   - 動的オブジェクト: sphere / AABB box
   - 静的オブジェクト: sphere / box / 床平面
   - 衝突検出・解決（逐次インパルス 4 iteration + 位置補正）
   - restitution / friction / sleep 機能
   - snapshot / restore による状態保存・復元

3. **`html/assets/js/scenesync/physics/lockstep.js`** (203行)
   - コマンド同期レイヤー
   - tick 固定・コマンド順序保証 `(tick, peerId, seq)`
   - 遅延到着コマンドの rollback 処理
   - snapshot による再同期機能
   - 途中参加時のフルステート配信

4. **`html/assets/js/scenesync/physics/index.js`** (6行)
   - エントリポイント

5. **`docs/scene-sync-physics.md`** (155行)
   - 仕様書（日本語）
   - 設計方針・固定小数点演算規則
   - World / Lockstep API ドキュメント
   - broadcast メッセージ形式（案）
   - 移植ガイド（C# / GDScript）

### テスト

6. **`html/assets/js/scenesync/physics/fixed.test.js`** (153行)
   - 固定小数点演算の単体テスト
   - 64bit 整数リファレンス実装との一致確認
   - `fmul`, `fdiv`, `fsqrt`, vec3 演算

7. **`html/assets/js/scenesync/physics/world.test.js`** (165行)
   - 物理ワールドの統合テスト
   - 重力・衝突・restitution・friction・sleep
   - 複数ワールド間のビット一致確認

8. **`html/assets/js/scenesync/physics/lockstep.test.js`** (147行)
   - lockstep 同期のテスト
   - コマンド順序保証
   - 遅延到着・rollback・再同期

### ドキュメント更新

9. **`CLAUDE.md`** (更新)
   - 決定論的物理エンジンの説明を追加

10. **`docs/scene-sync-spec.md`** (更新)
    - 仕様書インデックスに物

https://claude.ai/code/session_011wHPUy6DcbUizBDwzkgwBu