### PR TITLE
[codex] Add scene physics inspector controls

### DIFF
--- a/html/assets/js/scenesync/history/history-manager.js
+++ b/html/assets/js/scenesync/history/history-manager.js
@@ -158,6 +158,24 @@ export class HistoryManager {
     };
   }
 
+  static createScenePhysicsEntry(beforePhysics, afterPhysics) {
+    return {
+      id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: Date.now(),
+      summary: afterPhysics?.enabled
+        ? 'Scene physics enabled'
+        : 'Scene physics disabled',
+      forward: {
+        kind: 'scene-physics',
+        physics: afterPhysics || { enabled: false },
+      },
+      backward: {
+        kind: 'scene-physics',
+        physics: beforePhysics || { enabled: false },
+      },
+    };
+  }
+
   static createBatchEntry(forwardActions, backwardActions, summary = 'Batch operation') {
     return {
       id: `hist-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/html/assets/js/scenesync/history/history-manager.test.js
+++ b/html/assets/js/scenesync/history/history-manager.test.js
@@ -53,3 +53,26 @@ test('remove history omits optional restore fields when they are not provided', 
   assert.equal(Object.prototype.hasOwnProperty.call(entry.backward, 'physics'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(entry.backward, 'audioSources'), false);
 });
+
+test('scene physics history restores previous scene physics settings', () => {
+  const before = { enabled: false };
+  const after = {
+    enabled: true,
+    duration: 10,
+    worldOptions: {
+      gravity: -9.81,
+      ground: { y: 0, restitution: 0.2, friction: 0.5 },
+    },
+  };
+
+  const entry = HistoryManager.createScenePhysicsEntry(before, after);
+
+  assert.deepEqual(entry.forward, {
+    kind: 'scene-physics',
+    physics: after,
+  });
+  assert.deepEqual(entry.backward, {
+    kind: 'scene-physics',
+    physics: before,
+  });
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4446,6 +4446,13 @@ const sceneInspectorModeJsonBtn = document.getElementById('scene-inspector-mode-
 const sceneInspectorFormEl = document.getElementById('scene-inspector-form');
 const sceneInspectorEditorEl = document.getElementById('scene-inspector-editor');
 const sceneInspectorOutputEl = document.getElementById('scene-inspector-output');
+const sceneInspectorScenePhysicsControlsEl = document.getElementById('scene-inspector-scene-physics-controls');
+const sceneInspectorScenePhysicsMetaEl = document.getElementById('scene-inspector-scene-physics-meta');
+const sceneInspectorScenePhysicsEnabledEl = document.getElementById('scene-inspector-scene-physics-enabled');
+const sceneInspectorScenePhysicsDurationEl = document.getElementById('scene-inspector-scene-physics-duration');
+const sceneInspectorScenePhysicsGravityYEl = document.getElementById('scene-inspector-scene-physics-gravity-y');
+const sceneInspectorScenePhysicsGroundEnabledEl = document.getElementById('scene-inspector-scene-physics-ground-enabled');
+const sceneInspectorScenePhysicsGroundYEl = document.getElementById('scene-inspector-scene-physics-ground-y');
 const sceneInspectorObjectMetaEl = document.getElementById('scene-inspector-object-meta');
 const sceneInspectorObjectEmptyEl = document.getElementById('scene-inspector-object-empty');
 const sceneInspectorObjectHeadEl = document.getElementById('scene-inspector-object-head');
@@ -11466,6 +11473,57 @@ function renderSceneInspectorAnimationControls(selectedObject) {
   }
 }
 
+function scenePhysicsGravityY(physics) {
+  const gravity = physics?.worldOptions?.gravity;
+  if (Array.isArray(gravity)) return Number.isFinite(gravity[1]) ? gravity[1] : -9.81;
+  return Number.isFinite(gravity) ? gravity : -9.81;
+}
+
+function setSceneInspectorScenePhysicsFieldsDisabled(disabled) {
+  const groundDisabled = disabled || !sceneInspectorScenePhysicsGroundEnabledEl?.checked;
+  for (const el of [
+    sceneInspectorScenePhysicsDurationEl,
+    sceneInspectorScenePhysicsGravityYEl,
+    sceneInspectorScenePhysicsGroundEnabledEl,
+  ]) {
+    if (el) el.disabled = disabled;
+  }
+  if (sceneInspectorScenePhysicsGroundYEl) {
+    sceneInspectorScenePhysicsGroundYEl.disabled = groundDisabled;
+  }
+}
+
+function renderSceneInspectorScenePhysicsControls(snapshot) {
+  if (!sceneInspectorScenePhysicsControlsEl) return;
+
+  const physics = normalizeScenePhysics(snapshot?.physics || scenePhysicsState);
+  const enabled = physics.enabled === true;
+  const ground = physics.worldOptions?.ground || null;
+
+  if (sceneInspectorScenePhysicsMetaEl) {
+    sceneInspectorScenePhysicsMetaEl.textContent = enabled
+      ? `g ${scenePhysicsGravityY(physics)}`
+      : 'Off';
+  }
+  if (sceneInspectorScenePhysicsEnabledEl) {
+    sceneInspectorScenePhysicsEnabledEl.checked = enabled;
+  }
+  if (sceneInspectorScenePhysicsDurationEl) {
+    sceneInspectorScenePhysicsDurationEl.value = String(Number.isFinite(physics.duration) ? physics.duration : 10);
+  }
+  if (sceneInspectorScenePhysicsGravityYEl) {
+    sceneInspectorScenePhysicsGravityYEl.value = String(scenePhysicsGravityY(physics));
+  }
+  if (sceneInspectorScenePhysicsGroundEnabledEl) {
+    sceneInspectorScenePhysicsGroundEnabledEl.checked = !!ground;
+  }
+  if (sceneInspectorScenePhysicsGroundYEl) {
+    sceneInspectorScenePhysicsGroundYEl.value = String(Number.isFinite(ground?.y) ? ground.y : 0);
+  }
+
+  setSceneInspectorScenePhysicsFieldsDisabled(!enabled);
+}
+
 function setSceneInspectorPhysicsFieldsDisabled(disabled) {
   for (const el of [
     sceneInspectorPhysicsBodyTypeEl,
@@ -11554,6 +11612,7 @@ function renderSceneInspector(snapshot = buildSceneInspectorSnapshot()) {
   if (sceneInspectorOutputEl && !sceneInspectorState.isEditing) {
     sceneInspectorOutputEl.textContent = JSON.stringify(snapshot, null, 2);
   }
+  renderSceneInspectorScenePhysicsControls(snapshot);
 
   const isEditing = sceneInspectorState.isEditing;
   sceneInspectorEditBtn.hidden = isEditing;
@@ -12736,6 +12795,45 @@ function readSceneInspectorPhysicsControls() {
   });
 }
 
+function readSceneInspectorScenePhysicsControls() {
+  if (!sceneInspectorScenePhysicsEnabledEl?.checked) {
+    return { enabled: false };
+  }
+
+  const ground = sceneInspectorScenePhysicsGroundEnabledEl?.checked
+    ? {
+        y: Number(sceneInspectorScenePhysicsGroundYEl?.value),
+      }
+    : null;
+
+  return normalizeScenePhysics({
+    enabled: true,
+    duration: Number(sceneInspectorScenePhysicsDurationEl?.value),
+    worldOptions: {
+      gravity: Number(sceneInspectorScenePhysicsGravityYEl?.value),
+      ground,
+    },
+  });
+}
+
+function broadcastScenePhysicsDelta(physics) {
+  const before = getScenePhysicsForSerialize({ enableWhenObjectsExist: false }) || { enabled: false };
+  const after = serializeScenePhysics(physics) || { enabled: false };
+  if (valuesEqual(before, after)) {
+    renderSceneInspectorScenePhysicsControls(buildSceneInspectorSnapshot());
+    return;
+  }
+
+  presenceState.historyManager?.push(
+    HistoryManager.createScenePhysicsEntry(cloneJsonSafe(before), cloneJsonSafe(after))
+  );
+  applyScenePhysics(after, {
+    broadcastChange: true,
+    reason: 'scene-inspector-scene-physics-updated',
+  });
+  renderSceneInspectorScenePhysicsControls(buildSceneInspectorSnapshot());
+}
+
 function broadcastSelectedObjectPhysicsDelta(physics) {
   const snapshot = buildSceneInspectorSnapshot();
   const { objectId, objectSnapshot } = buildSelectedObjectInspectorContext(snapshot);
@@ -13008,6 +13106,23 @@ sceneInspectorAnimationOffsetEl?.addEventListener('change', () => {
     offset: Number(sceneInspectorAnimationOffsetEl.value),
   });
 });
+
+sceneInspectorScenePhysicsEnabledEl?.addEventListener('change', () => {
+  broadcastScenePhysicsDelta(readSceneInspectorScenePhysicsControls());
+});
+
+for (const control of [
+  sceneInspectorScenePhysicsDurationEl,
+  sceneInspectorScenePhysicsGravityYEl,
+  sceneInspectorScenePhysicsGroundEnabledEl,
+  sceneInspectorScenePhysicsGroundYEl,
+]) {
+  control?.addEventListener('change', () => {
+    setSceneInspectorScenePhysicsFieldsDisabled(!sceneInspectorScenePhysicsEnabledEl?.checked);
+    if (!sceneInspectorScenePhysicsEnabledEl?.checked) return;
+    broadcastScenePhysicsDelta(readSceneInspectorScenePhysicsControls());
+  });
+}
 
 sceneInspectorPhysicsEnabledEl?.addEventListener('change', () => {
   broadcastSelectedObjectPhysicsDelta(readSceneInspectorPhysicsControls());

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -586,6 +586,7 @@
     .scene-inspector-object-actions .chip {
       justify-content: center;
     }
+    .scene-inspector-scene-physics-controls,
     .scene-inspector-animation-controls,
     .scene-inspector-physics-controls {
       display: flex;
@@ -1399,6 +1400,37 @@
       <pre id="scene-inspector-output" class="scene-inspector-scene-json">{
   "status": "waiting-for-scene"
 }</pre>
+      <section id="scene-inspector-scene-physics-controls" class="scene-inspector-scene-physics-controls">
+        <div class="scene-inspector-section-header">
+          <div class="scene-inspector-section-title">Scene Physics</div>
+          <div id="scene-inspector-scene-physics-meta" class="scene-inspector-section-meta"></div>
+        </div>
+
+        <label class="scene-inspector-control-row">
+          <span>Enabled</span>
+          <input id="scene-inspector-scene-physics-enabled" type="checkbox">
+        </label>
+
+        <label class="scene-inspector-control-row">
+          <span>Duration</span>
+          <input id="scene-inspector-scene-physics-duration" class="scene-inspector-number-input" type="number" min="0.1" step="0.1" value="10">
+        </label>
+
+        <label class="scene-inspector-control-row">
+          <span>Gravity Y</span>
+          <input id="scene-inspector-scene-physics-gravity-y" class="scene-inspector-number-input" type="number" step="0.1" value="-9.81">
+        </label>
+
+        <label class="scene-inspector-control-row">
+          <span>Ground</span>
+          <input id="scene-inspector-scene-physics-ground-enabled" type="checkbox">
+        </label>
+
+        <label class="scene-inspector-control-row">
+          <span>Ground Y</span>
+          <input id="scene-inspector-scene-physics-ground-y" class="scene-inspector-number-input" type="number" step="0.1" value="0">
+        </label>
+      </section>
       <section id="scene-inspector-object-section" class="scene-inspector-section">
         <div class="scene-inspector-section-header">
           <div class="scene-inspector-section-title">Selected Object</div>


### PR DESCRIPTION
## Summary
- Add a Scene Physics section to the Scene Inspector for toggling scene physics, duration, gravity Y, ground, and ground Y.
- Broadcast scene-level physics changes through the existing `scene-physics` path.
- Add history entries so scene physics changes participate in Undo/Redo.

## Validation
- `npm run test:physics`
- `npm run test:scene-sync-export-import`
- `git diff --check`
- Playwright smoke check against local `http://127.0.0.1:4179/scenesync/?room=physics-smoke&noRestore=1` confirmed the Scene Physics controls are present with default values.