### PR TITLE
[codex] Handle SceneSync ZIP asset upload exceptions

### DIFF
--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
@@ -320,6 +320,85 @@ test('does not broadcast ZIP-only asset.path when re-upload fails and no fallbac
   }
 });
 
+test('keeps fallback URLs and clears ZIP paths when re-upload throws', async () => {
+  const managedObjects = new Map();
+  const calls = { addOrUpdate: [], broadcast: [] };
+  const zip = createFakeZip({
+    'assets/poster.png': new Uint8Array([1, 2, 3]).buffer,
+    'assets/speaker.mp3': new Uint8Array([4, 5, 6]).buffer,
+  });
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'poster',
+        name: 'Poster',
+        position: [1, 2, 3],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        visible: true,
+        asset: {
+          type: 'image',
+          source: 'blob',
+          path: 'assets/poster.png',
+          url: 'https://staging.afjk.jp/presence/blob/poster.png',
+          mime: 'image/png',
+        },
+        importAsset: {
+          kind: 'blob-file',
+          path: 'assets/poster.png',
+          originalName: 'poster.png',
+          mime: 'image/png',
+        },
+        audioSources: {
+          default: {
+            url: 'https://example.com/speaker.mp3',
+            loop: true,
+            asset: { path: 'assets/speaker.mp3', mime: 'audio/mpeg' },
+          },
+        },
+        importAudioSources: {
+          default: {
+            kind: 'blob-file',
+            path: 'assets/speaker.mp3',
+            originalName: 'speaker.mp3',
+            mime: 'audio/mpeg',
+          },
+        },
+      },
+    ],
+  };
+
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+  let stats;
+  try {
+    stats = await applySceneDocument(sceneDocument, {
+      managedObjects,
+      addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+      broadcast: (payload) => calls.broadcast.push(payload),
+      uploadBlobToStore: async () => {
+        throw new Error('Unsupported Media Type');
+      },
+      zip,
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  deepStrictEqual(stats, { total: 1, added: 1, updated: 0, glbImported: 0, skippedAssets: 0 });
+  strictEqual(warnings.length, 2);
+  strictEqual(calls.broadcast.length, 1);
+
+  const payload = calls.broadcast[0];
+  strictEqual(payload.asset.type, 'image');
+  strictEqual(payload.asset.url, 'https://staging.afjk.jp/presence/blob/poster.png');
+  strictEqual(payload.asset.path, undefined);
+  strictEqual(payload.audioSources.default.url, 'https://example.com/speaker.mp3');
+  strictEqual(payload.audioSources.default.asset, undefined);
+});
+
 test('falls back to placeholder when ZIP entry for importAsset is missing', async () => {
   const managedObjects = new Map();
   const calls = { addOrUpdate: [], broadcast: [] };

--- a/html/assets/js/scenesync/importers/scene-sync-export/zip-asset-upload.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/zip-asset-upload.js
@@ -78,16 +78,25 @@ export async function uploadZipAsset({
   const entry = zip.file(plan.path);
   if (!entry) return null;
 
-  const mime = plan.mime || inferMimeForExportAsset({ path: plan.path });
-  const buffer = await entry.async('arraybuffer');
-  const blob = new Blob([buffer], { type: mime });
-  const uploaded = await uploadBlobToStore(blob, mime, extensionForUpload(plan.path, mime));
-  if (!uploaded?.url) return null;
+  try {
+    const mime = plan.mime || inferMimeForExportAsset({ path: plan.path });
+    const buffer = await entry.async('arraybuffer');
+    const blob = new Blob([buffer], { type: mime });
+    const uploaded = await uploadBlobToStore(blob, mime, extensionForUpload(plan.path, mime));
+    if (!uploaded?.url) return null;
 
-  return {
-    ...uploaded,
-    mime,
-    size: blob.size,
-    originalName: plan.originalName || basename(plan.path),
-  };
+    return {
+      ...uploaded,
+      mime,
+      size: blob.size,
+      originalName: plan.originalName || basename(plan.path),
+    };
+  } catch (error) {
+    console.warn('[SceneSync Export Import] ZIP asset upload failed:', {
+      path: plan.path,
+      mime: plan.mime || inferMimeForExportAsset({ path: plan.path }),
+      error: error?.message || String(error),
+    });
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- Catch exceptions from ZIP-bundled asset re-uploads during SceneSync Export import.
- Let the existing fallback/sanitization path continue when `uploadBlobToStore()` throws, such as staging returning 415 for `audio/mpeg`.
- Add a regression test that keeps fallback URLs and clears ZIP-internal `asset.path` / `audioSources.*.asset.path` when re-upload throws.

## Why

On staging, importing `/Users/afjk/Downloads/scene-sync-export-20260613-123941.zip` failed when the bundled mp3 re-upload returned `415 Unsupported Media Type`. The thrown error escaped `uploadZipAsset()` and aborted the whole import, even though the scene document had a valid external fallback URL for that audio source.

## Validation

- `node --check html/assets/js/scenesync/importers/scene-sync-export/zip-asset-upload.js`
- `npm run test:scene-sync-export-import`
- Reproduced locally with a server that rejects only `audio/mpeg` uploads with 415 using `scene-sync-export-20260613-123941.zip`; all 3 objects restored, audio fell back to the original GitHub raw URL, and `unresolvedPaths: []`.
- Also reran `npm run test:e2e:scene-sync-export-import` before splitting this into a separate PR.