### PR TITLE
[codex] Allow scene physics payloads

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -5,6 +5,7 @@ const KNOWN_KINDS = new Set([
   'scene-mesh',
   'scene-env',
   'scene-bgm',
+  'scene-physics',
   'scene-state',
   'scene-request',
   'scene-avatar',
@@ -30,6 +31,62 @@ function hasFiniteNumberArray(value, size) {
   return Array.isArray(value)
     && value.length === size
     && value.every(item => typeof item === 'number' && Number.isFinite(item));
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function validateScenePhysicsPayload(physics) {
+  if (!physics || typeof physics !== 'object' || Array.isArray(physics)) {
+    return { ok: false, reason: 'physics must be an object' };
+  }
+
+  if (physics.version !== undefined && (!Number.isInteger(physics.version) || physics.version < 1)) {
+    return { ok: false, reason: 'physics.version must be a positive integer' };
+  }
+  if (physics.enabled !== undefined && typeof physics.enabled !== 'boolean') {
+    return { ok: false, reason: 'physics.enabled must be a boolean' };
+  }
+  if (physics.duration !== undefined && (!isFiniteNumber(physics.duration) || physics.duration <= 0)) {
+    return { ok: false, reason: 'physics.duration must be a positive finite number' };
+  }
+
+  const worldOptions = physics.worldOptions;
+  if (worldOptions !== undefined) {
+    if (!worldOptions || typeof worldOptions !== 'object' || Array.isArray(worldOptions)) {
+      return { ok: false, reason: 'physics.worldOptions must be an object' };
+    }
+
+    if (
+      worldOptions.gravity !== undefined
+      && !isFiniteNumber(worldOptions.gravity)
+      && !hasFiniteNumberArray(worldOptions.gravity, 3)
+    ) {
+      return { ok: false, reason: 'physics.worldOptions.gravity must be a finite number or [x,y,z]' };
+    }
+
+    if (
+      worldOptions.timestepFp !== undefined
+      && (!Number.isInteger(worldOptions.timestepFp) || worldOptions.timestepFp <= 0)
+    ) {
+      return { ok: false, reason: 'physics.worldOptions.timestepFp must be a positive integer' };
+    }
+
+    const ground = worldOptions.ground;
+    if (ground !== undefined && ground !== null && ground !== false) {
+      if (typeof ground !== 'object' || Array.isArray(ground)) {
+        return { ok: false, reason: 'physics.worldOptions.ground must be an object, null, or false' };
+      }
+      for (const field of ['y', 'restitution', 'friction']) {
+        if (ground[field] !== undefined && !isFiniteNumber(ground[field])) {
+          return { ok: false, reason: `physics.worldOptions.ground.${field} must be finite` };
+        }
+      }
+    }
+  }
+
+  return { ok: true };
 }
 
 // AudioSource component map（audioSources）のバリデーション。
@@ -132,6 +189,10 @@ export function validateSceneSyncPayload(payload, options = {}) {
     if (!isReasonableString(payload.bgm.url)) {
       return { ok: false, reason: 'bgm.url must be a reasonable string' };
     }
+  }
+
+  if (payload.kind === 'scene-physics') {
+    return validateScenePhysicsPayload(payload.physics);
   }
 
   if (payload.kind === 'scene-batch') {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -181,6 +181,34 @@ describe('Scene Sync guard helpers', () => {
     assert.equal(result.ok, true);
   });
 
+  it('accepts valid scene-physics settings', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-physics',
+      physics: {
+        version: 1,
+        enabled: true,
+        duration: 10,
+        worldOptions: {
+          gravity: -9.81,
+          ground: { y: 0, restitution: 0.35, friction: 0.72 },
+          timestepFp: 1092,
+        },
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects scene-physics with invalid gravity', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-physics',
+      physics: {
+        enabled: true,
+        worldOptions: { gravity: [0, Infinity, 0] },
+      },
+    });
+    assert.equal(result.ok, false);
+  });
+
   it('rejects scene-bgm without url', () => {
     const result = validateSceneSyncPayload({
       kind: 'scene-bgm',
@@ -357,6 +385,26 @@ describe('Scene Sync server guards', () => {
     assert.equal(avatar.status, 200);
     assert.equal(lock.status, 200);
     assert.equal(unlock.status, 200);
+  });
+
+  it('accepts scene-physics broadcast payloads', async () => {
+    const response = await fetch(`${baseUrl}/api/room/physics-protocol/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'scene-physics',
+        physics: {
+          version: 1,
+          enabled: true,
+          duration: 10,
+          worldOptions: {
+            gravity: -9.81,
+            ground: { y: 0, restitution: 0.35, friction: 0.72 },
+          },
+        },
+      }),
+    });
+    assert.equal(response.status, 200);
   });
 
   it('enforces object count limit for scene-add', async () => {


### PR DESCRIPTION
## Summary
- allow the presence server schema to accept `scene-physics` protocol messages
- validate scene physics settings shape, gravity, timestep, and ground numeric fields
- add guard coverage for helper validation and HTTP broadcast acceptance

## Why
Scene Sync clients can now export/import root `scene.physics`, but production presence rejected `scene-physics` broadcasts as an unknown kind. That made physics-enabled scene import look like a file-load failure until the server accepted the protocol payload.

## Validation
- `git diff --check`
- `node --check src/scenesync/message-schema.mjs`
- targeted `validateSceneSyncPayload()` smoke for valid and invalid `scene-physics`
- local presence API smoke: POST `/api/room/physics-protocol/broadcast` returned `200`

Note: the full `scenesync-guards` suite printed passing TAP subtests in this worktree, but the process stayed alive due an existing interval handle unrelated to this patch.