### PR TITLE
[codex] Add Scene Sync Export URL import

### DIFF
--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -269,7 +269,13 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
   } = context;
 
   const result = await loadExportPackageFromUrl(url, { fetchImpl });
-  if (!result.valid) return { handled: false, reason: result.reason };
+  if (!result.valid) {
+    if (result.shouldBlockGenericImport) {
+      showToast?.(`Scene Sync Export URLを読み込めませんでした（${result.reason}）`);
+      return { handled: true, error: result.reason };
+    }
+    return { handled: false, reason: result.reason };
+  }
 
   const { document: resolvedDocument } = result.zip
     ? await resolveSceneDocumentAssets(result.sceneDocument, { zip: result.zip })

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -1,6 +1,8 @@
 import { isZipFile } from './detect-scene-sync-export.js';
 import { loadExportPackageFromBlob } from './load-export-package.js';
+import { loadExportPackageFromUrl } from './load-export-package-from-url.js';
 import { resolveSceneDocumentAssets } from './resolve-export-assets.js';
+import { resolveSceneDocumentAssetsFromUrl } from './resolve-url-assets.js';
 import { applySceneDocument } from './apply-scene-document.js';
 import { applySceneDocumentSettings } from './apply-scene-settings.js';
 
@@ -250,4 +252,103 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
   );
 
   return { handled: true, stats, settings: settingsResult };
