### PR TITLE
[codex] Preview SceneSync export imports locally

### DIFF
--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -182,6 +182,7 @@ export async function applySceneDocument(sceneDocument, {
   importGlbFileAsSceneObject,
   zip,
   uploadBlobToStore,
+  existingObjectIds,
   onProgress,
 } = {}) {
   let added = 0;
@@ -205,7 +206,9 @@ export async function applySceneDocument(sceneDocument, {
   }
 
   for (const obj of sceneDocument.objects || []) {
-    const existed = managedObjects.has(obj.id);
+    const existed = existingObjectIds instanceof Set
+      ? existingObjectIds.has(obj.id)
+      : managedObjects.has(obj.id);
     if (existed) {
       updated += 1;
     } else {

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -182,11 +182,27 @@ export async function applySceneDocument(sceneDocument, {
   importGlbFileAsSceneObject,
   zip,
   uploadBlobToStore,
+  onProgress,
 } = {}) {
   let added = 0;
   let updated = 0;
   let glbImported = 0;
   let skippedAssets = 0;
+  const total = sceneDocument.objects?.length || 0;
+  let processed = 0;
+
+  function reportProgress(obj) {
+    processed += 1;
+    onProgress?.({
+      total,
+      processed,
+      objectId: obj?.id || null,
+      added,
+      updated,
+      glbImported,
+      skippedAssets,
+    });
+  }
 
   for (const obj of sceneDocument.objects || []) {
     const existed = managedObjects.has(obj.id);
@@ -227,6 +243,7 @@ export async function applySceneDocument(sceneDocument, {
         });
 
         glbImported += 1;
+        reportProgress(obj);
         continue;
       }
 
@@ -258,10 +275,11 @@ export async function applySceneDocument(sceneDocument, {
 
     addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import' });
     broadcast(payload);
+    reportProgress(obj);
   }
 
   return {
-    total: sceneDocument.objects?.length || 0,
+    total,
     added,
     updated,
     glbImported,

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.test.js
@@ -62,6 +62,41 @@ test('adds new objects and updates existing ones via addOrUpdateObject + broadca
   strictEqual(calls.addOrUpdate[1].payload.visible, false);
 });
 
+test('uses pre-preview existing object ids for added/updated stats', async () => {
+  const managedObjects = new Map([
+    ['existing-1', {}],
+    ['new-1', { userData: { metadata: { importPreview: true } } }],
+  ]);
+  const calls = { addOrUpdate: [], broadcast: [] };
+
+  const sceneDocument = {
+    objects: [
+      {
+        id: 'existing-1',
+        name: 'Existing',
+        asset: { type: 'primitive', primitive: 'box' },
+        visible: true,
+      },
+      {
+        id: 'new-1',
+        name: 'New',
+        asset: { type: 'primitive', primitive: 'sphere' },
+        visible: true,
+      },
+    ],
+  };
+
+  const stats = await applySceneDocument(sceneDocument, {
+    managedObjects,
+    existingObjectIds: new Set(['existing-1']),
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+  });
+
+  deepStrictEqual(stats, { total: 2, added: 1, updated: 1, glbImported: 0, skippedAssets: 0 });
+  deepStrictEqual(calls.addOrUpdate.map((call) => call.id), ['existing-1', 'new-1']);
+});
+
 test('imports ZIP-bundled GLB assets via importGlbFileAsSceneObject, keeping objectId', async () => {
   const managedObjects = new Map();
   const calls = { addOrUpdate: [], broadcast: [], importGlb: [] };

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -137,9 +137,6 @@ export async function showSceneDocumentImportPreview(sceneDocument, {
   for (const obj of sceneDocument.objects || []) {
     const payload = buildPreviewBasePayload(obj);
     payload.asset = await buildPreviewAsset(obj.asset, zip, objectUrls);
-    if (obj.audioSources !== undefined) {
-      payload.audioSources = cloneJson(obj.audioSources);
-    }
     addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import-preview' });
     previewed += 1;
   }
@@ -184,7 +181,12 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
   });
 
   const objects = resolvedDocument.objects || [];
-  const updateCount = objects.filter((obj) => managedObjects.has(obj.id)).length;
+  const existingObjectIds = new Set(
+    objects
+      .filter((obj) => managedObjects.has(obj.id))
+      .map((obj) => obj.id)
+  );
+  const updateCount = existingObjectIds.size;
   const addCount = objects.length - updateCount;
 
   const confirmFn = confirmOpen
@@ -222,6 +224,7 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
       importGlbFileAsSceneObject,
       zip: result.zip,
       uploadBlobToStore,
+      existingObjectIds,
       onProgress: ({ processed, total }) => {
         showToast?.(`Scene Sync Exportを復元中…（${processed}/${total}）`, 60000);
       },

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -6,6 +6,156 @@ import { applySceneDocumentSettings } from './apply-scene-settings.js';
 
 export { isZipFile };
 
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function inferPreviewMime(asset) {
+  const mime = typeof asset?.mime === 'string' ? asset.mime.trim() : '';
+  if (mime) return mime;
+  const path = String(asset?.path || '').toLowerCase();
+  if (path.endsWith('.png')) return 'image/png';
+  if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg';
+  if (path.endsWith('.webp')) return 'image/webp';
+  if (path.endsWith('.mp4') || path.endsWith('.m4v')) return 'video/mp4';
+  if (path.endsWith('.webm')) return 'video/webm';
+  if (path.endsWith('.ogv')) return 'video/ogg';
+  if (path.endsWith('.md') || path.endsWith('.markdown')) return 'text/markdown';
+  if (path.endsWith('.txt')) return 'text/plain';
+  return 'application/octet-stream';
+}
+
+function buildPreviewBasePayload(obj) {
+  const payload = {
+    kind: 'scene-add',
+    objectId: obj.id,
+    name: obj.name || obj.id,
+    position: obj.position,
+    rotation: obj.rotation,
+    scale: obj.scale,
+    visible: obj.visible !== false,
+  };
+
+  if (obj.metadata) {
+    payload.metadata = {
+      ...cloneJson(obj.metadata),
+      importPreview: true,
+    };
+  } else {
+    payload.metadata = { importPreview: true };
+  }
+
+  if (obj.animation) payload.animation = cloneJson(obj.animation);
+  return payload;
+}
+
+function buildPlaceholderPreviewAsset(asset) {
+  return {
+    type: 'primitive',
+    primitive: 'box',
+    color: '#4f8cff',
+    previewAssetType: asset?.type || 'unknown',
+  };
+}
+
+async function readZipEntryBlobUrl(zip, path, mime, objectUrls) {
+  const entry = path ? zip?.file?.(path) : null;
+  if (!entry || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    return null;
+  }
+
+  const buffer = await entry.async('arraybuffer');
+  const blob = new Blob([buffer], { type: mime || 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  objectUrls.push(url);
+  return url;
+}
+
+async function readZipEntryText(zip, path) {
+  const entry = path ? zip?.file?.(path) : null;
+  if (!entry) return null;
+  return await entry.async('string');
+}
+
+async function buildPreviewAsset(asset, zip, objectUrls) {
+  if (!asset || asset.type === 'primitive') {
+    return cloneJson(asset || { type: 'primitive', primitive: 'box', color: '#4f8cff' });
+  }
+
+  if (asset.type === 'image' || asset.type === 'video') {
+    const mime = inferPreviewMime(asset);
+    const localUrl = await readZipEntryBlobUrl(zip, asset.path, mime, objectUrls);
+    const url = localUrl || asset.url || null;
+    if (!url) return buildPlaceholderPreviewAsset(asset);
+    const previewAsset = {
+      ...cloneJson(asset),
+      source: localUrl ? 'local-preview' : (asset.source || 'url'),
+      url,
+      mime,
+    };
+    delete previewAsset.path;
+    return previewAsset;
+  }
+
+  if (asset.type === 'text') {
+    if (asset.source === 'inline') return cloneJson(asset);
+    const text = await readZipEntryText(zip, asset.path);
+    if (text != null) {
+      const previewAsset = {
+        ...cloneJson(asset),
+        source: 'inline',
+        text,
+      };
+      delete previewAsset.path;
+      delete previewAsset.url;
+      return previewAsset;
+    }
+    if (asset.url) {
+      const previewAsset = cloneJson(asset);
+      delete previewAsset.path;
+      return previewAsset;
+    }
+    return buildPlaceholderPreviewAsset(asset);
+  }
+
+  // Avoid double-parsing GLB files just for preview; the final import path
+  // loads the real mesh and replaces this placeholder as soon as it is ready.
+  return buildPlaceholderPreviewAsset(asset);
+}
+
+export async function showSceneDocumentImportPreview(sceneDocument, {
+  zip,
+  addOrUpdateObject,
+} = {}) {
+  if (typeof addOrUpdateObject !== 'function') {
+    return { previewed: 0, dispose() {} };
+  }
+
+  const objectUrls = [];
+  let previewed = 0;
+
+  for (const obj of sceneDocument.objects || []) {
+    const payload = buildPreviewBasePayload(obj);
+    payload.asset = await buildPreviewAsset(obj.asset, zip, objectUrls);
+    if (obj.audioSources !== undefined) {
+      payload.audioSources = cloneJson(obj.audioSources);
+    }
+    addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import-preview' });
+    previewed += 1;
+  }
+
+  return {
+    previewed,
+    dispose() {
+      if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') return;
+      for (const url of objectUrls) {
+        URL.revokeObjectURL(url);
+      }
+      objectUrls.length = 0;
+    },
+  };
+}
+
 // Entry point for "Open Export": detects whether `file` is a Scene Sync Export
 // ZIP and, if so, upserts its objects into the current scene.
 export async function tryOpenSceneSyncExportFile(file, context = {}) {
@@ -51,22 +201,46 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     return { handled: true, cancelled: true };
   }
 
-  const stats = await applySceneDocument(resolvedDocument, {
-    managedObjects,
-    addOrUpdateObject,
-    broadcast,
-    importGlbFileAsSceneObject,
-    zip: result.zip,
-    uploadBlobToStore,
-  });
+  showToast?.(`Scene Sync Exportを復元中…（0/${objects.length}）`, 60000);
 
-  const settingsResult = await applySceneDocumentSettings(resolvedDocument, {
-    environmentManager,
-    broadcast,
-    applySceneBgm,
+  const preview = await showSceneDocumentImportPreview(resolvedDocument, {
     zip: result.zip,
-    uploadBlobToStore,
+    addOrUpdateObject,
   });
+  if (preview.previewed > 0) {
+    showToast?.(`Scene Sync Exportを復元中…（プレビュー表示 / 0/${objects.length}）`, 60000);
+  }
+
+  let completed = false;
+  let stats;
+  let settingsResult;
+  try {
+    stats = await applySceneDocument(resolvedDocument, {
+      managedObjects,
+      addOrUpdateObject,
+      broadcast,
+      importGlbFileAsSceneObject,
+      zip: result.zip,
+      uploadBlobToStore,
+      onProgress: ({ processed, total }) => {
+        showToast?.(`Scene Sync Exportを復元中…（${processed}/${total}）`, 60000);
+      },
+    });
+
+    const settingsMessage = `Scene Sync Exportを復元中…（${objects.length}/${objects.length} / 設定を適用中）`;
+    showToast?.(settingsMessage, 60000);
+
+    settingsResult = await applySceneDocumentSettings(resolvedDocument, {
+      environmentManager,
+      broadcast,
+      applySceneBgm,
+      zip: result.zip,
+      uploadBlobToStore,
+    });
+    completed = true;
+  } finally {
+    if (completed) preview.dispose();
+  }
 
   showToast?.(
     `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}）`

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { showSceneDocumentImportPreview } from './index.js';
+
+function createFakeZip(entries) {
+  return {
+    file(path) {
+      const value = entries[path];
+      if (value == null) return null;
+      return {
+        async async(type) {
+          if (type === 'string') return String(value);
+          if (type === 'arraybuffer') {
+            return new TextEncoder().encode(String(value)).buffer;
+          }
+          throw new Error(`unsupported fake zip type: ${type}`);
+        },
+      };
+    },
+  };
+}
+
+test('shows local Scene Sync Export import previews without ZIP paths', async () => {
+  const calls = [];
+  const revoked = [];
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let nextBlobUrl = 1;
+
+  URL.createObjectURL = () => `blob:preview-${nextBlobUrl++}`;
+  URL.revokeObjectURL = (url) => revoked.push(url);
+
+  try {
+    const zip = createFakeZip({
+      'assets/poster.png': 'png-bytes',
+      'assets/caption.md': '# Caption',
+      'assets/model.glb': 'glb-bytes',
+    });
+
+    const preview = await showSceneDocumentImportPreview({
+      objects: [
+        {
+          id: 'poster',
+          name: 'Poster',
+          position: [1, 2, 3],
+          rotation: [0, 0, 0, 1],
+          scale: [1, 1, 1],
+          asset: { type: 'image', path: 'assets/poster.png', mime: 'image/png' },
+          metadata: { role: 'media-panel' },
+        },
+        {
+          id: 'caption',
+          name: 'Caption',
+          asset: { type: 'text', source: 'url', path: 'assets/caption.md', format: 'markdown' },
+        },
+        {
+          id: 'model',
+          name: 'Model',
+          asset: { type: 'mesh', path: 'assets/model.glb', mime: 'model/gltf-binary' },
+        },
+      ],
+    }, {
+      zip,
+      addOrUpdateObject: (id, payload, options) => calls.push({ id, payload, options }),
+    });
+
+    strictEqual(preview.previewed, 3);
+    strictEqual(calls.length, 3);
+    deepStrictEqual(calls.map((call) => call.options), [
+      { source: 'scene-sync-export-import-preview' },
+      { source: 'scene-sync-export-import-preview' },
+      { source: 'scene-sync-export-import-preview' },
+    ]);
+
+    strictEqual(calls[0].id, 'poster');
+    strictEqual(calls[0].payload.asset.type, 'image');
+    strictEqual(calls[0].payload.asset.source, 'local-preview');
+    strictEqual(calls[0].payload.asset.url, 'blob:preview-1');
+    strictEqual(calls[0].payload.asset.path, undefined);
+    strictEqual(calls[0].payload.metadata.importPreview, true);
+
+    strictEqual(calls[1].id, 'caption');
+    strictEqual(calls[1].payload.asset.type, 'text');
+    strictEqual(calls[1].payload.asset.source, 'inline');
+    strictEqual(calls[1].payload.asset.text, '# Caption');
+    strictEqual(calls[1].payload.asset.path, undefined);
+
+    strictEqual(calls[2].id, 'model');
+    strictEqual(calls[2].payload.asset.type, 'primitive');
+    strictEqual(calls[2].payload.asset.primitive, 'box');
+    strictEqual(calls[2].payload.asset.previewAssetType, 'mesh');
+
+    preview.dispose();
+    deepStrictEqual(revoked, ['blob:preview-1']);
+  } finally {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  }
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
@@ -47,6 +47,12 @@ test('shows local Scene Sync Export import previews without ZIP paths', async ()
           scale: [1, 1, 1],
           asset: { type: 'image', path: 'assets/poster.png', mime: 'image/png' },
           metadata: { role: 'media-panel' },
+          audioSources: {
+            default: {
+              url: 'https://example.com/poster.mp3',
+              asset: { path: 'assets/poster.mp3' },
+            },
+          },
         },
         {
           id: 'caption',
@@ -78,6 +84,8 @@ test('shows local Scene Sync Export import previews without ZIP paths', async ()
     strictEqual(calls[0].payload.asset.url, 'blob:preview-1');
     strictEqual(calls[0].payload.asset.path, undefined);
     strictEqual(calls[0].payload.metadata.importPreview, true);
+    strictEqual(calls[0].payload.audioSources, undefined);
+    strictEqual(JSON.stringify(calls[0].payload).includes('assets/poster.mp3'), false);
 
     strictEqual(calls[1].id, 'caption');
     strictEqual(calls[1].payload.asset.type, 'text');

--- a/scripts/scenesync-export-import-browser-e2e.mjs
+++ b/scripts/scenesync-export-import-browser-e2e.mjs
@@ -659,7 +659,10 @@ async function run() {
       ({ expectedIds }) => {
         const mod = window.__sceneSyncE2eModule;
         if (!mod) return false;
-        return expectedIds.every((objectId) => mod.managedObjects.has(objectId));
+        return expectedIds.every((objectId) => {
+          const obj = mod.managedObjects.get(objectId);
+          return obj && obj.userData?.metadata?.importPreview !== true;
+        });
       },
       { expectedIds: zipInspect.objectIds },
       { timeout: 90000 },


### PR DESCRIPTION
## Summary

- Show local SceneSync Export import previews immediately after the user confirms a ZIP import.
- Preview image/video/text assets from ZIP entries without broadcasting local `blob:` URLs.
- Use lightweight placeholder boxes for GLB/mesh assets until the real import path finishes loading and uploading them.
- Add long-running restore toast updates with object progress and update the browser E2E wait condition to wait for previews to be replaced by final restored objects.

## Why

Large SceneSync Export imports can take a while because bundled GLBs and media need to be read, loaded, uploaded, and broadcast. Previously the UI could look idle until completion. This makes the restore visibly start immediately while keeping shared scene state clean.

## Validation

- `node --check html/assets/js/scenesync/importers/scene-sync-export/index.js`
- `npm run test:scene-sync-export-import`
- `npm run test:e2e:scene-sync-export-import`
- Browser-verified `/Users/afjk/Downloads/scene-sync-export-20260613-123941.zip`: all three objects first appeared as local previews, then were replaced by final restored objects with no page errors.