### PR TITLE
Add Scene Sync deterministic physics demo

### DIFF
--- a/html/assets/js/scenesync/physics-demo.js
+++ b/html/assets/js/scenesync/physics-demo.js
@@ -1,0 +1,263 @@
+import * as THREE from 'three';
+import { createLockstepSession, tickForElapsedMs } from './physics/index.js';
+
+const VERSION = 1;
+const DEFAULT_ROOM = 'physics-toy';
+const WORLD_OPTIONS = { gravity: -9.81, ground: { y: 0, restitution: 0.35, friction: 0.72 } };
+const $ = (id) => document.getElementById(id);
+const ui = {
+  canvas: $('c'), room: $('room'), connect: $('connect'), reset: $('reset'), ball: $('ball'), crate: $('crate'), push: $('push'), copy: $('copy'), open: $('open'),
+  status: $('status'), tick: $('tick'), bodies: $('bodies'), hash: $('hash'), peers: $('peers'), log: $('log'),
+};
+let ws = null;
+let online = false;
+let peerId = `local-${Math.random().toString(36).slice(2, 9)}`;
+let session = null;
+let startHostTime = Date.now();
+let hasRemoteState = false;
+let lastStateReplyAt = 0;
+let ballCount = 0;
+let crateCount = 0;
+
+const renderer = new THREE.WebGLRenderer({ canvas: ui.canvas, antialias: true });
+renderer.setPixelRatio(Math.min(devicePixelRatio || 1, 2));
+renderer.setSize(innerWidth, innerHeight);
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x101827);
+scene.fog = new THREE.Fog(0x101827, 14, 34);
+const camera = new THREE.PerspectiveCamera(50, innerWidth / innerHeight, 0.05, 100);
+camera.position.set(6, 5.2, 8.4);
+camera.lookAt(0, 1.1, 0);
+scene.add(new THREE.HemisphereLight(0xdbe9ff, 0x151b28, 2.0));
+const light = new THREE.DirectionalLight(0xffffff, 2.3);
+light.position.set(4, 8, 5);
+scene.add(light);
+const floor = new THREE.Mesh(new THREE.BoxGeometry(9.2, 0.08, 7.2), new THREE.MeshStandardMaterial({ color: 0x263247, roughness: 0.86 }));
+floor.position.y = -0.04;
+scene.add(floor);
+const grid = new THREE.GridHelper(9.2, 23, 0x4e6b9f, 0x253650);
+grid.position.y = 0.01;
+scene.add(grid);
+const mats = {
+  sphere: new THREE.MeshStandardMaterial({ color: 0x6ea8ff, roughness: 0.48 }),
+  crate: new THREE.MeshStandardMaterial({ color: 0xffbd66, roughness: 0.62 }),
+  fixed: new THREE.MeshStandardMaterial({ color: 0x7ee0a7, roughness: 0.72 }),
+};
+const meshes = new Map();
+
+function roomId(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 32) || DEFAULT_ROOM;
+}
+function currentRoom() {
+  return roomId(new URLSearchParams(location.search).get('room') || DEFAULT_ROOM);
+}
+function setRoom(room) {
+  const url = new URL(location.href);
+  url.searchParams.set('room', room);
+  history.replaceState(null, '', url);
+  ui.room.value = room;
+  ui.open.href = `/scenesync/?room=${encodeURIComponent(room)}`;
+}
+function presenceUrl(room) {
+  const encoded = encodeURIComponent(room);
+  if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return `ws://${location.hostname}:8787?room=${encoded}`;
+  return `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/presence?room=${encoded}`;
+}
+function writeLog(type, text = '') {
+  const line = document.createElement('div');
+  line.innerHTML = `<b>${type}</b> ${new Date().toLocaleTimeString()} ${text}`;
+  ui.log.appendChild(line);
+  while (ui.log.childElementCount > 60) ui.log.firstElementChild.remove();
+  ui.log.scrollTop = ui.log.scrollHeight;
+}
+function setEnabled(enabled) {
+  [ui.reset, ui.ball, ui.crate, ui.push].forEach((button) => { button.disabled = !enabled; });
+}
+function updateUi() {
+  ui.status.textContent = online ? 'online' : 'offline';
+  ui.status.className = online ? 'on' : 'off';
+  ui.connect.textContent = online ? 'Disconnect' : 'Connect';
+  setEnabled(Boolean(session));
+}
+function seedTemplate() {
+  const bodies = [
+    { id: 'wall-left', shape: 'box', halfExtents: [0.18, 0.8, 3.2], position: [-4.2, 0.8, 0], static: true, restitution: 0.35, friction: 0.8 },
+    { id: 'wall-right', shape: 'box', halfExtents: [0.18, 0.8, 3.2], position: [4.2, 0.8, 0], static: true, restitution: 0.35, friction: 0.8 },
+    { id: 'back-stop', shape: 'box', halfExtents: [4.2, 0.75, 0.18], position: [0, 0.75, -3.2], static: true, restitution: 0.42, friction: 0.8 },
+    { id: 'bumper', shape: 'box', halfExtents: [1.7, 0.16, 0.55], position: [-1.9, 0.32, 1.3], static: true, restitution: 0.16, friction: 0.85 },
+    { id: 'target', shape: 'box', halfExtents: [0.72, 0.18, 0.72], position: [2.35, 0.18, -1.65], static: true, restitution: 0.8, friction: 0.15 },
+    { id: 'crate-0', shape: 'box', halfExtents: [0.35, 0.35, 0.35], position: [1.1, 0.35, -0.25], mass: 1, restitution: 0.08, friction: 0.62 },
+    { id: 'crate-1', shape: 'box', halfExtents: [0.35, 0.35, 0.35], position: [1.1, 1.05, -0.25], mass: 1, restitution: 0.08, friction: 0.62 },
+    { id: 'crate-2', shape: 'box', halfExtents: [0.35, 0.35, 0.35], position: [1.1, 1.75, -0.25], mass: 1, restitution: 0.08, friction: 0.62 },
+    { id: 'starter-ball', shape: 'sphere', radius: 0.34, position: [-2.9, 2.7, 1.35], mass: 1, restitution: 0.72, friction: 0.36 },
+  ];
+  bodies.forEach((body) => session.world.addBody(body));
+  ballCount = 1;
+  crateCount = 3;
+}
+function makeSession(nextStartHostTime = Date.now(), seed = true) {
+  session = createLockstepSession({ peerId, worldOptions: WORLD_OPTIONS, commandDelayTicks: 4, snapshotIntervalTicks: 30, maxSnapshots: 12 });
+  startHostTime = nextStartHostTime;
+  hasRemoteState = false;
+  if (seed) seedTemplate();
+  updateUi();
+}
+function send(payload) {
+  if (!online || !ws || ws.readyState !== WebSocket.OPEN) return false;
+  ws.send(JSON.stringify({ type: 'broadcast', payload }));
+  return true;
+}
+function issue(type, payload) {
+  if (!session) makeSession();
+  const command = session.issueCommand(type, payload);
+  send({ type: 'physics-demo-command', version: VERSION, command });
+  writeLog('cmd', `${type} tick=${command.tick}`);
+  return command;
+}
+function resetShared() {
+  const nextStartHostTime = Date.now() + 180;
+  makeSession(nextStartHostTime, true);
+  send({ type: 'physics-demo-start', version: VERSION, by: peerId, startHostTime: nextStartHostTime });
+  writeLog('reset', 'shared toy restarted');
+}
+function addBall() {
+  const id = `ball-${ballCount++}`;
+  issue('add-body', { body: { id, shape: 'sphere', radius: 0.28, position: [-3.05, 3.1, 1.55], velocity: [1.2, 0, -0.35], mass: 1, restitution: 0.76, friction: 0.28 } });
+}
+function addCrate() {
+  const id = `crate-${crateCount++}`;
+  const x = 0.15 + (crateCount % 4) * 0.42;
+  issue('add-body', { body: { id, shape: 'box', halfExtents: [0.32, 0.32, 0.32], position: [x, 2.8, 0.25], mass: 1, restitution: 0.12, friction: 0.72 } });
+}
+function pushTower() {
+  ['crate-0', 'crate-1', 'crate-2'].forEach((bodyId, index) => issue('impulse', { bodyId, impulse: [-1.6 - index * 0.25, 0.3, 0.7] }));
+}
+function connect() {
+  const room = roomId(ui.room.value);
+  setRoom(room);
+  ws = new WebSocket(presenceUrl(room));
+  writeLog('connect', room);
+  ws.onopen = () => ws.send(JSON.stringify({ type: 'hello', nickname: 'PhysicsToy', device: 'Scene Sync Physics Demo' }));
+  ws.onmessage = (event) => {
+    try { handleMessage(JSON.parse(event.data)); } catch (error) { console.error(error); writeLog('error', 'bad message'); }
+  };
+  ws.onclose = () => { online = false; updateUi(); writeLog('close', 'disconnected'); };
+  ws.onerror = () => writeLog('error', 'websocket');
+}
+function disconnect() {
+  if (ws) ws.close();
+  ws = null;
+  online = false;
+  updateUi();
+}
+function handleMessage(message) {
+  if (message.type === 'welcome') {
+    peerId = String(message.id || peerId);
+    online = true;
+    if (!session) makeSession();
+    updateUi();
+    writeLog('welcome', `peer=${peerId}`);
+    setTimeout(() => send({ type: 'physics-demo-state-request', version: VERSION, by: peerId }), 250);
+    return;
+  }
+  if (message.type === 'peers') {
+    ui.peers.textContent = String(message.peers?.length || 0);
+    return;
+  }
+  if (message.type === 'handoff' && message.payload) handlePayload(message.payload);
+}
+function handlePayload(payload) {
+  if (!payload || (payload.version && payload.version !== VERSION) || payload.by === peerId) return;
+  if (payload.type === 'physics-demo-start') {
+    makeSession(Number(payload.startHostTime) || Date.now(), true);
+    hasRemoteState = true;
+    writeLog('remote', 'reset/start');
+    return;
+  }
+  if (payload.type === 'physics-demo-command') {
+    if (!session) makeSession();
+    const result = session.receiveCommand(payload.command);
+    if (result.applied) writeLog('remote', `${payload.command?.type || 'command'}${result.rolledBack ? ' rollback' : ''}`);
+    return;
+  }
+  if (payload.type === 'physics-demo-state-request') {
+    if (!session || Date.now() - lastStateReplyAt < 1000) return;
+    lastStateReplyAt = Date.now();
+    send({ type: 'physics-demo-state', version: VERSION, by: peerId, startHostTime, state: session.createResyncState() });
+    writeLog('state', 'sent');
+    return;
+  }
+  if (payload.type === 'physics-demo-state' && payload.state) {
+    if (!session || !hasRemoteState || session.tick < payload.state.tick) {
+      if (!session) makeSession(Number(payload.startHostTime) || Date.now(), false);
+      startHostTime = Number(payload.startHostTime) || startHostTime;
+      session.applyResyncState(payload.state);
+      hasRemoteState = true;
+      writeLog('state', `applied tick=${payload.state.tick}`);
+    }
+  }
+}
+function materialFor(body) {
+  if (body.static) return mats.fixed;
+  return body.shape === 'sphere' ? mats.sphere : mats.crate;
+}
+function updateMeshes() {
+  if (!session) return;
+  const bodies = session.getBodies();
+  const active = new Set();
+  bodies.forEach((body) => {
+    active.add(body.id);
+    let mesh = meshes.get(body.id);
+    if (!mesh) {
+      mesh = body.shape === 'sphere'
+        ? new THREE.Mesh(new THREE.SphereGeometry(body.radius, 24, 16), materialFor(body))
+        : new THREE.Mesh(new THREE.BoxGeometry(body.halfExtents[0] * 2, body.halfExtents[1] * 2, body.halfExtents[2] * 2), materialFor(body));
+      mesh.name = body.id;
+      scene.add(mesh);
+      meshes.set(body.id, mesh);
+    }
+    mesh.position.set(body.position[0], body.position[1], body.position[2]);
+    mesh.material = materialFor(body);
+  });
+  for (const [id, mesh] of meshes) {
+    if (!active.has(id)) {
+      scene.remove(mesh);
+      mesh.geometry.dispose();
+      meshes.delete(id);
+    }
+  }
+}
+function resize() {
+  renderer.setSize(innerWidth, innerHeight);
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+}
+function animate() {
+  requestAnimationFrame(animate);
+  if (session) {
+    session.advanceTo(tickForElapsedMs(Date.now() - startHostTime, session.world.timestepFp));
+    updateMeshes();
+    ui.tick.textContent = String(session.tick);
+    ui.bodies.textContent = String(session.getBodies().length);
+    ui.hash.textContent = session.stateHash().toString(16).padStart(8, '0');
+  }
+  renderer.render(scene, camera);
+}
+ui.connect.addEventListener('click', () => (online ? disconnect() : connect()));
+ui.reset.addEventListener('click', resetShared);
+ui.ball.addEventListener('click', addBall);
+ui.crate.addEventListener('click', addCrate);
+ui.push.addEventListener('click', pushTower);
+ui.copy.addEventListener('click', async () => {
+  setRoom(roomId(ui.room.value));
+  try { await navigator.clipboard.writeText(location.href); writeLog('copy', 'room URL'); } catch { writeLog('copy', location.href); }
+});
+ui.room.addEventListener('change', () => setRoom(roomId(ui.room.value)));
+addEventListener('resize', resize);
+
+setRoom(currentRoom());
+makeSession();
+updateUi();
+animate();
+setTimeout(connect, 100);