+}
+
+export async function tryOpenSceneSyncExportUrl(url, context = {}) {
+  const {
+    managedObjects,
+    addOrUpdateObject,
+    broadcast,
+    showToast,
+    confirmOpen,
+    environmentManager,
+    importGlbFileAsSceneObject,
+    uploadBlobToStore,
+    applySceneBgm,
+    fetchImpl,
+  } = context;
+
+  const result = await loadExportPackageFromUrl(url, { fetchImpl });
+  if (!result.valid) return { handled: false, reason: result.reason };
+
+  const { document: resolvedDocument } = result.zip
+    ? await resolveSceneDocumentAssets(result.sceneDocument, { zip: result.zip })
+    : resolveSceneDocumentAssetsFromUrl(result.sceneDocument, { baseUrl: result.baseUrl });
+
+  const objects = resolvedDocument.objects || [];
+  const existingObjectIds = new Set(
+    objects
+      .filter((obj) => managedObjects.has(obj.id))
+      .map((obj) => obj.id)
+  );
+  const updateCount = existingObjectIds.size;
+  const addCount = objects.length - updateCount;
+
+  const confirmFn = confirmOpen
+    || (typeof window !== 'undefined' ? window.confirm.bind(window) : null);
+  const message =
+    'Scene Sync Exportを読み込みます\n\n'
+    + `- objects: ${objects.length}\n`
+    + `- update existing: ${updateCount}\n`
+    + `- add new: ${addCount}\n\n`
+    + '同じIDのオブジェクトは上書きされます。\n'
+    + 'Exportに含まれない既存オブジェクトは残ります。';
+
+  if (confirmFn && !confirmFn(message)) {
+    return { handled: true, cancelled: true };
+  }
+
+  showToast?.(`Scene Sync Exportを復元中…（0/${objects.length}）`, 60000);
+
+  const preview = await showSceneDocumentImportPreview(resolvedDocument, {
+    zip: result.zip,
+    addOrUpdateObject,
+  });
+  if (preview.previewed > 0) {
+    showToast?.(`Scene Sync Exportを復元中…（プレビュー表示 / 0/${objects.length}）`, 60000);
+  }
+
+  let completed = false;
+  let stats;
+  let settingsResult;
+  try {
+    stats = await applySceneDocument(resolvedDocument, {
+      managedObjects,
+      addOrUpdateObject,
+      broadcast,
+      importGlbFileAsSceneObject,
+      zip: result.zip,
+      uploadBlobToStore,
+      existingObjectIds,
+      onProgress: ({ processed, total }) => {
+        showToast?.(`Scene Sync Exportを復元中…（${processed}/${total}）`, 60000);
+      },
+    });
+
+    const settingsMessage = `Scene Sync Exportを復元中…（${objects.length}/${objects.length} / 設定を適用中）`;
+    showToast?.(settingsMessage, 60000);
+
+    settingsResult = await applySceneDocumentSettings(resolvedDocument, {
+      environmentManager,
+      broadcast,
+      applySceneBgm,
+      zip: result.zip,
+      uploadBlobToStore,
+    });
+    completed = true;
+  } finally {
+    if (completed) preview.dispose();
+  }
+
+  showToast?.(
+    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}）`
+  );
+
+  return {
+    handled: true,
+    stats,
+    settings: settingsResult,
+    sourceUrl: result.sourceUrl || url,
+    kind: result.kind,
+  };
 }

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import { strictEqual, deepStrictEqual } from 'node:assert';
-import { showSceneDocumentImportPreview } from './index.js';
+import { showSceneDocumentImportPreview, tryOpenSceneSyncExportUrl } from './index.js';
 
 function createFakeZip(entries) {
   return {
@@ -104,4 +104,146 @@ test('shows local Scene Sync Export import previews without ZIP paths', async ()
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
   }
+});
+
+function response({ url, body, contentType = 'application/json', ok = true, status = 200 }) {
+  return {
+    ok,
+    status,
+    url,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === 'content-type' ? contentType : '';
+      },
+    },
+    async text() {
+      return typeof body === 'string' ? body : JSON.stringify(body);
+    },
+  };
+}
+
+function createFetch(routes) {
+  return async (url) => {
+    const href = String(url);
+    const route = routes[href];
+    if (!route) {
+      return response({ url: href, body: 'not found', ok: false, status: 404 });
+    }
+    return response({ url: href, ...route });
+  };
+}
+
+test('imports Scene Sync Export scene.json URLs without broadcasting relative asset paths', async () => {
+  const sceneDocument = {
+    format: 'scene-sync-export-scene',
+    version: 2,
+    objects: [
+      {
+        id: 'image-1',
+        name: 'Image',
+        position: [0, 1, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'image', source: 'blob', path: 'assets/poster.png' },
+        audioSources: {
+          default: {
+            type: 'audioSource',
+            asset: { path: 'assets/narration.mp3' },
+            volume: 1,
+          },
+        },
+      },
+      {
+        id: 'mesh-1',
+        name: 'Mesh',
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'mesh', source: 'carrier', path: 'assets/model.glb' },
+      },
+      {
+        id: 'text-1',
+        name: 'Text',
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'text', source: 'url', path: 'assets/story.md', format: 'markdown' },
+      },
+    ],
+    bgm: {
+      name: 'bgm.mp3',
+      asset: { path: 'assets/bgm.mp3' },
+    },
+  };
+  const fetchImpl = createFetch({
+    'https://example.com/world/scene.json': { body: sceneDocument },
+  });
+  const managedObjects = new Map();
+  const calls = { addOrUpdate: [], broadcast: [], bgm: [], uploads: 0, toasts: [] };
+
+  const result = await tryOpenSceneSyncExportUrl('https://example.com/world/scene.json', {
+    managedObjects,
+    fetchImpl,
+    confirmOpen: () => true,
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+    applySceneBgm: (bgm, options) => calls.bgm.push({ bgm, options }),
+    uploadBlobToStore: async () => {
+      calls.uploads += 1;
+      throw new Error('URL import should not upload assets');
+    },
+    showToast: (message) => calls.toasts.push(message),
+  });
+
+  strictEqual(result.handled, true);
+  strictEqual(result.stats.added, 3);
+  strictEqual(calls.uploads, 0);
+
+  const finalAdds = calls.addOrUpdate.filter((call) => call.options?.source === 'scene-sync-export-import');
+  strictEqual(finalAdds.length, 3);
+  strictEqual(finalAdds[0].payload.asset.url, 'https://example.com/world/assets/poster.png');
+  strictEqual(finalAdds[0].payload.asset.source, 'url');
+  strictEqual(finalAdds[0].payload.audioSources.default.url, 'https://example.com/world/assets/narration.mp3');
+  strictEqual(finalAdds[1].payload.asset.url, 'https://example.com/world/assets/model.glb');
+  strictEqual(finalAdds[1].payload.asset.source, 'url');
+  strictEqual(finalAdds[2].payload.asset.url, 'https://example.com/world/assets/story.md');
+  strictEqual(calls.bgm[0].bgm.url, 'https://example.com/world/assets/bgm.mp3');
+
+  const broadcastJson = JSON.stringify(calls.broadcast);
+  strictEqual(broadcastJson.includes('"path"'), false);
+  strictEqual(JSON.stringify(calls.bgm).includes('"asset"'), false);
+});
+
+test('falls through when URL is not a Scene Sync Export', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/page/': {
+      body: '<!doctype html><title>Plain page</title>',
+      contentType: 'text/html',
+    },
+    'https://example.com/page/scene.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/page/current.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+  });
+  const calls = { addOrUpdate: [], broadcast: [] };
+
+  const result = await tryOpenSceneSyncExportUrl('https://example.com/page/', {
+    managedObjects: new Map(),
+    fetchImpl,
+    confirmOpen: () => {
+      throw new Error('confirm should not be called');
+    },
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+  });
+
+  strictEqual(result.handled, false);
+  strictEqual(calls.addOrUpdate.length, 0);
+  strictEqual(calls.broadcast.length, 0);
 });

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.test.js
@@ -247,3 +247,33 @@ test('falls through when URL is not a Scene Sync Export', async () => {
   strictEqual(calls.addOrUpdate.length, 0);
   strictEqual(calls.broadcast.length, 0);
 });
+
+test('stops generic URL fallback for explicit invalid Scene Sync Export URLs', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/world/scene.json': {
+      body: {
+        format: 'not-scene-sync-export',
+        version: 2,
+        objects: [],
+      },
+    },
+  });
+  const calls = { addOrUpdate: [], broadcast: [], toasts: [] };
+
+  const result = await tryOpenSceneSyncExportUrl('https://example.com/world/scene.json', {
+    managedObjects: new Map(),
+    fetchImpl,
+    confirmOpen: () => {
+      throw new Error('confirm should not be called for invalid exports');
+    },
+    addOrUpdateObject: (id, payload, options) => calls.addOrUpdate.push({ id, payload, options }),
+    broadcast: (payload) => calls.broadcast.push(payload),
+    showToast: (message) => calls.toasts.push(message),
+  });
+
+  strictEqual(result.handled, true);
+  strictEqual(result.error, 'invalid-scene-document');
+  strictEqual(calls.addOrUpdate.length, 0);
+  strictEqual(calls.broadcast.length, 0);
+  strictEqual(calls.toasts[0], 'Scene Sync Export URLを読み込めませんでした（invalid-scene-document）');
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.js
@@ -2,6 +2,17 @@ import { isValidSceneDocument } from '../../../scenesync-export/viewer/scene-doc
 import { loadExportPackageFromBlob } from './load-export-package.js';
 
 const ZIP_EXT_RE = /\.zip(?:$|[?#])/i;
+const SCENE_JSON_RE = /(?:^|\/)scene\.json$/i;
+const CURRENT_JSON_RE = /(?:^|\/)current\.json$/i;
+const ZIP_CONTENT_TYPES = new Set([
+  'application/zip',
+  'application/x-zip-compressed',
+]);
+const ZIP_MAGIC_SIGNATURES = new Set([
+  '80,75,3,4',
+  '80,75,5,6',
+  '80,75,7,8',
+]);
 
 function fetchImplFromOptions(options = {}) {
   return options.fetchImpl || globalThis.fetch?.bind(globalThis);
@@ -22,6 +33,22 @@ function isZipUrl(url) {
   }
 }
 
+function isSceneJsonUrl(url) {
+  try {
+    return SCENE_JSON_RE.test(new URL(url).pathname);
+  } catch {
+    return SCENE_JSON_RE.test(String(url || '').split(/[?#]/)[0]);
+  }
+}
+
+function isCurrentJsonUrl(url) {
+  try {
+    return CURRENT_JSON_RE.test(new URL(url).pathname);
+  } catch {
+    return CURRENT_JSON_RE.test(String(url || '').split(/[?#]/)[0]);
+  }
+}
+
 function asDirectoryUrl(url) {
   const parsed = new URL(url);
   if (!parsed.pathname.endsWith('/')) parsed.pathname += '/';
@@ -32,6 +59,51 @@ function asDirectoryUrl(url) {
 
 function directoryOfUrl(url) {
   return new URL('./', url).href;
+}
+
+function normalizeContentType(contentType = '') {
+  return String(contentType || '').split(';')[0].trim().toLowerCase();
+}
+
+function hasZipContentType(contentType) {
+  return ZIP_CONTENT_TYPES.has(normalizeContentType(contentType));
+}
+
+function hasOctetStreamContentType(contentType) {
+  return normalizeContentType(contentType) === 'application/octet-stream';
+}
+
+async function blobHasZipMagic(blob) {
+  if (!blob || typeof blob.slice !== 'function') return false;
+  const buffer = await blob.slice(0, 4).arrayBuffer();
+  const bytes = Array.from(new Uint8Array(buffer));
+  if (bytes.length < 2) return false;
+  if (bytes[0] !== 0x50 || bytes[1] !== 0x4b) return false;
+  if (bytes.length < 4) return true;
+  return ZIP_MAGIC_SIGNATURES.has(bytes.slice(0, 4).join(','));
+}
+
+async function fetchBlob(url, fetchImpl) {
+  const response = await fetchImpl(url, { mode: 'cors' });
+  if (!response?.ok) {
+    return { ok: false, status: response?.status || 0, url };
+  }
+
+  let blob;
+  if (typeof response.blob === 'function') {
+    blob = await response.blob();
+  } else if (typeof response.arrayBuffer === 'function') {
+    blob = new Blob([await response.arrayBuffer()]);
+  } else {
+    blob = new Blob([await response.text()]);
+  }
+
+  return {
+    ok: true,
+    blob,
+    contentType: response.headers?.get?.('content-type') || blob.type || '',
+    url: response.url || url,
+  };
 }
 
 async function fetchText(url, fetchImpl) {
@@ -48,13 +120,10 @@ async function fetchText(url, fetchImpl) {
   };
 }
 
-async function tryFetchSceneJson(sceneUrl, fetchImpl) {
-  const fetched = await fetchText(sceneUrl, fetchImpl);
-  if (!fetched.ok) return { valid: false, reason: 'scene-json-fetch-failed', fetched };
-
+function parseSceneJsonText(text, fetched) {
   let sceneDocument;
   try {
-    sceneDocument = JSON.parse(fetched.text);
+    sceneDocument = JSON.parse(text);
   } catch (error) {
     return { valid: false, reason: 'invalid-scene-json', error, fetched };
   }
@@ -73,6 +142,12 @@ async function tryFetchSceneJson(sceneUrl, fetchImpl) {
   };
 }
 
+async function tryFetchSceneJson(sceneUrl, fetchImpl) {
+  const fetched = await fetchText(sceneUrl, fetchImpl);
+  if (!fetched.ok) return { valid: false, reason: 'scene-json-fetch-failed', fetched };
+  return parseSceneJsonText(fetched.text, fetched);
+}
+
 function looksLikeHtml(text, contentType = '') {
   return /html/i.test(contentType) || /^\s*<!doctype html/i.test(text) || /^\s*<html[\s>]/i.test(text);
 }
@@ -87,16 +162,61 @@ function extractSceneSyncExportHref(html) {
   return metaMatch?.[1] || null;
 }
 
-async function tryFetchZip(url, fetchImpl) {
-  const response = await fetchImpl(url, { mode: 'cors' });
-  if (!response?.ok) return { valid: false, reason: 'zip-fetch-failed' };
-  const blob = await response.blob();
+async function shouldTreatAsZip(fetched, originalUrl) {
+  const contentType = fetched?.contentType || '';
+  if (isZipUrl(originalUrl)) return true;
+  if (hasZipContentType(contentType)) return true;
+  if (hasOctetStreamContentType(contentType) && await blobHasZipMagic(fetched.blob)) return true;
+  return false;
+}
+
+async function tryLoadZipBlob(blob, url) {
   const result = await loadExportPackageFromBlob(blob);
   if (!result.valid) return result;
   return {
     ...result,
-    sourceUrl: response.url || url,
+    sourceUrl: url,
     kind: 'zip-url',
+  };
+}
+
+function shouldBlockSceneJsonFallback(result) {
+  return result && !result.valid && result.reason !== 'scene-json-fetch-failed';
+}
+
+function blockingResult(result, attempts) {
+  return {
+    valid: false,
+    reason: result?.reason || 'invalid-scene-sync-export-url',
+    error: result?.error,
+    attempts,
+    shouldBlockGenericImport: true,
+  };
+}
+
+async function resolveCurrentJson(current, directoryUrl, fetchImpl) {
+  const versionPath = typeof current?.versionPath === 'string' && current.versionPath.trim()
+    ? current.versionPath.trim()
+    : (typeof current?.versionId === 'string' && current.versionId.trim()
+      ? `versions/${current.versionId.trim()}/`
+      : '');
+  if (!versionPath) return { valid: false, reason: 'current-json-missing-version' };
+
+  const versionDirectoryUrl = asDirectoryUrl(new URL(versionPath, directoryUrl).href);
+  const sceneUrl = new URL('scene.json', versionDirectoryUrl).href;
+  const result = await tryFetchSceneJson(sceneUrl, fetchImpl);
+  if (!result.valid) {
+    return {
+      ...result,
+      shouldBlockGenericImport: true,
+    };
+  }
+  return {
+    ...result,
+    current,
+    baseUrl: versionDirectoryUrl,
+    sourceUrl: sceneUrl,
+    kind: 'current-json-url',
   };
 }
 
@@ -112,24 +232,7 @@ async function tryFetchCurrentJson(directoryUrl, fetchImpl) {
     return { valid: false, reason: 'invalid-current-json', error, fetched };
   }
 
-  const versionPath = typeof current?.versionPath === 'string' && current.versionPath.trim()
-    ? current.versionPath.trim()
-    : (typeof current?.versionId === 'string' && current.versionId.trim()
-      ? `versions/${current.versionId.trim()}/`
-      : '');
-  if (!versionPath) return { valid: false, reason: 'current-json-missing-version' };
-
-  const versionDirectoryUrl = asDirectoryUrl(new URL(versionPath, directoryUrl).href);
-  const sceneUrl = new URL('scene.json', versionDirectoryUrl).href;
-  const result = await tryFetchSceneJson(sceneUrl, fetchImpl);
-  if (!result.valid) return result;
-  return {
-    ...result,
-    current,
-    baseUrl: versionDirectoryUrl,
-    sourceUrl: sceneUrl,
-    kind: 'current-json-url',
-  };
+  return resolveCurrentJson(current, directoryUrl, fetchImpl);
 }
 
 export async function loadExportPackageFromUrl(url, options = {}) {
@@ -146,28 +249,49 @@ export async function loadExportPackageFromUrl(url, options = {}) {
   const fetchImpl = ensureFetch(fetchImplFromOptions(options));
   const attempts = [];
 
-  if (isZipUrl(parsed.href)) {
-    const zipResult = await tryFetchZip(parsed.href, fetchImpl).catch((error) => (
-      { valid: false, reason: 'zip-fetch-threw', error }
-    ));
-    if (zipResult.valid) return zipResult;
-    attempts.push({ step: 'zip', reason: zipResult.reason });
-  }
-
-  const directFetched = await fetchText(parsed.href, fetchImpl).catch((error) => (
+  const directFetched = await fetchBlob(parsed.href, fetchImpl).catch((error) => (
     { ok: false, reason: 'direct-fetch-threw', error, url: parsed.href }
   ));
+  let directText = null;
   if (directFetched.ok) {
-    const directResult = await tryFetchSceneJson(directFetched.url, async () => ({
-      ok: true,
-      url: directFetched.url,
-      headers: { get: (name) => name.toLowerCase() === 'content-type' ? directFetched.contentType : '' },
-      text: async () => directFetched.text,
-    }));
+    const zipCandidate = await shouldTreatAsZip(directFetched, parsed.href);
+    if (zipCandidate) {
+      const zipResult = await tryLoadZipBlob(directFetched.blob, directFetched.url)
+        .catch((error) => ({ valid: false, reason: 'zip-load-threw', error }));
+      if (zipResult.valid) return zipResult;
+      attempts.push({ step: 'zip', reason: zipResult.reason });
+      return blockingResult(zipResult, attempts);
+    }
+
+    directText = await directFetched.blob.text();
+    const directResult = parseSceneJsonText(directText, {
+      ...directFetched,
+      text: directText,
+    });
     if (directResult.valid) return directResult;
     attempts.push({ step: 'direct-scene-json', reason: directResult.reason });
+
+    if (isSceneJsonUrl(directFetched.url || parsed.href)) {
+      return blockingResult(directResult, attempts);
+    }
+
+    if (isCurrentJsonUrl(directFetched.url || parsed.href)) {
+      let current;
+      try {
+        current = JSON.parse(directText);
+      } catch (error) {
+        return blockingResult({ reason: 'invalid-current-json', error }, attempts);
+      }
+      const currentResult = await resolveCurrentJson(current, directoryOfUrl(directFetched.url), fetchImpl)
+        .catch((error) => ({ valid: false, reason: 'current-json-threw', error }));
+      if (currentResult.valid) return currentResult;
+      return blockingResult(currentResult, attempts);
+    }
   } else {
     attempts.push({ step: 'direct-scene-json', reason: directFetched.reason || 'fetch-failed' });
+    if (isZipUrl(parsed.href) || isSceneJsonUrl(parsed.href) || isCurrentJsonUrl(parsed.href)) {
+      return blockingResult({ reason: directFetched.reason || 'fetch-failed', error: directFetched.error }, attempts);
+    }
   }
 
   const directoryUrl = asDirectoryUrl(parsed.href);
@@ -179,14 +303,20 @@ export async function loadExportPackageFromUrl(url, options = {}) {
     kind: 'directory-scene-json-url',
   };
   attempts.push({ step: 'directory-scene-json', reason: directorySceneResult.reason });
+  if (shouldBlockSceneJsonFallback(directorySceneResult)) {
+    return blockingResult(directorySceneResult, attempts);
+  }
 
   const currentResult = await tryFetchCurrentJson(directoryUrl, fetchImpl)
     .catch((error) => ({ valid: false, reason: 'current-json-threw', error }));
   if (currentResult.valid) return currentResult;
   attempts.push({ step: 'current-json', reason: currentResult.reason });
+  if (currentResult.shouldBlockGenericImport) {
+    return blockingResult(currentResult, attempts);
+  }
 
-  if (directFetched.ok && looksLikeHtml(directFetched.text, directFetched.contentType)) {
-    const href = extractSceneSyncExportHref(directFetched.text);
+  if (directFetched.ok && looksLikeHtml(directText, directFetched.contentType)) {
+    const href = extractSceneSyncExportHref(directText);
     if (href) {
       const markerSceneUrl = new URL(href, directFetched.url).href;
       const markerResult = await tryFetchSceneJson(markerSceneUrl, fetchImpl)
@@ -196,6 +326,7 @@ export async function loadExportPackageFromUrl(url, options = {}) {
         kind: 'html-marker-url',
       };
       attempts.push({ step: 'html-marker', reason: markerResult.reason });
+      return blockingResult(markerResult, attempts);
     }
   }
 

--- a/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.js
@@ -1,0 +1,207 @@
+import { isValidSceneDocument } from '../../../scenesync-export/viewer/scene-document.js';
+import { loadExportPackageFromBlob } from './load-export-package.js';
+
+const ZIP_EXT_RE = /\.zip(?:$|[?#])/i;
+
+function fetchImplFromOptions(options = {}) {
+  return options.fetchImpl || globalThis.fetch?.bind(globalThis);
+}
+
+function ensureFetch(fetchImpl) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch is not available');
+  }
+  return fetchImpl;
+}
+
+function isZipUrl(url) {
+  try {
+    return ZIP_EXT_RE.test(new URL(url).pathname);
+  } catch {
+    return ZIP_EXT_RE.test(String(url || ''));
+  }
+}
+
+function asDirectoryUrl(url) {
+  const parsed = new URL(url);
+  if (!parsed.pathname.endsWith('/')) parsed.pathname += '/';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.href;
+}
+
+function directoryOfUrl(url) {
+  return new URL('./', url).href;
+}
+
+async function fetchText(url, fetchImpl) {
+  const response = await fetchImpl(url, { mode: 'cors' });
+  if (!response?.ok) {
+    return { ok: false, status: response?.status || 0, url };
+  }
+  const text = await response.text();
+  return {
+    ok: true,
+    text,
+    contentType: response.headers?.get?.('content-type') || '',
+    url: response.url || url,
+  };
+}
+
+async function tryFetchSceneJson(sceneUrl, fetchImpl) {
+  const fetched = await fetchText(sceneUrl, fetchImpl);
+  if (!fetched.ok) return { valid: false, reason: 'scene-json-fetch-failed', fetched };
+
+  let sceneDocument;
+  try {
+    sceneDocument = JSON.parse(fetched.text);
+  } catch (error) {
+    return { valid: false, reason: 'invalid-scene-json', error, fetched };
+  }
+
+  if (!isValidSceneDocument(sceneDocument)) {
+    return { valid: false, reason: 'invalid-scene-document', fetched };
+  }
+
+  return {
+    valid: true,
+    sceneDocument,
+    manifest: null,
+    baseUrl: directoryOfUrl(fetched.url),
+    sourceUrl: fetched.url,
+    kind: 'scene-json-url',
+  };
+}
+
+function looksLikeHtml(text, contentType = '') {
+  return /html/i.test(contentType) || /^\s*<!doctype html/i.test(text) || /^\s*<html[\s>]/i.test(text);
+}
+
+function extractSceneSyncExportHref(html) {
+  const linkMatch = html.match(/<link\b[^>]*\brel=["']scene-sync-export["'][^>]*\bhref=["']([^"']+)["'][^>]*>/i)
+    || html.match(/<link\b[^>]*\bhref=["']([^"']+)["'][^>]*\brel=["']scene-sync-export["'][^>]*>/i);
+  if (linkMatch) return linkMatch[1];
+
+  const metaMatch = html.match(/<meta\b[^>]*\bname=["']scene-sync-export["'][^>]*\bcontent=["']([^"']+)["'][^>]*>/i)
+    || html.match(/<meta\b[^>]*\bcontent=["']([^"']+)["'][^>]*\bname=["']scene-sync-export["'][^>]*>/i);
+  return metaMatch?.[1] || null;
+}
+
+async function tryFetchZip(url, fetchImpl) {
+  const response = await fetchImpl(url, { mode: 'cors' });
+  if (!response?.ok) return { valid: false, reason: 'zip-fetch-failed' };
+  const blob = await response.blob();
+  const result = await loadExportPackageFromBlob(blob);
+  if (!result.valid) return result;
+  return {
+    ...result,
+    sourceUrl: response.url || url,
+    kind: 'zip-url',
+  };
+}
+
+async function tryFetchCurrentJson(directoryUrl, fetchImpl) {
+  const currentUrl = new URL('current.json', directoryUrl).href;
+  const fetched = await fetchText(currentUrl, fetchImpl);
+  if (!fetched.ok) return { valid: false, reason: 'current-json-fetch-failed', fetched };
+
+  let current;
+  try {
+    current = JSON.parse(fetched.text);
+  } catch (error) {
+    return { valid: false, reason: 'invalid-current-json', error, fetched };
+  }
+
+  const versionPath = typeof current?.versionPath === 'string' && current.versionPath.trim()
+    ? current.versionPath.trim()
+    : (typeof current?.versionId === 'string' && current.versionId.trim()
+      ? `versions/${current.versionId.trim()}/`
+      : '');
+  if (!versionPath) return { valid: false, reason: 'current-json-missing-version' };
+
+  const versionDirectoryUrl = asDirectoryUrl(new URL(versionPath, directoryUrl).href);
+  const sceneUrl = new URL('scene.json', versionDirectoryUrl).href;
+  const result = await tryFetchSceneJson(sceneUrl, fetchImpl);
+  if (!result.valid) return result;
+  return {
+    ...result,
+    current,
+    baseUrl: versionDirectoryUrl,
+    sourceUrl: sceneUrl,
+    kind: 'current-json-url',
+  };
+}
+
+export async function loadExportPackageFromUrl(url, options = {}) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    return { valid: false, reason: 'invalid-url', error };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { valid: false, reason: 'unsupported-url-protocol' };
+  }
+
+  const fetchImpl = ensureFetch(fetchImplFromOptions(options));
+  const attempts = [];
+
+  if (isZipUrl(parsed.href)) {
+    const zipResult = await tryFetchZip(parsed.href, fetchImpl).catch((error) => (
+      { valid: false, reason: 'zip-fetch-threw', error }
+    ));
+    if (zipResult.valid) return zipResult;
+    attempts.push({ step: 'zip', reason: zipResult.reason });
+  }
+
+  const directFetched = await fetchText(parsed.href, fetchImpl).catch((error) => (
+    { ok: false, reason: 'direct-fetch-threw', error, url: parsed.href }
+  ));
+  if (directFetched.ok) {
+    const directResult = await tryFetchSceneJson(directFetched.url, async () => ({
+      ok: true,
+      url: directFetched.url,
+      headers: { get: (name) => name.toLowerCase() === 'content-type' ? directFetched.contentType : '' },
+      text: async () => directFetched.text,
+    }));
+    if (directResult.valid) return directResult;
+    attempts.push({ step: 'direct-scene-json', reason: directResult.reason });
+  } else {
+    attempts.push({ step: 'direct-scene-json', reason: directFetched.reason || 'fetch-failed' });
+  }
+
+  const directoryUrl = asDirectoryUrl(parsed.href);
+  const directorySceneResult = await tryFetchSceneJson(new URL('scene.json', directoryUrl).href, fetchImpl)
+    .catch((error) => ({ valid: false, reason: 'directory-scene-json-threw', error }));
+  if (directorySceneResult.valid) return {
+    ...directorySceneResult,
+    baseUrl: directoryUrl,
+    kind: 'directory-scene-json-url',
+  };
+  attempts.push({ step: 'directory-scene-json', reason: directorySceneResult.reason });
+
+  const currentResult = await tryFetchCurrentJson(directoryUrl, fetchImpl)
+    .catch((error) => ({ valid: false, reason: 'current-json-threw', error }));
+  if (currentResult.valid) return currentResult;
+  attempts.push({ step: 'current-json', reason: currentResult.reason });
+
+  if (directFetched.ok && looksLikeHtml(directFetched.text, directFetched.contentType)) {
+    const href = extractSceneSyncExportHref(directFetched.text);
+    if (href) {
+      const markerSceneUrl = new URL(href, directFetched.url).href;
+      const markerResult = await tryFetchSceneJson(markerSceneUrl, fetchImpl)
+        .catch((error) => ({ valid: false, reason: 'html-marker-scene-json-threw', error }));
+      if (markerResult.valid) return {
+        ...markerResult,
+        kind: 'html-marker-url',
+      };
+      attempts.push({ step: 'html-marker', reason: markerResult.reason });
+    }
+  }
+
+  return {
+    valid: false,
+    reason: 'not-scene-sync-export-url',
+    attempts,
+  };
+}

--- a/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.test.js
@@ -20,6 +20,18 @@ function sceneDocument(extra = {}) {
   };
 }
 
+async function bodyToText(body) {
+  if (body instanceof Blob) return await body.text();
+  return typeof body === 'string' ? body : JSON.stringify(body);
+}
+
+function bodyToBlob(body, contentType) {
+  if (body instanceof Blob) return body;
+  return new Blob([
+    typeof body === 'string' ? body : JSON.stringify(body),
+  ], { type: contentType });
+}
+
 function response({ url, body, contentType = 'application/json', ok = true, status = 200 }) {
   return {
     ok,
@@ -31,7 +43,13 @@ function response({ url, body, contentType = 'application/json', ok = true, stat
       },
     },
     async text() {
-      return typeof body === 'string' ? body : JSON.stringify(body);
+      return await bodyToText(body);
+    },
+    async blob() {
+      return bodyToBlob(body, contentType);
+    },
+    async arrayBuffer() {
+      return await bodyToBlob(body, contentType).arrayBuffer();
     },
   };
 }
@@ -51,6 +69,76 @@ function createFetch(routes) {
   return fetchImpl;
 }
 
+async function withFakeJSZip(scene, fn) {
+  const original = globalThis.JSZip;
+  globalThis.JSZip = {
+    async loadAsync() {
+      return {
+        file(path) {
+          if (path === 'scene.json') {
+            return {
+              async async(type) {
+                strictEqual(type, 'string');
+                return JSON.stringify(scene);
+              },
+            };
+          }
+          return null;
+        },
+      };
+    },
+  };
+
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete globalThis.JSZip;
+    } else {
+      globalThis.JSZip = original;
+    }
+  }
+}
+
+test('loads ZIP content from application/zip URLs without requiring a .zip extension', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/download?id=123': {
+      body: new Blob(['zip-like-bytes'], { type: 'application/zip' }),
+      contentType: 'application/zip',
+    },
+  });
+
+  await withFakeJSZip(sceneDocument({ objects: [{ ...sceneDocument().objects[0], id: 'zip-box' }] }), async () => {
+    const result = await loadExportPackageFromUrl('https://example.com/download?id=123', { fetchImpl });
+
+    strictEqual(result.valid, true);
+    strictEqual(result.kind, 'zip-url');
+    strictEqual(result.sourceUrl, 'https://example.com/download?id=123');
+    strictEqual(result.sceneDocument.objects[0].id, 'zip-box');
+    deepStrictEqual(fetchImpl.calls, ['https://example.com/download?id=123']);
+  });
+});
+
+test('loads octet-stream ZIP content when magic bytes start with PK', async () => {
+  const fetchImpl = createFetch({
+    'https://cdn.example.com/export/abc': {
+      body: new Blob([new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0])], {
+        type: 'application/octet-stream',
+      }),
+      contentType: 'application/octet-stream',
+    },
+  });
+
+  await withFakeJSZip(sceneDocument({ objects: [{ ...sceneDocument().objects[0], id: 'octet-zip-box' }] }), async () => {
+    const result = await loadExportPackageFromUrl('https://cdn.example.com/export/abc', { fetchImpl });
+
+    strictEqual(result.valid, true);
+    strictEqual(result.kind, 'zip-url');
+    strictEqual(result.sceneDocument.objects[0].id, 'octet-zip-box');
+    deepStrictEqual(fetchImpl.calls, ['https://cdn.example.com/export/abc']);
+  });
+});
+
 test('loads a direct scene.json URL', async () => {
   const fetchImpl = createFetch({
     'https://example.com/world/scene.json': { body: sceneDocument() },
@@ -62,6 +150,43 @@ test('loads a direct scene.json URL', async () => {
   strictEqual(result.kind, 'scene-json-url');
   strictEqual(result.baseUrl, 'https://example.com/world/');
   strictEqual(result.sceneDocument.objects[0].id, 'box-1');
+});
+
+test('marks explicit invalid scene.json URLs as blocking generic URL fallback', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/world/scene.json': {
+      body: {
+        format: 'not-scene-sync-export',
+        version: 2,
+        objects: [],
+      },
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/world/scene.json', { fetchImpl });
+
+  strictEqual(result.valid, false);
+  strictEqual(result.reason, 'invalid-scene-document');
+  strictEqual(result.shouldBlockGenericImport, true);
+  deepStrictEqual(fetchImpl.calls, ['https://example.com/world/scene.json']);
+});
+
+test('loads a direct current.json URL through versionPath', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/world/current.json': {
+      body: { versionPath: 'versions/v4/' },
+    },
+    'https://example.com/world/versions/v4/scene.json': {
+      body: sceneDocument({ objects: [{ ...sceneDocument().objects[0], id: 'box-4' }] }),
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/world/current.json', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.kind, 'current-json-url');
+  strictEqual(result.baseUrl, 'https://example.com/world/versions/v4/');
+  strictEqual(result.sceneDocument.objects[0].id, 'box-4');
 });
 
 test('loads a version directory URL by resolving ./scene.json', async () => {

--- a/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.test.js
@@ -1,0 +1,190 @@
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { loadExportPackageFromUrl } from './load-export-package-from-url.js';
+
+function sceneDocument(extra = {}) {
+  return {
+    format: 'scene-sync-export-scene',
+    version: 2,
+    objects: [
+      {
+        id: 'box-1',
+        name: 'Box',
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        asset: { type: 'primitive', primitive: 'box' },
+      },
+    ],
+    ...extra,
+  };
+}
+
+function response({ url, body, contentType = 'application/json', ok = true, status = 200 }) {
+  return {
+    ok,
+    status,
+    url,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === 'content-type' ? contentType : '';
+      },
+    },
+    async text() {
+      return typeof body === 'string' ? body : JSON.stringify(body);
+    },
+  };
+}
+
+function createFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    const href = String(url);
+    calls.push(href);
+    const route = routes[href];
+    if (!route) {
+      return response({ url: href, body: 'not found', ok: false, status: 404 });
+    }
+    return response({ url: href, ...route });
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+test('loads a direct scene.json URL', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/world/scene.json': { body: sceneDocument() },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/world/scene.json', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.kind, 'scene-json-url');
+  strictEqual(result.baseUrl, 'https://example.com/world/');
+  strictEqual(result.sceneDocument.objects[0].id, 'box-1');
+});
+
+test('loads a version directory URL by resolving ./scene.json', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/worlds/demo/versions/v1/': {
+      body: '<!doctype html><title>Demo</title>',
+      contentType: 'text/html',
+    },
+    'https://example.com/worlds/demo/versions/v1/scene.json': { body: sceneDocument() },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/worlds/demo/versions/v1/', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.kind, 'directory-scene-json-url');
+  strictEqual(result.baseUrl, 'https://example.com/worlds/demo/versions/v1/');
+});
+
+test('loads a stable world URL through current.json versionPath', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/worlds/demo/': {
+      body: '<!doctype html><title>Demo</title>',
+      contentType: 'text/html',
+    },
+    'https://example.com/worlds/demo/scene.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/worlds/demo/current.json': {
+      body: { versionPath: 'versions/v2/' },
+    },
+    'https://example.com/worlds/demo/versions/v2/scene.json': {
+      body: sceneDocument({ objects: [{ ...sceneDocument().objects[0], id: 'box-2' }] }),
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/worlds/demo/', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.kind, 'current-json-url');
+  strictEqual(result.baseUrl, 'https://example.com/worlds/demo/versions/v2/');
+  strictEqual(result.sceneDocument.objects[0].id, 'box-2');
+});
+
+test('loads a stable world URL through current.json versionId', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/worlds/demo/': {
+      body: '<!doctype html><title>Demo</title>',
+      contentType: 'text/html',
+    },
+    'https://example.com/worlds/demo/scene.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/worlds/demo/current.json': {
+      body: { versionId: 'v3' },
+    },
+    'https://example.com/worlds/demo/versions/v3/scene.json': {
+      body: sceneDocument(),
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/worlds/demo/', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.baseUrl, 'https://example.com/worlds/demo/versions/v3/');
+});
+
+test('loads HTML scene-sync-export marker without executing HTML', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/worlds/demo/index.html': {
+      body: '<!doctype html><link rel="scene-sync-export" href="./data/scene.json"><script>throw new Error("no")</script>',
+      contentType: 'text/html',
+    },
+    'https://example.com/worlds/demo/index.html/scene.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/worlds/demo/index.html/current.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/worlds/demo/data/scene.json': {
+      body: sceneDocument(),
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/worlds/demo/index.html', { fetchImpl });
+
+  strictEqual(result.valid, true);
+  strictEqual(result.kind, 'html-marker-url');
+  strictEqual(result.baseUrl, 'https://example.com/worlds/demo/data/');
+});
+
+test('returns invalid for non-SceneSync URLs so generic URL handling can continue', async () => {
+  const fetchImpl = createFetch({
+    'https://example.com/page/': {
+      body: '<!doctype html><title>Not Scene Sync</title>',
+      contentType: 'text/html',
+    },
+    'https://example.com/page/scene.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+    'https://example.com/page/current.json': {
+      body: 'not found',
+      ok: false,
+      status: 404,
+    },
+  });
+
+  const result = await loadExportPackageFromUrl('https://example.com/page/', { fetchImpl });
+
+  strictEqual(result.valid, false);
+  strictEqual(result.reason, 'not-scene-sync-export-url');
+  deepStrictEqual(fetchImpl.calls, [
+    'https://example.com/page/',
+    'https://example.com/page/scene.json',
+    'https://example.com/page/current.json',
+  ]);
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-url-assets.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-url-assets.js
@@ -1,0 +1,101 @@
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function resolveUrl(path, baseUrl) {
+  if (!path || typeof path !== 'string') return null;
+  try {
+    return new URL(path, baseUrl).href;
+  } catch {
+    return null;
+  }
+}
+
+function resolveAsset(asset, baseUrl) {
+  const next = cloneJson(asset);
+  if (!next || typeof next !== 'object') return next;
+
+  if (next.type === 'text' && next.source === 'inline') {
+    delete next.path;
+    return next;
+  }
+
+  if (next.path) {
+    const url = resolveUrl(next.path, baseUrl);
+    if (url) {
+      next.url = url;
+      next.source = 'url';
+    }
+    delete next.path;
+  }
+
+  return next;
+}
+
+function resolveAudioSources(audioSources, baseUrl) {
+  if (!audioSources || typeof audioSources !== 'object' || Array.isArray(audioSources)) {
+    return cloneJson(audioSources);
+  }
+
+  const resolved = {};
+  for (const [name, source] of Object.entries(audioSources)) {
+    const next = cloneJson(source);
+    if (!next || typeof next !== 'object') {
+      resolved[name] = next;
+      continue;
+    }
+
+    const assetPath = next.asset?.path;
+    if (assetPath) {
+      const url = resolveUrl(assetPath, baseUrl);
+      if (url) next.url = url;
+    }
+    if (next.asset) delete next.asset;
+    resolved[name] = next;
+  }
+  return resolved;
+}
+
+function resolveBgm(bgm, baseUrl) {
+  const next = cloneJson(bgm);
+  if (!next || typeof next !== 'object') return next;
+
+  const assetPath = next.asset?.path;
+  if (assetPath) {
+    const url = resolveUrl(assetPath, baseUrl);
+    if (url) next.url = url;
+  }
+  delete next.asset;
+  delete next.importAsset;
+  return next;
+}
+
+export function resolveSceneDocumentAssetsFromUrl(sceneDocument, { baseUrl } = {}) {
+  if (!baseUrl) {
+    return { document: cloneJson(sceneDocument) };
+  }
+
+  const objects = (sceneDocument.objects || []).map((obj) => {
+    const next = {
+      ...cloneJson(obj),
+      asset: resolveAsset(obj.asset, baseUrl),
+    };
+
+    delete next.importAsset;
+    delete next.importAudioSources;
+
+    if (obj.audioSources !== undefined) {
+      next.audioSources = resolveAudioSources(obj.audioSources, baseUrl);
+    }
+
+    return next;
+  });
+
+  return {
+    document: {
+      ...cloneJson(sceneDocument),
+      objects,
+      bgm: resolveBgm(sceneDocument.bgm, baseUrl),
+    },
+  };
+}

--- a/html/assets/js/scenesync/importers/scene-sync-export/resolve-url-assets.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/resolve-url-assets.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { resolveSceneDocumentAssetsFromUrl } from './resolve-url-assets.js';
+
+test('converts relative object and scene asset paths to URL-backed assets', () => {
+  const sceneDocument = {
+    format: 'scene-sync-export-scene',
+    version: 2,
+    objects: [
+      {
+        id: 'image-1',
+        asset: { type: 'image', source: 'blob', path: 'assets/poster.png', url: 'https://old.example/poster.png' },
+        audioSources: {
+          default: {
+            url: 'https://old.example/audio.mp3',
+            volume: 0.8,
+            asset: { path: 'assets/audio.mp3', mime: 'audio/mpeg' },
+          },
+        },
+        importAsset: { kind: 'blob-file', path: 'assets/poster.png' },
+        importAudioSources: {
+          default: { kind: 'blob-file', path: 'assets/audio.mp3' },
+        },
+      },
+      {
+        id: 'video-1',
+        asset: { type: 'video', path: './assets/movie.webm' },
+      },
+      {
+        id: 'text-1',
+        asset: { type: 'text', source: 'url', path: 'assets/story.md', format: 'markdown' },
+      },
+      {
+        id: 'mesh-1',
+        asset: { type: 'mesh', source: 'carrier', path: 'assets/model.glb' },
+      },
+      {
+        id: 'inline-1',
+        asset: { type: 'text', source: 'inline', path: 'assets/ignored.txt', text: 'Inline text' },
+      },
+    ],
+    bgm: {
+      url: 'https://old.example/bgm.mp3',
+      asset: { path: 'assets/bgm.mp3', mime: 'audio/mpeg' },
+      importAsset: { kind: 'blob-file', path: 'assets/bgm.mp3' },
+    },
+  };
+
+  const { document } = resolveSceneDocumentAssetsFromUrl(sceneDocument, {
+    baseUrl: 'https://example.com/worlds/demo/versions/v1/',
+  });
+
+  strictEqual(document.objects[0].asset.url, 'https://example.com/worlds/demo/versions/v1/assets/poster.png');
+  strictEqual(document.objects[0].asset.source, 'url');
+  strictEqual(document.objects[0].asset.path, undefined);
+  strictEqual(document.objects[0].importAsset, undefined);
+  strictEqual(document.objects[0].importAudioSources, undefined);
+  strictEqual(document.objects[0].audioSources.default.url, 'https://example.com/worlds/demo/versions/v1/assets/audio.mp3');
+  strictEqual(document.objects[0].audioSources.default.asset, undefined);
+
+  strictEqual(document.objects[1].asset.url, 'https://example.com/worlds/demo/versions/v1/assets/movie.webm');
+  strictEqual(document.objects[1].asset.path, undefined);
+  strictEqual(document.objects[2].asset.url, 'https://example.com/worlds/demo/versions/v1/assets/story.md');
+  strictEqual(document.objects[2].asset.source, 'url');
+  strictEqual(document.objects[2].asset.path, undefined);
+  strictEqual(document.objects[3].asset.url, 'https://example.com/worlds/demo/versions/v1/assets/model.glb');
+  strictEqual(document.objects[3].asset.source, 'url');
+  strictEqual(document.objects[3].asset.path, undefined);
+
+  strictEqual(document.objects[4].asset.source, 'inline');
+  strictEqual(document.objects[4].asset.text, 'Inline text');
+  strictEqual(document.objects[4].asset.path, undefined);
+
+  strictEqual(document.bgm.url, 'https://example.com/worlds/demo/versions/v1/assets/bgm.mp3');
+  strictEqual(document.bgm.asset, undefined);
+  strictEqual(document.bgm.importAsset, undefined);
+  strictEqual(JSON.stringify(document).includes('"path"'), false);
+  strictEqual(JSON.stringify(document).includes('"asset":{"path"'), false);
+});
+
+test('preserves already URL-backed assets when no path is present', () => {
+  const sceneDocument = {
+    format: 'scene-sync-export-scene',
+    version: 2,
+    objects: [
+      {
+        id: 'image-1',
+        asset: { type: 'image', source: 'url', url: 'https://cdn.example/poster.png' },
+      },
+    ],
+  };
+
+  const { document } = resolveSceneDocumentAssetsFromUrl(sceneDocument, {
+    baseUrl: 'https://example.com/worlds/demo/versions/v1/',
+  });
+
+  deepStrictEqual(document.objects[0].asset, sceneDocument.objects[0].asset);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -10,7 +10,7 @@ import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFa
 import { createThreeApp } from './core/three-app.js';
 import { createEnvironmentManager } from './core/environment.js';
 import { DragDropManager, SKY_DROP_UPNESS_THRESHOLD } from './components/drag-drop-manager.js';
-import { tryOpenSceneSyncExportFile } from './importers/scene-sync-export/index.js';
+import { tryOpenSceneSyncExportFile, tryOpenSceneSyncExportUrl } from './importers/scene-sync-export/index.js';
 import { ClipboardImportManager } from './components/clipboard-import-manager.js';
 import { parseLoomletGraphClipboardText } from './components/loomlet-graph-clipboard.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
@@ -9470,6 +9470,20 @@ async function urlImporterCallback(url, position, context = {}) {
   const classified = classifyUrl(resolved.resolvedUrl);
   const normalizedUrl = classified.url || resolved.resolvedUrl;
   const urlKind = classified.kind;
+
+  if (urlKind === URL_KIND.WEBPAGE) {
+    const sceneSyncExportResult = await tryOpenSceneSyncExportUrl(normalizedUrl, {
+      managedObjects,
+      addOrUpdateObject,
+      broadcast,
+      showToast,
+      environmentManager,
+      importGlbFileAsSceneObject,
+      uploadBlobToStore,
+      applySceneBgm,
+    });
+    if (sceneSyncExportResult?.handled) return;
+  }
 
   // Skybox intent takes priority for image URLs when looking up.
   const isImageUrl = urlKind === URL_KIND.IMAGE;


### PR DESCRIPTION
## Summary

- Detect Scene Sync Export URLs in the existing URL drag/drop and paste flow before generic URL asset handling.
- Add content-based URL loading for ZIP URLs, direct `scene.json`, version directories, stable world directories via `current.json`, and optional non-executed HTML markers.
- Resolve published relative asset paths into URL-backed object assets, audio sources, and BGM without uploading those assets to the Scene Sync blob store.
- Keep non-SceneSync URLs falling through to the existing image/video/text/GLB URL handling.

## Validation

- `node --check html/assets/js/scenesync/importers/scene-sync-export/load-export-package-from-url.js`
- `node --check html/assets/js/scenesync/importers/scene-sync-export/resolve-url-assets.js`
- `node --check html/assets/js/scenesync/importers/scene-sync-export/index.js`
- `node --check html/assets/js/scenesync/scene.js`
- `npm run test:scene-sync-export-import`
- `npm run test:e2e:scene-sync-export-import`

Also checked that GitHub Pages serves the template catalog with `access-control-allow-origin: *`, so browser `fetch()` can read published Scene Sync template files cross-origin.