### PR TITLE
[codex] Integrate Scene Sync physics playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Unity Editor / Unity Runtime / Godot 4.x / Web ブラウザ間で 3D シーン�
 - **編集ロック**: オブジェクト選択時に自動ロック。他クライアントはバウンディングボックス + ラベルで視覚表示
 - **参加者一覧**: 接続中のクライアント名・編集中オブジェクトをリアルタイム表示
 - **モバイル対応**: iPhone Safari タッチ操作（ダブルタップ選択、スワイプカメラ）対応
+- **Physics**: Scene Clock / Player UI の時刻を入力にした deterministic physics。現在は並進のみ、sphere / AABB box / ground をサポート
 - **Unity パッケージ**: `com.afjk.scene-sync`（upm.afjk.jp）で配布。Editor 拡張と Runtime（MonoBehaviour）の両方を提供
 - **Godot addon**: `godot/addons/scene_sync`。Editor Dock と Runtime `SceneSyncManager` ノードを提供
 

--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -132,6 +132,36 @@ canonical なコマンド payload は raw int(`body`(raw record) / `impulseFp` /
 `stateHash()` は world 設定(gravity / timestep / ground)も hash に含めるため、
 `physics-start` の `worldOptions` が一致しないクライアントは即座にハッシュ不一致として検出される。
 
+## Scene Sync 組み込み
+
+Web 版 Scene Sync では、まず object component と Export/Import 対応として physics を組み込む。
+
+- object state: `objects.<id>.physics`
+- scene state / SceneDocument root: `physics`
+- Editor 再生: 既存の Scene Clock / Player UI が供給する `time.t` を入力にして評価する
+- seek / pause / reset: 物理 world を初期 snapshot から対象 tick まで再計算する
+- Export Viewer: `scene.json` の `physics` と object physics を読み込み、静的 Viewer 内の最小 Player UI で再生する
+
+現在の object physics は以下の形を想定する。
+
+```json
+{
+  "enabled": true,
+  "bodyType": "dynamic",
+  "shape": "sphere",
+  "mass": 1,
+  "restitution": 0.2,
+  "friction": 0.5,
+  "velocity": [0, 0, 0]
+}
+```
+
+`bodyType` は `dynamic` / `static`、`shape` は `sphere` / `box`。
+`radius` / `halfExtents` が省略された場合は Scene object の scale から推定する。
+
+Editor の通常表示中は host-follow の wall-clock 秒を物理に直接使わない。
+Player transport が local timeline を所有している間だけ、Scene Clock の `t` から物理 tick を計算する。
+
 ## broadcast メッセージ(案)
 
 Scene Sync の broadcast に以下の kind を載せる。シミュレーションは tick のみに依存するため、`hostTime` はペーシング(進行速度合わせ)にだけ使い、結果には影響しない。

--- a/docs/scene-sync-runtime-time-model.md
+++ b/docs/scene-sync-runtime-time-model.md
@@ -174,7 +174,8 @@ Touch / click / grab / trigger などの event は、発生時刻を environment
 - runtime / animation / Loomlet graph を `enabled = false` にしない
 - GLB animation は `mixer.update(delta)` だけに依存しない
 - GLB animation と Loomlet object graph は同じ runtime time model を使う
-- 将来の particles / physics / scripts / sounds も同じ `f(t)` モデルに乗せる
+- physics は Scene Clock / Player UI が供給する `time.t` を入力にし、seek 時は初期 snapshot から対象 tick まで再計算する
+- 将来の particles / scripts / sounds も同じ `f(t)` モデルに乗せる
 - 同期が必要な animation / behavior は、必要に応じて host-provided time 基準で評価する
 
 ---

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -10,6 +10,11 @@ export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync-export/viewer/object-audio-controller.js', dest: 'viewer/object-audio-controller.js' },
   { src: '/assets/js/scenesync-export/viewer/static-asset-resolver.js', dest: 'viewer/static-asset-resolver.js' },
   { src: '/assets/js/scenesync-export/viewer/scene-document.js', dest: 'viewer/scene-document.js' },
+  { src: '/assets/js/scenesync/scene-physics.js', dest: 'viewer/scene-physics.js' },
+  { src: '/assets/js/scenesync/physics/fixed.js', dest: 'viewer/physics/fixed.js' },
+  { src: '/assets/js/scenesync/physics/world.js', dest: 'viewer/physics/world.js' },
+  { src: '/assets/js/scenesync/physics/lockstep.js', dest: 'viewer/physics/lockstep.js' },
+  { src: '/assets/js/scenesync/physics/index.js', dest: 'viewer/physics/index.js' },
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },
   // Pinned Loomlet behavior graph runtime. Exported viewers must not depend on afjk.jp at runtime.
   {
@@ -134,6 +139,7 @@ export async function buildExportPackage({
   envOrigin = location.origin,
   assetCache = null,
   behaviorState = null,
+  physicsState = null,
 }) {
   // 1. Build SceneDocument from current state
   let sceneDocument;
@@ -143,6 +149,7 @@ export async function buildExportPackage({
       bgmState,
       envId,
       behaviorState,
+      physicsState,
     });
   } catch (err) {
     throw new Error(`SceneDocument generation failed: ${err.message}`);

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -174,6 +174,7 @@ export function createSceneDocumentFromSceneSyncState({
   bgmState,
   envId,
   behaviorState = null,
+  physicsState = null,
 }) {
   if (!(managedObjects instanceof Map)) {
     throw new Error('managedObjects must be a Map');
@@ -218,6 +219,11 @@ export function createSceneDocumentFromSceneSyncState({
       docObj.audioSources = audioSources;
     }
 
+    const physics = clonePlainObject(obj.userData?.physics);
+    if (physics) {
+      docObj.physics = physics;
+    }
+
     objects.push(docObj);
   }
 
@@ -233,6 +239,11 @@ export function createSceneDocumentFromSceneSyncState({
 
   if (behaviorState) {
     doc.behaviors = JSON.parse(JSON.stringify(behaviorState));
+  }
+
+  const physics = clonePlainObject(physicsState);
+  if (physics?.enabled) {
+    doc.physics = physics;
   }
 
   return doc;

--- a/html/assets/js/scenesync-export/export/export-scene-document.test.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSceneDocumentFromSceneSyncState } from './export-scene-document.js';
+
+function vec(values) {
+  return { toArray: () => [...values] };
+}
+
+test('exports scene and object physics state', () => {
+  const managedObjects = new Map([
+    ['ball', {
+      name: 'Ball',
+      visible: true,
+      position: vec([0, 2, 0]),
+      quaternion: vec([0, 0, 0, 1]),
+      scale: vec([1, 1, 1]),
+      userData: {
+        name: 'Ball',
+        asset: {
+          type: 'primitive',
+          primitive: 'sphere',
+          color: '#44aaff',
+        },
+        physics: {
+          enabled: true,
+          bodyType: 'dynamic',
+          shape: 'sphere',
+          mass: 1,
+          restitution: 0.4,
+          friction: 0.5,
+          velocity: [0, 0, 0],
+        },
+      },
+    }],
+  ]);
+
+  const physicsState = {
+    version: 1,
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+      timestepFp: 1092,
+    },
+  };
+
+  const doc = createSceneDocumentFromSceneSyncState({
+    managedObjects,
+    physicsState,
+  });
+
+  assert.deepEqual(doc.physics, physicsState);
+  assert.equal(doc.objects.length, 1);
+  assert.deepEqual(doc.objects[0].physics, managedObjects.get('ball').userData.physics);
+});

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -6,6 +6,10 @@ import { isValidSceneDocument } from './scene-document.js';
 import { createStaticAssetResolver } from './static-asset-resolver.js';
 import { createSceneSyncRuntime } from './loomlet/loomlet-scenesync-runtime.browser.js';
 import { createObjectAudioController } from './object-audio-controller.js';
+import {
+  createScenePhysicsRuntime,
+  normalizeScenePhysics,
+} from './scene-physics.js';
 
 const DRACO_DECODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/libs/draco/gltf/';
 
@@ -229,6 +233,14 @@ function applyTransform(obj, entry) {
   }
 }
 
+function registerViewerObject(objectMap, entry, object) {
+  object.userData.objectId = entry.id;
+  if (entry.physics && typeof entry.physics === 'object') {
+    object.userData.physics = cloneJson(entry.physics);
+  }
+  objectMap.set(entry.id, object);
+}
+
 function resolveAnimationClip(clips, animState) {
   const clipName = typeof animState?.clipName === 'string' ? animState.clipName.trim() : '';
   if (clipName) {
@@ -406,9 +418,8 @@ export async function createViewerCore({
     if (!assetDef || assetDef.type === 'primitive') {
       const mesh = buildPrimitive(assetDef || {});
       applyTransform(mesh, entry);
-      mesh.userData.objectId = entry.id;
       scene.add(mesh);
-      objectMap.set(entry.id, mesh);
+      registerViewerObject(objectMap, entry, mesh);
     } else if (assetDef.type === 'image') {
       const assetPath = resolver.resolveAsset(assetDef);
       if (!assetPath) {
@@ -435,9 +446,8 @@ export async function createViewerCore({
         const group = new THREE.Group();
         group.add(mesh);
         applyTransform(group, entry);
-        group.userData.objectId = entry.id;
         scene.add(group);
-        objectMap.set(entry.id, group);
+        registerViewerObject(objectMap, entry, group);
       } catch {
         onMissingAsset?.({ id: entry.id, kind: 'image', path: assetPath });
       }
@@ -481,9 +491,8 @@ export async function createViewerCore({
         const group = new THREE.Group();
         group.add(mesh);
         applyTransform(group, entry);
-        group.userData.objectId = entry.id;
         scene.add(group);
-        objectMap.set(entry.id, group);
+        registerViewerObject(objectMap, entry, group);
 
         video.autoplay = true;
         video.play().catch(() => {});
@@ -513,9 +522,8 @@ export async function createViewerCore({
       const group = new THREE.Group();
       group.add(mesh);
       applyTransform(group, entry);
-      group.userData.objectId = entry.id;
       scene.add(group);
-      objectMap.set(entry.id, group);
+      registerViewerObject(objectMap, entry, group);
     } else {
       const assetPath = resolver.resolveAsset(assetDef);
       if (!assetPath) {
@@ -535,9 +543,8 @@ export async function createViewerCore({
         const wrapper = new THREE.Group();
         wrapper.add(gltf.scene);
         applyTransform(wrapper, entry);
-        wrapper.userData.objectId = entry.id;
         scene.add(wrapper);
-        objectMap.set(entry.id, wrapper);
+        registerViewerObject(objectMap, entry, wrapper);
 
         if (Array.isArray(gltf.animations) && gltf.animations.length > 0) {
           const mixer = new THREE.AnimationMixer(wrapper);
@@ -583,16 +590,95 @@ export async function createViewerCore({
     loomAdapter = createExportBehaviorRuntime(sceneDoc.behaviors, objectMap, objectAudioController);
   }
 
+  const physicsState = normalizeScenePhysics(sceneDoc.physics);
+  const physicsPlayback = {
+    time: 0,
+    playing: false,
+    lastNow: performance.now(),
+    duration: physicsState.enabled ? physicsState.duration : 0,
+  };
+  const physicsRuntime = createScenePhysicsRuntime({
+    getScenePhysics: () => physicsState,
+    getObjectEntries: () => (sceneDoc.objects || []).map((entry) => ({
+      objectId: entry.id,
+      object: objectMap.get(entry.id),
+      physics: entry.physics,
+    })),
+    isClockActive: () => true,
+  });
+
+  function tickPhysicsPlayback(now = performance.now()) {
+    if (!physicsState.enabled) return;
+    if (physicsPlayback.playing) {
+      const delta = Math.max(0, (now - physicsPlayback.lastNow) / 1000);
+      physicsPlayback.time += delta;
+      if (physicsPlayback.duration > 0 && physicsPlayback.time > physicsPlayback.duration) {
+        physicsPlayback.time = physicsPlayback.duration;
+        physicsPlayback.playing = false;
+      }
+    }
+    physicsPlayback.lastNow = now;
+    physicsRuntime.update({
+      t: physicsPlayback.time,
+      mode: 'local',
+      transportActive: true,
+      isPaused: !physicsPlayback.playing,
+      rate: 1,
+    });
+  }
+
   const api = {
     update() {
       const delta = clock.getDelta();
       for (const m of mixers) m.update(delta);
 
       const now = performance.now();
+      tickPhysicsPlayback(now);
       if (loomAdapter) {
         loomAdapter.tick(now);
       }
       objectAudioController.tick(now);
+    },
+
+    hasPhysics() {
+      return physicsState.enabled && physicsRuntime.hasBodies();
+    },
+
+    getPhysicsPlaybackState() {
+      return {
+        time: physicsPlayback.time,
+        duration: physicsPlayback.duration,
+        playing: physicsPlayback.playing,
+      };
+    },
+
+    playPhysics() {
+      if (!physicsState.enabled) return;
+      if (physicsPlayback.duration > 0 && physicsPlayback.time >= physicsPlayback.duration) {
+        physicsPlayback.time = 0;
+        physicsRuntime.markDirty();
+      }
+      physicsPlayback.playing = true;
+      physicsPlayback.lastNow = performance.now();
+    },
+
+    pausePhysics() {
+      physicsPlayback.playing = false;
+      physicsPlayback.lastNow = performance.now();
+    },
+
+    resetPhysics() {
+      physicsPlayback.time = 0;
+      physicsPlayback.playing = false;
+      physicsPlayback.lastNow = performance.now();
+      physicsRuntime.markDirty();
+      tickPhysicsPlayback(physicsPlayback.lastNow);
+    },
+
+    seekPhysics(time) {
+      physicsPlayback.time = Math.max(0, Math.min(Number(time) || 0, physicsPlayback.duration || Number.MAX_SAFE_INTEGER));
+      physicsPlayback.lastNow = performance.now();
+      tickPhysicsPlayback(physicsPlayback.lastNow);
     },
 
     getBgmAudio() {
@@ -636,6 +722,7 @@ export async function createViewerCore({
       bgmAudio?.pause();
       objectAudioController.dispose();
       loomAdapter?.dispose?.();
+      physicsRuntime.dispose();
     },
   };
 

--- a/html/assets/js/scenesync-export/viewer/scene-physics.js
+++ b/html/assets/js/scenesync-export/viewer/scene-physics.js
@@ -1,0 +1,1 @@
+export * from '../../scenesync/scene-physics.js';

--- a/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
+++ b/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
@@ -161,6 +161,67 @@ async function main() {
     controlsEl.appendChild(enableBtn);
   }
 
+  let updatePhysicsControls = null;
+  if (viewerCore.hasPhysics?.() && controlsEl) {
+    const physicsGroup = document.createElement('div');
+    physicsGroup.className = 'viewer-transport';
+
+    const playBtn = document.createElement('button');
+    playBtn.className = 'viewer-btn';
+    playBtn.textContent = 'Play Physics';
+
+    const resetBtn = document.createElement('button');
+    resetBtn.className = 'viewer-btn';
+    resetBtn.textContent = 'Reset';
+
+    const seek = document.createElement('input');
+    seek.className = 'viewer-range';
+    seek.type = 'range';
+    seek.min = '0';
+    seek.step = '0.01';
+    seek.value = '0';
+
+    const timeLabel = document.createElement('span');
+    timeLabel.className = 'viewer-time-label';
+    timeLabel.textContent = '0.00s';
+
+    physicsGroup.append(playBtn, resetBtn, seek, timeLabel);
+    controlsEl.appendChild(physicsGroup);
+
+    playBtn.addEventListener('click', () => {
+      const state = viewerCore.getPhysicsPlaybackState?.();
+      if (state?.playing) {
+        viewerCore.pausePhysics?.();
+      } else {
+        viewerCore.playPhysics?.();
+      }
+      updatePhysicsControls?.();
+    });
+
+    resetBtn.addEventListener('click', () => {
+      viewerCore.resetPhysics?.();
+      updatePhysicsControls?.();
+    });
+
+    seek.addEventListener('input', () => {
+      viewerCore.seekPhysics?.(Number(seek.value));
+      updatePhysicsControls?.();
+    });
+
+    updatePhysicsControls = () => {
+      const state = viewerCore.getPhysicsPlaybackState?.();
+      if (!state) return;
+      playBtn.textContent = state.playing ? 'Pause Physics' : 'Play Physics';
+      const duration = Number.isFinite(state.duration) && state.duration > 0 ? state.duration : 10;
+      seek.max = String(duration);
+      if (document.activeElement !== seek) {
+        seek.value = String(Math.max(0, Math.min(duration, state.time || 0)));
+      }
+      timeLabel.textContent = `${(state.time || 0).toFixed(2)}s`;
+    };
+    updatePhysicsControls();
+  }
+
   // Immersive entry button
   if (navigator.xr && controlsEl) {
     for (const mode of ['immersive-vr', 'immersive-ar']) {
@@ -196,6 +257,7 @@ async function main() {
   // Render loop
   renderer.setAnimationLoop(() => {
     viewerCore.update();
+    updatePhysicsControls?.();
     controls.update();
     renderer.render(scene, camera);
   });

--- a/html/assets/js/scenesync-export/viewer/viewer.css
+++ b/html/assets/js/scenesync-export/viewer/viewer.css
@@ -107,6 +107,36 @@ body {
   cursor: default;
 }
 
+.viewer-transport {
+  width: min(320px, calc(100vw - 32px));
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(30, 30, 40, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+}
+
+.viewer-transport .viewer-btn {
+  white-space: nowrap;
+  border-radius: 6px;
+  padding: 7px 10px;
+}
+
+.viewer-range {
+  width: 100%;
+  min-width: 72px;
+}
+
+.viewer-time-label {
+  color: rgba(255, 255, 255, 0.76);
+  font: 12px/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: nowrap;
+}
+
 /* ── Missing assets notice ── */
 #missing-notice {
   position: absolute;

--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -90,7 +90,24 @@ export class HistoryManager {
     };
   }
 
-  static createRemoveEntry(objectId, name, asset, position, rotation, scale) {
+  static createRemoveEntry(objectId, name, asset, position, rotation, scale, extra = {}) {
+    const backward = {
+      kind: 'scene-add',
+      objectId,
+      name,
+      position,
+      rotation,
+      scale,
+      asset,
+    };
+
+    if (extra.physics !== undefined) {
+      backward.physics = extra.physics;
+    }
+    if (extra.audioSources !== undefined) {
+      backward.audioSources = extra.audioSources;
+    }
+
     return {
       id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       timestamp: Date.now(),
@@ -99,15 +116,7 @@ export class HistoryManager {
         kind: 'scene-remove',
         objectId,
       },
-      backward: {
-        kind: 'scene-add',
-        objectId,
-        name,
-        position,
-        rotation,
-        scale,
-        asset,
-      },
+      backward,
     };
   }
 

--- a/html/assets/js/scenesync/history/history-manager.test.js
+++ b/html/assets/js/scenesync/history/history-manager.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { HistoryManager } from './history-manager.js';
+
+test('remove history restores object physics and audio sources on undo', () => {
+  const physics = {
+    version: 1,
+    enabled: true,
+    bodyType: 'dynamic',
+    shape: 'sphere',
+    mass: 1,
+    restitution: 0.4,
+    friction: 0.5,
+    velocity: [0, 0, 0],
+  };
+  const audioSources = {
+    default: {
+      type: 'audioSource',
+      name: 'default',
+      url: 'https://example.com/sound.mp3',
+    },
+  };
+
+  const entry = HistoryManager.createRemoveEntry(
+    'ball',
+    'Ball',
+    { type: 'primitive', primitive: 'sphere' },
+    [0, 2, 0],
+    [0, 0, 0, 1],
+    [1, 1, 1],
+    { physics, audioSources },
+  );
+
+  assert.deepEqual(entry.forward, {
+    kind: 'scene-remove',
+    objectId: 'ball',
+  });
+  assert.equal(entry.backward.kind, 'scene-add');
+  assert.deepEqual(entry.backward.physics, physics);
+  assert.deepEqual(entry.backward.audioSources, audioSources);
+});
+
+test('remove history omits optional restore fields when they are not provided', () => {
+  const entry = HistoryManager.createRemoveEntry(
+    'box',
+    'Box',
+    { type: 'primitive', primitive: 'box' },
+    [0, 0, 0],
+    [0, 0, 0, 1],
+    [1, 1, 1],
+  );
+
+  assert.equal(Object.prototype.hasOwnProperty.call(entry.backward, 'physics'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(entry.backward, 'audioSources'), false);
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-document.js
@@ -241,6 +241,7 @@ export async function applySceneDocument(sceneDocument, {
           metadata: prepared.metadata,
           animation: obj.animation,
           audioSources: prepared.audioSources,
+          physics: obj.physics,
           selectAfterLoad: false,
           source: 'scene-sync-export-import',
         });
@@ -275,6 +276,7 @@ export async function applySceneDocument(sceneDocument, {
     if (prepared.metadata) payload.metadata = prepared.metadata;
     if (obj.animation) payload.animation = obj.animation;
     if (prepared.audioSources) payload.audioSources = prepared.audioSources;
+    if (obj.physics) payload.physics = obj.physics;
 
     addOrUpdateObject(obj.id, payload, { source: 'scene-sync-export-import' });
     broadcast(payload);

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js
@@ -21,6 +21,7 @@ export async function applySceneDocumentSettings(sceneDocument, {
   environmentManager,
   broadcast,
   applySceneBgm,
+  applyScenePhysics,
   zip,
   uploadBlobToStore,
 } = {}) {
@@ -64,6 +65,18 @@ export async function applySceneDocumentSettings(sceneDocument, {
       result.bgmApplied = false;
       result.bgmSkipped = true;
     }
+  }
+
+  if (sceneDocument?.physics && typeof sceneDocument.physics === 'object') {
+    const appliedPhysics = applyScenePhysics?.(sceneDocument.physics, {
+      source: 'scene-sync-export-import',
+      notify: true,
+    });
+    broadcast?.({
+      kind: 'scene-physics',
+      physics: appliedPhysics || sceneDocument.physics,
+    });
+    result.physicsApplied = true;
   }
 
   return result;

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.test.js
@@ -92,6 +92,44 @@ test('applies BGM from ZIP-bundled asset via shared Scene Sync URL', async () =>
   });
 });
 
+test('applies scene physics settings and broadcasts scene-physics', async () => {
+  const calls = { physics: [], broadcast: [] };
+  const physics = {
+    version: 1,
+    enabled: true,
+    duration: 8,
+    worldOptions: {
+      gravity: -9.81,
+      ground: { y: 0, restitution: 0.2, friction: 0.5 },
+      timestepFp: 1092,
+    },
+  };
+
+  const result = await applySceneDocumentSettings({ physics }, {
+    applyScenePhysics: (next, options) => {
+      calls.physics.push({ next, options });
+      return { ...next, applied: true };
+    },
+    broadcast: (payload) => calls.broadcast.push(payload),
+  });
+
+  deepStrictEqual(result, {
+    envApplied: false,
+    physicsApplied: true,
+  });
+  deepStrictEqual(calls.physics[0], {
+    next: physics,
+    options: {
+      source: 'scene-sync-export-import',
+      notify: true,
+    },
+  });
+  deepStrictEqual(calls.broadcast[0], {
+    kind: 'scene-physics',
+    physics: { ...physics, applied: true },
+  });
+});
+
 test('does nothing when skybox is absent (keeps current environment)', async () => {
   const calls = { loadEnvironment: [], broadcast: [] };
   const environmentManager = {

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -170,6 +170,7 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     importGlbFileAsSceneObject,
     uploadBlobToStore,
     applySceneBgm,
+    applyScenePhysics,
   } = context;
 
   const result = await loadExportPackageFromBlob(file);
@@ -239,6 +240,7 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
       environmentManager,
       broadcast,
       applySceneBgm,
+      applyScenePhysics,
       zip: result.zip,
       uploadBlobToStore,
     });
@@ -265,6 +267,7 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
     importGlbFileAsSceneObject,
     uploadBlobToStore,
     applySceneBgm,
+    applyScenePhysics,
     fetchImpl,
   } = context;
 
@@ -338,6 +341,7 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
       environmentManager,
       broadcast,
       applySceneBgm,
+      applyScenePhysics,
       zip: result.zip,
       uploadBlobToStore,
     });

--- a/html/assets/js/scenesync/runtime/playback-duration.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.js
@@ -57,6 +57,7 @@ export function calculateAnimationEntryPlaybackDuration(entry) {
 
 export function calculateScenePlaybackDuration({
   animationEntries = [],
+  physicsDuration = 0,
   defaultDuration = DEFAULT_SCENE_PLAYBACK_DURATION,
 } = {}) {
   let duration = isPositiveFiniteNumber(defaultDuration)
@@ -65,6 +66,9 @@ export function calculateScenePlaybackDuration({
 
   for (const entry of animationEntries) {
     duration = Math.max(duration, calculateAnimationEntryPlaybackDuration(entry));
+  }
+  if (isPositiveFiniteNumber(physicsDuration)) {
+    duration = Math.max(duration, physicsDuration);
   }
 
   return Math.ceil(duration * 100) / 100;

--- a/html/assets/js/scenesync/runtime/playback-duration.test.js
+++ b/html/assets/js/scenesync/runtime/playback-duration.test.js
@@ -97,3 +97,11 @@ test('ignores disabled animation entries', () => {
 
   assert.equal(duration, 60);
 });
+
+test('extends duration for physics playback', () => {
+  const duration = calculateScenePlaybackDuration({
+    physicsDuration: 75.234,
+  });
+
+  assert.equal(duration, 75.24);
+});

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -282,9 +282,17 @@ export function createScenePhysicsRuntime({
   }
 
   function resetToInitialPose() {
-    if (!world || !initialSnapshot) return;
+    if (!world || !initialSnapshot) return false;
     world.restore(initialSnapshot);
     applyWorldToObjects();
+    return true;
+  }
+
+  function resetActiveToInitialPose() {
+    if (!active) return false;
+    const reset = resetToInitialPose();
+    if (reset) active = false;
+    return reset;
   }
 
   function update(clockState = null) {
@@ -295,12 +303,7 @@ export function createScenePhysicsRuntime({
     }
 
     if (!isClockActive(clockState)) {
-      let reset = false;
-      if (active) {
-        resetToInitialPose();
-        reset = true;
-      }
-      active = false;
+      const reset = resetActiveToInitialPose();
       return { active: false, reason: 'clock-inactive', reset };
     }
 
@@ -326,6 +329,7 @@ export function createScenePhysicsRuntime({
     rebuild,
     update,
     resetToInitialPose,
+    resetActiveToInitialPose,
     hasBodies() {
       if (dirty || !world) {
         return collectRuntimeEntries(getObjectEntries?.()).length > 0;

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -1,0 +1,339 @@
+import { createWorld, DEFAULT_TIMESTEP_FP } from './physics/index.js';
+
+export const DEFAULT_SCENE_PHYSICS_DURATION = 10;
+export const DEFAULT_SCENE_PHYSICS = Object.freeze({
+  version: 1,
+  enabled: false,
+  duration: DEFAULT_SCENE_PHYSICS_DURATION,
+  worldOptions: {
+    gravity: -9.81,
+    ground: {
+      y: 0,
+      restitution: 0.2,
+      friction: 0.5,
+    },
+    timestepFp: DEFAULT_TIMESTEP_FP,
+  },
+});
+
+const BODY_TYPES = new Set(['dynamic', 'static']);
+const SHAPES = new Set(['box', 'sphere']);
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function clampNumber(value, min, max, fallback = min) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return Math.max(min, Math.min(max, fallback));
+  return Math.max(min, Math.min(max, number));
+}
+
+function readVec3(value, fallback = [0, 0, 0]) {
+  if (!Array.isArray(value) || value.length < 3) return [...fallback];
+  return [
+    finiteNumber(value[0], fallback[0] || 0),
+    finiteNumber(value[1], fallback[1] || 0),
+    finiteNumber(value[2], fallback[2] || 0),
+  ];
+}
+
+function readPositiveVec3(value, fallback) {
+  const next = readVec3(value, fallback);
+  return next.map((component, index) => positiveNumber(component, fallback[index] || 0.5));
+}
+
+function normalizeGround(input) {
+  if (input === null || input === false) return null;
+  const source = input && typeof input === 'object'
+    ? input
+    : DEFAULT_SCENE_PHYSICS.worldOptions.ground;
+  return {
+    y: finiteNumber(source.y, DEFAULT_SCENE_PHYSICS.worldOptions.ground.y),
+    restitution: clampNumber(
+      source.restitution,
+      0,
+      1,
+      DEFAULT_SCENE_PHYSICS.worldOptions.ground.restitution,
+    ),
+    friction: clampNumber(
+      source.friction,
+      0,
+      1,
+      DEFAULT_SCENE_PHYSICS.worldOptions.ground.friction,
+    ),
+  };
+}
+
+function normalizeWorldOptions(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  const gravity = Array.isArray(source.gravity)
+    ? readVec3(source.gravity, [0, -9.81, 0])
+    : finiteNumber(source.gravity, DEFAULT_SCENE_PHYSICS.worldOptions.gravity);
+
+  return {
+    gravity,
+    ground: normalizeGround(source.ground),
+    timestepFp: Number.isInteger(source.timestepFp) && source.timestepFp > 0
+      ? source.timestepFp
+      : DEFAULT_TIMESTEP_FP,
+  };
+}
+
+export function normalizeScenePhysics(input = null) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    version: 1,
+    enabled: source.enabled === true,
+    duration: positiveNumber(source.duration, DEFAULT_SCENE_PHYSICS_DURATION),
+    worldOptions: normalizeWorldOptions(source.worldOptions || source),
+  };
+}
+
+export function normalizeObjectPhysics(input = null) {
+  if (!input || typeof input !== 'object' || input.enabled === false) return null;
+
+  const bodyType = BODY_TYPES.has(input.bodyType)
+    ? input.bodyType
+    : (input.static === true ? 'static' : 'dynamic');
+  const shape = SHAPES.has(input.shape) ? input.shape : 'box';
+
+  const physics = {
+    version: 1,
+    enabled: true,
+    bodyType,
+    shape,
+    mass: bodyType === 'static' ? 0 : positiveNumber(input.mass, 1),
+    restitution: clampNumber(input.restitution, 0, 1, 0.2),
+    friction: clampNumber(input.friction, 0, 1, 0.5),
+  };
+
+  if (Array.isArray(input.velocity)) {
+    physics.velocity = readVec3(input.velocity);
+  } else if (bodyType === 'dynamic') {
+    physics.velocity = [0, 0, 0];
+  }
+
+  if (shape === 'sphere' && Number.isFinite(Number(input.radius))) {
+    physics.radius = positiveNumber(input.radius, 0.5);
+  }
+  if (shape === 'box' && Array.isArray(input.halfExtents)) {
+    physics.halfExtents = readPositiveVec3(input.halfExtents, [0.5, 0.5, 0.5]);
+  }
+
+  return physics;
+}
+
+export function serializeScenePhysics(input = null) {
+  const physics = normalizeScenePhysics(input);
+  if (!physics.enabled) return null;
+  return cloneJson(physics);
+}
+
+export function serializeObjectPhysics(input = null) {
+  const physics = normalizeObjectPhysics(input);
+  return physics ? cloneJson(physics) : null;
+}
+
+function getPositionArray(object) {
+  if (typeof object?.position?.toArray === 'function') return object.position.toArray();
+  return readVec3(object?.position);
+}
+
+function getScaleArray(object) {
+  if (typeof object?.scale?.toArray === 'function') return object.scale.toArray();
+  return readVec3(object?.scale, [1, 1, 1]);
+}
+
+function inferShape(physics, object) {
+  if (physics?.shape === 'sphere') return 'sphere';
+  if (physics?.shape === 'box') return 'box';
+  return object?.userData?.asset?.primitive === 'sphere' ? 'sphere' : 'box';
+}
+
+export function buildPhysicsBodyDef({ objectId, object, physics }) {
+  const normalized = normalizeObjectPhysics(physics);
+  if (!objectId || !object || !normalized) return null;
+
+  const scale = getScaleArray(object).map((component) => Math.abs(component || 1));
+  const shape = inferShape(normalized, object);
+  const body = {
+    id: objectId,
+    shape,
+    position: getPositionArray(object),
+    velocity: normalized.bodyType === 'static'
+      ? [0, 0, 0]
+      : readVec3(normalized.velocity, [0, 0, 0]),
+    mass: normalized.bodyType === 'static' ? 0 : normalized.mass,
+    static: normalized.bodyType === 'static',
+    restitution: normalized.restitution,
+    friction: normalized.friction,
+  };
+
+  if (shape === 'sphere') {
+    body.radius = positiveNumber(
+      normalized.radius,
+      Math.max(scale[0], scale[1], scale[2]) / 2 || 0.5,
+    );
+  } else {
+    body.halfExtents = readPositiveVec3(
+      normalized.halfExtents,
+      [
+        Math.max(0.01, scale[0] / 2 || 0.5),
+        Math.max(0.01, scale[1] / 2 || 0.5),
+        Math.max(0.01, scale[2] / 2 || 0.5),
+      ],
+    );
+  }
+
+  return body;
+}
+
+function applyBodyPosition(object, body) {
+  if (!object || !body?.position) return;
+  if (typeof object.position?.fromArray === 'function') {
+    object.position.fromArray(body.position);
+  } else if (object.position) {
+    object.position.x = body.position[0];
+    object.position.y = body.position[1];
+    object.position.z = body.position[2];
+  }
+  object.updateMatrixWorld?.(true);
+}
+
+function collectRuntimeEntries(entries) {
+  return Array.from(entries || [])
+    .map((entry) => {
+      const objectId = entry?.objectId || entry?.id || entry?.object?.userData?.objectId || null;
+      const physics = normalizeObjectPhysics(entry?.physics || entry?.object?.userData?.physics);
+      if (!objectId || !entry?.object || !physics) return null;
+      return { objectId, object: entry.object, physics };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.objectId.localeCompare(right.objectId));
+}
+
+export function createScenePhysicsRuntime({
+  getScenePhysics,
+  getObjectEntries,
+  isClockActive = (clockState) => clockState?.transportActive === true,
+} = {}) {
+  let dirty = true;
+  let world = null;
+  let initialSnapshot = null;
+  let entryMap = new Map();
+  let active = false;
+  let timestepSeconds = DEFAULT_TIMESTEP_FP / 65536;
+
+  function clear() {
+    world = null;
+    initialSnapshot = null;
+    entryMap = new Map();
+    active = false;
+    timestepSeconds = DEFAULT_TIMESTEP_FP / 65536;
+  }
+
+  function markDirty() {
+    dirty = true;
+  }
+
+  function rebuild() {
+    const scenePhysics = normalizeScenePhysics(getScenePhysics?.());
+    const entries = collectRuntimeEntries(getObjectEntries?.());
+    if (!scenePhysics.enabled || entries.length === 0) {
+      clear();
+      dirty = false;
+      return false;
+    }
+
+    world = createWorld(scenePhysics.worldOptions);
+    timestepSeconds = world.timestepFp / 65536;
+    entryMap = new Map();
+
+    for (const entry of entries) {
+      const body = buildPhysicsBodyDef(entry);
+      if (!body) continue;
+      world.addBody(body);
+      entryMap.set(entry.objectId, entry);
+    }
+
+    initialSnapshot = world.snapshot();
+    dirty = false;
+    return entryMap.size > 0;
+  }
+
+  function applyWorldToObjects() {
+    if (!world) return;
+    for (const [objectId, entry] of entryMap) {
+      const body = world.getBody(objectId);
+      if (!body || body.static) continue;
+      applyBodyPosition(entry.object, body);
+    }
+  }
+
+  function resetToInitialPose() {
+    if (!world || !initialSnapshot) return;
+    world.restore(initialSnapshot);
+    applyWorldToObjects();
+  }
+
+  function update(clockState = null) {
+    const scenePhysics = normalizeScenePhysics(getScenePhysics?.());
+    if (!scenePhysics.enabled) {
+      clear();
+      return { active: false, reason: 'disabled' };
+    }
+
+    if (!isClockActive(clockState)) {
+      let reset = false;
+      if (active) {
+        resetToInitialPose();
+        reset = true;
+      }
+      active = false;
+      return { active: false, reason: 'clock-inactive', reset };
+    }
+
+    if (dirty || !world) {
+      if (!rebuild()) {
+        return { active: false, reason: 'no-bodies' };
+      }
+    }
+
+    const targetTime = Math.max(0, Number(clockState?.t) || 0);
+    const targetTick = Math.max(0, Math.floor(targetTime / timestepSeconds));
+    if (targetTick < world.tick && initialSnapshot) {
+      world.restore(initialSnapshot);
+    }
+    world.stepTo(targetTick);
+    applyWorldToObjects();
+    active = true;
+    return { active: true, tick: world.tick };
+  }
+
+  return {
+    markDirty,
+    rebuild,
+    update,
+    resetToInitialPose,
+    hasBodies() {
+      if (dirty || !world) {
+        return collectRuntimeEntries(getObjectEntries?.()).length > 0;
+      }
+      return entryMap.size > 0;
+    },
+    dispose() {
+      clear();
+    },
+  };
+}

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createScenePhysicsRuntime,
+  normalizeObjectPhysics,
+  normalizeScenePhysics,
+} from './scene-physics.js';
+
+function vector(values) {
+  return {
+    values: [...values],
+    toArray() {
+      return [...this.values];
+    },
+    fromArray(next) {
+      this.values = [...next];
+    },
+  };
+}
+
+function makeObject({
+  position = [0, 2, 0],
+  scale = [1, 1, 1],
+  physics = { enabled: true, shape: 'sphere', velocity: [0, 0, 0] },
+} = {}) {
+  return {
+    userData: {
+      objectId: 'ball',
+      physics,
+      asset: { type: 'primitive', primitive: 'sphere' },
+    },
+    position: vector(position),
+    scale: vector(scale),
+    updateMatrixWorldCalled: 0,
+    updateMatrixWorld() {
+      this.updateMatrixWorldCalled += 1;
+    },
+  };
+}
+
+test('normalizes object physics with practical defaults', () => {
+  assert.deepEqual(normalizeObjectPhysics({ enabled: true }), {
+    version: 1,
+    enabled: true,
+    bodyType: 'dynamic',
+    shape: 'box',
+    mass: 1,
+    restitution: 0.2,
+    friction: 0.5,
+    velocity: [0, 0, 0],
+  });
+});
+
+test('scene physics runtime is a function of supplied clock time', () => {
+  const object = makeObject();
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => [{
+      objectId: 'ball',
+      object,
+      physics: object.userData.physics,
+    }],
+    isClockActive: () => true,
+  });
+
+  runtime.update({ t: 0, mode: 'local', transportActive: true });
+  assert.equal(object.position.toArray()[1], 2);
+
+  runtime.update({ t: 0.5, mode: 'local', transportActive: true });
+  const yAtHalfSecond = object.position.toArray()[1];
+  assert.ok(yAtHalfSecond < 2);
+
+  runtime.update({ t: 0.1, mode: 'local', transportActive: true });
+  const yAfterSeekBack = object.position.toArray()[1];
+  assert.ok(yAfterSeekBack > yAtHalfSecond);
+  assert.ok(yAfterSeekBack < 2);
+  assert.ok(object.updateMatrixWorldCalled > 0);
+});
+
+test('scene physics runtime resets to initial pose when the clock becomes inactive', () => {
+  const object = makeObject();
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  let clockActive = true;
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => [{
+      objectId: 'ball',
+      object,
+      physics: object.userData.physics,
+    }],
+    isClockActive: () => clockActive,
+  });
+
+  runtime.update({ t: 0.5, mode: 'local', transportActive: true });
+  assert.ok(object.position.toArray()[1] < 2);
+
+  clockActive = false;
+  const result = runtime.update({ t: 0.5, mode: 'local', transportActive: false });
+  assert.equal(result.reset, true);
+  assert.equal(object.position.toArray()[1], 2);
+});

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -113,3 +113,67 @@ test('scene physics runtime resets to initial pose when the clock becomes inacti
   assert.equal(result.reset, true);
   assert.equal(object.position.toArray()[1], 2);
 });
+
+test('scene physics runtime drops removed bodies after it is marked dirty', () => {
+  const object = makeObject();
+  let entries = [{
+    objectId: 'ball',
+    object,
+    physics: object.userData.physics,
+  }];
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => entries,
+    isClockActive: () => true,
+  });
+
+  runtime.update({ t: 0, mode: 'local', transportActive: true });
+  assert.equal(runtime.hasBodies(), true);
+
+  entries = [];
+  runtime.markDirty();
+
+  assert.equal(runtime.hasBodies(), false);
+  const result = runtime.update({ t: 0.5, mode: 'local', transportActive: true });
+  assert.equal(result.active, false);
+  assert.equal(result.reason, 'no-bodies');
+});
+
+test('scene physics runtime does not reset inactive dirty authoring transforms', () => {
+  const object = makeObject();
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => [{
+      objectId: 'ball',
+      object,
+      physics: object.userData.physics,
+    }],
+    isClockActive: (clockState) => clockState?.transportActive === true,
+  });
+
+  runtime.update({ t: 0.5, mode: 'local', transportActive: true });
+  assert.ok(object.position.toArray()[1] < 2);
+
+  runtime.update({ t: 0.5, mode: 'local', transportActive: false });
+  assert.equal(object.position.toArray()[1], 2);
+
+  object.position.fromArray([0, 5, 0]);
+  runtime.markDirty();
+
+  assert.equal(runtime.resetActiveToInitialPose(), false);
+  assert.equal(object.position.toArray()[1], 5);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -64,6 +64,13 @@ import {
   normalizeSceneClockDeactivateArgs,
   preserveLocalSceneClockTimeline,
 } from './runtime/scene-clock-transport.js';
+import {
+  createScenePhysicsRuntime,
+  normalizeObjectPhysics,
+  normalizeScenePhysics,
+  serializeObjectPhysics,
+  serializeScenePhysics,
+} from './scene-physics.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
@@ -511,6 +518,7 @@ function onXrSelectEnd(ctrl) {
   if (!stillHeld) {
     if (obj.userData?.objectId) {
       // 最終姿勢を送信してから unlock
+      markScenePhysicsRuntimeDirty();
       broadcastObjectDelta(obj, broadcast);
       ensureUnlock(obj.userData.objectId);
     }
@@ -727,6 +735,7 @@ function updateXrGrab() {
   if (xrState.twoHand.active && xrState.twoHand.object) {
     const id = xrState.twoHand.object.userData?.objectId;
     if (id && !sentIds.has(id)) {
+      markScenePhysicsRuntimeDirty();
       broadcastObjectDelta(xrState.twoHand.object, broadcast);
       sentIds.add(id);
     }
@@ -735,6 +744,7 @@ function updateXrGrab() {
       if (!grabber.active || !grabber.object) continue;
       const id = grabber.object.userData?.objectId;
       if (id && !sentIds.has(id)) {
+        markScenePhysicsRuntimeDirty();
         broadcastObjectDelta(grabber.object, broadcast);
         sentIds.add(id);
       }
@@ -884,6 +894,7 @@ renderer.xr.addEventListener('sessionend', () => {
     grabber.active = false;
     grabber.object = null;
     if (obj.userData?.objectId) {
+      markScenePhysicsRuntimeDirty();
       broadcastObjectDelta(obj, broadcast);
       ensureUnlock(obj.userData.objectId);
     }
@@ -1060,6 +1071,7 @@ function sendSelectedDelta() {
   }
 
   broadcast(payload);
+  markScenePhysicsRuntimeDirty();
   notifySceneStateChanged('selected-transform-sent');
 }
 
@@ -1358,6 +1370,16 @@ function createSampleCube() {
 const managedObjects = new Map();
 const selectedObjectIds = new Set();
 const selectionHelpers = new Map();
+let scenePhysicsState = normalizeScenePhysics();
+const scenePhysicsRuntime = createScenePhysicsRuntime({
+  getScenePhysics: () => scenePhysicsState,
+  getObjectEntries: () => Array.from(managedObjects.entries()).map(([objectId, object]) => ({
+    objectId,
+    object,
+    physics: object.userData?.physics,
+  })),
+  isClockActive: (clockState) => clockState?.transportActive === true && clockState?.mode === 'local',
+});
 const removedObjectIds = new Set();
 
 function isSampleCubeObjectId(objectId) {
@@ -1552,6 +1574,7 @@ function updateTransformTweens(now = performance.now()) {
   }
 
   if (completedCount > 0) {
+    markScenePhysicsRuntimeDirty();
     updateSelectionHelpers();
     scheduleAiTransformTweenSnapshot();
   }
@@ -2653,9 +2676,77 @@ function getSceneAnimationPlaybackEntries() {
 }
 
 function getScenePlaybackDuration() {
+  const physicsDuration = getScenePhysicsPlaybackDuration();
   return calculateScenePlaybackDuration({
     animationEntries: getSceneAnimationPlaybackEntries(),
+    physicsDuration,
+    defaultDuration: physicsDuration > 0 ? physicsDuration : undefined,
   });
+}
+
+function hasPhysicsObjects() {
+  for (const obj of managedObjects.values()) {
+    if (normalizeObjectPhysics(obj?.userData?.physics)) return true;
+  }
+  return false;
+}
+
+function getScenePhysicsPlaybackDuration() {
+  const physics = normalizeScenePhysics(scenePhysicsState);
+  return physics.enabled && hasPhysicsObjects() ? physics.duration : 0;
+}
+
+function getScenePhysicsForSerialize({ enableWhenObjectsExist = true } = {}) {
+  const physics = normalizeScenePhysics(scenePhysicsState);
+  if (!physics.enabled && enableWhenObjectsExist && hasPhysicsObjects()) {
+    return {
+      ...physics,
+      enabled: true,
+    };
+  }
+  return serializeScenePhysics(physics);
+}
+
+function getObjectPhysicsForSerialize(obj) {
+  return serializeObjectPhysics(obj?.userData?.physics);
+}
+
+function markScenePhysicsRuntimeDirty() {
+  scenePhysicsRuntime.markDirty();
+}
+
+function applyScenePhysics(physics, options = {}) {
+  scenePhysicsState = normalizeScenePhysics(physics);
+  markScenePhysicsRuntimeDirty();
+  if (options.broadcastChange) {
+    const serialized = getScenePhysicsForSerialize({ enableWhenObjectsExist: false });
+    broadcast({
+      kind: 'scene-physics',
+      physics: serialized || { enabled: false },
+    });
+  }
+  if (options.notify !== false) {
+    notifySceneStateChanged(options.reason || 'scene-physics-updated');
+  }
+  return getScenePhysicsForSerialize({ enableWhenObjectsExist: false });
+}
+
+function applyObjectPhysicsDelta(obj, physics) {
+  if (!obj) return null;
+  const next = normalizeObjectPhysics(physics);
+  if (next) {
+    obj.userData.physics = next;
+    if (!scenePhysicsState.enabled) {
+      scenePhysicsState = {
+        ...normalizeScenePhysics(scenePhysicsState),
+        enabled: true,
+      };
+    }
+  } else {
+    delete obj.userData.physics;
+  }
+  markScenePhysicsRuntimeDirty();
+  return next;
 }
 
 function showTemporaryImagePreview(objectId, file, position, options = {}) {
@@ -4282,6 +4373,10 @@ renderer.setAnimationLoop((time, frame) => {
 
   const now = performance.now();
   const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
+  const physicsTick = scenePhysicsRuntime.update(sceneClockStateForTick);
+  if ((physicsTick.active || physicsTick.reset) && selectedObjectIds.size > 0) {
+    updateSelectionHelpers();
+  }
   updateObjectGlbAnimations(now, sceneClockStateForTick);
   updateGazeStateFromCamera();
   updateGazeDwellState(now);
@@ -4364,6 +4459,17 @@ const sceneInspectorAnimationEnabledEl = document.getElementById('scene-inspecto
 const sceneInspectorAnimationClipEl = document.getElementById('scene-inspector-animation-clip');
 const sceneInspectorAnimationSpeedEl = document.getElementById('scene-inspector-animation-speed');
 const sceneInspectorAnimationOffsetEl = document.getElementById('scene-inspector-animation-offset');
+const sceneInspectorPhysicsControlsEl = document.getElementById('scene-inspector-physics-controls');
+const sceneInspectorPhysicsMetaEl = document.getElementById('scene-inspector-physics-meta');
+const sceneInspectorPhysicsEnabledEl = document.getElementById('scene-inspector-physics-enabled');
+const sceneInspectorPhysicsBodyTypeEl = document.getElementById('scene-inspector-physics-body-type');
+const sceneInspectorPhysicsShapeEl = document.getElementById('scene-inspector-physics-shape');
+const sceneInspectorPhysicsMassEl = document.getElementById('scene-inspector-physics-mass');
+const sceneInspectorPhysicsRestitutionEl = document.getElementById('scene-inspector-physics-restitution');
+const sceneInspectorPhysicsFrictionEl = document.getElementById('scene-inspector-physics-friction');
+const sceneInspectorPhysicsVelocityXEl = document.getElementById('scene-inspector-physics-velocity-x');
+const sceneInspectorPhysicsVelocityYEl = document.getElementById('scene-inspector-physics-velocity-y');
+const sceneInspectorPhysicsVelocityZEl = document.getElementById('scene-inspector-physics-velocity-z');
 
 function resolvePresenceUrl() {
   const params = new URLSearchParams(location.search);
@@ -5514,6 +5620,11 @@ async function respondToSceneRequest(from) {
       entry.audioSources = audioSources;
     }
 
+    const physics = getObjectPhysicsForSerialize(obj);
+    if (physics) {
+      entry.physics = physics;
+    }
+
     objects[objectId] = entry;
   }
 
@@ -5531,6 +5642,11 @@ async function respondToSceneRequest(from) {
     const loomGraphState = loomIntegration.exportState();
     if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
       payload.loomGraphs = loomGraphState;
+    }
+
+    const physicsState = getScenePhysicsForSerialize();
+    if (physicsState) {
+      payload.physics = physicsState;
     }
 
     ws.send(JSON.stringify({
@@ -5591,7 +5707,8 @@ function handleHandoff(data) {
     payload.kind === 'scene-batch' ||
     payload.kind === 'scene-delta' ||
     payload.kind === 'scene-add' ||
-    payload.kind === 'scene-remove'
+    payload.kind === 'scene-remove' ||
+    payload.kind === 'scene-physics'
   ) {
     console.debug('[handoff] scene mutation received', {
       kind: payload.kind,
@@ -5614,6 +5731,12 @@ function handleHandoff(data) {
         environmentManager.loadEnvironment(payload.envId, {
           source: 'handoff',
           broadcastChange: false,
+        });
+      }
+      if (payload.physics && typeof payload.physics === 'object') {
+        applyScenePhysics(payload.physics, {
+          notify: false,
+          reason: 'scene-state-physics',
         });
       }
       const objects = payload.objects || {};
@@ -5709,6 +5832,9 @@ function handleHandoff(data) {
               : obj.userData?.metadata,
             // コンテンツ差し替え時も既存の AudioSource component を保持する。
             audioSources: payload.audioSources ?? obj.userData?.audioSources,
+            physics: Object.prototype.hasOwnProperty.call(payload, 'physics')
+              ? payload.physics
+              : obj.userData?.physics,
           };
           addOrUpdateObject(payload.objectId, mergedInfo);
 
@@ -5723,6 +5849,7 @@ function handleHandoff(data) {
               asset: cloneJsonSafe(mergedInfo.asset),
               metadata: cloneJsonSafe(mergedInfo.metadata || null),
               audioSources: cloneJsonSafe(getObjectAudioSourcesForSerialize(managedObjects.get(payload.objectId)) || {}),
+              physics: cloneJsonSafe(getObjectPhysicsForSerialize(managedObjects.get(payload.objectId)) || null),
             };
 
             presenceState.historyManager?.push(
@@ -5754,6 +5881,13 @@ function handleHandoff(data) {
           audioSources: payload.audioSources,
         });
       }
+      if (Object.prototype.hasOwnProperty.call(payload, 'physics')) {
+        applyObjectPhysicsDelta(obj, payload.physics);
+        console.debug('[scene-delta] physics applied', {
+          objectId: payload.objectId,
+          physics: payload.physics,
+        });
+      }
 
       // Handle transform updates (animated or immediate)
       if (shouldAnimateTransform && (
@@ -5778,6 +5912,9 @@ function handleHandoff(data) {
         if (payload.position) obj.position.fromArray(payload.position);
         if (payload.rotation) obj.quaternion.fromArray(payload.rotation);
         if (payload.scale) obj.scale.fromArray(payload.scale);
+        if (payload.position || payload.rotation || payload.scale) {
+          markScenePhysicsRuntimeDirty();
+        }
         console.debug('[scene-delta] applied', {
           objectId: payload.objectId,
           position: obj.position.toArray(),
@@ -5845,6 +5982,15 @@ function handleHandoff(data) {
       loomIntegration.clearObjectGraph(objectId);
       notifySceneStateChanged('scene-remove-handoff');
       updateEnvironmentMenuSkyboxControls();
+      break;
+    }
+    case 'scene-physics': {
+      if (isOwn) break;
+      applyScenePhysics(payload.physics || { enabled: false }, {
+        notify: false,
+        reason: 'scene-physics-handoff',
+      });
+      notifySceneStateChanged('scene-physics-handoff');
       break;
     }
     case 'scene-mesh': {
@@ -6338,6 +6484,7 @@ async function importGlbFileAsSceneObject(file, {
   metadata,
   animation,
   audioSources,
+  physics,
   selectAfterLoad = false,
   showImportToast = false,
 } = {}) {
@@ -6359,6 +6506,7 @@ async function importGlbFileAsSceneObject(file, {
   if (metadata) info.metadata = metadata;
   if (animation) info.animation = animation;
   if (audioSources !== undefined) info.audioSources = audioSources;
+  if (physics !== undefined) info.physics = physics;
 
   // GLB は内部に元のシーン座標を持つため、info の transform で上書きする
   replaceManagedObject(objectId, model, info);
@@ -6388,6 +6536,7 @@ async function importGlbFileAsSceneObject(file, {
     ...(metadata ? { metadata } : {}),
     ...(animation ? { animation } : {}),
     ...(audioSources !== undefined ? { audioSources } : {}),
+    ...(physics !== undefined ? { physics } : {}),
   });
 
   return model;
@@ -6619,6 +6768,11 @@ function serializeSceneObjectForExternalUse(objectId, obj) {
   const audioSources = getObjectAudioSourcesForSerialize(obj);
   if (audioSources) {
     result.audioSources = audioSources;
+  }
+
+  const physics = getObjectPhysicsForSerialize(obj);
+  if (physics) {
+    result.physics = physics;
   }
 
   return result;
@@ -7129,6 +7283,9 @@ function addOrUpdateObject(objectId, info, options = {}) {
   applyObjectVisibility(existing, info.visible);
   if (info.audioSources !== undefined) {
     setObjectAudioSourcesFull(objectId, info.audioSources);
+  }
+  if (info.physics !== undefined) {
+    applyObjectPhysicsDelta(existing, info.physics);
   }
   notifySceneStateChanged('managed-object-updated');
 }
@@ -7910,6 +8067,7 @@ function createContentReplaceSnapshot(obj, fallbackObjectId = null) {
     asset: cloneJsonSafe(obj.userData?.asset || null),
     metadata: cloneJsonSafe(obj.userData?.metadata || null),
     audioSources: cloneJsonSafe(getObjectAudioSourcesForSerialize(obj) || {}),
+    physics: cloneJsonSafe(getObjectPhysicsForSerialize(obj) || null),
   };
 }
 
@@ -7987,6 +8145,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
 
   // コンテンツ差し替えではオブジェクトを作り直すため、既存の AudioSource component を保持する。
   const preservedAudioSources = getObjectAudioSourcesForSerialize(existing) || {};
+  const preservedPhysics = getObjectPhysicsForSerialize(existing);
 
   const deltaPayload = {
     kind: 'scene-delta',
@@ -7995,6 +8154,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
     asset: newAsset,
     metadata: newMetadata,
     audioSources: preservedAudioSources,
+    ...(preservedPhysics ? { physics: preservedPhysics } : {}),
   };
 
   broadcast(deltaPayload);
@@ -8009,6 +8169,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
     asset: newAsset,
     metadata: newMetadata,
     audioSources: preservedAudioSources,
+    ...(preservedPhysics ? { physics: preservedPhysics } : {}),
   };
   addOrUpdateObject(objectId, mergedInfo, { ...options, pushHistory: false });
 
@@ -8023,6 +8184,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
       asset: cloneJsonSafe(newAsset),
       metadata: cloneJsonSafe(newMetadata),
       audioSources: cloneJsonSafe(preservedAudioSources),
+      physics: cloneJsonSafe(preservedPhysics),
     };
 
     presenceState.historyManager?.push(
@@ -8160,6 +8322,22 @@ function replaceManagedObject(objectId, nextObject, info) {
   if (info.audioSources !== undefined) {
     setObjectAudioSourcesFull(objectId, info.audioSources);
   }
+
+  const nextPhysics = Object.prototype.hasOwnProperty.call(info || {}, 'physics')
+    ? normalizeObjectPhysics(info.physics)
+    : getObjectPhysicsForSerialize(current);
+  if (nextPhysics) {
+    nextObject.userData.physics = nextPhysics;
+    if (!scenePhysicsState.enabled) {
+      scenePhysicsState = {
+        ...normalizeScenePhysics(scenePhysicsState),
+        enabled: true,
+      };
+    }
+  } else {
+    delete nextObject.userData.physics;
+  }
+  markScenePhysicsRuntimeDirty();
 
   console.debug('[scene-add] applied transform', {
     objectId: nextObject.userData?.objectId || null,
@@ -8510,6 +8688,9 @@ function applyOperationToScene(operation) {
             audioSources: Object.prototype.hasOwnProperty.call(operation, 'audioSources')
               ? cloneJsonSafe(operation.audioSources)
               : cloneJsonSafe(getObjectAudioSourcesForSerialize(obj) || {}),
+            physics: Object.prototype.hasOwnProperty.call(operation, 'physics')
+              ? cloneJsonSafe(operation.physics)
+              : cloneJsonSafe(getObjectPhysicsForSerialize(obj) || null),
           };
 
           addOrUpdateObject(operation.objectId, mergedInfo, {
@@ -8523,6 +8704,9 @@ function applyOperationToScene(operation) {
 
         if (typeof operation.name === 'string') applyObjectName(obj, operation.name);
         applyTransform(obj, operation);
+        if (operation.position || operation.rotation || operation.scale) {
+          markScenePhysicsRuntimeDirty();
+        }
         if (typeof operation.visible === 'boolean') applyObjectVisibility(obj, operation.visible);
         if (operation.asset) {
           applyAssetDelta(obj, operation.asset);
@@ -8533,8 +8717,19 @@ function applyOperationToScene(operation) {
         if (operation.audioSources !== undefined) {
           applyIncomingAudioSources(operation.objectId, operation.audioSources);
         }
+        if (Object.prototype.hasOwnProperty.call(operation, 'physics')) {
+          applyObjectPhysicsDelta(obj, operation.physics);
+        }
       }
       notifySceneStateChanged('undo-redo-scene-delta');
+      break;
+    }
+    case 'scene-physics': {
+      applyScenePhysics(operation.physics || { enabled: false }, {
+        notify: false,
+        reason: 'undo-redo-scene-physics',
+      });
+      notifySceneStateChanged('undo-redo-scene-physics');
       break;
     }
     case 'scene-env': {
@@ -8598,6 +8793,9 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
   const preservedAudioSources = Object.prototype.hasOwnProperty.call(info || {}, 'audioSources')
     ? info.audioSources
     : obj?.userData?.audioSources;
+  const preservedPhysics = Object.prototype.hasOwnProperty.call(info || {}, 'physics')
+    ? info.physics
+    : getObjectPhysicsForSerialize(obj);
   if (!obj && !info) {
     console.warn('[SceneSync] Object not found for loading recovered GLB:', objectId);
     return;
@@ -8674,6 +8872,9 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
       ? structuredClone(obj.userData.asset)
       : (info?.asset ? structuredClone(info.asset) : null);
     if (options.assetId) wrapper.userData.assetId = options.assetId;
+    if (preservedPhysics) {
+      wrapper.userData.physics = normalizeObjectPhysics(preservedPhysics);
+    }
 
     const animations = Array.isArray(gltf.animations) ? gltf.animations : [];
     const animationState = animations.length > 0
@@ -8723,6 +8924,7 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
     if (preservedAudioSources !== undefined) {
       setObjectAudioSourcesFull(objectId, preservedAudioSources);
     }
+    markScenePhysicsRuntimeDirty();
     notifySceneStateChanged('glb-blob-loaded');
     markCrashProbe('glb-scene-attach-success', { objectId });
     clearCrashProbe('glb-object-ready');
@@ -8893,6 +9095,15 @@ function applySceneActionLocally(action, options = {}) {
     loomIntegration.clearObjectGraph(action.objectId);
     updateEnvironmentMenuSkyboxControls();
     notifySceneStateChanged('local-scene-remove');
+    return;
+  }
+
+  if (action.kind === 'scene-physics') {
+    applyScenePhysics(action.physics || { enabled: false }, {
+      notify: false,
+      reason: 'local-scene-physics',
+    });
+    notifySceneStateChanged('local-scene-physics');
     return;
   }
 
@@ -9481,6 +9692,7 @@ async function urlImporterCallback(url, position, context = {}) {
       importGlbFileAsSceneObject,
       uploadBlobToStore,
       applySceneBgm,
+      applyScenePhysics,
     });
     if (sceneSyncExportResult?.handled) return;
   }
@@ -9582,6 +9794,7 @@ const dragDropManager = new DragDropManager({
     importGlbFileAsSceneObject,
     uploadBlobToStore,
     applySceneBgm,
+    applyScenePhysics,
   }),
   onLoadStart: async ({
     objectId,
@@ -10112,6 +10325,7 @@ const EDITABLE_SCENE_OBJECT_FIELDS = new Set([
   'visible',
   'asset',
   'audioSources',
+  'physics',
 ]);
 
 const EDITABLE_TEXT_ASSET_FIELDS = new Set([
@@ -10515,6 +10729,18 @@ function buildSceneInspectorEditableDiff(baseSnapshot, editedSnapshot) {
       }
     }
 
+    if (!valuesEqual(baseObject.physics ?? null, editedObject.physics ?? null)) {
+      if (editedObject.physics == null) {
+        objectDelta.physics = null;
+        changedFields.push('physics');
+      } else if (typeof editedObject.physics !== 'object' || Array.isArray(editedObject.physics)) {
+        errors.push(`objects.${objectId}.physics must be an object or null.`);
+      } else {
+        objectDelta.physics = normalizeObjectPhysics(editedObject.physics);
+        changedFields.push('physics');
+      }
+    }
+
     const objectKeys = new Set([
       ...Object.keys(baseObject || {}),
       ...Object.keys(editedObject || {}),
@@ -10805,7 +11031,7 @@ function setOrDeleteInspectorValueAtPath(root, path, value) {
 function applyBaseInspectorField(targetObject, baseObject, field) {
   if (!targetObject || !baseObject || typeof field !== 'string') return;
 
-  if (['name', 'position', 'rotation', 'scale', 'visible', 'audioSources'].includes(field)) {
+  if (['name', 'position', 'rotation', 'scale', 'visible', 'audioSources', 'physics'].includes(field)) {
     setOrDeleteInspectorValueAtPath(targetObject, [field], baseObject[field]);
     return;
   }
@@ -11222,6 +11448,71 @@ function renderSceneInspectorAnimationControls(selectedObject) {
   }
 }
 
+function setSceneInspectorPhysicsFieldsDisabled(disabled) {
+  for (const el of [
+    sceneInspectorPhysicsBodyTypeEl,
+    sceneInspectorPhysicsShapeEl,
+    sceneInspectorPhysicsMassEl,
+    sceneInspectorPhysicsRestitutionEl,
+    sceneInspectorPhysicsFrictionEl,
+    sceneInspectorPhysicsVelocityXEl,
+    sceneInspectorPhysicsVelocityYEl,
+    sceneInspectorPhysicsVelocityZEl,
+  ]) {
+    if (el) el.disabled = disabled;
+  }
+}
+
+function renderSceneInspectorPhysicsControls(selectedObject) {
+  const objectId = selectedObject?.objectId;
+  const objectSnapshot = selectedObject?.objectSnapshot;
+  const hasSelection = !!objectId && !!objectSnapshot;
+
+  if (sceneInspectorPhysicsControlsEl) {
+    sceneInspectorPhysicsControlsEl.hidden = !hasSelection;
+  }
+  if (!hasSelection) return;
+
+  const physics = normalizeObjectPhysics(objectSnapshot.physics) || {
+    enabled: false,
+    bodyType: 'dynamic',
+    shape: objectSnapshot.asset?.primitive === 'sphere' ? 'sphere' : 'box',
+    mass: 1,
+    restitution: 0.2,
+    friction: 0.5,
+    velocity: [0, 0, 0],
+  };
+  const enabled = physics.enabled === true;
+
+  if (sceneInspectorPhysicsMetaEl) {
+    sceneInspectorPhysicsMetaEl.textContent = enabled ? physics.bodyType : 'Off';
+  }
+  if (sceneInspectorPhysicsEnabledEl) {
+    sceneInspectorPhysicsEnabledEl.checked = enabled;
+  }
+  if (sceneInspectorPhysicsBodyTypeEl) {
+    sceneInspectorPhysicsBodyTypeEl.value = physics.bodyType || 'dynamic';
+  }
+  if (sceneInspectorPhysicsShapeEl) {
+    sceneInspectorPhysicsShapeEl.value = physics.shape || 'box';
+  }
+  if (sceneInspectorPhysicsMassEl) {
+    sceneInspectorPhysicsMassEl.value = String(Number.isFinite(physics.mass) ? physics.mass : 1);
+  }
+  if (sceneInspectorPhysicsRestitutionEl) {
+    sceneInspectorPhysicsRestitutionEl.value = String(Number.isFinite(physics.restitution) ? physics.restitution : 0.2);
+  }
+  if (sceneInspectorPhysicsFrictionEl) {
+    sceneInspectorPhysicsFrictionEl.value = String(Number.isFinite(physics.friction) ? physics.friction : 0.5);
+  }
+  const velocity = Array.isArray(physics.velocity) ? physics.velocity : [0, 0, 0];
+  if (sceneInspectorPhysicsVelocityXEl) sceneInspectorPhysicsVelocityXEl.value = String(Number(velocity[0]) || 0);
+  if (sceneInspectorPhysicsVelocityYEl) sceneInspectorPhysicsVelocityYEl.value = String(Number(velocity[1]) || 0);
+  if (sceneInspectorPhysicsVelocityZEl) sceneInspectorPhysicsVelocityZEl.value = String(Number(velocity[2]) || 0);
+
+  setSceneInspectorPhysicsFieldsDisabled(!enabled);
+}
+
 function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   let selectedObject = buildSelectedObjectInspectorContext(snapshot);
   let objectEditorState = sceneInspectorState.objectEditor;
@@ -11278,7 +11569,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (sceneInspectorEditMetaEl) {
     const baseTime = baseSnapshot?.generatedAt || 'unknown';
     sceneInspectorEditMetaEl.textContent =
-      `Base snapshot captured at ${baseTime}.\nApplied fields: existing object \`name\`, \`position\`, \`rotation\`, \`scale\`, \`visible\`, \`audio\`, and primitive \`asset.color\`.\nIgnored fields: root metadata, object add/remove, ids, locks, room, connection, environment, raw Loom graph state, \`meshPath\`, and all other non-editable fields.`;
+      `Base snapshot captured at ${baseTime}.\nApplied fields: existing object \`name\`, \`position\`, \`rotation\`, \`scale\`, \`visible\`, \`audio\`, \`physics\`, and primitive \`asset.color\`.\nIgnored fields: root metadata, object add/remove, ids, locks, room, connection, environment, raw Loom graph state, \`meshPath\`, and all other non-editable fields.`;
   }
 
   const hasErrors = sceneInspectorState.validationErrors.length > 0;
@@ -11352,6 +11643,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   updateSceneInspectorObjectEditorModeUi();
 
   renderSceneInspectorAnimationControls(selectedObject);
+  renderSceneInspectorPhysicsControls(selectedObject);
 
   const objectHasErrors = objectEditorState.validationErrors.length > 0;
   const objectSummary = objectEditorState.diffSummary;
@@ -11497,6 +11789,7 @@ function hasSceneDeltaPayload(operation) {
     'visible',
     'animation',
     'audioSources',
+    'physics',
   ].some((key) => Object.prototype.hasOwnProperty.call(operation, key));
 }
 
@@ -11512,7 +11805,7 @@ function applySceneInspectorTextAssetPreviewDelta(operation, fieldMask) {
       kind: 'scene-delta',
       objectId: operation.objectId,
     };
-    for (const key of ['name', 'position', 'rotation', 'scale', 'visible', 'animation', 'audioSources']) {
+    for (const key of ['name', 'position', 'rotation', 'scale', 'visible', 'animation', 'audioSources', 'physics']) {
       if (Object.prototype.hasOwnProperty.call(operation, key)) {
         nonAssetOperation[key] = cloneInspectorValue(operation[key]);
       }
@@ -12019,9 +12312,15 @@ function buildSceneInspectorSnapshot() {
       entry.audioSources = audioSources;
     }
 
+    const physics = getObjectPhysicsForSerialize(obj);
+    if (physics) {
+      entry.physics = physics;
+    }
+
     objects[objectId] = entry;
   }
 
+  const physicsState = getScenePhysicsForSerialize({ enableWhenObjectsExist: false });
   const snapshot = {
     kind: 'scene-inspector',
     room: presenceState.room || activeRoomCode || null,
@@ -12042,6 +12341,10 @@ function buildSceneInspectorSnapshot() {
     objects,
     generatedAt: new Date().toISOString(),
   };
+
+  if (physicsState) {
+    snapshot.physics = physicsState;
+  }
 
   if (loomGraphState.scene !== null || Object.keys(loomGraphState.objects).length > 0) {
     snapshot.loomGraphs = loomGraphState;
@@ -12109,6 +12412,7 @@ function createCurrentSceneSnapshot() {
     const metadata = safeCloneJson(object.userData?.metadata || null);
     const animation = serializeObjectAnimationState(object);
     const audioSources = getObjectAudioSourcesForSerialize(object);
+    const physics = getObjectPhysicsForSerialize(object);
 
     const entry = {
       objectId,
@@ -12128,16 +12432,26 @@ function createCurrentSceneSnapshot() {
     if (audioSources) {
       entry.audioSources = audioSources;
     }
+    if (physics) {
+      entry.physics = physics;
+    }
 
     objects.push(entry);
   }
 
-  return {
+  const snapshot = {
     schemaVersion: 1,
     savedAt: Date.now(),
     envId: environmentManager.getCurrentEnvId?.() || dom.envSelect?.value || null,
     objects,
   };
+
+  const physicsState = getScenePhysicsForSerialize();
+  if (physicsState) {
+    snapshot.physics = physicsState;
+  }
+
+  return snapshot;
 }
 
 function getCurrentRoomId() {
@@ -12268,6 +12582,13 @@ async function applyRoomSnapshot(snapshot, options = {}) {
       });
     }
 
+    if (snapshot.physics && typeof snapshot.physics === 'object') {
+      applyScenePhysics(snapshot.physics, {
+        notify: false,
+        reason: 'snapshot-physics-restore',
+      });
+    }
+
     for (const entry of snapshot.objects || []) {
       try {
         restoreSnapshotObject(entry, options);
@@ -12338,6 +12659,9 @@ function restoreSnapshotObject(entry, options = {}) {
   if (audioSources) {
     payload.audioSources = audioSources;
   }
+  if (entry.physics && typeof entry.physics === 'object') {
+    payload.physics = safeCloneJson(entry.physics);
+  }
 
   addOrUpdateObject(objectId, payload, {
     skipFallbackOnFailure: true,
@@ -12372,6 +12696,44 @@ function broadcastSelectedObjectAnimationDelta(delta) {
   broadcast(operation);
   notifySceneStateChanged('scene-inspector-animation-updated');
   notifySelectionChanged('scene-inspector-animation-updated');
+}
+
+function readSceneInspectorPhysicsControls() {
+  if (!sceneInspectorPhysicsEnabledEl?.checked) return null;
+
+  return normalizeObjectPhysics({
+    enabled: true,
+    bodyType: sceneInspectorPhysicsBodyTypeEl?.value || 'dynamic',
+    shape: sceneInspectorPhysicsShapeEl?.value || 'box',
+    mass: Number(sceneInspectorPhysicsMassEl?.value),
+    restitution: Number(sceneInspectorPhysicsRestitutionEl?.value),
+    friction: Number(sceneInspectorPhysicsFrictionEl?.value),
+    velocity: [
+      Number(sceneInspectorPhysicsVelocityXEl?.value) || 0,
+      Number(sceneInspectorPhysicsVelocityYEl?.value) || 0,
+      Number(sceneInspectorPhysicsVelocityZEl?.value) || 0,
+    ],
+  });
+}
+
+function broadcastSelectedObjectPhysicsDelta(physics) {
+  const snapshot = buildSceneInspectorSnapshot();
+  const { objectId, objectSnapshot } = buildSelectedObjectInspectorContext(snapshot);
+  if (!objectId || !objectSnapshot) {
+    showToast('オブジェクトを選択してください');
+    return;
+  }
+
+  const operation = {
+    kind: 'scene-delta',
+    objectId,
+    physics,
+  };
+
+  applyOperationToScene(operation);
+  broadcast(operation);
+  notifySceneStateChanged('scene-inspector-physics-updated');
+  notifySelectionChanged('scene-inspector-physics-updated');
 }
 
 function notifySceneStateChanged(reason) {
@@ -12627,6 +12989,26 @@ sceneInspectorAnimationOffsetEl?.addEventListener('change', () => {
   });
 });
 
+sceneInspectorPhysicsEnabledEl?.addEventListener('change', () => {
+  broadcastSelectedObjectPhysicsDelta(readSceneInspectorPhysicsControls());
+});
+
+for (const control of [
+  sceneInspectorPhysicsBodyTypeEl,
+  sceneInspectorPhysicsShapeEl,
+  sceneInspectorPhysicsMassEl,
+  sceneInspectorPhysicsRestitutionEl,
+  sceneInspectorPhysicsFrictionEl,
+  sceneInspectorPhysicsVelocityXEl,
+  sceneInspectorPhysicsVelocityYEl,
+  sceneInspectorPhysicsVelocityZEl,
+]) {
+  control?.addEventListener('change', () => {
+    if (!sceneInspectorPhysicsEnabledEl?.checked) return;
+    broadcastSelectedObjectPhysicsDelta(readSceneInspectorPhysicsControls());
+  });
+}
+
 pairingDialog?.addEventListener('click', (event) => {
   if (event.target === pairingDialog) {
     cancelPairing();
@@ -12863,6 +13245,7 @@ async function triggerExport() {
       envOrigin: location.origin,
       assetCache,
       behaviorState,
+      physicsState: getScenePhysicsForSerialize(),
     });
 
     if (missingAssets.length > 0) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -2715,6 +2715,12 @@ function markScenePhysicsRuntimeDirty() {
   scenePhysicsRuntime.markDirty();
 }
 
+function resetScenePhysicsRuntimeBeforePersistence() {
+  // Until authoring/base transforms are stored separately from runtime transforms,
+  // persistence paths must read the initial physics pose rather than the last sim pose.
+  scenePhysicsRuntime.resetActiveToInitialPose();
+}
+
 function applyScenePhysics(physics, options = {}) {
   scenePhysicsState = normalizeScenePhysics(physics);
   markScenePhysicsRuntimeDirty();
@@ -4144,6 +4150,8 @@ function deleteObjectById(objectId, options = {}) {
   const rotation = attached.quaternion.toArray();
   const scale = attached.scale.toArray();
   const asset = attached.userData.asset || {};
+  const physics = getObjectPhysicsForSerialize(attached);
+  const audioSources = getObjectAudioSourcesForSerialize(attached);
 
   scene.remove(attached);
   attached.traverse(child => {
@@ -4157,6 +4165,7 @@ function deleteObjectById(objectId, options = {}) {
     }
   });
   managedObjects.delete(objectId);
+  markScenePhysicsRuntimeDirty();
   removedObjectIds.add(objectId);
   selectedObjectIds.delete(objectId);
   removeSelectionHelper(objectId);
@@ -4168,7 +4177,10 @@ function deleteObjectById(objectId, options = {}) {
   // 履歴に追加
   if (pushHistory) {
     presenceState.historyManager?.push(
-      HistoryManager.createRemoveEntry(objectId, name, asset, position, rotation, scale)
+      HistoryManager.createRemoveEntry(objectId, name, asset, position, rotation, scale, {
+        physics,
+        audioSources,
+      })
     );
   }
 
@@ -5576,6 +5588,8 @@ async function respondToSceneRequest(from) {
   console.log('[SceneSync] Responding to scene-request from:',
     from?.nickname || from?.id);
 
+  resetScenePhysicsRuntimeBeforePersistence();
+
   const objects = {};
 
   for (const [objectId, obj] of managedObjects) {
@@ -5968,7 +5982,11 @@ function handleHandoff(data) {
           obj.userData?.asset || {},
           obj.position.toArray(),
           obj.quaternion.toArray(),
-          obj.scale.toArray()
+          obj.scale.toArray(),
+          {
+            physics: getObjectPhysicsForSerialize(obj),
+            audioSources: getObjectAudioSourcesForSerialize(obj),
+          }
         );
         presenceState.historyManager.push(historyEntry);
       }
@@ -12403,6 +12421,8 @@ function hasSnapshotRestorableObjects() {
 }
 
 function createCurrentSceneSnapshot() {
+  resetScenePhysicsRuntimeBeforePersistence();
+
   const objects = [];
 
   for (const [objectId, object] of managedObjects.entries()) {
@@ -13236,6 +13256,7 @@ async function triggerExport() {
   showToast('Exporting...');
 
   try {
+    resetScenePhysicsRuntimeBeforePersistence();
     const behaviorState = loomIntegration?.exportState?.() ?? null;
     const { missingAssets } = await buildExportPackage({
       managedObjects,

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -586,7 +586,8 @@
     .scene-inspector-object-actions .chip {
       justify-content: center;
     }
-    .scene-inspector-animation-controls {
+    .scene-inspector-animation-controls,
+    .scene-inspector-physics-controls {
       display: flex;
       flex-direction: column;
       gap: 8px;
@@ -614,6 +615,11 @@
     .scene-inspector-number-input:focus {
       border-color: rgba(68,136,255,0.5);
       outline: none;
+    }
+    .scene-inspector-vector-inputs {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 6px;
     }
     .scene-inspector-body {
       flex: 1 1 auto;
@@ -1379,7 +1385,7 @@
         <a class="chip" href="/scenesync/dev-tool/">Payload Tester</a>
       </div>
       <p id="scene-inspector-edit-note" class="scene-inspector-note" hidden>
-        Prototype edit mode: only existing object `name`, `position`, `rotation`, `scale`, `visible`, and primitive `asset.color` changes are broadcast. Root metadata, object add/remove, locks, and non-editable fields are ignored and shown in the preview below.
+        Prototype edit mode: only existing object `name`, `position`, `rotation`, `scale`, `visible`, `audio`, `physics`, and primitive `asset.color` changes are broadcast. Root metadata, object add/remove, locks, and non-editable fields are ignored and shown in the preview below.
       </p>
       <div id="scene-inspector-edit-meta" class="scene-inspector-edit-meta" hidden></div>
       <div id="scene-inspector-validation" class="scene-inspector-validation" hidden></div>
@@ -1425,6 +1431,58 @@
           <label class="scene-inspector-control-row">
             <span>Offset (s)</span>
             <input id="scene-inspector-animation-offset" class="scene-inspector-number-input" type="number" step="0.1" value="0">
+          </label>
+        </div>
+
+        <div id="scene-inspector-physics-controls" class="scene-inspector-physics-controls" hidden>
+          <div class="scene-inspector-section-header">
+            <div class="scene-inspector-section-title">Physics</div>
+            <div id="scene-inspector-physics-meta" class="scene-inspector-section-meta"></div>
+          </div>
+
+          <label class="scene-inspector-control-row">
+            <span>Enabled</span>
+            <input id="scene-inspector-physics-enabled" type="checkbox">
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Body</span>
+            <select id="scene-inspector-physics-body-type" class="chip">
+              <option value="dynamic">Dynamic</option>
+              <option value="static">Static</option>
+            </select>
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Shape</span>
+            <select id="scene-inspector-physics-shape" class="chip">
+              <option value="box">Box</option>
+              <option value="sphere">Sphere</option>
+            </select>
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Mass</span>
+            <input id="scene-inspector-physics-mass" class="scene-inspector-number-input" type="number" min="0" step="0.1" value="1">
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Bounce</span>
+            <input id="scene-inspector-physics-restitution" class="scene-inspector-number-input" type="number" min="0" max="1" step="0.05" value="0.2">
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Friction</span>
+            <input id="scene-inspector-physics-friction" class="scene-inspector-number-input" type="number" min="0" max="1" step="0.05" value="0.5">
+          </label>
+
+          <label class="scene-inspector-control-row">
+            <span>Velocity</span>
+            <div class="scene-inspector-vector-inputs">
+              <input id="scene-inspector-physics-velocity-x" class="scene-inspector-number-input" type="number" step="0.1" value="0" aria-label="Velocity X">
+              <input id="scene-inspector-physics-velocity-y" class="scene-inspector-number-input" type="number" step="0.1" value="0" aria-label="Velocity Y">
+              <input id="scene-inspector-physics-velocity-z" class="scene-inspector-number-input" type="number" step="0.1" value="0" aria-label="Velocity Z">
+            </div>
           </label>
         </div>
         <div id="scene-inspector-object-actions" class="scene-inspector-object-actions" hidden>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
-    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js html/assets/js/scenesync/scene-physics.test.js",
+    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js html/assets/js/scenesync/scene-physics.test.js html/assets/js/scenesync/history/history-manager.test.js",
     "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
-    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js",
-    "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js",
+    "test:physics": "node --test html/assets/js/scenesync/physics/fixed.test.js html/assets/js/scenesync/physics/world.test.js html/assets/js/scenesync/physics/lockstep.test.js html/assets/js/scenesync/scene-physics.test.js",
+    "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"
   },


### PR DESCRIPTION
## Summary

- Integrates deterministic Scene Sync physics into the main web editor using the existing Scene Clock / Player transport as the host time source.
- Adds object-level Physics controls in Scene Inspector and persists `physics` through scene-state, snapshots, Export ZIP, Import ZIP/URL, and broadcast payloads.
- Bundles the shared physics runtime into exported viewers and adds a minimal public viewer Play/Pause/Reset/Seek control when a scene contains physics.
- Documents the current physics scope: translation-only, sphere / AABB box / ground.

## Validation

- `npm run test:physics`
- `npm run test:playback-duration`
- `npm run test:scene-sync-export-import`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `node --check html/assets/js/scenesync-export/viewer/create-viewer-core.js`
- `node --check html/assets/js/scenesync-export/viewer/static-viewer-entry.js`
- `node --check html/assets/js/scenesync-export/export/build-export-package.js`
- `node --check html/assets/js/scenesync/importers/scene-sync-export/apply-scene-settings.js`
- Local Playwright smoke check against `http://127.0.0.1:8891/scenesync/?room=codex-physics-check`: scene module loaded, Physics Inspector DOM present, no page/console errors observed.