--- a/html/scenesync/physics-demo.html
+++ b/html/scenesync/physics-demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Scene Sync Physics Toy</title>
+  <meta name="description" content="Scene Sync の決定論的物理エンジンをルーム同期で試す物理サンプル。">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <style>
+    *{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#101827;color:#fff;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono",monospace;touch-action:none}#c{display:block;width:100vw;height:100dvh}.panel{position:fixed;z-index:10;border:1px solid rgba(255,255,255,.14);border-radius:14px;background:rgba(8,12,22,.78);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);box-shadow:0 16px 48px rgba(0,0,0,.28)}#ui{top:max(12px,env(safe-area-inset-top));left:12px;width:min(390px,calc(100vw - 24px));padding:14px}h1{margin:0 0 8px;font-size:18px;line-height:1.25}.lead{margin:0 0 12px;color:rgba(255,255,255,.72);font-size:12px;line-height:1.55}.row,.grid,.meta{display:grid;gap:8px}.row{grid-template-columns:minmax(0,1fr) auto;margin-bottom:8px}.grid{grid-template-columns:repeat(2,minmax(0,1fr));margin-top:8px}.meta{grid-template-columns:repeat(3,minmax(0,1fr));margin-top:10px}input,button,a.chip{min-height:38px;border:0;border-radius:10px;color:#fff;font:inherit;font-size:12px}input{min-width:0;padding:8px 10px;border:1px solid rgba(255,255,255,.14);background:rgba(0,0,0,.35);outline:none}button,a.chip{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:8px 10px;background:rgba(255,255,255,.12);text-decoration:none;cursor:pointer;user-select:none}button:hover,a.chip:hover{background:rgba(255,255,255,.2)}button.primary{background:rgba(67,136,255,.68)}button.danger{background:rgba(255,80,80,.46)}button:disabled{opacity:.45;cursor:not-allowed}.stat{padding:8px;border-radius:10px;background:rgba(255,255,255,.06);color:rgba(255,255,255,.72);font-size:11px;line-height:1.4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.stat strong{display:block;color:#fff;font-size:13px;margin-top:2px}#status.off{color:#ff8b8b}#status.on{color:#65ee9a}#log{left:12px;bottom:max(12px,env(safe-area-inset-bottom));width:min(560px,calc(100vw - 24px));max-height:144px;padding:10px 12px;overflow:auto;color:rgba(255,255,255,.72);font-size:11px;line-height:1.45}#log div{white-space:nowrap}#log b{display:inline-block;min-width:64px;color:#8fc2ff}.hint{right:12px;top:max(12px,env(safe-area-inset-top));width:min(310px,calc(100vw - 24px));padding:12px;font-size:12px;line-height:1.55;color:rgba(255,255,255,.72)}.hint strong{color:#fff}@media(max-width:760px){.hint{display:none}#ui{padding:12px}.grid{grid-template-columns:1fr}.meta{grid-template-columns:repeat(2,minmax(0,1fr))}h1{font-size:16px}}
+  </style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <section id="ui" class="panel" aria-label="Physics demo controls">
+    <h1>Scene Sync Physics Toy</h1>
+    <p class="lead">決定論的物理エンジン + Scene Sync ルーム同期の最小サンプル。同じURLを別タブ/別端末で開くと、追加・リセット・インパルスが同じ順序で流れます。</p>
+    <div class="row"><input id="room" maxlength="32" spellcheck="false" aria-label="Room ID"><button id="connect" class="primary" type="button">Connect</button></div>
+    <div class="grid">
+      <button id="reset" class="danger" type="button" disabled>Reset shared toy</button>
+      <button id="ball" type="button" disabled>Add ball</button>
+      <button id="crate" type="button" disabled>Add crate</button>
+      <button id="push" type="button" disabled>Push tower</button>
+      <button id="copy" type="button">Copy room URL</button>
+      <a id="open" class="chip" href="/scenesync/" target="_blank" rel="noopener noreferrer">Open Scene Sync</a>
+    </div>
+    <div class="meta">
+      <div class="stat">status<strong id="status" class="off">offline</strong></div>
+      <div class="stat">tick<strong id="tick">0</strong></div>
+      <div class="stat">bodies<strong id="bodies">0</strong></div>
+      <div class="stat">hash<strong id="hash">—</strong></div>
+      <div class="stat">peers<strong id="peers">0</strong></div>
+    </div>
+  </section>
+  <aside class="panel hint"><strong>Try it</strong><br>1. このページを2タブで開く<br>2. 片方で Add ball / Push tower<br>3. もう片方でも同じ tick/hash になることを確認<br><br>Scene Sync本体統合前の「動く入口」です。次はテンプレート/Remix導線へ昇格できます。</aside>
+  <div id="log" class="panel" aria-live="polite"></div>
+  <script type="importmap">{"imports":{"three":"https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js"}}</script>
+  <script type="module" src="/assets/js/scenesync/physics-demo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a Scene Sync-runnable deterministic physics sample at `/scenesync/physics-demo.html`.

This is intentionally a small standalone demo rather than a deep Editor integration, so the newly merged deterministic physics engine immediately has a visible Scene Sync entry point.

## What it does

- Renders a small physics toy scene with Three.js
- Uses `createLockstepSession()` from `html/assets/js/scenesync/physics/`
- Connects to the Scene Sync presence room transport
- Broadcasts physics commands through room messages
- Supports:
  - Reset shared toy
  - Add ball
  - Add crate
  - Push tower
  - Late-join state resync request/reply
  - Tick/hash display for two-tab sanity checking
- Links back to `/scenesync/?room=...` so this can become a bridge toward the main Scene Sync template/remix flow

## Verification

- Ran local syntax check for the demo runtime with `node --check` before committing.
- Did not run browser E2E in this environment.