### PR TITLE
[codex] Add SceneSync export/import E2E coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ https-portal-certs/
 verdaccio/
 
 node_modules/
+.playwright-browsers/
 plans/
 !docs/plans/
 !docs/plans/**/

--- a/html/assets/js/scenesync-export/export/collect-export-assets.js
+++ b/html/assets/js/scenesync-export/export/collect-export-assets.js
@@ -30,11 +30,19 @@ function audioExtForUrl(url) {
 }
 
 async function tryFetch(url) {
+  const fetched = await tryFetchAsset(url);
+  return fetched?.buffer || null;
+}
+
+async function tryFetchAsset(url) {
   if (!url) return null;
   try {
     const res = await fetch(url);
     if (!res.ok) return null;
-    return await res.arrayBuffer();
+    return {
+      buffer: await res.arrayBuffer(),
+      contentType: res.headers.get('content-type') || null,
+    };
   } catch {
     return null;
   }
@@ -187,13 +195,14 @@ export async function collectExportAssets({
       const imageUrl = obj.asset.url;
       if (!imageUrl) { updatedObjects.push(await withCollectedAudioSources(obj)); continue; }
 
-      const ext = extensionFor(obj.asset.mime || 'image/jpeg', 'jpg');
-      const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
-      const buffer = await tryFetch(imageUrl);
-      if (buffer) {
-        files[zipPath] = buffer;
+      const fetched = await tryFetchAsset(imageUrl);
+      if (fetched) {
+        const mime = obj.asset.mime || fetched.contentType || 'image/jpeg';
+        const ext = extensionFor(mime, 'jpg');
+        const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
+        files[zipPath] = fetched.buffer;
         assetManifest.push({ id: obj.id, kind: 'image', path: zipPath, status: 'included' });
-        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, path: zipPath } }));
+        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, mime, path: zipPath } }));
       } else {
         missingAssets.push({ id: obj.id, kind: 'image', url: imageUrl, reason: 'fetch-failed' });
         updatedObjects.push(await withCollectedAudioSources(obj)); // keep url as fallback for static-asset-resolver
@@ -205,13 +214,14 @@ export async function collectExportAssets({
       const videoUrl = obj.asset.url;
       if (!videoUrl) { updatedObjects.push(await withCollectedAudioSources(obj)); continue; }
 
-      const ext = videoExtFor(obj.asset.mime);
-      const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
-      const buffer = await tryFetch(videoUrl);
-      if (buffer) {
-        files[zipPath] = buffer;
+      const fetched = await tryFetchAsset(videoUrl);
+      if (fetched) {
+        const mime = obj.asset.mime || fetched.contentType || null;
+        const ext = videoExtFor(mime);
+        const zipPath = uniquePath(sanitizeFilename(obj.id), ext);
+        files[zipPath] = fetched.buffer;
         assetManifest.push({ id: obj.id, kind: 'video', path: zipPath, status: 'included' });
-        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, path: zipPath } }));
+        updatedObjects.push(await withCollectedAudioSources({ ...obj, asset: { ...obj.asset, ...(mime ? { mime } : {}), path: zipPath } }));
       } else {
         // Videos often have CORS restrictions; keep url so static viewer can stream
         missingAssets.push({ id: obj.id, kind: 'video', url: videoUrl, reason: 'fetch-failed' });
@@ -250,18 +260,23 @@ export async function collectExportAssets({
     const zipPath = uniquePath(baseName, ext);
 
     let fetchUrl = null;
+    let fetchSource = null;
     if (meshPath && blobBase) {
       fetchUrl = `${blobBase}/${meshPath}`;
+      fetchSource = 'blob';
+    } else if (obj.asset.url) {
+      fetchUrl = obj.asset.url;
+      fetchSource = 'url';
     }
 
     const blobBuffer = await tryFetch(fetchUrl);
 
     if (blobBuffer) {
       files[zipPath] = blobBuffer;
-      assetManifest.push({ id: obj.id, kind: 'mesh', path: zipPath, status: 'included', source: 'blob' });
+      assetManifest.push({ id: obj.id, kind: 'mesh', path: zipPath, status: 'included', source: fetchSource || 'unknown' });
       updatedObjects.push(await withCollectedAudioSources({
         ...obj,
-        asset: { ...obj.asset, path: zipPath, meshPath: undefined, assetId: undefined },
+        asset: { ...obj.asset, path: zipPath, url: undefined, meshPath: undefined, assetId: undefined },
       }));
     } else {
       // Try IndexedDB cache as fallback
@@ -286,6 +301,7 @@ export async function collectExportAssets({
           kind: 'mesh',
           assetId: assetId || null,
           meshPath: meshPath || null,
+          url: obj.asset.url || null,
           reason: cachedAsset.hasError ? 'blob-fetch-and-cache-error' : 'blob-fetch-and-cache-miss',
         });
         updatedObjects.push(await withCollectedAudioSources({

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -77,8 +77,8 @@ function buildAssetEntry(obj) {
       source: asset.source || 'url',
       url: asset.url || null,
       path: null, // filled by collect-export-assets.js
-      mime: asset.mime || 'image/jpeg',
     };
+    copyStringField(entry, asset, 'mime');
     copyFiniteNumberField(entry, asset, 'width');
     copyFiniteNumberField(entry, asset, 'height');
     copyStringField(entry, asset, 'assetId');
@@ -92,8 +92,8 @@ function buildAssetEntry(obj) {
       source: asset.source || 'url',
       url: asset.url || null,
       path: null, // filled by collect-export-assets.js
-      mime: asset.mime || 'video/mp4',
     };
+    copyStringField(entry, asset, 'mime');
     copyFiniteNumberField(entry, asset, 'width');
     copyFiniteNumberField(entry, asset, 'height');
     copyStringField(entry, asset, 'assetId');
@@ -131,8 +131,9 @@ function buildAssetEntry(obj) {
   const meshPath = obj.userData?.meshPath || asset.meshPath || null;
   const assetId = asset.assetId || obj.userData?.assetId || obj.userData?.scenesync?.assetId || null;
 
-  return {
+  const entry = {
     type: 'mesh',
+    source: asset.source || (asset.url ? 'url' : 'carrier'),
     // path will be filled by collect-export-assets.js
     path: null,
     meshPath,
@@ -141,6 +142,9 @@ function buildAssetEntry(obj) {
     visualBasis: asset.visualBasis || null,
     originalName: asset.originalName || null,
   };
+
+  copyStringField(entry, asset, 'url');
+  return entry;
 }
 
 function buildSkyboxEntry(envId) {

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -6,12 +6,91 @@
 // ZIP via `importGlbFileAsSceneObject`, reusing the normal GLB-file import
 // route with an explicit objectId/transform. All other objects go through
 // `addOrUpdateObject` + `broadcast` as before.
+import { uploadZipAsset } from './zip-asset-upload.js';
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function cleanUploadedAsset(asset, uploaded) {
+  const next = {
+    ...(asset || {}),
+    url: uploaded.url,
+    mime: uploaded.mime || asset?.mime,
+  };
+
+  if (next.type === 'text') {
+    next.source = 'url';
+  } else {
+    next.source = 'blob';
+  }
+
+  delete next.path;
+  return next;
+}
+
+function cleanUploadedAudioSource(source, uploaded) {
+  const next = {
+    ...(source || {}),
+    url: uploaded.url,
+  };
+  delete next.asset;
+  return next;
+}
+
+async function prepareZipBackedObjectAssets(obj, {
+  zip,
+  uploadBlobToStore,
+} = {}) {
+  let asset = cloneJson(obj.asset);
+  let audioSources = cloneJson(obj.audioSources);
+  let skippedAssets = 0;
+
+  if (obj.importAsset?.kind === 'blob-file') {
+    const uploaded = await uploadZipAsset({
+      zip,
+      plan: obj.importAsset,
+      uploadBlobToStore,
+    });
+
+    if (uploaded) {
+      asset = cleanUploadedAsset(asset, uploaded);
+    } else if (!asset?.url) {
+      skippedAssets += 1;
+    }
+  }
+
+  const audioPlans = obj.importAudioSources || {};
+  for (const [name, plan] of Object.entries(audioPlans)) {
+    const source = audioSources?.[name];
+    if (!source || !plan?.path) continue;
+
+    const uploaded = await uploadZipAsset({
+      zip,
+      plan,
+      uploadBlobToStore,
+    });
+
+    if (uploaded) {
+      audioSources = {
+        ...(audioSources || {}),
+        [name]: cleanUploadedAudioSource(source, uploaded),
+      };
+    } else if (!source.url) {
+      skippedAssets += 1;
+    }
+  }
+
+  return { asset, audioSources, skippedAssets };
+}
+
 export async function applySceneDocument(sceneDocument, {
   managedObjects,
   addOrUpdateObject,
   broadcast,
   importGlbFileAsSceneObject,
   zip,
+  uploadBlobToStore,
 } = {}) {
   let added = 0;
   let updated = 0;
@@ -25,6 +104,12 @@ export async function applySceneDocument(sceneDocument, {
     } else {
       added += 1;
     }
+
+    const prepared = await prepareZipBackedObjectAssets(obj, {
+      zip,
+      uploadBlobToStore,
+    });
+    skippedAssets += prepared.skippedAssets;
 
     if (obj.importAsset?.kind === 'glb-file') {
       const entry = zip?.file(obj.importAsset.path);
@@ -45,7 +130,7 @@ export async function applySceneDocument(sceneDocument, {
           visible: obj.visible !== false,
           metadata: obj.metadata,
           animation: obj.animation,
-          audioSources: obj.audioSources,
+          audioSources: prepared.audioSources,
           selectAfterLoad: false,
           source: 'scene-sync-export-import',
         });
@@ -64,13 +149,13 @@ export async function applySceneDocument(sceneDocument, {
       position: obj.position,
       rotation: obj.rotation,
       scale: obj.scale,
-      asset: obj.asset,
+      asset: prepared.asset,
       visible: obj.visible !== false,
     };
 
     if (obj.metadata) payload.metadata = obj.metadata;
     if (obj.animation) payload.animation = obj.animation;
-    if (obj.audioSources) payload.audioSources = obj.audioSources;
+    if (prepared.audioSources) payload.audioSources = prepared.audioSources;
 
     addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import' });
     broadcast(payload);

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -38,12 +38,60 @@ function cleanUploadedAudioSource(source, uploaded) {
   return next;
 }
 
+function appendImportWarning(metadata, warning) {
+  const previous = typeof metadata?.importWarning === 'string'
+    ? metadata.importWarning.trim()
+    : '';
+  if (previous && previous.includes(warning)) {
+    return metadata || {};
+  }
+  return {
+    ...(metadata || {}),
+    importWarning: previous ? `${previous}; ${warning}` : warning,
+  };
+}
+
+function placeholderAssetForFailedZipImport(asset) {
+  return {
+    type: 'primitive',
+    primitive: 'box',
+    color: '#ff4d4f',
+    missingAssetType: asset?.type || 'unknown',
+  };
+}
+
+function cleanFailedZipBackedAsset(asset, plan) {
+  const next = { ...(asset || {}) };
+  delete next.path;
+
+  if (next.url) {
+    return {
+      asset: next,
+      fallbackUsed: true,
+    };
+  }
+
+  return {
+    asset: placeholderAssetForFailedZipImport(asset),
+    fallbackUsed: false,
+    warning: `ZIP asset could not be re-uploaded: ${plan?.path || '(unknown)'}`,
+  };
+}
+
+function cleanFailedZipBackedAudioSource(source) {
+  if (!source?.url) return null;
+  const next = { ...source };
+  delete next.asset;
+  return next;
+}
+
 async function prepareZipBackedObjectAssets(obj, {
   zip,
   uploadBlobToStore,
 } = {}) {
   let asset = cloneJson(obj.asset);
   let audioSources = cloneJson(obj.audioSources);
+  let metadata = cloneJson(obj.metadata);
   let skippedAssets = 0;
 
   if (obj.importAsset?.kind === 'blob-file') {
@@ -55,8 +103,13 @@ async function prepareZipBackedObjectAssets(obj, {
 
     if (uploaded) {
       asset = cleanUploadedAsset(asset, uploaded);
-    } else if (!asset?.url) {
-      skippedAssets += 1;
+    } else {
+      const cleaned = cleanFailedZipBackedAsset(asset, obj.importAsset);
+      asset = cleaned.asset;
+      if (!cleaned.fallbackUsed) {
+        skippedAssets += 1;
+        metadata = appendImportWarning(metadata, cleaned.warning);
+      }
     }
   }
 
@@ -76,12 +129,50 @@ async function prepareZipBackedObjectAssets(obj, {
         ...(audioSources || {}),
         [name]: cleanUploadedAudioSource(source, uploaded),
       };
-    } else if (!source.url) {
-      skippedAssets += 1;
+    } else {
+      const cleanedSource = cleanFailedZipBackedAudioSource(source);
+      audioSources = { ...(audioSources || {}) };
+      if (cleanedSource) {
+        audioSources[name] = cleanedSource;
+      } else {
+        delete audioSources[name];
+        skippedAssets += 1;
+        metadata = appendImportWarning(
+          metadata,
+          `ZIP audio source could not be re-uploaded: ${plan.path || '(unknown)'}`
+        );
+      }
     }
   }
 
-  return { asset, audioSources, skippedAssets };
+  if (asset?.path && !obj.importAsset) {
+    const cleaned = cleanFailedZipBackedAsset(asset, { path: asset.path });
+    asset = cleaned.asset;
+    if (!cleaned.fallbackUsed) {
+      skippedAssets += 1;
+      metadata = appendImportWarning(metadata, cleaned.warning);
+    }
+  }
+
+  if (audioSources && typeof audioSources === 'object' && !Array.isArray(audioSources)) {
+    for (const [name, source] of Object.entries(audioSources)) {
+      if (!source?.asset?.path) continue;
+      const cleanedSource = cleanFailedZipBackedAudioSource(source);
+      audioSources = { ...audioSources };
+      if (cleanedSource) {
+        audioSources[name] = cleanedSource;
+      } else {
+        delete audioSources[name];
+        skippedAssets += 1;
+        metadata = appendImportWarning(
+          metadata,
+          `ZIP audio source could not be re-uploaded: ${source.asset.path || '(unknown)'}`
+        );
+      }
+    }
+  }
+
+  return { asset, audioSources, metadata, skippedAssets };
 }
 
 export async function applySceneDocument(sceneDocument, {
@@ -128,7 +219,7 @@ export async function applySceneDocument(sceneDocument, {
           rotation: obj.rotation,
           scale: obj.scale,
           visible: obj.visible !== false,
-          metadata: obj.metadata,
+          metadata: prepared.metadata,
           animation: obj.animation,
           audioSources: prepared.audioSources,
           selectAfterLoad: false,
@@ -139,7 +230,15 @@ export async function applySceneDocument(sceneDocument, {
         continue;
       }
 
-      skippedAssets += 1;
+      const cleaned = cleanFailedZipBackedAsset(prepared.asset, obj.importAsset);
+      prepared.asset = cleaned.asset;
+      if (!cleaned.fallbackUsed) {
+        skippedAssets += 1;
+        prepared.metadata = appendImportWarning(
+          prepared.metadata,
+          cleaned.warning || `ZIP asset could not be re-uploaded: ${obj.importAsset.path || '(unknown)'}`
+        );
+      }
     }
 
     const payload = {
@@ -153,7 +252,7 @@ export async function applySceneDocument(sceneDocument, {
       visible: obj.visible !== false,
     };
 
-    if (obj.metadata) payload.metadata = obj.metadata;
+    if (prepared.metadata) payload.metadata = prepared.metadata;
     if (obj.animation) payload.animation = obj.animation;
     if (prepared.audioSources) payload.audioSources = prepared.audioSources;
 

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
@@ -230,6 +230,96 @@ test('imports ZIP-bundled image/text/audio assets as shared Scene Sync URLs', as
   strictEqual(caption.asset.source, 'url');
 });
 
+test('does not broadcast ZIP-only asset.path when re-upload fails and no fallback URL exists', async (t) => {
+  const cases = [
+    {
+      name: 'uploadBlobToStore: undefined',
+      uploadBlobToStore: undefined,
+    },
+    {
+      name: 'uploadBlobToStore returns null',
+      uploadBlobToStore: async () => null,
+    },
+    {
+      name: 'uploadBlobToStore returns path without url',
+      uploadBlobToStore: async (_blob, _mime, extension) => ({ path: `uploaded${extension}` }),
+    },
+  ];
+
+  for (const item of cases) {
+    await t.test(item.name, async () => {
+      const managedObjects = new Map();
+      const calls = { addOrUpdate: [], broadcast: [] };
+      const zip = createFakeZip({
+        'assets/poster.png': new Uint8Array([1, 2, 3]).buffer,
+        'assets/speaker.mp3': new Uint8Array([4, 5, 6]).buffer,
+      });
+
+      const sceneDocument = {
+        objects: [
+          {
+            id: 'poster',
+            name: 'Poster',
+            position: [1, 2, 3],
+            rotation: [0, 0, 0, 1],
+            scale: [1, 1, 1],
+            visible: true,
+            metadata: { role: 'media-panel' },
+            asset: {
+              type: 'image',
+              source: 'url',
+              path: 'assets/poster.png',
+              mime: 'image/png',
+            },
+            importAsset: {
+              kind: 'blob-file',
+              path: 'assets/poster.png',
+              originalName: 'poster.png',
+              mime: 'image/png',
+            },
+            audioSources: {
+              default: {
+                loop: true,
+                asset: { path: 'assets/speaker.mp3', mime: 'audio/mpeg' },
+              },
+            },
+            importAudioSources: {
+              default: {
+                kind: 'blob-file',
+                path: 'assets/speaker.mp3',
+                originalName: 'speaker.mp3',
+                mime: 'audio/mpeg',
+              },
+            },
+          },
+        ],
+      };
+
+      const stats = await applySceneDocument(sceneDocument, {
+        managedObjects,
+        addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+        broadcast: (payload) => calls.broadcast.push(payload),
+        uploadBlobToStore: item.uploadBlobToStore,
+        zip,
+      });
+
+      deepStrictEqual(stats, { total: 1, added: 1, updated: 0, glbImported: 0, skippedAssets: 2 });
+      strictEqual(calls.broadcast.length, 1);
+
+      const payload = calls.broadcast[0];
+      strictEqual(payload.asset.path, undefined);
+      strictEqual(payload.asset.type, 'primitive');
+      strictEqual(payload.asset.primitive, 'box');
+      strictEqual(payload.asset.missingAssetType, 'image');
+      ok(payload.metadata.importWarning.includes('assets/poster.png'));
+      ok(payload.metadata.importWarning.includes('assets/speaker.mp3'));
+      strictEqual(payload.audioSources.default, undefined);
+      strictEqual(JSON.stringify(payload.asset).includes('assets/poster.png'), false);
+      strictEqual(JSON.stringify(payload.audioSources || {}).includes('assets/speaker.mp3'), false);
+    });
+  }
+});
+
 test('falls back to placeholder when ZIP entry for importAsset is missing', async () => {
   const managedObjects = new Map();
   const calls = { addOrUpdate: [], broadcast: [] };
@@ -266,5 +356,7 @@ test('falls back to placeholder when ZIP entry for importAsset is missing', asyn
   strictEqual(stats.glbImported, 0);
   strictEqual(stats.skippedAssets, 1);
   strictEqual(calls.addOrUpdate.length, 1);
-  strictEqual(calls.addOrUpdate[0].payload.asset.type, 'mesh');
+  strictEqual(calls.addOrUpdate[0].payload.asset.type, 'primitive');
+  strictEqual(calls.addOrUpdate[0].payload.asset.path, undefined);
+  ok(calls.addOrUpdate[0].payload.metadata.importWarning.includes('assets/booth-2.glb'));
 });

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
@@ -118,6 +118,118 @@ test('imports ZIP-bundled GLB assets via importGlbFileAsSceneObject, keeping obj
   ok(options.audioSources.ambient);
 });
 
+test('imports ZIP-bundled image/text/audio assets as shared Scene Sync URLs', async () => {
+  const managedObjects = new Map();
+  const calls = { addOrUpdate: [], broadcast: [], uploads: [] };
+
+  const zip = createFakeZip({
+    'assets/poster.jpg': new Uint8Array([1, 2, 3]).buffer,
+    'assets/caption.md': new Uint8Array([4, 5]).buffer,
+    'assets/speaker.mp3': new Uint8Array([6, 7, 8, 9]).buffer,
+  });
+
+  const uploadBlobToStore = async (blob, mime, extension) => {
+    calls.uploads.push({ blob, mime, extension });
+    return {
+      path: `uploaded-${calls.uploads.length}${extension}`,
+      url: `https://blob.test/uploaded-${calls.uploads.length}${extension}`,
+    };
+  };
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'poster',
+        name: 'Poster',
+        position: [1, 2, 3],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: {
+          type: 'image',
+          source: 'url',
+          path: 'assets/poster.jpg',
+          url: 'https://example.com/poster.jpg',
+          mime: 'image/jpeg',
+        },
+        importAsset: {
+          kind: 'blob-file',
+          path: 'assets/poster.jpg',
+          originalName: 'poster.jpg',
+          mime: 'image/jpeg',
+        },
+        audioSources: {
+          default: {
+            url: 'https://example.com/speaker.mp3',
+            loop: true,
+            asset: { path: 'assets/speaker.mp3', mime: 'audio/mpeg' },
+          },
+        },
+        importAudioSources: {
+          default: {
+            kind: 'blob-file',
+            path: 'assets/speaker.mp3',
+            originalName: 'speaker.mp3',
+            mime: 'audio/mpeg',
+          },
+        },
+      },
+      {
+        id: 'caption',
+        name: 'Caption',
+        position: [0, 1, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: {
+          type: 'text',
+          source: 'url',
+          path: 'assets/caption.md',
+          url: 'https://example.com/caption.md',
+          mime: 'text/markdown',
+          format: 'markdown',
+        },
+        importAsset: {
+          kind: 'blob-file',
+          path: 'assets/caption.md',
+          originalName: 'caption.md',
+          mime: 'text/markdown',
+        },
+      },
+    ],
+  };
+
+  const stats = await applySceneDocument(sceneDocument, {
+    managedObjects,
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+    uploadBlobToStore,
+    zip,
+  });
+
+  deepStrictEqual(stats, { total: 2, added: 2, updated: 0, glbImported: 0, skippedAssets: 0 });
+  strictEqual(calls.uploads.length, 3);
+  deepStrictEqual(calls.uploads.map((u) => [u.mime, u.extension]), [
+    ['image/jpeg', '.jpg'],
+    ['audio/mpeg', '.mp3'],
+    ['text/markdown', '.md'],
+  ]);
+
+  const poster = calls.broadcast.find((payload) => payload.objectId === 'poster');
+  strictEqual(poster.asset.type, 'image');
+  strictEqual(poster.asset.url, 'https://blob.test/uploaded-1.jpg');
+  strictEqual(poster.asset.path, undefined);
+  strictEqual(poster.asset.source, 'blob');
+  strictEqual(poster.audioSources.default.url, 'https://blob.test/uploaded-2.mp3');
+  strictEqual(poster.audioSources.default.asset, undefined);
+
+  const caption = calls.broadcast.find((payload) => payload.objectId === 'caption');
+  strictEqual(caption.asset.type, 'text');
+  strictEqual(caption.asset.url, 'https://blob.test/uploaded-3.md');
+  strictEqual(caption.asset.path, undefined);
+  strictEqual(caption.asset.source, 'url');
+});
+
 test('falls back to placeholder when ZIP entry for importAsset is missing', async () => {
   const managedObjects = new Map();
   const calls = { addOrUpdate: [], broadcast: [] };

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
@@ -1,10 +1,30 @@
-// Applies scene-level settings (currently: skybox/environment) from a
+import { uploadZipAsset } from './zip-asset-upload.js';
+
+function buildBgmPayload(bgm, uploaded = null) {
+  if (!bgm) return null;
+  const url = uploaded?.url || bgm.url;
+  if (!url) return null;
+  return {
+    version: bgm.version ?? 1,
+    url,
+    name: bgm.name || uploaded?.originalName || 'bgm',
+    loop: bgm.loop !== false,
+    volume: Number.isFinite(bgm.volume) ? bgm.volume : 1,
+    playback: bgm.playback || { mode: 'local-loop' },
+  };
+}
+
+// Applies scene-level settings (skybox/environment and BGM) from a
 // SceneDocument. If the document has no skybox.envId, the current
 // environment is left untouched (no reset to default).
-export function applySceneDocumentSettings(sceneDocument, {
+export async function applySceneDocumentSettings(sceneDocument, {
   environmentManager,
   broadcast,
+  applySceneBgm,
+  zip,
+  uploadBlobToStore,
 } = {}) {
+  const result = { envApplied: false };
   const envId = sceneDocument?.skybox?.envId;
 
   if (typeof envId === 'string' && envId.trim()) {
@@ -18,8 +38,33 @@ export function applySceneDocumentSettings(sceneDocument, {
       envId,
     });
 
-    return { envApplied: true, envId };
+    result.envApplied = true;
+    result.envId = envId;
   }
 
-  return { envApplied: false };
+  const bgm = sceneDocument?.bgm || null;
+  if (bgm) {
+    const uploaded = bgm.importAsset?.kind === 'blob-file'
+      ? await uploadZipAsset({
+          zip,
+          plan: bgm.importAsset,
+          uploadBlobToStore,
+        })
+      : null;
+    const bgmPayload = buildBgmPayload(bgm, uploaded);
+    if (bgmPayload) {
+      applySceneBgm?.(bgmPayload, { source: 'scene-sync-export-import' });
+      broadcast?.({
+        kind: 'scene-bgm',
+        bgm: bgmPayload,
+      });
+      result.bgmApplied = true;
+      result.bgmUrl = bgmPayload.url;
+    } else {
+      result.bgmApplied = false;
+      result.bgmSkipped = true;
+    }
+  }
+
+  return result;
 }

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
@@ -5,14 +5,29 @@ import { test } from 'node:test';
 import { strictEqual, deepStrictEqual } from 'node:assert';
 import { applySceneDocumentSettings } from './apply-scene-settings.js';
 
-test('applies envId from skybox and broadcasts scene-env', () => {
+function createFakeZip(files) {
+  return {
+    file(path) {
+      const data = files[path];
+      if (!data) return null;
+      return {
+        async async(type) {
+          strictEqual(type, 'arraybuffer');
+          return data;
+        },
+      };
+    },
+  };
+}
+
+test('applies envId from skybox and broadcasts scene-env', async () => {
   const calls = { loadEnvironment: [], broadcast: [] };
   const environmentManager = {
     loadEnvironment: (envId, options) => calls.loadEnvironment.push({ envId, options }),
   };
   const broadcast = (payload) => calls.broadcast.push(payload);
 
-  const result = applySceneDocumentSettings({ skybox: { envId: 'outdoor_night' } }, {
+  const result = await applySceneDocumentSettings({ skybox: { envId: 'outdoor_night' } }, {
     environmentManager,
     broadcast,
   });
@@ -24,21 +39,74 @@ test('applies envId from skybox and broadcasts scene-env', () => {
   deepStrictEqual(calls.broadcast[0], { kind: 'scene-env', envId: 'outdoor_night' });
 });
 
-test('does nothing when skybox is absent (keeps current environment)', () => {
+test('applies BGM from ZIP-bundled asset via shared Scene Sync URL', async () => {
+  const calls = { bgm: [], broadcast: [], uploads: [] };
+  const zip = createFakeZip({
+    'assets/bgm.mp3': new Uint8Array([1, 2, 3]).buffer,
+  });
+  const uploadBlobToStore = async (blob, mime, extension) => {
+    calls.uploads.push({ blob, mime, extension });
+    return { path: `bgm${extension}`, url: `https://blob.test/bgm${extension}` };
+  };
+
+  const result = await applySceneDocumentSettings({
+    bgm: {
+      version: 1,
+      url: 'https://example.com/bgm.mp3',
+      name: 'BGM',
+      loop: false,
+      volume: 0.4,
+      playback: { mode: 'local-loop' },
+      importAsset: {
+        kind: 'blob-file',
+        path: 'assets/bgm.mp3',
+        originalName: 'bgm.mp3',
+        mime: 'audio/mpeg',
+      },
+    },
+  }, {
+    zip,
+    uploadBlobToStore,
+    applySceneBgm: (bgm, options) => calls.bgm.push({ bgm, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+  });
+
+  deepStrictEqual(result, {
+    envApplied: false,
+    bgmApplied: true,
+    bgmUrl: 'https://blob.test/bgm.mp3',
+  });
+  deepStrictEqual(calls.uploads.map((u) => [u.mime, u.extension]), [['audio/mpeg', '.mp3']]);
+  strictEqual(calls.bgm.length, 1);
+  deepStrictEqual(calls.bgm[0].bgm, {
+    version: 1,
+    url: 'https://blob.test/bgm.mp3',
+    name: 'BGM',
+    loop: false,
+    volume: 0.4,
+    playback: { mode: 'local-loop' },
+  });
+  deepStrictEqual(calls.broadcast[0], {
+    kind: 'scene-bgm',
+    bgm: calls.bgm[0].bgm,
+  });
+});
+
+test('does nothing when skybox is absent (keeps current environment)', async () => {
   const calls = { loadEnvironment: [], broadcast: [] };
   const environmentManager = {
     loadEnvironment: (envId, options) => calls.loadEnvironment.push({ envId, options }),
   };
   const broadcast = (payload) => calls.broadcast.push(payload);
 
-  const result = applySceneDocumentSettings({}, { environmentManager, broadcast });
+  const result = await applySceneDocumentSettings({}, { environmentManager, broadcast });
 
   deepStrictEqual(result, { envApplied: false });
   strictEqual(calls.loadEnvironment.length, 0);
   strictEqual(calls.broadcast.length, 0);
 });
 
-test('does nothing when skybox.envId is null', () => {
-  const result = applySceneDocumentSettings({ skybox: { envId: null } }, {});
+test('does nothing when skybox.envId is null', async () => {
+  const result = await applySceneDocumentSettings({ skybox: { envId: null } }, {});
   deepStrictEqual(result, { envApplied: false });
 });

--- a/html/assets/js/scenesync/importers/scene-sync-export/export-import-roundtrip.e2e.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/export-import-roundtrip.e2e.test.js
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSceneDocumentAssets } from './resolve-export-assets.js';
+import { applySceneDocument } from './apply-scene-document.js';
+import { applySceneDocumentSettings } from './apply-scene-settings.js';
+
+function createFakeZip(files) {
+  return {
+    file(path) {
+      const data = files[path];
+      if (!data) return null;
+      return {
+        async async(type) {
+          assert.equal(type, 'arraybuffer');
+          return data;
+        },
+      };
+    },
+  };
+}
+
+function arrayBufferOfLength(length) {
+  return new Uint8Array(Array.from({ length }, (_, index) => index + 1)).buffer;
+}
+
+test('E2E: exported static assets and SceneSync import resolve to the same source files', async () => {
+  const files = {
+    'assets/poster.jpg': arrayBufferOfLength(11),
+    'assets/story.md': arrayBufferOfLength(13),
+    'assets/speaker.mp3': arrayBufferOfLength(17),
+    'assets/bgm.mp3': arrayBufferOfLength(19),
+  };
+  const sourcePathBySize = new Map(
+    Object.entries(files).map(([path, buffer]) => [buffer.byteLength, path])
+  );
+  const uploadedUrlToSourcePath = new Map();
+
+  const zip = createFakeZip(files);
+  const uploadBlobToStore = async (blob, mime, extension) => {
+    const sourcePath = sourcePathBySize.get(blob.size);
+    assert.ok(sourcePath, `unexpected upload size: ${blob.size}`);
+    const url = `https://blob.test/${sourcePath.replace(/^assets\//, '')}`;
+    uploadedUrlToSourcePath.set(url, sourcePath);
+    return { path: `uploaded/${sourcePath.split('/').pop()}`, url, mime, extension };
+  };
+
+  const exportedSceneDocument = {
+    format: 'scene-sync-export-scene',
+    version: 1,
+    units: 'meters',
+    skybox: { type: 'env', envId: 'outdoor_day', asset: { path: 'assets/env.hdr' } },
+    bgm: {
+      url: 'https://example.com/bgm.mp3',
+      name: 'BGM',
+      loop: true,
+      volume: 0.5,
+      asset: { path: 'assets/bgm.mp3', mime: 'audio/mpeg' },
+    },
+    objects: [
+      {
+        id: 'box',
+        name: 'Box',
+        position: [0, 0.5, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: { type: 'primitive', primitive: 'box', color: '#4488ff' },
+      },
+      {
+        id: 'poster',
+        name: 'Poster',
+        position: [1, 1, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: {
+          type: 'image',
+          source: 'url',
+          url: 'https://example.com/poster.jpg',
+          path: 'assets/poster.jpg',
+          mime: 'image/jpeg',
+        },
+      },
+      {
+        id: 'story',
+        name: 'Story',
+        position: [-1, 1, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: {
+          type: 'text',
+          source: 'url',
+          url: 'https://example.com/story.md',
+          path: 'assets/story.md',
+          mime: 'text/markdown',
+          format: 'markdown',
+        },
+      },
+      {
+        id: 'speaker',
+        name: 'Speaker',
+        position: [0, 1, 1],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: { type: 'primitive', primitive: 'sphere', color: '#ffffff' },
+        audioSources: {
+          default: {
+            url: 'https://example.com/speaker.mp3',
+            loop: true,
+            playOnAwake: true,
+            asset: { path: 'assets/speaker.mp3', mime: 'audio/mpeg' },
+          },
+        },
+      },
+    ],
+  };
+
+  const { document: importDocument } = await resolveSceneDocumentAssets(exportedSceneDocument, { zip });
+
+  const addedPayloads = [];
+  const broadcasts = [];
+  const stats = await applySceneDocument(importDocument, {
+    managedObjects: new Map(),
+    addOrUpdateObject: (id, payload) => addedPayloads.push(payload),
+    broadcast: (payload) => broadcasts.push(payload),
+    zip,
+    uploadBlobToStore,
+  });
+
+  const bgmCalls = [];
+  const settings = await applySceneDocumentSettings(importDocument, {
+    environmentManager: { loadEnvironment() {} },
+    applySceneBgm: (bgm) => bgmCalls.push(bgm),
+    broadcast: (payload) => broadcasts.push(payload),
+    zip,
+    uploadBlobToStore,
+  });
+
+  assert.deepEqual(stats, { total: 4, added: 4, updated: 0, glbImported: 0, skippedAssets: 0 });
+  assert.equal(settings.envApplied, true);
+  assert.equal(settings.bgmApplied, true);
+
+  const byId = new Map(addedPayloads.map((payload) => [payload.objectId, payload]));
+  assert.equal(byId.get('box').asset.primitive, 'box');
+
+  assert.equal(uploadedUrlToSourcePath.get(byId.get('poster').asset.url), 'assets/poster.jpg');
+  assert.equal(byId.get('poster').asset.path, undefined);
+
+  assert.equal(uploadedUrlToSourcePath.get(byId.get('story').asset.url), 'assets/story.md');
+  assert.equal(byId.get('story').asset.path, undefined);
+  assert.equal(byId.get('story').asset.source, 'url');
+
+  assert.equal(
+    uploadedUrlToSourcePath.get(byId.get('speaker').audioSources.default.url),
+    'assets/speaker.mp3'
+  );
+  assert.equal(byId.get('speaker').audioSources.default.asset, undefined);
+
+  assert.equal(uploadedUrlToSourcePath.get(bgmCalls[0].url), 'assets/bgm.mp3');
+  assert.equal(broadcasts.filter((payload) => payload.kind === 'scene-add').length, 4);
+  assert.equal(broadcasts.some((payload) => payload.kind === 'scene-bgm'), true);
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -19,6 +19,8 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     confirmOpen,
     environmentManager,
     importGlbFileAsSceneObject,
+    uploadBlobToStore,
+    applySceneBgm,
   } = context;
 
   const result = await loadExportPackageFromBlob(file);
@@ -55,11 +57,15 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     broadcast,
     importGlbFileAsSceneObject,
     zip: result.zip,
+    uploadBlobToStore,
   });
 
-  const settingsResult = applySceneDocumentSettings(resolvedDocument, {
+  const settingsResult = await applySceneDocumentSettings(resolvedDocument, {
     environmentManager,
     broadcast,
+    applySceneBgm,
+    zip: result.zip,
+    uploadBlobToStore,
   });
 
   showToast?.(

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.js
@@ -1,14 +1,64 @@
+import { inferMimeForExportAsset, makeZipAssetImportPlan } from './zip-asset-upload.js';
+
 // Resolves SceneDocument objects for import, keeping primitives and inline
 // text as-is, and passing through assets that already have a shareable URL.
 //
 // ZIP-bundled GLB ("mesh") assets are marked with an `importAsset` plan so
 // applySceneDocument() can load them via the normal GLB-file import route.
 //
-// Other ZIP-bundled image/mesh/video/text assets (asset.path with no
-// asset.url) are not yet imported as shared Scene Sync assets — they are
-// marked with metadata.importWarning so the object still appears (as a
-// placeholder) without producing local-only blob: URLs that would leak into
-// scene-state, snapshots, or re-export.
+// ZIP-bundled image/video/text/audio assets are marked with upload plans.
+// applySceneDocument() uploads those files to the Scene Sync blob store and
+// replaces asset.path with a shareable asset.url before broadcasting.
+const ZIP_IMPORTABLE_ASSET_TYPES = new Set(['image', 'video', 'text']);
+
+function zipHas(zip, path) {
+  return Boolean(path && zip?.file?.(path));
+}
+
+function addImportWarning(obj, path) {
+  return {
+    ...obj,
+    metadata: {
+      ...(obj.metadata || {}),
+      importWarning: `Asset not imported (unsupported in this version): ${path || '(unknown)'}`,
+    },
+  };
+}
+
+function resolveObjectAudioSources(obj, zip) {
+  const audioSources = obj.audioSources;
+  if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) {
+    return obj;
+  }
+
+  const importAudioSources = {};
+  for (const [name, source] of Object.entries(audioSources)) {
+    const path = source?.asset?.path;
+    if (!zipHas(zip, path)) continue;
+    importAudioSources[name] = makeZipAssetImportPlan({
+      path,
+      mime: inferMimeForExportAsset(source.asset, 'audio/mpeg'),
+      originalName: source.asset?.originalName,
+    });
+  }
+
+  if (Object.keys(importAudioSources).length === 0) return obj;
+  return { ...obj, importAudioSources };
+}
+
+function resolveBgm(bgm, zip) {
+  const path = bgm?.asset?.path;
+  if (!zipHas(zip, path)) return bgm;
+  return {
+    ...bgm,
+    importAsset: makeZipAssetImportPlan({
+      path,
+      mime: inferMimeForExportAsset(bgm.asset, 'audio/mpeg'),
+      originalName: bgm.asset?.originalName || bgm.name,
+    }),
+  };
+}
+
 export async function resolveSceneDocumentAssets(sceneDocument, { zip } = {}) {
   const objects = [];
 
@@ -16,22 +66,17 @@ export async function resolveSceneDocumentAssets(sceneDocument, { zip } = {}) {
     const asset = obj.asset;
 
     if (!asset || asset.type === 'primitive') {
-      objects.push(obj);
+      objects.push(resolveObjectAudioSources(obj, zip));
       continue;
     }
 
     if (asset.type === 'text' && asset.source === 'inline') {
-      objects.push(obj);
-      continue;
-    }
-
-    if (asset.url) {
-      objects.push(obj);
+      objects.push(resolveObjectAudioSources(obj, zip));
       continue;
     }
 
     if (asset.type === 'mesh' && asset.path && zip?.file(asset.path)) {
-      objects.push({
+      objects.push(resolveObjectAudioSources({
         ...obj,
         importAsset: {
           kind: 'glb-file',
@@ -39,18 +84,35 @@ export async function resolveSceneDocumentAssets(sceneDocument, { zip } = {}) {
           originalName: asset.originalName || asset.path.split('/').pop() || `${obj.id}.glb`,
           mime: asset.mime || 'model/gltf-binary',
         },
-      });
+      }, zip));
       continue;
     }
 
-    objects.push({
-      ...obj,
-      metadata: {
-        ...(obj.metadata || {}),
-        importWarning: `Asset not imported (unsupported in this version): ${asset.path || '(unknown)'}`,
-      },
-    });
+    if (ZIP_IMPORTABLE_ASSET_TYPES.has(asset.type) && asset.path && zipHas(zip, asset.path)) {
+      objects.push(resolveObjectAudioSources({
+        ...obj,
+        importAsset: makeZipAssetImportPlan({
+          path: asset.path,
+          mime: inferMimeForExportAsset(asset),
+          originalName: asset.originalName,
+        }),
+      }, zip));
+      continue;
+    }
+
+    if (asset.url) {
+      objects.push(resolveObjectAudioSources(obj, zip));
+      continue;
+    }
+
+    objects.push(resolveObjectAudioSources(addImportWarning(obj, asset.path), zip));
   }
 
-  return { document: { ...sceneDocument, objects } };
+  return {
+    document: {
+      ...sceneDocument,
+      objects,
+      bgm: resolveBgm(sceneDocument.bgm, zip),
+    },
+  };
 }

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-export-assets.test.js
@@ -49,6 +49,101 @@ test('marks ZIP-bundled GLB assets with an importAsset plan when the zip entry e
   strictEqual(obj.asset.type, 'mesh');
 });
 
+test('marks ZIP-bundled image/video/text assets with upload import plans even when URL fallback exists', async () => {
+  const zip = createFakeZip(['assets/img-1.jpg', 'assets/video-1.mp4', 'assets/story.md']);
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'img-1',
+        asset: {
+          type: 'image',
+          path: 'assets/img-1.jpg',
+          url: 'https://example.com/img-1.jpg',
+          mime: 'image/jpeg',
+        },
+      },
+      {
+        id: 'video-1',
+        asset: {
+          type: 'video',
+          path: 'assets/video-1.mp4',
+          url: 'https://example.com/video-1.mp4',
+          mime: 'video/mp4',
+        },
+      },
+      {
+        id: 'story',
+        asset: {
+          type: 'text',
+          source: 'url',
+          path: 'assets/story.md',
+          url: 'https://example.com/story.md',
+          mime: 'text/markdown',
+        },
+      },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument, { zip });
+
+  deepStrictEqual(
+    document.objects.map((obj) => obj.importAsset),
+    [
+      { kind: 'blob-file', path: 'assets/img-1.jpg', originalName: 'img-1.jpg', mime: 'image/jpeg' },
+      { kind: 'blob-file', path: 'assets/video-1.mp4', originalName: 'video-1.mp4', mime: 'video/mp4' },
+      { kind: 'blob-file', path: 'assets/story.md', originalName: 'story.md', mime: 'text/markdown' },
+    ]
+  );
+});
+
+test('marks ZIP-bundled object audio source assets with upload import plans', async () => {
+  const zip = createFakeZip(['assets/speaker-default.mp3']);
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'speaker',
+        asset: { type: 'primitive', primitive: 'box' },
+        audioSources: {
+          default: {
+            url: 'https://example.com/speaker-default.mp3',
+            asset: { path: 'assets/speaker-default.mp3', mime: 'audio/mpeg' },
+          },
+        },
+      },
+    ],
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument, { zip });
+  deepStrictEqual(document.objects[0].importAudioSources, {
+    default: {
+      kind: 'blob-file',
+      path: 'assets/speaker-default.mp3',
+      originalName: 'speaker-default.mp3',
+      mime: 'audio/mpeg',
+    },
+  });
+});
+
+test('marks ZIP-bundled BGM asset with upload import plan', async () => {
+  const zip = createFakeZip(['assets/bgm.mp3']);
+  const sceneDocument = {
+    objects: [],
+    bgm: {
+      url: 'https://example.com/bgm.mp3',
+      name: 'bgm.mp3',
+      asset: { path: 'assets/bgm.mp3', mime: 'audio/mpeg' },
+    },
+  };
+
+  const { document } = await resolveSceneDocumentAssets(sceneDocument, { zip });
+  deepStrictEqual(document.bgm.importAsset, {
+    kind: 'blob-file',
+    path: 'assets/bgm.mp3',
+    originalName: 'bgm.mp3',
+    mime: 'audio/mpeg',
+  });
+});
+
 test('falls back to importWarning placeholder when GLB zip entry is missing', async () => {
   const zip = createFakeZip([]);
   const sceneDocument = {

--- a/html/assets/js/scenesync/importers/scene-sync-export/zip-asset-upload.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/zip-asset-upload.js
@@ -1,0 +1,93 @@
+function basename(path, fallback = 'asset') {
+  if (typeof path !== 'string' || !path.trim()) return fallback;
+  return path.split('/').filter(Boolean).pop() || fallback;
+}
+
+function extensionFromPath(path) {
+  const name = basename(path, '');
+  const match = name.match(/(\.[a-z0-9]+)$/i);
+  return match ? match[1].toLowerCase() : '';
+}
+
+export function inferMimeForExportAsset(asset, fallback = 'application/octet-stream') {
+  if (typeof asset?.mime === 'string' && asset.mime.trim()) return asset.mime.trim();
+
+  const path = asset?.path || asset?.asset?.path || '';
+  const ext = extensionFromPath(path);
+  switch (ext) {
+    case '.glb': return 'model/gltf-binary';
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg';
+    case '.png': return 'image/png';
+    case '.webp': return 'image/webp';
+    case '.mp4':
+    case '.m4v': return 'video/mp4';
+    case '.webm': return 'video/webm';
+    case '.ogv': return 'video/ogg';
+    case '.mp3': return 'audio/mpeg';
+    case '.ogg':
+    case '.oga': return 'audio/ogg';
+    case '.wav': return 'audio/wav';
+    case '.m4a': return 'audio/mp4';
+    case '.md':
+    case '.markdown': return 'text/markdown';
+    case '.txt': return 'text/plain';
+    default: return fallback;
+  }
+}
+
+function extensionForUpload(path, mime) {
+  const fromPath = extensionFromPath(path);
+  if (fromPath) return fromPath;
+  if (mime.includes('gltf-binary')) return '.glb';
+  if (mime.includes('jpeg')) return '.jpg';
+  if (mime.includes('png')) return '.png';
+  if (mime.includes('webp')) return '.webp';
+  if (mime.includes('video/mp4')) return '.mp4';
+  if (mime.includes('video/webm')) return '.webm';
+  if (mime.includes('audio/mpeg') || mime.includes('audio/mp3')) return '.mp3';
+  if (mime.includes('audio/ogg')) return '.ogg';
+  if (mime.includes('audio/wav')) return '.wav';
+  if (mime.includes('markdown')) return '.md';
+  if (mime.includes('text/plain')) return '.txt';
+  return '';
+}
+
+export function makeZipAssetImportPlan({
+  path,
+  mime,
+  originalName,
+  kind = 'blob-file',
+} = {}) {
+  if (typeof path !== 'string' || !path.trim()) return null;
+  return {
+    kind,
+    path,
+    originalName: originalName || basename(path),
+    mime: mime || inferMimeForExportAsset({ path }),
+  };
+}
+
+export async function uploadZipAsset({
+  zip,
+  plan,
+  uploadBlobToStore,
+} = {}) {
+  if (!zip || !plan?.path || typeof uploadBlobToStore !== 'function') return null;
+
+  const entry = zip.file(plan.path);
+  if (!entry) return null;
+
+  const mime = plan.mime || inferMimeForExportAsset({ path: plan.path });
+  const buffer = await entry.async('arraybuffer');
+  const blob = new Blob([buffer], { type: mime });
+  const uploaded = await uploadBlobToStore(blob, mime, extensionForUpload(plan.path, mime));
+  if (!uploaded?.url) return null;
+
+  return {
+    ...uploaded,
+    mime,
+    size: blob.size,
+    originalName: plan.originalName || basename(plan.path),
+  };
+}

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -9566,6 +9566,8 @@ const dragDropManager = new DragDropManager({
     showToast,
     environmentManager,
     importGlbFileAsSceneObject,
+    uploadBlobToStore,
+    applySceneBgm,
   }),
   onLoadStart: async ({
     objectId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@gltf-transform/core": "^4.3.0",
         "@gltf-transform/extensions": "^4.3.0",
-        "@gltf-transform/functions": "^4.3.0"
+        "@gltf-transform/functions": "^4.3.0",
+        "playwright": "^1.60.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -586,6 +587,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/iota-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
@@ -650,6 +665,36 @@
         "ndarray": "^1.0.19",
         "ndarray-ops": "^1.2.2",
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/property-graph": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
     "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js",
-    "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js"
+    "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js",
+    "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
+    "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",
     "@gltf-transform/extensions": "^4.3.0",
-    "@gltf-transform/functions": "^4.3.0"
+    "@gltf-transform/functions": "^4.3.0",
+    "playwright": "^1.60.0"
   }
 }

--- a/scripts/scenesync-export-import-browser-e2e.mjs
+++ b/scripts/scenesync-export-import-browser-e2e.mjs
@@ -1,0 +1,730 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), '..');
+const htmlRoot = path.join(repoRoot, 'html');
+const browserPath = path.join(repoRoot, '.playwright-browsers');
+
+process.env.PLAYWRIGHT_BROWSERS_PATH ||= browserPath;
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+  'base64',
+);
+
+function createWavBuffer() {
+  const sampleRate = 8000;
+  const durationSeconds = 0.18;
+  const samples = Math.floor(sampleRate * durationSeconds);
+  const dataBytes = samples * 2;
+  const buffer = Buffer.alloc(44 + dataBytes);
+  buffer.write('RIFF', 0);
+  buffer.writeUInt32LE(36 + dataBytes, 4);
+  buffer.write('WAVE', 8);
+  buffer.write('fmt ', 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write('data', 36);
+  buffer.writeUInt32LE(dataBytes, 40);
+  for (let i = 0; i < samples; i += 1) {
+    const t = i / sampleRate;
+    const sample = Math.round(Math.sin(2 * Math.PI * 440 * t) * 0x2200);
+    buffer.writeInt16LE(sample, 44 + i * 2);
+  }
+  return buffer;
+}
+
+const testAssets = new Map([
+  ['url-image.png', { body: PNG_1X1, mime: 'image/png' }],
+  ['file-image.png', { body: PNG_1X1, mime: 'image/png' }],
+  ['url-text.md', { body: Buffer.from('# URL Text\n\nExport Import E2E\n', 'utf8'), mime: 'text/markdown; charset=utf-8' }],
+  ['tone.wav', { body: createWavBuffer(), mime: 'audio/wav' }],
+]);
+
+const blobStore = new Map();
+const blobUploads = [];
+
+const mimeTypes = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.webp', 'image/webp'],
+  ['.hdr', 'application/octet-stream'],
+  ['.glb', 'model/gltf-binary'],
+  ['.wasm', 'application/wasm'],
+]);
+
+function sendBuffer(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,POST,DELETE,OPTIONS,HEAD',
+    'access-control-allow-headers': 'content-type',
+    'content-length': body.byteLength,
+    ...headers,
+  });
+  res.end(body);
+}
+
+async function readRequestBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function resolveStaticPath(urlPath) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(urlPath, 'http://localhost').pathname);
+  } catch {
+    return null;
+  }
+
+  if (pathname.endsWith('/')) {
+    pathname = `${pathname}index.html`;
+  }
+
+  const candidate = path.resolve(htmlRoot, `.${pathname}`);
+  if (!candidate.startsWith(`${htmlRoot}${path.sep}`) && candidate !== htmlRoot) {
+    return null;
+  }
+  return candidate;
+}
+
+function createStaticServer() {
+  const server = createServer(async (req, res) => {
+    if (req.method === 'OPTIONS') {
+      sendBuffer(res, 204, Buffer.alloc(0));
+      return;
+    }
+
+    const url = new URL(req.url || '/', 'http://localhost');
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (pathname.startsWith('/presence/blob/')) {
+      const key = pathname.slice('/presence/blob/'.length);
+      if (req.method === 'POST') {
+        const body = await readRequestBody(req);
+        const mime = req.headers['content-type'] || 'application/octet-stream';
+        blobStore.set(key, { body, mime });
+        blobUploads.push({ key, mime, size: body.byteLength });
+        sendBuffer(res, 200, Buffer.from(JSON.stringify({ ok: true, path: key })), {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        return;
+      }
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        const record = blobStore.get(key);
+        if (!record) {
+          sendBuffer(res, 404, Buffer.from('Not found'), { 'content-type': 'text/plain; charset=utf-8' });
+          return;
+        }
+        sendBuffer(res, 200, req.method === 'HEAD' ? Buffer.alloc(0) : record.body, {
+          'content-type': record.mime,
+          ...(req.method === 'HEAD' ? { 'content-length': record.body.byteLength } : {}),
+        });
+        return;
+      }
+    }
+
+    if (pathname.startsWith('/__e2e/assets/')) {
+      const name = pathname.slice('/__e2e/assets/'.length);
+      if (req.method === 'POST') {
+        const body = await readRequestBody(req);
+        const mime = req.headers['content-type'] || 'application/octet-stream';
+        testAssets.set(name, { body, mime });
+        sendBuffer(res, 200, Buffer.from(JSON.stringify({ ok: true, name })), {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        return;
+      }
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        const record = testAssets.get(name);
+        if (!record) {
+          sendBuffer(res, 404, Buffer.from('Not found'), { 'content-type': 'text/plain; charset=utf-8' });
+          return;
+        }
+        sendBuffer(res, 200, req.method === 'HEAD' ? Buffer.alloc(0) : record.body, {
+          'content-type': record.mime,
+          ...(req.method === 'HEAD' ? { 'content-length': record.body.byteLength } : {}),
+        });
+        return;
+      }
+    }
+
+    if (pathname.startsWith('/__e2e/blob/')) {
+      const key = pathname.slice('/__e2e/blob/'.length);
+      if (req.method === 'DELETE' || req.method === 'POST') {
+        const deleted = blobStore.delete(key);
+        sendBuffer(res, 200, Buffer.from(JSON.stringify({ ok: true, deleted, key })), {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        return;
+      }
+    }
+
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      sendBuffer(res, 405, Buffer.from('Method not allowed'), { 'content-type': 'text/plain; charset=utf-8' });
+      return;
+    }
+
+    const filePath = resolveStaticPath(req.url || '/');
+    if (!filePath) {
+      sendBuffer(res, 400, Buffer.from('Bad request'), { 'content-type': 'text/plain; charset=utf-8' });
+      return;
+    }
+
+    try {
+      const body = await readFile(filePath);
+      const contentType = mimeTypes.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
+      sendBuffer(res, 200, req.method === 'HEAD' ? Buffer.alloc(0) : body, {
+        'content-type': contentType,
+        ...(req.method === 'HEAD' ? { 'content-length': body.byteLength } : {}),
+      });
+    } catch {
+      sendBuffer(res, 404, Buffer.from('Not found'), { 'content-type': 'text/plain; charset=utf-8' });
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function serverUrl(server) {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Static server did not expose a TCP address');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function summarizeConsole(consoleMessages) {
+  return consoleMessages.filter((entry) => {
+    if (/GL Driver Message .*ReadPixels/.test(entry.text)) return false;
+    if (/BGM.*autoplay blocked/.test(entry.text)) return false;
+    if (/THREE\.GLTFExporter: Creating normalized normal attribute/.test(entry.text)) return false;
+    if (/Failed to load resource: the server responded with a status of 404/.test(entry.text)) return false;
+    if (/TransformControls: The attached 3D object must be a part of the scene graph/.test(entry.text)) return false;
+    return true;
+  });
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function run() {
+  const { chromium } = await import('playwright');
+  const server = await createStaticServer();
+  const baseUrl = serverUrl(server);
+  const result = {
+    url: `${baseUrl}/scenesync/?room=e2e-export-import-${Date.now()}`,
+    console: [],
+    pageErrors: [],
+    assertions: [],
+  };
+
+  let browser;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      acceptDownloads: true,
+      viewport: { width: 1280, height: 900 },
+    });
+
+    await context.addInitScript(() => {
+      localStorage.setItem('sceneSync.welcomeSeen', 'true');
+      localStorage.setItem('sceneSync.displayName', 'SceneSync E2E');
+    });
+
+    const page = await context.newPage();
+    page.on('console', (msg) => {
+      const type = msg.type();
+      if (type === 'error' || type === 'warning') {
+        result.console.push({ type, text: msg.text() });
+      }
+    });
+    page.on('pageerror', (error) => {
+      result.pageErrors.push(error.message || String(error));
+    });
+    page.on('dialog', async (dialog) => {
+      result.assertions.push(`dialog:${dialog.type()}`);
+      await dialog.accept();
+    });
+
+    await page.goto(result.url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#export-btn', { state: 'visible', timeout: 60000 });
+    await page.waitForFunction(() => window.__sceneSyncDebug?.dragDropManager, null, { timeout: 60000 });
+    await page.waitForFunction(
+      () => document.querySelector('canvas') && document.querySelector('canvas').width > 0,
+      null,
+      { timeout: 60000 },
+    );
+
+    const seeded = await page.evaluate(async ({ baseUrl }) => {
+      const mod = await import('/assets/js/scenesync/scene.js');
+      const THREE = await import('three');
+      const { GLTFExporter } = await import('three/addons/exporters/GLTFExporter.js');
+      const { createSceneAssetCache } = await import('/assets/js/scenesync/assets/asset-cache.js');
+      window.__sceneSyncE2eModule = mod;
+
+      const dragDropManager = window.__sceneSyncDebug.dragDropManager;
+      const cache = createSceneAssetCache();
+      const positionContext = (x, y, z) => ({
+        position: new THREE.Vector3(x, y, z),
+        targetKind: 'scene',
+        surfaceKind: 'floor',
+        normalArray: [0, 1, 0],
+      });
+      const findBy = (predicate) => {
+        for (const [objectId, obj] of mod.managedObjects.entries()) {
+          if (predicate(obj, objectId)) return { objectId, obj };
+        }
+        return null;
+      };
+      const waitForObject = async (predicate, label) => {
+        const started = performance.now();
+        while (performance.now() - started < 20000) {
+          const found = findBy(predicate);
+          if (found) return found;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        const current = Array.from(mod.managedObjects.entries()).map(([objectId, obj]) => ({
+          objectId,
+          name: obj.userData?.name || obj.name || null,
+          asset: obj.userData?.asset || null,
+          metadata: obj.userData?.metadata || null,
+        }));
+        throw new Error(`Timed out waiting for ${label}: ${JSON.stringify(current)}`);
+      };
+      const waitForMeshAsset = async (objectId) => {
+        const started = performance.now();
+        while (performance.now() - started < 20000) {
+          const obj = mod.managedObjects.get(objectId);
+          const asset = obj?.userData?.asset;
+          if (asset?.type === 'mesh' && asset.meshPath && asset.assetId) {
+            return { objectId, asset };
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        throw new Error(`Timed out waiting for mesh upload ${objectId}`);
+      };
+      const makePngFile = async (name) => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 64;
+        canvas.height = 48;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#2c7be5';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#ffdd55';
+        ctx.fillRect(10, 8, 36, 24);
+        const blob = await new Promise((resolve, reject) => {
+          canvas.toBlob((value) => value ? resolve(value) : reject(new Error('canvas.toBlob failed')), 'image/png');
+        });
+        return new File([blob], name, { type: 'image/png' });
+      };
+      const makeGlbBlob = async (name, color) => {
+        const mesh = new THREE.Mesh(
+          new THREE.BoxGeometry(0.4, 0.4, 0.4),
+          new THREE.MeshStandardMaterial({ color }),
+        );
+        mesh.name = name;
+        const exporter = new GLTFExporter();
+        const arrayBuffer = await new Promise((resolve, reject) => {
+          exporter.parse(mesh, resolve, reject, { binary: true });
+        });
+        return new Blob([arrayBuffer], { type: 'model/gltf-binary' });
+      };
+      const makeVideoBlob = async () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 64;
+        canvas.height = 64;
+        const ctx = canvas.getContext('2d');
+        const stream = canvas.captureStream(10);
+        const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp8')
+          ? 'video/webm;codecs=vp8'
+          : 'video/webm';
+        const recorder = new MediaRecorder(stream, { mimeType });
+        const chunks = [];
+        recorder.addEventListener('dataavailable', (event) => {
+          if (event.data?.size) chunks.push(event.data);
+        });
+        recorder.start();
+        for (let i = 0; i < 8; i += 1) {
+          ctx.fillStyle = i % 2 ? '#3366ff' : '#ffcc33';
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.fillStyle = '#101010';
+          ctx.fillRect(8 + i, 8 + i, 20, 20);
+          await new Promise((resolve) => setTimeout(resolve, 70));
+        }
+        await new Promise((resolve) => {
+          recorder.addEventListener('stop', resolve, { once: true });
+          recorder.stop();
+        });
+        stream.getTracks().forEach((track) => track.stop());
+        return new Blob(chunks, { type: 'video/webm' });
+      };
+      const uploadTestAsset = async (name, blob) => {
+        const response = await fetch(`/__e2e/assets/${name}`, {
+          method: 'POST',
+          headers: { 'Content-Type': blob.type || 'application/octet-stream' },
+          body: blob,
+        });
+        if (!response.ok) throw new Error(`Failed to upload test asset ${name}`);
+        return `${baseUrl}/__e2e/assets/${name}`;
+      };
+
+      for (const obj of mod.managedObjects.values()) {
+        mod.scene.remove(obj);
+      }
+      mod.managedObjects.clear();
+
+      const seededObjects = {};
+
+      const primitive = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 1, 1),
+        new THREE.MeshStandardMaterial({ color: 0xff3355 }),
+      );
+      primitive.position.set(1.25, 0.75, -0.5);
+      primitive.scale.set(1.1, 1.2, 1.3);
+      primitive.name = 'E2E Primitive';
+      primitive.userData.objectId = 'e2e-primitive';
+      primitive.userData.name = 'E2E Primitive';
+      primitive.userData.asset = { type: 'primitive', primitive: 'box', color: '#ff3355' };
+      primitive.userData.metadata = { e2e: true, role: 'prop' };
+      mod.scene.add(primitive);
+      mod.managedObjects.set('e2e-primitive', primitive);
+      seededObjects.primitive = 'e2e-primitive';
+
+      await uploadTestAsset('url-image.png', await makePngFile('url-image.png'));
+      await dragDropManager.urlImporter(
+        `${baseUrl}/__e2e/assets/url-image.png`,
+        new THREE.Vector3(-1, 1, 0),
+        { surfaceKind: 'floor', normalArray: [0, 1, 0] },
+      );
+      seededObjects.urlImage = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'image' && obj.userData.asset.url?.endsWith('/url-image.png'),
+        'URL image object',
+      )).objectId;
+
+      const imageFile = await makePngFile('e2e-file-image.png');
+      await dragDropManager.handleFile(imageFile, positionContext(-2, 1, 0));
+      seededObjects.fileImage = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'image' && obj.userData?.name === 'image: e2e-file-image.png',
+        'file image object',
+      )).objectId;
+
+      await dragDropManager.urlImporter(
+        `${baseUrl}/__e2e/assets/url-text.md`,
+        new THREE.Vector3(0, 1, 0.5),
+        { surfaceKind: 'floor', normalArray: [0, 1, 0] },
+      );
+      seededObjects.urlText = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'text' && obj.userData.asset.url?.endsWith('/url-text.md'),
+        'URL text object',
+      )).objectId;
+
+      const textFile = new File(['File text E2E\n'], 'e2e-file-text.md', { type: 'text/markdown' });
+      await dragDropManager.handleFile(textFile, positionContext(0.5, 1, 0.5));
+      seededObjects.fileText = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'text' && obj.userData.asset.text === 'File text E2E\n',
+        'file text object',
+      )).objectId;
+
+      const videoUrl = await uploadTestAsset('url-video.webm', await makeVideoBlob());
+      await dragDropManager.urlImporter(
+        videoUrl,
+        new THREE.Vector3(1.5, 1, 0),
+        { surfaceKind: 'floor', normalArray: [0, 1, 0] },
+      );
+      seededObjects.urlVideo = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'video' && obj.userData.asset.url?.endsWith('/url-video.webm'),
+        'URL video object',
+      )).objectId;
+
+      await dragDropManager.urlImporter(
+        `${baseUrl}/__e2e/assets/tone.wav`,
+        new THREE.Vector3(0, 1, 0),
+        { hitObjectId: 'e2e-primitive' },
+      );
+      await waitForObject(
+        (obj, id) => id === 'e2e-primitive' && obj.userData?.audioSources?.default?.url?.endsWith('/tone.wav'),
+        'object audio source',
+      );
+
+      await dragDropManager.urlImporter(
+        `${baseUrl}/__e2e/assets/tone.wav`,
+        new THREE.Vector3(3, 1, 0),
+        { surfaceKind: 'floor', normalArray: [0, 1, 0] },
+      );
+
+      await dragDropManager.urlImporter(
+        `${baseUrl}/__e2e/assets/url-image.png`,
+        new THREE.Vector3(0, 2, -2),
+        { upness: 1, targetKind: 'sky' },
+      );
+      const urlSkyboxObject = await waitForObject(
+        (obj) => obj.userData?.metadata?.role === 'sky-sphere'
+          && obj.userData?.metadata?.sourceName === 'url-image.png',
+        'URL skybox image object',
+      );
+      seededObjects.urlSkyImageReplaced = urlSkyboxObject.objectId;
+
+      const skyboxFile = await makePngFile('e2e-file-skybox.png');
+      await dragDropManager.handleFile(skyboxFile, {
+        ...positionContext(0, 2, -2),
+        targetKind: 'sky',
+        upness: 1,
+      });
+      seededObjects.fileSkyImage = (await waitForObject(
+        (obj, id) => id !== urlSkyboxObject.objectId
+          && obj.userData?.metadata?.role === 'sky-sphere'
+          && obj.userData?.metadata?.sourceName === 'e2e-file-skybox.png',
+        'file skybox image object',
+      )).objectId;
+
+      const urlGlbBlob = await makeGlbBlob('e2e-url-model', 0x33dd99);
+      const urlGlb = await uploadTestAsset('url-model.glb', urlGlbBlob);
+      await dragDropManager.urlImporter(
+        urlGlb,
+        new THREE.Vector3(-1.5, 0, -1),
+        { surfaceKind: 'floor', normalArray: [0, 1, 0] },
+      );
+      seededObjects.urlGlb = (await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'mesh' && obj.userData.asset.url?.endsWith('/url-model.glb'),
+        'URL GLB object',
+      )).objectId;
+
+      const fileGlb = new File(
+        [await makeGlbBlob('e2e-file-model', 0xdd9933)],
+        'e2e-file-model.glb',
+        { type: 'model/gltf-binary' },
+      );
+      await dragDropManager.handleFile(fileGlb, positionContext(2, 0, -1));
+      const fileGlbObject = await waitForObject(
+        (obj) => obj.userData?.asset?.type === 'mesh' && obj.userData.asset.originalName === 'e2e-file-model.glb',
+        'file GLB object',
+      );
+      seededObjects.fileGlb = fileGlbObject.objectId;
+      const fileGlbAsset = await waitForMeshAsset(fileGlbObject.objectId);
+      await fetch(`/__e2e/blob/${fileGlbAsset.asset.meshPath}`, { method: 'DELETE' });
+      seededObjects.fileGlbMeshPathDeletedBeforeExport = fileGlbAsset.asset.meshPath;
+      seededObjects.fileGlbAssetId = fileGlbAsset.asset.assetId;
+
+      return {
+        objects: seededObjects,
+        objectIds: Array.from(mod.managedObjects.keys()).sort(),
+        summary: Array.from(mod.managedObjects.entries()).map(([objectId, obj]) => ({
+          objectId,
+          name: obj.userData?.name || obj.name || objectId,
+          asset: obj.userData?.asset || null,
+          audioSources: obj.userData?.audioSources || null,
+          metadata: obj.userData?.metadata || null,
+        })).sort((a, b) => a.objectId.localeCompare(b.objectId)),
+      };
+    }, { baseUrl });
+    result.seeded = seeded;
+    result.assertions.push(`seeded:${seeded.objectIds.length}`);
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 120000 });
+    await page.locator('#export-btn').click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+    assert(downloadPath, 'Download path unavailable');
+    result.download = {
+      suggested: download.suggestedFilename(),
+    };
+
+    const zipBuffer = await readFile(downloadPath);
+    const zipInspect = await page.evaluate(async (base64) => {
+      if (!window.JSZip) {
+        throw new Error('JSZip not available after export');
+      }
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      const zip = await window.JSZip.loadAsync(bytes);
+      const files = Object.keys(zip.files).sort();
+      const sceneJson = JSON.parse(await zip.file('scene.json').async('string'));
+      const manifestJson = JSON.parse(await zip.file('manifest.json').async('string'));
+      return {
+        fileCount: files.length,
+        files,
+        hasIndex: files.includes('index.html'),
+        hasScene: files.includes('scene.json'),
+        hasManifest: files.includes('manifest.json'),
+        hasViewer: files.includes('viewer/viewer.js'),
+        hasLoomletRuntime: files.includes('viewer/loomlet/loomlet-scenesync-runtime.browser.js'),
+        objectIds: (sceneJson.objects || []).map((o) => o.id).sort(),
+        objects: sceneJson.objects || [],
+        bgm: sceneJson.bgm || null,
+        skybox: sceneJson.skybox || null,
+        assetManifest: manifestJson.assets || manifestJson.assetManifest || [],
+        missingAssets: manifestJson.missingAssets || [],
+      };
+    }, zipBuffer.toString('base64'));
+    result.zipInspect = {
+      fileCount: zipInspect.fileCount,
+      hasIndex: zipInspect.hasIndex,
+      hasScene: zipInspect.hasScene,
+      hasManifest: zipInspect.hasManifest,
+      hasViewer: zipInspect.hasViewer,
+      hasLoomletRuntime: zipInspect.hasLoomletRuntime,
+      objectIds: zipInspect.objectIds,
+      assetManifest: zipInspect.assetManifest,
+      missingAssets: zipInspect.missingAssets,
+      bgm: zipInspect.bgm,
+      skybox: zipInspect.skybox,
+    };
+
+    assert(zipInspect.hasIndex, 'Export ZIP missing index.html');
+    assert(zipInspect.hasScene, 'Export ZIP missing scene.json');
+    assert(zipInspect.hasManifest, 'Export ZIP missing manifest.json');
+    assert(zipInspect.hasViewer, 'Export ZIP missing viewer/viewer.js');
+    assert(zipInspect.hasLoomletRuntime, 'Export ZIP missing Loomlet runtime');
+    assert(zipInspect.missingAssets.length === 0, `Export had missing assets: ${JSON.stringify(zipInspect.missingAssets)}`);
+
+    const byId = new Map(zipInspect.objects.map((obj) => [obj.id, obj]));
+    const seededIds = seeded.objects;
+    for (const [label, objectId] of Object.entries(seededIds)) {
+      if (label.endsWith('DeletedBeforeExport') || label.endsWith('AssetId')) continue;
+      if (label === 'urlSkyImageReplaced') continue;
+      assert(byId.has(objectId), `scene.json missing seeded object ${label}:${objectId}`);
+    }
+    assert(!byId.has(seededIds.urlSkyImageReplaced), 'replaced URL skybox object should not remain in scene.json');
+    assert(byId.get(seededIds.primitive)?.audioSources?.default?.asset?.path, 'object audio source was not bundled');
+    assert(zipInspect.bgm?.asset?.path, 'BGM was not bundled');
+    assert(byId.get(seededIds.urlImage)?.asset?.path, 'URL image was not bundled');
+    assert(byId.get(seededIds.fileImage)?.asset?.path, 'file image blob was not bundled');
+    assert(byId.get(seededIds.urlText)?.asset?.path, 'URL text was not bundled');
+    assert(byId.get(seededIds.urlVideo)?.asset?.path, 'URL video was not bundled');
+    assert(byId.get(seededIds.fileSkyImage)?.asset?.path, 'file skybox image mesh was not bundled');
+    assert(byId.get(seededIds.urlGlb)?.asset?.path, 'URL GLB was not bundled');
+    assert(byId.get(seededIds.fileGlb)?.asset?.path, 'file GLB IndexedDB fallback was not bundled');
+    assert(
+      zipInspect.assetManifest.some((entry) => entry.id === seededIds.fileGlb && entry.source === 'indexeddb'),
+      'file GLB did not export from IndexedDB fallback',
+    );
+    result.assertions.push('export-zip-all-assets-ok');
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    const cleared = await page.evaluate(() => {
+      const mod = window.__sceneSyncE2eModule;
+      for (const obj of mod.managedObjects.values()) {
+        mod.scene.remove(obj);
+      }
+      mod.managedObjects.clear();
+      return mod.managedObjects.size;
+    });
+    assert(cleared === 0, 'Could not clear scene before import');
+    result.assertions.push('cleared-before-import');
+
+    const uploadsBeforeImport = blobUploads.length;
+    await page.setInputFiles('#file-input', {
+      name: result.download.suggested,
+      mimeType: 'application/zip',
+      buffer: zipBuffer,
+    });
+
+    await page.waitForFunction(
+      ({ expectedIds }) => {
+        const mod = window.__sceneSyncE2eModule;
+        if (!mod) return false;
+        return expectedIds.every((objectId) => mod.managedObjects.has(objectId));
+      },
+      { expectedIds: zipInspect.objectIds },
+      { timeout: 90000 },
+    );
+    await page.waitForTimeout(1000);
+
+    const imported = await page.evaluate(({ expectedIds }) => {
+      const mod = window.__sceneSyncE2eModule;
+      return expectedIds.map((objectId) => {
+        const obj = mod.managedObjects.get(objectId);
+        return {
+          objectId,
+          name: obj?.userData?.name || obj?.name || null,
+          asset: obj?.userData?.asset || null,
+          audioSources: obj?.userData?.audioSources || null,
+          metadata: obj?.userData?.metadata || null,
+          position: obj?.position?.toArray?.() || null,
+          scale: obj?.scale?.toArray?.() || null,
+          visible: obj?.visible ?? null,
+        };
+      }).sort((a, b) => a.objectId.localeCompare(b.objectId));
+    }, { expectedIds: zipInspect.objectIds });
+    result.imported = imported;
+
+    const importedById = new Map(imported.map((obj) => [obj.objectId, obj]));
+    const expectBlobUrl = (url, label) => {
+      assert(typeof url === 'string' && url.includes('/presence/blob/'), `${label} did not resolve to presence blob URL: ${url}`);
+    };
+
+    assert(importedById.get(seededIds.primitive)?.asset?.type === 'primitive', 'primitive import mismatch');
+    expectBlobUrl(importedById.get(seededIds.primitive)?.audioSources?.default?.url, 'object audio source');
+    assert(importedById.get(seededIds.fileText)?.asset?.text === 'File text E2E\n', 'file text import mismatch');
+    expectBlobUrl(importedById.get(seededIds.urlText)?.asset?.url, 'URL text import');
+    expectBlobUrl(importedById.get(seededIds.urlImage)?.asset?.url, 'URL image import');
+    expectBlobUrl(importedById.get(seededIds.fileImage)?.asset?.url, 'file image import');
+    expectBlobUrl(importedById.get(seededIds.urlVideo)?.asset?.url, 'URL video import');
+    assert(importedById.get(seededIds.urlGlb)?.asset?.type === 'mesh', 'URL GLB import did not produce mesh asset');
+    assert(importedById.get(seededIds.urlGlb)?.asset?.meshPath, 'URL GLB import missing meshPath after re-upload');
+    assert(importedById.get(seededIds.fileGlb)?.asset?.type === 'mesh', 'file GLB import did not produce mesh asset');
+    assert(importedById.get(seededIds.fileGlb)?.asset?.meshPath, 'file GLB import missing meshPath after re-upload');
+    assert(importedById.get(seededIds.fileSkyImage)?.asset?.type === 'mesh', 'file skybox image import did not produce mesh asset');
+    assert(importedById.get(seededIds.fileSkyImage)?.asset?.meshPath, 'file skybox image import missing meshPath after re-upload');
+    assert(blobUploads.length > uploadsBeforeImport, 'Scene Sync Export import did not upload ZIP-bundled assets');
+    result.blobUploads = {
+      total: blobUploads.length,
+      duringImport: blobUploads.slice(uploadsBeforeImport),
+    };
+    result.assertions.push('import-all-assets-ok');
+
+    result.console = summarizeConsole(result.console);
+    result.status = 'passed';
+    return result;
+  } finally {
+    if (browser) await browser.close();
+    await closeServer(server);
+  }
+}
+
+try {
+  const result = await run();
+  console.log(JSON.stringify(result, null, 2));
+} catch (error) {
+  console.error(error?.stack || error?.message || String(error));
+  if (/Executable doesn't exist|browserType\.launch/.test(String(error?.message || error))) {
+    console.error(`\nInstall the local Chromium binary with:\n  npm run test:e2e:install-browsers`);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- Add a Playwright-backed browser E2E for SceneSync Export/Import roundtrips.
- Cover URL-added and file-added assets across image, text, video, GLB, object audio, BGM, and image-generated skybox flows.
- Verify ZIP contents, bundled asset manifests, Import re-uploads, and IndexedDB fallback for file-added GLB assets.
- Preserve URL mesh export data and infer bundled image/video MIME from fetched response headers.

## Why

SceneSync supports several asset formats and two different add paths: direct URL imports and file imports that are stored through temporary blob URLs and IndexedDB-backed GLB cache. Export/Import needed a browser-level regression test that exercises those real paths instead of only document-level helpers.

## Validation

- `node --check scripts/scenesync-export-import-browser-e2e.mjs`
- `npm run test:scene-sync-export-import`
- `npm run test:e2e:scene-sync-export-import`

The E2E run passed with `missingAssets: []` and no page errors. The only remaining browser console warning was the existing `[SceneSyncShell] unknown input adapter: xr` warning.