### PR TITLE
Support GLB file import from Scene Sync Export packages

### DIFF
--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -1,11 +1,62 @@
 // Upserts every object in a SceneDocument into the current scene.
 // Objects with an existing objectId are updated in place; new objectIds are added.
 // Objects not present in the document are left untouched (no scene clear).
-export function applySceneDocument(sceneDocument, { managedObjects, addOrUpdateObject, broadcast }) {
+//
+// Objects marked with `importAsset.kind === 'glb-file'` are loaded from the
+// ZIP via `importGlbFileAsSceneObject`, reusing the normal GLB-file import
+// route with an explicit objectId/transform. All other objects go through
+// `addOrUpdateObject` + `broadcast` as before.
+export async function applySceneDocument(sceneDocument, {
+  managedObjects,
+  addOrUpdateObject,
+  broadcast,
+  importGlbFileAsSceneObject,
+  zip,
+} = {}) {
   let added = 0;
   let updated = 0;
+  let glbImported = 0;
+  let skippedAssets = 0;
 
   for (const obj of sceneDocument.objects || []) {
+    const existed = managedObjects.has(obj.id);
+    if (existed) {
+      updated += 1;
+    } else {
+      added += 1;
+    }
+
+    if (obj.importAsset?.kind === 'glb-file') {
+      const entry = zip?.file(obj.importAsset.path);
+      if (entry && importGlbFileAsSceneObject) {
+        const buffer = await entry.async('arraybuffer');
+        const file = new File(
+          [buffer],
+          obj.importAsset.originalName,
+          { type: obj.importAsset.mime || 'model/gltf-binary' }
+        );
+
+        await importGlbFileAsSceneObject(file, {
+          objectId: obj.id,
+          name: obj.name || obj.id,
+          position: obj.position,
+          rotation: obj.rotation,
+          scale: obj.scale,
+          visible: obj.visible !== false,
+          metadata: obj.metadata,
+          animation: obj.animation,
+          audioSources: obj.audioSources,
+          selectAfterLoad: false,
+          source: 'scene-sync-export-import',
+        });
+
+        glbImported += 1;
+        continue;
+      }
+
+      skippedAssets += 1;
+    }
+
     const payload = {
       kind: 'scene-add',
       objectId: obj.id,
@@ -21,15 +72,15 @@ export function applySceneDocument(sceneDocument, { managedObjects, addOrUpdateO
     if (obj.animation) payload.animation = obj.animation;
     if (obj.audioSources) payload.audioSources = obj.audioSources;
 
-    if (managedObjects.has(obj.id)) {
-      updated += 1;
-    } else {
-      added += 1;
-    }
-
     addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import' });
     broadcast(payload);
   }
 
-  return { total: sceneDocument.objects?.length || 0, added, updated };
+  return {
+    total: sceneDocument.objects?.length || 0,
+    added,
+    updated,
+    glbImported,
+    skippedAssets,
+  };
 }

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
@@ -1,0 +1,158 @@
+// Tests for apply-scene-document.js
+// Run: node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual, ok } from 'node:assert';
+import { applySceneDocument } from './apply-scene-document.js';
+
+function createFakeZip(files) {
+  return {
+    file(path) {
+      const data = files[path];
+      if (!data) return null;
+      return {
+        async async(type) {
+          strictEqual(type, 'arraybuffer');
+          return data;
+        },
+      };
+    },
+  };
+}
+
+test('adds new objects and updates existing ones via addOrUpdateObject + broadcast', async () => {
+  const managedObjects = new Map([['existing-1', {}]]);
+  const calls = { addOrUpdate: [], broadcast: [] };
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'existing-1',
+        name: 'Existing',
+        position: [1, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'primitive', primitive: 'box', color: '#ffffff' },
+        visible: true,
+        metadata: { foo: 'bar' },
+      },
+      {
+        id: 'new-1',
+        name: 'New',
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'primitive', primitive: 'sphere', color: '#000000' },
+        visible: false,
+      },
+    ],
+  };
+
+  const stats = await applySceneDocument(sceneDocument, {
+    managedObjects,
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+  });
+
+  deepStrictEqual(stats, { total: 2, added: 1, updated: 1, glbImported: 0, skippedAssets: 0 });
+  strictEqual(calls.addOrUpdate.length, 2);
+  strictEqual(calls.broadcast.length, 2);
+  strictEqual(calls.addOrUpdate[0].id, 'existing-1');
+  strictEqual(calls.addOrUpdate[0].payload.metadata.foo, 'bar');
+  strictEqual(calls.addOrUpdate[1].payload.visible, false);
+});
+
+test('imports ZIP-bundled GLB assets via importGlbFileAsSceneObject, keeping objectId', async () => {
+  const managedObjects = new Map();
+  const calls = { addOrUpdate: [], broadcast: [], importGlb: [] };
+
+  const glbBytes = new ArrayBuffer(8);
+  const zip = createFakeZip({ 'assets/booth-1.glb': glbBytes });
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'booth-1',
+        name: 'Booth',
+        position: [1, 0.5, -2],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        metadata: { role: 'booth' },
+        animation: { enabled: true, clip: 0 },
+        audioSources: { ambient: { url: 'https://example.com/a.mp3' } },
+        importAsset: {
+          kind: 'glb-file',
+          path: 'assets/booth-1.glb',
+          originalName: 'booth-1.glb',
+          mime: 'model/gltf-binary',
+        },
+      },
+    ],
+  };
+
+  const stats = await applySceneDocument(sceneDocument, {
+    managedObjects,
+    addOrUpdateObject: (id, payload) => calls.addOrUpdate.push({ id, payload }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+    importGlbFileAsSceneObject: async (file, options) => {
+      calls.importGlb.push({ file, options });
+    },
+    zip,
+  });
+
+  deepStrictEqual(stats, { total: 1, added: 1, updated: 0, glbImported: 1, skippedAssets: 0 });
+  strictEqual(calls.addOrUpdate.length, 0);
+  strictEqual(calls.broadcast.length, 0);
+  strictEqual(calls.importGlb.length, 1);
+
+  const { file, options } = calls.importGlb[0];
+  strictEqual(file.name, 'booth-1.glb');
+  strictEqual(file.type, 'model/gltf-binary');
+  strictEqual(options.objectId, 'booth-1');
+  strictEqual(options.name, 'Booth');
+  deepStrictEqual(options.position, [1, 0.5, -2]);
+  strictEqual(options.selectAfterLoad, false);
+  deepStrictEqual(options.metadata, { role: 'booth' });
+  deepStrictEqual(options.animation, { enabled: true, clip: 0 });
+  ok(options.audioSources.ambient);
+});
+
+test('falls back to placeholder when ZIP entry for importAsset is missing', async () => {
+  const managedObjects = new Map();
+  const calls = { addOrUpdate: [], broadcast: [] };
+
+  const zip = createFakeZip({});
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'booth-2',
+        name: 'Missing GLB',
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: { type: 'mesh', path: 'assets/booth-2.glb' },
+        importAsset: {
+          kind: 'glb-file',
+          path: 'assets/booth-2.glb',
+          originalName: 'booth-2.glb',
+          mime: 'model/gltf-binary',
+        },
+      },
+    ],
+  };
+
+  const stats = await applySceneDocument(sceneDocument, {
+    managedObjects,
+    addOrUpdateObject: (id, payload) => calls.addOrUpdate.push({ id, payload }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+    zip,
+  });
+
+  strictEqual(stats.glbImported, 0);
+  strictEqual(stats.skippedAssets, 1);
+  strictEqual(calls.addOrUpdate.length, 1);
+  strictEqual(calls.addOrUpdate[0].payload.asset.type, 'mesh');
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
@@ -1,0 +1,25 @@
+// Applies scene-level settings (currently: skybox/environment) from a
+// SceneDocument. If the document has no skybox.envId, the current
+// environment is left untouched (no reset to default).
+export function applySceneDocumentSettings(sceneDocument, {
+  environmentManager,
+  broadcast,
+} = {}) {
+  const envId = sceneDocument?.skybox?.envId;
+
+  if (typeof envId === 'string' && envId.trim()) {
+    environmentManager?.loadEnvironment?.(envId, {
+      source: 'scene-sync-export-import',
+      broadcastChange: false,
+    });
+
+    broadcast?.({
+      kind: 'scene-env',
+      envId,
+    });
+
+    return { envApplied: true, envId };
+  }
+
+  return { envApplied: false };
+}

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
@@ -1,0 +1,44 @@
+// Tests for apply-scene-settings.js
+// Run: node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
+
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { applySceneDocumentSettings } from './apply-scene-settings.js';
+
+test('applies envId from skybox and broadcasts scene-env', () => {
+  const calls = { loadEnvironment: [], broadcast: [] };
+  const environmentManager = {
+    loadEnvironment: (envId, options) => calls.loadEnvironment.push({ envId, options }),
+  };
+  const broadcast = (payload) => calls.broadcast.push(payload);
+
+  const result = applySceneDocumentSettings({ skybox: { envId: 'outdoor_night' } }, {
+    environmentManager,
+    broadcast,
+  });
+
+  deepStrictEqual(result, { envApplied: true, envId: 'outdoor_night' });
+  strictEqual(calls.loadEnvironment.length, 1);
+  strictEqual(calls.loadEnvironment[0].envId, 'outdoor_night');
+  strictEqual(calls.loadEnvironment[0].options.broadcastChange, false);
+  deepStrictEqual(calls.broadcast[0], { kind: 'scene-env', envId: 'outdoor_night' });
+});
+
+test('does nothing when skybox is absent (keeps current environment)', () => {
+  const calls = { loadEnvironment: [], broadcast: [] };
+  const environmentManager = {
+    loadEnvironment: (envId, options) => calls.loadEnvironment.push({ envId, options }),
+  };
+  const broadcast = (payload) => calls.broadcast.push(payload);
+
+  const result = applySceneDocumentSettings({}, { environmentManager, broadcast });
+
+  deepStrictEqual(result, { envApplied: false });
+  strictEqual(calls.loadEnvironment.length, 0);
+  strictEqual(calls.broadcast.length, 0);
+});
+
+test('does nothing when skybox.envId is null', () => {
+  const result = applySceneDocumentSettings({ skybox: { envId: null } }, {});
+  deepStrictEqual(result, { envApplied: false });
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -2,6 +2,7 @@ import { isZipFile } from './detect-scene-sync-export.js';
 import { loadExportPackageFromBlob } from './load-export-package.js';
 import { resolveSceneDocumentAssets } from './resolve-export-assets.js';
 import { applySceneDocument } from './apply-scene-document.js';
+import { applySceneDocumentSettings } from './apply-scene-settings.js';
 
 export { isZipFile };
 
@@ -10,7 +11,15 @@ export { isZipFile };
 export async function tryOpenSceneSyncExportFile(file, context = {}) {
   if (!isZipFile(file)) return { handled: false };
 
-  const { managedObjects, addOrUpdateObject, broadcast, showToast, confirmOpen } = context;
+  const {
+    managedObjects,
+    addOrUpdateObject,
+    broadcast,
+    showToast,
+    confirmOpen,
+    environmentManager,
+    importGlbFileAsSceneObject,
+  } = context;
 
   const result = await loadExportPackageFromBlob(file);
   if (!result.valid) {
@@ -18,7 +27,9 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     return { handled: true, error: result.reason };
   }
 
-  const { document: resolvedDocument } = await resolveSceneDocumentAssets(result.sceneDocument);
+  const { document: resolvedDocument } = await resolveSceneDocumentAssets(result.sceneDocument, {
+    zip: result.zip,
+  });
 
   const objects = resolvedDocument.objects || [];
   const updateCount = objects.filter((obj) => managedObjects.has(obj.id)).length;
@@ -38,8 +49,22 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     return { handled: true, cancelled: true };
   }
 
-  const stats = applySceneDocument(resolvedDocument, { managedObjects, addOrUpdateObject, broadcast });
-  showToast?.(`Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated}）`);
+  const stats = await applySceneDocument(resolvedDocument, {
+    managedObjects,
+    addOrUpdateObject,
+    broadcast,
+    importGlbFileAsSceneObject,
+    zip: result.zip,
+  });
 
-  return { handled: true, stats };
+  const settingsResult = applySceneDocumentSettings(resolvedDocument, {
+    environmentManager,
+    broadcast,
+  });
+
+  showToast?.(
+    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}）`
+  );
+
+  return { handled: true, stats, settings: settingsResult };
 }

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.js
@@ -1,11 +1,15 @@
 // Resolves SceneDocument objects for import, keeping primitives and inline
 // text as-is, and passing through assets that already have a shareable URL.
-// ZIP-bundled image/mesh/video/text assets (asset.path with no asset.url)
-// are not yet imported as shared Scene Sync assets — they are marked with
-// metadata.importWarning so the object still appears (as a placeholder)
-// without producing local-only blob: URLs that would leak into scene-state,
-// snapshots, or re-export.
-export async function resolveSceneDocumentAssets(sceneDocument) {
+//
+// ZIP-bundled GLB ("mesh") assets are marked with an `importAsset` plan so
+// applySceneDocument() can load them via the normal GLB-file import route.
+//
+// Other ZIP-bundled image/mesh/video/text assets (asset.path with no
+// asset.url) are not yet imported as shared Scene Sync assets — they are
+// marked with metadata.importWarning so the object still appears (as a
+// placeholder) without producing local-only blob: URLs that would leak into
+// scene-state, snapshots, or re-export.
+export async function resolveSceneDocumentAssets(sceneDocument, { zip } = {}) {
   const objects = [];
 
   for (const obj of sceneDocument.objects || []) {
@@ -23,6 +27,19 @@ export async function resolveSceneDocumentAssets(sceneDocument) {
 
     if (asset.url) {
       objects.push(obj);
+      continue;
+    }
+
+    if (asset.type === 'mesh' && asset.path && zip?.file(asset.path)) {
+      objects.push({
+        ...obj,
+        importAsset: {
+          kind: 'glb-file',
+          path: asset.path,
+          originalName: asset.originalName || asset.path.split('/').pop() || `${obj.id}.glb`,
+          mime: asset.mime || 'model/gltf-binary',
+        },
+      });
       continue;
     }
 

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.test.js
@@ -1,0 +1,79 @@
+// Tests for resolve-export-assets.js
+// Run: node --test html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.test.js
+
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual, ok } from 'node:assert';
+import { resolveSceneDocumentAssets } from './resolve-export-assets.js';
+
+function createFakeZip(paths) {
+  const set = new Set(paths);
+  return {
+    file(path) {
+      return set.has(path) ? {} : null;
+    },
+  };
+}
+
+test('passes through primitives, inline text, and URL assets unchanged', async () => {
+  const sceneDocument = {
+    objects: [
+      { id: 'a', asset: { type: 'primitive', primitive: 'box', color: '#fff' } },
+      { id: 'b', asset: { type: 'text', source: 'inline', text: 'hello' } },
+      { id: 'c', asset: { type: 'image', url: 'https://example.com/i.png' } },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument);
+  deepStrictEqual(document.objects, sceneDocument.objects);
+});
+
+test('marks ZIP-bundled GLB assets with an importAsset plan when the zip entry exists', async () => {
+  const zip = createFakeZip(['assets/booth-1.glb']);
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'booth-1',
+        asset: { type: 'mesh', path: 'assets/booth-1.glb', mime: 'model/gltf-binary', originalName: 'booth-1.glb' },
+      },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument, { zip });
+  const obj = document.objects[0];
+  ok(obj.importAsset);
+  strictEqual(obj.importAsset.kind, 'glb-file');
+  strictEqual(obj.importAsset.path, 'assets/booth-1.glb');
+  strictEqual(obj.importAsset.originalName, 'booth-1.glb');
+  strictEqual(obj.importAsset.mime, 'model/gltf-binary');
+  // original asset is left untouched
+  strictEqual(obj.asset.type, 'mesh');
+});
+
+test('falls back to importWarning placeholder when GLB zip entry is missing', async () => {
+  const zip = createFakeZip([]);
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'booth-2',
+        asset: { type: 'mesh', path: 'assets/booth-2.glb' },
+      },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument, { zip });
+  const obj = document.objects[0];
+  strictEqual(obj.importAsset, undefined);
+  ok(obj.metadata.importWarning.includes('assets/booth-2.glb'));
+});
+
+test('falls back to importWarning placeholder for path-only image/video assets', async () => {
+  const sceneDocument = {
+    objects: [
+      { id: 'img-1', asset: { type: 'image', path: 'assets/img-1.jpg' } },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument);
+  const obj = document.objects[0];
+  ok(obj.metadata.importWarning.includes('assets/img-1.jpg'));
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6324,6 +6324,73 @@ async function uploadGlbFromUrl(url, params = {}) {
   };
 }
 
+// Loads a GLB File into the scene as a managed object with an explicit
+// objectId/transform, reusing the same normalization/animation/upload
+// pipeline as the normal drag-and-drop GLB route. Used by Scene Sync Export
+// Import to restore GLB objects while keeping their original objectId.
+async function importGlbFileAsSceneObject(file, {
+  objectId,
+  name,
+  position,
+  rotation,
+  scale,
+  metadata,
+  animation,
+  audioSources,
+  selectAfterLoad = false,
+  showImportToast = false,
+} = {}) {
+  const loadPosition = Array.isArray(position)
+    ? new THREE.Vector3().fromArray(position)
+    : new THREE.Vector3();
+
+  const model = await glbLoader.loadFromFile(file, loadPosition, scene);
+  model.userData.objectId = objectId;
+  model.userData.name = name || file.name;
+
+  const info = {
+    name: name || file.name,
+    position: Array.isArray(position) ? position : model.position.toArray(),
+    rotation: Array.isArray(rotation) ? rotation : model.quaternion.toArray(),
+    scale: Array.isArray(scale) ? scale : model.scale.toArray(),
+    visible: true,
+  };
+  if (metadata) info.metadata = metadata;
+  if (animation) info.animation = animation;
+  if (audioSources !== undefined) info.audioSources = audioSources;
+
+  // GLB は内部に元のシーン座標を持つため、info の transform で上書きする
+  replaceManagedObject(objectId, model, info);
+
+  if (selectAfterLoad) {
+    selectManagedObject(model);
+    notifySelectionChanged('drag-drop-object-selected');
+  }
+
+  // 正規化の結果をトーストで通知
+  const glbMetadata = model.userData?.scenesync?.glbMetadata;
+  if (showImportToast) {
+    if (glbMetadata?.normalized) {
+      showToast('Sketchfab形式のマテリアルをScene Sync向けに変換しました');
+    } else if (glbMetadata?.normalizationSkipped) {
+      showToast('このモデルはScene Syncで正しく表示できない可能性があるマテリアルを使用しています');
+    }
+  }
+
+  // 変換後 ArrayBuffer を優先（upload / broadcast / cache すべてに変換後を使う）
+  const arrayBuffer = model.userData.normalizedGlbArrayBuffer
+    ? model.userData.normalizedGlbArrayBuffer
+    : await file.arrayBuffer();
+
+  await uploadAndBroadcast(objectId, name || file.name, model, arrayBuffer, {
+    ...(metadata ? { metadata } : {}),
+    ...(animation ? { animation } : {}),
+    ...(audioSources !== undefined ? { audioSources } : {}),
+  });
+
+  return model;
+}
+
 function readVector3Array(value, fallback) {
   return Array.isArray(value) && value.length === 3 ? value : fallback;
 }
@@ -8694,7 +8761,7 @@ function generateRandomPath() {
   return Math.random().toString(36).slice(2, 10);
 }
 
-async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
+async function uploadAndBroadcast(objectId, name, model, arrayBuffer, extraFields = {}) {
   const uploadBlob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
   const meshPath = generateRandomPath();
   let actualMeshPath = null;
@@ -8768,6 +8835,7 @@ async function uploadAndBroadcast(objectId, name, model, arrayBuffer) {
       scale: model.scale.toArray(),
       asset: { ...asset },
       meshPath: actualMeshPath,
+      ...extraFields,
     };
 
     presenceState.historyManager.push(
@@ -9494,6 +9562,8 @@ const dragDropManager = new DragDropManager({
     addOrUpdateObject,
     broadcast,
     showToast,
+    environmentManager,
+    importGlbFileAsSceneObject,
   }),
   onLoadStart: async ({
     objectId,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6334,6 +6334,7 @@ async function importGlbFileAsSceneObject(file, {
   position,
   rotation,
   scale,
+  visible = true,
   metadata,
   animation,
   audioSources,
@@ -6353,7 +6354,7 @@ async function importGlbFileAsSceneObject(file, {
     position: Array.isArray(position) ? position : model.position.toArray(),
     rotation: Array.isArray(rotation) ? rotation : model.quaternion.toArray(),
     scale: Array.isArray(scale) ? scale : model.scale.toArray(),
-    visible: true,
+    visible,
   };
   if (metadata) info.metadata = metadata;
   if (animation) info.animation = animation;
@@ -6383,6 +6384,7 @@ async function importGlbFileAsSceneObject(file, {
     : await file.arrayBuffer();
 
   await uploadAndBroadcast(objectId, name || file.name, model, arrayBuffer, {
+    visible,
     ...(metadata ? { metadata } : {}),
     ...(animation ? { animation } : {}),
     ...(audioSources !== undefined ? { audioSources } : {}),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
-    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js"
+    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js",
+    "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",


### PR DESCRIPTION
## 概要

Scene Sync Export パッケージから GLB ファイルをインポートする機能を追加しました。ZIP に含まれる GLB アセットを通常のドラッグ&ドロップ GLB インポートと同じパイプラインで読み込み、元の objectId と transform を保持します。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 主要な変更

1. **GLB ファイルインポート関数の追加** (`scene.js`)
   - `importGlbFileAsSceneObject()` を新規実装
   - ファイル、objectId、transform、メタデータ、アニメーション、オーディオソースを指定して GLB をシーンに追加
   - 正規化パイプライン（Sketchfab マテリアル変換など）を再利用
   - `uploadAndBroadcast()` に `extraFields` パラメータを追加して、メタデータ・アニメーション・オーディオソースを broadcast に含める

2. **アセット解決の改善** (`resolve-export-assets.js`)
   - ZIP に含まれる mesh 型アセット（GLB）を検出し、`importAsset` マーカーを付与
   - 他の path ベースアセット（画像・動画）は従来通り `importWarning` で処理

3. **シーン適用ロジックの拡張** (`apply-scene-document.js`)
   - `importAsset.kind === 'glb-file'` のオブジェクトを `importGlbFileAsSceneObject()` で処理
   - ZIP エントリが見つからない場合はフォールバック（`skippedAssets` カウント）
   - 統計情報に `glbImported` と `skippedAssets` を追加

4. **シーン設定の適用** (`apply-scene-settings.js` 新規)
   - SceneDocument の `skybox.envId` を環境光として適用
   - 設定がない場合は現在の環境を保持（リセットしない）

5. **インポート処理の統合** (`index.js`)
   - `resolveSceneDocumentAssets()` に ZIP を渡す
   - `applySceneDocument()` を async に変更し、GLB インポートを待機
   - `applySceneDocumentSettings()` を呼び出して環境光を適用
   - toast メッセージに GLB インポート数を追加

### テスト

- `apply-scene-document.test.js`: GLB インポート、フォールバック、既存オブジェクト更新をカバー
- `resolve-export-assets.test.js`: primitive・inline text・URL アセットのパススルー、GLB マーキング、importWarning をカバー
- `apply-scene-settings.test.js`: 環境光の適用、設定なしの場合の動作をカバー

## 変更していないこと

- 画像・動画・テキストアセットのインポート（従来通り importWarning で処理）
- 既存の drag-drop GLB インポート機能
- 物理エンジン、ロックステップ同期

## staging確認

未確認

## テスト/チェック

- 新規テストファイル 3 つを追加（`apply-scene-document.test.js`, `resolve-export-assets.test.js`, `apply-scene-settings.test.js`）
- `npm run test:*` で各テストが実行可能

https://claude.ai/code/session_01JJDPWui9pvUVLJAugc4uHF