### PR TITLE
[codex] Implement Scene Sync time controls

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -7,6 +7,7 @@ const KNOWN_KINDS = new Set([
   'scene-bgm',
   'scene-state',
   'scene-request',
+  'scene-clock',
   'scene-avatar',
   'scene-lock',
   'scene-unlock',
@@ -111,6 +112,36 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-env' && !ENV_IDS.has(payload.envId)) {
     return { ok: false, reason: 'envId is invalid' };
+  }
+
+  if (payload.kind === 'scene-clock') {
+    const allowedModes = new Set(['local-preview', 'shared-playback', 'room-time']);
+    const allowedSources = new Set(['local', 'room']);
+    if (payload.mode !== undefined && !allowedModes.has(payload.mode)) {
+      return { ok: false, reason: 'scene-clock.mode is invalid' };
+    }
+    if (payload.source !== undefined && !allowedSources.has(payload.source)) {
+      return { ok: false, reason: 'scene-clock.source is invalid' };
+    }
+    for (const key of ['offset', 'pausedTime', 'rate', 'roomNow', 'sentAt', 'revision']) {
+      if (payload[key] !== undefined && (typeof payload[key] !== 'number' || !Number.isFinite(payload[key]))) {
+        return { ok: false, reason: `scene-clock.${key} must be a finite number` };
+      }
+    }
+    if (payload.paused !== undefined && typeof payload.paused !== 'boolean') {
+      return { ok: false, reason: 'scene-clock.paused must be a boolean' };
+    }
+    if (payload.controller !== undefined && payload.controller !== null) {
+      if (typeof payload.controller !== 'object' || Array.isArray(payload.controller)) {
+        return { ok: false, reason: 'scene-clock.controller must be an object or null' };
+      }
+      if (payload.controller.id !== undefined && !isReasonableString(payload.controller.id, maxStringLength)) {
+        return { ok: false, reason: 'scene-clock.controller.id must be a reasonable string' };
+      }
+      if (payload.controller.nickname !== undefined && !isReasonableString(payload.controller.nickname, maxStringLength)) {
+        return { ok: false, reason: 'scene-clock.controller.nickname must be a reasonable string' };
+      }
+    }
   }
 
   // audioSources は scene-add / scene-delta などでオブジェクトに AudioSource を付与する。

--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -33,6 +33,19 @@ function hasFiniteNumberArray(value, size) {
     && value.every(item => typeof item === 'number' && Number.isFinite(item));
 }
 
+function validateObjectClock(clock, path = 'clock') {
+  if (clock === undefined) return { ok: true };
+  if (!clock || typeof clock !== 'object' || Array.isArray(clock)) {
+    return { ok: false, reason: `${path} must be an object` };
+  }
+  for (const key of ['epochTime', 'sharedEpochTime', 'sharedEpoch']) {
+    if (clock[key] !== undefined && (typeof clock[key] !== 'number' || !Number.isFinite(clock[key]))) {
+      return { ok: false, reason: `${path}.${key} must be a finite number` };
+    }
+  }
+  return { ok: true };
+}
+
 // AudioSource component map（audioSources）のバリデーション。
 // value が null のキーは「その AudioSource を削除する」patch を意味する。
 // 完全な型の正規化は html/assets/js/scenesync/audio/audio-source.js が担当する。
@@ -110,6 +123,11 @@ export function validateSceneSyncPayload(payload, options = {}) {
     return { ok: false, reason: 'scale must be finite [x,y,z]' };
   }
 
+  const clockValidation = validateObjectClock(payload.clock, 'clock');
+  if (!clockValidation.ok) {
+    return clockValidation;
+  }
+
   if (payload.kind === 'scene-env' && !ENV_IDS.has(payload.envId)) {
     return { ok: false, reason: 'envId is invalid' };
   }
@@ -140,6 +158,20 @@ export function validateSceneSyncPayload(payload, options = {}) {
       }
       if (payload.controller.nickname !== undefined && !isReasonableString(payload.controller.nickname, maxStringLength)) {
         return { ok: false, reason: 'scene-clock.controller.nickname must be a reasonable string' };
+      }
+    }
+    if (payload.objectClocks !== undefined) {
+      if (!payload.objectClocks || typeof payload.objectClocks !== 'object' || Array.isArray(payload.objectClocks)) {
+        return { ok: false, reason: 'scene-clock.objectClocks must be an object map' };
+      }
+      for (const [objectId, clock] of Object.entries(payload.objectClocks)) {
+        if (!isReasonableString(objectId, maxStringLength)) {
+          return { ok: false, reason: 'scene-clock.objectClocks keys must be reasonable strings' };
+        }
+        const objectClockValidation = validateObjectClock(clock, `scene-clock.objectClocks.${objectId}`);
+        if (!objectClockValidation.ok) {
+          return objectClockValidation;
+        }
       }
     }
   }

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -1635,7 +1635,7 @@ function createPresenceServer() {
       roomOverride: Boolean(roomOverride)
     });
 
-    conn.send({ type: 'welcome', id: client.id, room: roomId });
+    conn.send({ type: 'welcome', id: client.id, room: roomId, serverTime: Date.now() });
     broadcastPeers(roomId);
 
     conn.onMessage = raw => {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -128,6 +128,14 @@ describe('Scene Sync guard helpers', () => {
       paused: false,
       rate: 1,
       controller: { id: 'peer-1', nickname: 'Akihiro' },
+      objectClocks: {
+        'obj-1': { sharedEpochTime: 12.5 },
+      },
+    }).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'obj-1',
+      clock: { sharedEpochTime: 12.5 },
     }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'ai-link-established', linkId: 'l1' }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'ai-link-revoked', linkId: 'l1' }).ok, true);
@@ -140,6 +148,21 @@ describe('Scene Sync guard helpers', () => {
       offset: Infinity,
     });
     assert.equal(result.ok, false);
+  });
+
+  it('rejects invalid shared object clock numbers', () => {
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-delta',
+      objectId: 'o1',
+      clock: { sharedEpochTime: Infinity },
+    }).ok, false);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-clock',
+      mode: 'shared-playback',
+      objectClocks: {
+        o1: { sharedEpochTime: NaN },
+      },
+    }).ok, false);
   });
 
   it('rejects scene-batch with NaN in nested op', () => {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -119,8 +119,27 @@ describe('Scene Sync guard helpers', () => {
     assert.equal(validateSceneSyncPayload({ kind: 'scene-avatar', position: [0, 1, 2] }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'scene-lock', objectId: 'obj-1' }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'scene-unlock', objectId: 'obj-1' }).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-clock',
+      action: 'seek',
+      mode: 'shared-playback',
+      source: 'room',
+      offset: -100,
+      paused: false,
+      rate: 1,
+      controller: { id: 'peer-1', nickname: 'Akihiro' },
+    }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'ai-link-established', linkId: 'l1' }).ok, true);
     assert.equal(validateSceneSyncPayload({ kind: 'ai-link-revoked', linkId: 'l1' }).ok, true);
+  });
+
+  it('rejects invalid scene-clock numbers', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-clock',
+      mode: 'shared-playback',
+      offset: Infinity,
+    });
+    assert.equal(result.ok, false);
   });
 
   it('rejects scene-batch with NaN in nested op', () => {

--- a/docs/editor-runtime-behavior.md
+++ b/docs/editor-runtime-behavior.md
@@ -1,0 +1,53 @@
+# Editor Runtime Behavior
+
+Editor Shell is shared editing, not shared playback.
+
+## Synchronized State
+
+Editor Shell synchronizes object creation, deletion, transform, hierarchy, component add/remove, component settings, GLB/image/video/audio/text assets, Loomlet attach/replace, physics settings, and animation settings.
+
+## Local Runtime Time
+
+Editor Shell does not synchronize current playback time, play/pause, seek, ObjectAge progress, animation frames, Loomlet in-flight state, physics velocity, angular velocity, or intermediate physics simulation state.
+
+Each client uses Local Preview time unless the Player UI switches to Shared Playback or Room Time.
+
+## Immediate Runtime Reaction
+
+Runtime components react immediately after placement or setting changes:
+
+- GLB models with animations start sampling immediately.
+- Loomlet graphs start evaluating immediately after attachment.
+- Physics starts simulating immediately after a physics component is added.
+- Gravity changes apply on the spot; users must not need to press Play after changing gravity.
+
+## ObjectAge Start Conditions
+
+ObjectAge starts at `0` when:
+
+- an object is placed
+- transform editing completes
+- an object is restored after reload
+- animation settings change
+- Loomlet is attached, replaced, or cleared
+- audio or physics components are added or replaced
+- the user explicitly resets or rebases runtime time
+
+## Physics Rebase / Reset
+
+When transform editing completes, dynamic physics is rebased:
+
+```txt
+velocity = [0, 0, 0]
+angularVelocity = [0, 0, 0]
+initialTransform = current transform
+clock.epochTime = activeClock.now()
+```
+
+Reloads also discard physics velocity and angular velocity. Physics uses the restored transform as its initial transform and restarts from ObjectAge `0`.
+
+For shared-playback seek, prefer snapshot restore if available. If no snapshot exists, reset. Avoid long fast-forward catch-up.
+
+## XR
+
+XR changes view and input, not time. Entering XR must not change Clock Mode and must not reset ObjectAge.

--- a/docs/editor-runtime-behavior.md
+++ b/docs/editor-runtime-behavior.md
@@ -33,6 +33,8 @@ ObjectAge starts at `0` when:
 - audio or physics components are added or replaced
 - the user explicitly resets or rebases runtime time
 
+Editor Shell rebases each client's local `clock.epochTime` independently. Shared Playback and Room Time use `clock.sharedEpochTime`, so scene-state, scene-delta, and scene-clock reset/mode events must carry shared epoch baselines for synchronized ObjectAge.
+
 ## Physics Rebase / Reset
 
 When transform editing completes, dynamic physics is rebased:
@@ -42,6 +44,7 @@ velocity = [0, 0, 0]
 angularVelocity = [0, 0, 0]
 initialTransform = current transform
 clock.epochTime = activeClock.now()
+clock.sharedEpochTime = shared active baseline
 ```
 
 Reloads also discard physics velocity and angular velocity. Physics uses the restored transform as its initial transform and restarts from ObjectAge `0`.

--- a/docs/player-ui-time-control.md
+++ b/docs/player-ui-time-control.md
@@ -44,7 +44,7 @@ Shared Playback
 Following Akihiro
 ```
 
-Followers cannot play, pause, seek, reset, or change rate until they take control. Controller transfer adopts the currently displayed SharedTime and publishes the next shared operation against `RoomNow + sharedOffset`.
+Followers cannot play, pause, seek, reset, or change rate until they take control. Controller transfer adopts the currently displayed SharedTime and publishes the next shared operation against `RoomNow * rate + sharedOffset`.
 
 ## Room Time
 

--- a/docs/player-ui-time-control.md
+++ b/docs/player-ui-time-control.md
@@ -1,0 +1,60 @@
+# Player UI Time Control
+
+All time operations belong in Player UI. Scene Inspector and component controls can edit settings, but they must not become separate play/pause/seek/reset surfaces.
+
+Player UI owns:
+
+- Clock Mode switching
+- play / pause
+- seek / reset
+- playbackRate
+- shared controller request / release
+- local preview reset
+- selected ObjectAge display
+
+## Local Preview
+
+Editor Shell uses Local Preview by default.
+
+Display:
+
+```txt
+Local Preview
+自分だけに反映
+```
+
+Operations affect only the current client. Objects still animate, run Loomlet graphs, and simulate physics immediately after placement or setting changes; the Player UI is a controller for pausing, resetting, seeking, or slow checking, not a required start button.
+
+## Shared Playback
+
+Shared Playback synchronizes controller operations, not the controller's frame-by-frame local clock.
+
+Controller display:
+
+```txt
+Shared Playback
+Controller: Akihiro
+全員に反映
+```
+
+Follower display:
+
+```txt
+Shared Playback
+Following Akihiro
+```
+
+Followers cannot play, pause, seek, reset, or change rate until they take control. Controller transfer adopts the currently displayed SharedTime and publishes the next shared operation against `RoomNow + sharedOffset`.
+
+## Room Time
+
+Room Time follows RoomNow.
+
+Display:
+
+```txt
+Room Time
+現在時刻に同期
+```
+
+Pause and seek are disabled or hidden in this mode because the mode represents current room time, not a transport timeline.

--- a/docs/time-model.md
+++ b/docs/time-model.md
@@ -1,0 +1,63 @@
+# Scene Sync Time Model
+
+Scene Sync separates editing state synchronization from runtime time synchronization.
+
+## Terms
+
+`LocalNow` is each client's local monotonic preview time. Editor Shell uses this by default, and it is not synchronized with other clients.
+
+`RoomNow` is the room-level reference time. It can be computed from server time or a room time offset:
+
+```txt
+RoomNow ~= LocalWallClock + roomTimeOffset
+```
+
+`ActiveTime` is the time exposed by the current Shell / Clock Mode:
+
+```txt
+ActiveTime = SourceNow * rate + Offset
+SourceNow = LocalNow | RoomNow
+```
+
+`ObjectAge` is the runtime age of an object in its current state:
+
+```txt
+ObjectAge = ActiveTime - ObjectEpoch
+```
+
+`ObjectAge = 0` when an object is placed, edited, reloaded, has a component added or replaced, or is explicitly reset/rebased.
+
+## Clock Mode
+
+`local-preview` uses `LocalNow`. It is the Editor Shell default. Play, pause, seek, reset, rate, and ObjectAge are local-only.
+
+`shared-playback` uses `RoomNow`. Controller operations are synchronized as events:
+
+```txt
+SharedTime = RoomNow * rate + sharedOffset
+seek:  sharedOffset = targetTime - RoomNow * rate
+pause: pausedTime = SharedTime
+play:  sharedOffset = pausedTime - RoomNow * rate
+```
+
+Clients must not chase the controller's local clock every frame.
+
+`room-time` uses `RoomNow` continuously. It is for clock-like, live, or installation-style worlds and does not assume pause or seek.
+
+## Shell Policy
+
+Editor Shell defaults to `local-preview`. It synchronizes object creation, deletion, transforms, hierarchy, assets, component settings, Loomlet attachment, physics settings, and animation settings. It does not synchronize play, pause, seek, current frames, ObjectAge progress, Loomlet runtime state, physics velocity, or intermediate simulation state.
+
+Playback / Viewer Shell defaults to `shared-playback`. A controller changes play, pause, seek, reset, and rate; followers use `RoomNow + sharedOffset`.
+
+Room Time Shell defaults to `room-time`.
+
+Game Shell should use game-owned shared simulation time and should not expose free-form player seek/pause unless the game UI supports it.
+
+## Reloads
+
+Reload is regeneration, not resume. Restored objects receive a fresh `clock.epochTime = activeClock.now()`. Physics runtime velocity and angular velocity are discarded, and the restored transform becomes the new initial transform.
+
+## XR
+
+XR is not a time mode. Entering or exiting XR must not change Clock Mode and must not reset ObjectAge. XR inherits the current Shell / Clock Mode.

--- a/docs/time-model.md
+++ b/docs/time-model.md
@@ -25,6 +25,13 @@ SourceNow = LocalNow | RoomNow
 ObjectAge = ActiveTime - ObjectEpoch
 ```
 
+Each object keeps two epoch baselines:
+
+- `clock.epochTime` for Local Preview.
+- `clock.sharedEpochTime` for Shared Playback and Room Time.
+
+Local Preview may rebase `epochTime` independently on each client. Shared Playback and Room Time must use the shared epoch baseline distributed through scene state, scene deltas, and scene-clock baseline events.
+
 `ObjectAge = 0` when an object is placed, edited, reloaded, has a component added or replaced, or is explicitly reset/rebased.
 
 ## Clock Mode
@@ -48,7 +55,7 @@ Clients must not chase the controller's local clock every frame.
 
 Editor Shell defaults to `local-preview`. It synchronizes object creation, deletion, transforms, hierarchy, assets, component settings, Loomlet attachment, physics settings, and animation settings. It does not synchronize play, pause, seek, current frames, ObjectAge progress, Loomlet runtime state, physics velocity, or intermediate simulation state.
 
-Playback / Viewer Shell defaults to `shared-playback`. A controller changes play, pause, seek, reset, and rate; followers use `RoomNow + sharedOffset`.
+Playback / Viewer Shell defaults to `shared-playback`. A controller changes play, pause, seek, reset, and rate; followers use `RoomNow * rate + sharedOffset`.
 
 Room Time Shell defaults to `room-time`.
 
@@ -56,7 +63,7 @@ Game Shell should use game-owned shared simulation time and should not expose fr
 
 ## Reloads
 
-Reload is regeneration, not resume. Restored objects receive a fresh `clock.epochTime = activeClock.now()`. Physics runtime velocity and angular velocity are discarded, and the restored transform becomes the new initial transform.
+Reload is regeneration, not resume. Restored objects receive fresh local and shared epochs for the current active state. Physics runtime velocity and angular velocity are discarded, and the restored transform becomes the new initial transform.
 
 ## XR
 

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.js
@@ -124,8 +124,15 @@ export function setClockMode(state, mode, sources = {}, {
   return true;
 }
 
-export function getObjectAge(activeTime, objectClockState) {
-  const epochTime = Number(objectClockState?.epochTime);
+export function getObjectAge(activeTime, objectClockState, {
+  mode = CLOCK_MODES.LOCAL_PREVIEW,
+} = {}) {
+  const normalizedMode = normalizeClockMode(mode);
+  const epochTime = normalizedMode === CLOCK_MODES.LOCAL_PREVIEW
+    ? Number(objectClockState?.epochTime)
+    : (Number.isFinite(Number(objectClockState?.sharedEpochTime))
+      ? Number(objectClockState.sharedEpochTime)
+      : Number(objectClockState?.epochTime));
   if (!Number.isFinite(activeTime) || !Number.isFinite(epochTime)) return 0;
   return Math.max(0, activeTime - epochTime);
 }

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.js
@@ -1,3 +1,135 @@
+export const CLOCK_SOURCES = Object.freeze({
+  LOCAL: 'local',
+  ROOM: 'room',
+});
+
+export const CLOCK_MODES = Object.freeze({
+  LOCAL_PREVIEW: 'local-preview',
+  SHARED_PLAYBACK: 'shared-playback',
+  ROOM_TIME: 'room-time',
+});
+
+export const CLOCK_MODE_LABELS = Object.freeze({
+  [CLOCK_MODES.LOCAL_PREVIEW]: 'Local Preview',
+  [CLOCK_MODES.SHARED_PLAYBACK]: 'Shared Playback',
+  [CLOCK_MODES.ROOM_TIME]: 'Room Time',
+});
+
+export function normalizeClockMode(mode, fallback = CLOCK_MODES.LOCAL_PREVIEW) {
+  return Object.values(CLOCK_MODES).includes(mode) ? mode : fallback;
+}
+
+export function clockSourceForMode(mode) {
+  switch (normalizeClockMode(mode)) {
+    case CLOCK_MODES.SHARED_PLAYBACK:
+    case CLOCK_MODES.ROOM_TIME:
+      return CLOCK_SOURCES.ROOM;
+    case CLOCK_MODES.LOCAL_PREVIEW:
+    default:
+      return CLOCK_SOURCES.LOCAL;
+  }
+}
+
+export function createClockState({
+  mode = CLOCK_MODES.LOCAL_PREVIEW,
+  offset = 0,
+  paused = false,
+  pausedTime,
+  rate = 1,
+} = {}) {
+  const normalizedMode = normalizeClockMode(mode);
+  const normalizedRate = Number.isFinite(rate) && rate >= 0 ? rate : 1;
+  return {
+    mode: normalizedMode,
+    source: clockSourceForMode(normalizedMode),
+    offset: Number.isFinite(offset) ? offset : 0,
+    paused: paused === true,
+    pausedTime: Number.isFinite(pausedTime) ? pausedTime : undefined,
+    rate: normalizedRate,
+  };
+}
+
+export function getClockSourceNow(state, {
+  localNow = 0,
+  roomNow = 0,
+} = {}) {
+  return state?.source === CLOCK_SOURCES.ROOM ? roomNow : localNow;
+}
+
+export function getActiveClockTime(state, sources = {}) {
+  if (!state) return 0;
+  if (state.paused && Number.isFinite(state.pausedTime)) {
+    return Math.max(0, state.pausedTime);
+  }
+  const sourceNow = getClockSourceNow(state, sources);
+  const rate = Number.isFinite(state.rate) && state.rate >= 0 ? state.rate : 1;
+  const offset = Number.isFinite(state.offset) ? state.offset : 0;
+  return Math.max(0, sourceNow * rate + offset);
+}
+
+export function seekClockState(state, targetTime, sources = {}) {
+  if (!state) return false;
+  const time = Math.max(0, Number(targetTime) || 0);
+  const sourceNow = getClockSourceNow(state, sources);
+  const rate = Number.isFinite(state.rate) && state.rate >= 0 ? state.rate : 1;
+  state.offset = time - sourceNow * rate;
+  if (state.paused) state.pausedTime = time;
+  return true;
+}
+
+export function pauseClockState(state, sources = {}) {
+  if (!state || state.paused) return false;
+  state.pausedTime = getActiveClockTime(state, sources);
+  state.paused = true;
+  return true;
+}
+
+export function resumeClockState(state, sources = {}) {
+  if (!state || !state.paused) return false;
+  const pausedTime = Number.isFinite(state.pausedTime)
+    ? state.pausedTime
+    : getActiveClockTime(state, sources);
+  state.paused = false;
+  state.pausedTime = undefined;
+  seekClockState(state, pausedTime, sources);
+  return true;
+}
+
+export function setClockRate(state, rate, sources = {}) {
+  if (!state) return false;
+  const nextRate = Number(rate);
+  if (!Number.isFinite(nextRate) || nextRate < 0) return false;
+  const currentTime = getActiveClockTime(state, sources);
+  state.rate = nextRate;
+  seekClockState(state, currentTime, sources);
+  return true;
+}
+
+export function setClockMode(state, mode, sources = {}, {
+  preserveTime = true,
+  resetToZero = false,
+} = {}) {
+  if (!state) return false;
+  const nextMode = normalizeClockMode(mode, state.mode);
+  const nextSource = clockSourceForMode(nextMode);
+  const currentTime = resetToZero
+    ? 0
+    : (preserveTime ? getActiveClockTime(state, sources) : 0);
+
+  state.mode = nextMode;
+  state.source = nextSource;
+  state.paused = nextMode === CLOCK_MODES.ROOM_TIME ? false : state.paused;
+  state.pausedTime = state.paused ? currentTime : undefined;
+  seekClockState(state, currentTime, sources);
+  return true;
+}
+
+export function getObjectAge(activeTime, objectClockState) {
+  const epochTime = Number(objectClockState?.epochTime);
+  if (!Number.isFinite(activeTime) || !Number.isFinite(epochTime)) return 0;
+  return Math.max(0, activeTime - epochTime);
+}
+
 export function normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions = {}, getNow = () => performance.now()) {
   const now = typeof nowOrOptions === 'number' ? nowOrOptions : getNow();
   const options = nowOrOptions && typeof nowOrOptions === 'object'
@@ -16,9 +148,13 @@ export function preserveLocalSceneClockTimeline(state, {
   getSceneClockTime,
   resume = false,
 } = {}) {
-  if (!state || state.mode !== 'local' || typeof getSceneClockTime !== 'function') return false;
+  if (!state || !['local', CLOCK_MODES.LOCAL_PREVIEW].includes(state.mode) || typeof getSceneClockTime !== 'function') return false;
 
-  state.localTime = getSceneClockTime(now);
+  const preservedTime = getSceneClockTime(now);
+  state.localTime = preservedTime;
+  if (state.mode === CLOCK_MODES.LOCAL_PREVIEW) {
+    state.offset = preservedTime - (now / 1000) * (state.rate || 1);
+  }
   state.lastUpdateNow = now;
 
   if (resume) {

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
@@ -68,6 +68,14 @@ test('object age is active time minus epoch and clamps at zero', () => {
   assert.equal(getObjectAge(2, { epochTime: 4 }), 0);
 });
 
+test('shared object age uses shared epoch in shared modes', () => {
+  const clock = { epochTime: 90, sharedEpochTime: 4 };
+
+  assert.equal(getObjectAge(10, clock, { mode: CLOCK_MODES.LOCAL_PREVIEW }), 0);
+  assert.equal(getObjectAge(10, clock, { mode: CLOCK_MODES.SHARED_PLAYBACK }), 6);
+  assert.equal(getObjectAge(10, clock, { mode: CLOCK_MODES.ROOM_TIME }), 6);
+});
+
 test('deactivate scene clock args preserve existing numeric now calls', () => {
   const result = normalizeSceneClockDeactivateArgs(1234, undefined, () => 9999);
 

--- a/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
+++ b/html/assets/js/scenesync/runtime/scene-clock-transport.test.js
@@ -2,9 +2,71 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  CLOCK_MODES,
+  createClockState,
+  getActiveClockTime,
+  getObjectAge,
+  pauseClockState,
+  resumeClockState,
+  seekClockState,
+  setClockMode,
+  setClockRate,
   normalizeSceneClockDeactivateArgs,
   preserveLocalSceneClockTimeline,
 } from './scene-clock-transport.js';
+
+test('active clock defaults local preview to local source', () => {
+  const state = createClockState({ mode: CLOCK_MODES.LOCAL_PREVIEW, offset: -10 });
+
+  assert.equal(state.source, 'local');
+  assert.equal(getActiveClockTime(state, { localNow: 12, roomNow: 100 }), 2);
+});
+
+test('shared playback uses room source and offset for seek', () => {
+  const state = createClockState({ mode: CLOCK_MODES.SHARED_PLAYBACK });
+
+  assert.equal(state.source, 'room');
+  seekClockState(state, 15, { localNow: 1, roomNow: 100 });
+
+  assert.equal(state.offset, -85);
+  assert.equal(getActiveClockTime(state, { localNow: 2, roomNow: 101 }), 16);
+});
+
+test('pause and resume preserve room-based shared time without following controller local time', () => {
+  const state = createClockState({ mode: CLOCK_MODES.SHARED_PLAYBACK });
+  seekClockState(state, 20, { roomNow: 100 });
+
+  pauseClockState(state, { roomNow: 105 });
+  assert.equal(getActiveClockTime(state, { roomNow: 999 }), 25);
+
+  resumeClockState(state, { roomNow: 110 });
+  assert.equal(getActiveClockTime(state, { roomNow: 111 }), 26);
+});
+
+test('rate changes preserve current active time', () => {
+  const state = createClockState({ mode: CLOCK_MODES.LOCAL_PREVIEW, offset: 0 });
+  assert.equal(getActiveClockTime(state, { localNow: 4 }), 4);
+
+  setClockRate(state, 2, { localNow: 4 });
+
+  assert.equal(getActiveClockTime(state, { localNow: 4 }), 4);
+  assert.equal(getActiveClockTime(state, { localNow: 5 }), 6);
+});
+
+test('room time mode switches source and clears pause', () => {
+  const state = createClockState({ mode: CLOCK_MODES.LOCAL_PREVIEW, offset: -5, paused: true, pausedTime: 3 });
+
+  setClockMode(state, CLOCK_MODES.ROOM_TIME, { localNow: 10, roomNow: 100 });
+
+  assert.equal(state.mode, CLOCK_MODES.ROOM_TIME);
+  assert.equal(state.source, 'room');
+  assert.equal(state.paused, false);
+});
+
+test('object age is active time minus epoch and clamps at zero', () => {
+  assert.equal(getObjectAge(10, { epochTime: 4 }), 6);
+  assert.equal(getObjectAge(2, { epochTime: 4 }), 0);
+});
 
 test('deactivate scene clock args preserve existing numeric now calls', () => {
   const result = normalizeSceneClockDeactivateArgs(1234, undefined, () => 9999);

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -124,6 +124,12 @@ export function normalizeObjectPhysics(input = null) {
     physics.velocity = [0, 0, 0];
   }
 
+  if (Array.isArray(input.angularVelocity)) {
+    physics.angularVelocity = readVec3(input.angularVelocity);
+  } else if (bodyType === 'dynamic') {
+    physics.angularVelocity = [0, 0, 0];
+  }
+
   if (shape === 'sphere' && Number.isFinite(Number(input.radius))) {
     physics.radius = positiveNumber(input.radius, 0.5);
   }
@@ -227,6 +233,8 @@ export function createScenePhysicsRuntime({
   getScenePhysics,
   getObjectEntries,
   isClockActive = (clockState) => clockState?.transportActive === true,
+  getObjectAge = null,
+  isObjectPaused = null,
 } = {}) {
   let dirty = true;
   let world = null;
@@ -272,27 +280,46 @@ export function createScenePhysicsRuntime({
     return entryMap.size > 0;
   }
 
-  function applyWorldToObjects() {
+  function applyWorldToObjects(clockState = null) {
     if (!world) return;
     for (const [objectId, entry] of entryMap) {
       const body = world.getBody(objectId);
       if (!body || body.static) continue;
+      if (isObjectPaused?.(objectId, clockState) === true) continue;
       applyBodyPosition(entry.object, body);
     }
   }
 
-  function resetToInitialPose() {
+  function resetToInitialPose(clockState = null) {
     if (!world || !initialSnapshot) return false;
     world.restore(initialSnapshot);
-    applyWorldToObjects();
+    applyWorldToObjects(clockState);
     return true;
   }
 
-  function resetActiveToInitialPose() {
+  function resetActiveToInitialPose(clockState = null) {
     if (!active) return false;
-    const reset = resetToInitialPose();
+    const reset = resetToInitialPose(clockState);
     if (reset) active = false;
     return reset;
+  }
+
+  function getTargetTime(clockState) {
+    if (typeof getObjectAge !== 'function' || entryMap.size === 0) {
+      return Math.max(0, Number(clockState?.t) || 0);
+    }
+
+    const ages = [];
+    for (const objectId of entryMap.keys()) {
+      const age = Number(getObjectAge(objectId, clockState));
+      if (Number.isFinite(age)) ages.push(Math.max(0, age));
+    }
+
+    if (ages.length === 0) {
+      return Math.max(0, Number(clockState?.t) || 0);
+    }
+
+    return Math.min(...ages);
   }
 
   function update(clockState = null) {
@@ -303,7 +330,7 @@ export function createScenePhysicsRuntime({
     }
 
     if (!isClockActive(clockState)) {
-      const reset = resetActiveToInitialPose();
+      const reset = resetActiveToInitialPose(clockState);
       return { active: false, reason: 'clock-inactive', reset };
     }
 
@@ -313,13 +340,13 @@ export function createScenePhysicsRuntime({
       }
     }
 
-    const targetTime = Math.max(0, Number(clockState?.t) || 0);
+    const targetTime = getTargetTime(clockState);
     const targetTick = Math.max(0, Math.floor(targetTime / timestepSeconds));
     if (targetTick < world.tick && initialSnapshot) {
       world.restore(initialSnapshot);
     }
     world.stepTo(targetTick);
-    applyWorldToObjects();
+    applyWorldToObjects(clockState);
     active = true;
     return { active: true, tick: world.tick };
   }

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -48,6 +48,7 @@ test('normalizes object physics with practical defaults', () => {
     restitution: 0.2,
     friction: 0.5,
     velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
   });
 });
 
@@ -83,6 +84,32 @@ test('scene physics runtime is a function of supplied clock time', () => {
   assert.ok(yAfterSeekBack > yAtHalfSecond);
   assert.ok(yAfterSeekBack < 2);
   assert.ok(object.updateMatrixWorldCalled > 0);
+});
+
+test('scene physics runtime uses object age instead of raw active time when provided', () => {
+  const object = makeObject();
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => [{
+      objectId: 'ball',
+      object,
+      physics: object.userData.physics,
+    }],
+    isClockActive: () => true,
+    getObjectAge: () => 0,
+  });
+
+  runtime.update({ t: 1_780_000_000, mode: 'room-time', active: true });
+
+  assert.equal(object.position.toArray()[1], 2);
 });
 
 test('scene physics runtime resets to initial pose when the clock becomes inactive', () => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -991,9 +991,9 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
       lockMultiSelectedObjects();
       ensureMultiMoveBroadcastInterval();
     } else {
-      flushMultiMoveBroadcast();
       stopMultiMoveBroadcastInterval();
       endMultiTransformHistory();
+      flushMultiMoveBroadcast();
       unlockMultiSelectedObjects();
     }
     return;
@@ -1018,10 +1018,9 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
     dragIntervalId = null;
 
     // Text Panel scale bake (sendSelectedDelta と history 記録より前)
-    const wasBaked = transformCtrl.object &&
+    if (transformCtrl.object) {
       bakeTextPanelScaleToLayout(transformCtrl.object);
-
-    sendSelectedDelta();
+    }
 
     // ドラッグ終了時に履歴に追加
     if (dragStartState) {
@@ -1054,6 +1053,7 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
       }
       dragStartState = null;
     }
+    sendSelectedDelta({ includeClock: true });
   }
 });
 
@@ -1062,7 +1062,7 @@ function arraysEqual(a, b) {
   return a.every((v, i) => Math.abs(v - b[i]) < 0.0001);
 }
 
-function sendSelectedDelta() {
+function sendSelectedDelta({ includeClock = false } = {}) {
   const obj = transformCtrl.object;
   if (!obj || !obj.userData.objectId) return;
 
@@ -1079,6 +1079,9 @@ function sendSelectedDelta() {
     rotation: rot,
     scale: scl,
   };
+  if (includeClock) {
+    payload.clock = serializeObjectClockForSceneSync(obj);
+  }
 
   // Text Panel scale bake では asset.layout が本体なので、asset を含める
   if (obj.userData?.asset?.type === 'text') {
@@ -5136,7 +5139,12 @@ function applyRemoteSceneClock(payload, from = null) {
   if (!payload || typeof payload !== 'object') return;
   const nextMode = normalizeClockMode(payload.mode, CLOCK_MODES.SHARED_PLAYBACK);
   if (nextMode !== CLOCK_MODES.SHARED_PLAYBACK) return;
-  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (
+    sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK &&
+    payload.action !== 'mode'
+  ) {
+    return;
+  }
 
   const revision = Number(payload.revision);
   if (Number.isFinite(revision) && revision <= sceneClockState.sharedRevision) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1609,7 +1609,8 @@ const glbAnimationMixers = new Map();
 
 // ── Runtime Time Model / ObjectAge ───────────────────────
 // Runtime code evaluates ObjectAge, not raw host or room time.
-// ObjectAge = ActiveTime - object.userData.clock.epochTime.
+// Local Preview uses object.userData.clock.epochTime.
+// Shared Playback and Room Time use object.userData.clock.sharedEpochTime.
 
 function ensureObjectRuntime(obj) {
   if (!obj) return null;
@@ -1647,14 +1648,41 @@ function getActiveClockNow(now = performance.now()) {
   return getActiveClockTime(sceneClockState, getActiveClockSources(now));
 }
 
+function getSharedEpochTimeForCurrentState(now = performance.now()) {
+  return sceneClockState.mode === CLOCK_MODES.LOCAL_PREVIEW
+    ? getRoomNowSeconds()
+    : getSceneClockTime(now);
+}
+
+function readSharedEpochTime(clockLike) {
+  const sharedEpochTime = Number(clockLike?.sharedEpochTime ?? clockLike?.sharedEpoch);
+  return Number.isFinite(sharedEpochTime) ? sharedEpochTime : null;
+}
+
 function ensureObjectClock(obj, now = performance.now()) {
   if (!obj) return null;
   const activeTime = getActiveClockNow(now);
   const current = obj.userData?.clock;
+  const existingSharedEpochTime = readSharedEpochTime(current);
   obj.userData.clock = {
     epochTime: Number.isFinite(current?.epochTime) ? current.epochTime : activeTime,
+    sharedEpochTime: existingSharedEpochTime ?? getSharedEpochTimeForCurrentState(now),
   };
   return obj.userData.clock;
+}
+
+function getObjectAgeMode(clockState = null) {
+  return normalizeClockMode(clockState?.mode || sceneClockState.mode, sceneClockState.mode);
+}
+
+function serializeObjectClockForSceneSync(obj, now = performance.now()) {
+  const clock = ensureObjectClock(obj, now);
+  if (!clock) return null;
+  return {
+    sharedEpochTime: Number.isFinite(clock.sharedEpochTime)
+      ? clock.sharedEpochTime
+      : getSharedEpochTimeForCurrentState(now),
+  };
 }
 
 function resetObjectPhysicsMotion(obj) {
@@ -1677,6 +1705,7 @@ function resetObjectPhysicsMotion(obj) {
 function rebaseObjectClock(obj, {
   now = performance.now(),
   resetPhysicsMotion = false,
+  sharedEpochTime = null,
   reason = 'object-rebased',
 } = {}) {
   if (!obj) return null;
@@ -1688,6 +1717,9 @@ function rebaseObjectClock(obj, {
 
   const clock = {
     epochTime: getActiveClockNow(now),
+    sharedEpochTime: Number.isFinite(sharedEpochTime)
+      ? sharedEpochTime
+      : getSharedEpochTimeForCurrentState(now),
   };
   obj.userData.clock = clock;
 
@@ -1733,7 +1765,9 @@ function getObjectRuntimeTime(objectId, now = performance.now(), clockState = nu
   const activeTime = Number.isFinite(clockState?.t)
     ? clockState.t
     : getActiveClockNow(now);
-  const objectAge = getObjectAgeFromClock(activeTime, objectClock);
+  const objectAge = getObjectAgeFromClock(activeTime, objectClock, {
+    mode: getObjectAgeMode(clockState),
+  });
   const speed = Number.isFinite(runtime.speed) ? runtime.speed : 1;
   return Math.max(0, objectAge * speed);
 }
@@ -1745,23 +1779,13 @@ function getObjectAge(objectId, now = performance.now(), clockState = null) {
   const activeTime = Number.isFinite(clockState?.t)
     ? clockState.t
     : getActiveClockNow(now);
-  return getObjectAgeFromClock(activeTime, clock);
+  return getObjectAgeFromClock(activeTime, clock, {
+    mode: getObjectAgeMode(clockState),
+  });
 }
 
-// The host owns the clock source used for shared runtime behavior.
-// Desired deterministic model when the host supplies a room clock:
-//
-// selected:
-//   t = 0
-//
-// unselected:
-//   t = ((hostNow - runtime.startHostTime) / 1000) * speed
-//
-// On deselect:
-//   runtime.startHostTime = hostNow
-//
-// This should make GLB animation and Loomlet object graphs deterministic
-// for late joiners and multi-client synchronization.
+// Runtime uses ObjectAge derived from ActiveClock. Editor Shell defaults to
+// local-preview; Shared Playback and Room Time use shared object epochs.
 
 function resetObjectRuntimeOrigin(objectId, now = performance.now()) {
   const obj = managedObjects.get(objectId);
@@ -4828,15 +4852,28 @@ function getLocalClockControllerInfo() {
   };
 }
 
-function preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime) {
+function preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime, {
+  previousMode = sceneClockState.mode,
+  nextMode = sceneClockState.mode,
+  now = performance.now(),
+} = {}) {
   if (!Number.isFinite(previousActiveTime) || !Number.isFinite(nextActiveTime)) return;
+  const previousClockMode = normalizeClockMode(previousMode, sceneClockState.mode);
+  const nextClockMode = normalizeClockMode(nextMode, sceneClockState.mode);
   for (const obj of managedObjects.values()) {
-    const clock = ensureObjectClock(obj);
-    const age = getObjectAgeFromClock(previousActiveTime, clock);
+    const clock = ensureObjectClock(obj, now);
+    const age = getObjectAgeFromClock(previousActiveTime, clock, {
+      mode: previousClockMode,
+    });
+    const nextEpochTime = nextActiveTime - age;
     obj.userData.clock = {
-      epochTime: nextActiveTime - age,
+      ...clock,
+      ...(nextClockMode === CLOCK_MODES.LOCAL_PREVIEW
+        ? { epochTime: nextEpochTime }
+        : { sharedEpochTime: nextEpochTime }),
     };
   }
+  markScenePhysicsRuntimeDirty();
 }
 
 function updateClockLegacyFields(now = performance.now()) {
@@ -4950,10 +4987,112 @@ function canControlSceneClock() {
   return sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK || isSceneClockControllerSelf();
 }
 
+function getSharedObjectClockPayload(now = performance.now()) {
+  const objectClocks = {};
+  for (const [objectId, obj] of managedObjects.entries()) {
+    const clock = serializeObjectClockForSceneSync(obj, now);
+    if (clock) objectClocks[objectId] = clock;
+  }
+  return objectClocks;
+}
+
+function applySharedObjectClockBaseline(objectId, clockLike, {
+  now = performance.now(),
+  resetLocalEpoch = false,
+  resetPhysicsMotion = false,
+} = {}) {
+  const obj = managedObjects.get(objectId);
+  if (!obj) return false;
+  const sharedEpochTime = readSharedEpochTime(clockLike);
+  if (!Number.isFinite(sharedEpochTime)) return false;
+
+  const clock = ensureObjectClock(obj, now);
+  obj.userData.clock = {
+    ...clock,
+    ...(resetLocalEpoch ? { epochTime: getActiveClockNow(now) } : {}),
+    sharedEpochTime,
+  };
+
+  if (resetPhysicsMotion) {
+    resetObjectPhysicsMotion(obj);
+  }
+  return true;
+}
+
+function applySharedObjectClockBaselines(objectClocks, {
+  now = performance.now(),
+  resetLocalEpoch = false,
+  resetPhysicsMotion = false,
+} = {}) {
+  if (!objectClocks || typeof objectClocks !== 'object') return false;
+  let applied = false;
+  for (const [objectId, clockLike] of Object.entries(objectClocks)) {
+    applied = applySharedObjectClockBaseline(objectId, clockLike, {
+      now,
+      resetLocalEpoch,
+      resetPhysicsMotion,
+    }) || applied;
+  }
+  if (applied) {
+    markScenePhysicsRuntimeDirty();
+  }
+  return applied;
+}
+
+function resetAllObjectClocksForSceneClock(now = performance.now(), {
+  objectClocks = null,
+  reason = 'player-reset',
+  resetPhysicsMotion = true,
+} = {}) {
+  for (const [objectId, obj] of managedObjects.entries()) {
+    const baseline = objectClocks && Object.prototype.hasOwnProperty.call(objectClocks, objectId)
+      ? objectClocks[objectId]
+      : null;
+    const appliedBaseline = baseline
+      ? applySharedObjectClockBaseline(objectId, baseline, {
+          now,
+          resetLocalEpoch: true,
+          resetPhysicsMotion,
+        })
+      : false;
+    if (appliedBaseline) continue;
+    rebaseObjectClock(obj, {
+      now,
+      resetPhysicsMotion,
+      reason,
+    });
+  }
+
+  scenePhysicsRuntime.resetToInitialPose();
+  markScenePhysicsRuntimeDirty();
+}
+
+function publishSharedObjectClockBaselines(reason = 'baseline') {
+  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (!isSceneClockControllerSelf()) return;
+
+  const now = performance.now();
+  const activeTime = getSceneClockTime(now);
+  preserveObjectAgesAcrossActiveTimeChange(activeTime, activeTime, {
+    previousMode: CLOCK_MODES.SHARED_PLAYBACK,
+    nextMode: CLOCK_MODES.SHARED_PLAYBACK,
+    now,
+  });
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent(reason, {
+    objectClocks: getSharedObjectClockPayload(now),
+  });
+}
+
 function broadcastSceneClockEvent(action, extra = {}) {
   if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
   if (!presenceState.ws || presenceState.ws.readyState !== WebSocket.OPEN) return;
   sceneClockState.sharedRevision += 1;
+  const shouldIncludeObjectClocks =
+    extra.objectClocks ||
+    action === 'mode' ||
+    action === 'reset' ||
+    action === 'controller';
   broadcast({
     kind: 'scene-clock',
     action,
@@ -4967,6 +5106,9 @@ function broadcastSceneClockEvent(action, extra = {}) {
     revision: sceneClockState.sharedRevision,
     roomNow: getRoomNowSeconds(),
     sentAt: Date.now(),
+    ...(shouldIncludeObjectClocks ? {
+      objectClocks: extra.objectClocks || getSharedObjectClockPayload(),
+    } : {}),
     ...extra,
   });
 }
@@ -4994,6 +5136,12 @@ function applyRemoteSceneClock(payload, from = null) {
   if (!payload || typeof payload !== 'object') return;
   const nextMode = normalizeClockMode(payload.mode, CLOCK_MODES.SHARED_PLAYBACK);
   if (nextMode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+
+  const revision = Number(payload.revision);
+  if (Number.isFinite(revision) && revision <= sceneClockState.sharedRevision) {
+    return;
+  }
 
   sceneClockState.mode = CLOCK_MODES.SHARED_PLAYBACK;
   sceneClockState.source = 'room';
@@ -5007,16 +5155,30 @@ function applyRemoteSceneClock(payload, from = null) {
         id: from.id,
         nickname: from.nickname || 'Controller',
       } : null);
-  sceneClockState.sharedRevision = Math.max(sceneClockState.sharedRevision, Number(payload.revision) || 0);
+  if (Number.isFinite(revision)) {
+    sceneClockState.sharedRevision = revision;
+  }
   sceneClockState.sharedUpdatedAt = Date.now();
   sceneClockState.transportActive = true;
   sceneClockState.active = true;
   updateClockLegacyFields();
+
+  if (payload.action === 'reset') {
+    resetAllObjectClocksForSceneClock(performance.now(), {
+      objectClocks: payload.objectClocks,
+      reason: 'remote-player-reset',
+      resetPhysicsMotion: true,
+    });
+  } else if (payload.objectClocks) {
+    applySharedObjectClockBaselines(payload.objectClocks);
+  }
+
   notifySceneSyncShellStateChanged(`scene-clock-remote-${payload.action || 'update'}`);
 }
 
 function setSceneClockMode(mode, now = performance.now(), options = {}) {
   const nextMode = normalizeClockMode(mode, sceneClockState.mode);
+  const previousMode = sceneClockState.mode;
   const previousActiveTime = getSceneClockTime(now);
   const sources = getSceneClockSources(now);
 
@@ -5041,9 +5203,11 @@ function setSceneClockMode(mode, now = performance.now(), options = {}) {
   }
 
   const nextActiveTime = getSceneClockTime(now);
-  if (nextMode === CLOCK_MODES.ROOM_TIME) {
-    preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime);
-  }
+  preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime, {
+    previousMode,
+    nextMode,
+    now,
+  });
 
   sceneClockState.transportActive = true;
   sceneClockState.active = true;
@@ -5072,22 +5236,28 @@ function resumeSceneClock(now = performance.now()) {
   notifySceneSyncShellStateChanged('scene-clock-playing');
 }
 
-function seekSceneClock(t, now = performance.now()) {
+function seekSceneClock(t, now = performance.now(), options = {}) {
   if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
   if (!canControlSceneClock()) return;
   seekClockState(sceneClockState, Math.max(0, Number(t) || 0), getSceneClockSources(now));
   updateClockLegacyFields(now);
-  broadcastSceneClockEvent('seek');
+  if (options.broadcast !== false) {
+    broadcastSceneClockEvent('seek');
+  }
   notifySceneSyncShellStateChanged('scene-clock-seek');
 }
 
 function resetSceneClock(now = performance.now()) {
-  seekSceneClock(0, now);
-  for (const obj of managedObjects.values()) {
-    rebaseObjectClock(obj, { now, resetPhysicsMotion: true, reason: 'player-reset' });
-  }
-  scenePhysicsRuntime.resetToInitialPose();
-  broadcastSceneClockEvent('reset');
+  if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
+  if (!canControlSceneClock()) return;
+  seekSceneClock(0, now, { broadcast: false });
+  resetAllObjectClocksForSceneClock(now, {
+    reason: 'player-reset',
+    resetPhysicsMotion: true,
+  });
+  broadcastSceneClockEvent('reset', {
+    objectClocks: getSharedObjectClockPayload(now),
+  });
 }
 
 function followHostClock(now = performance.now()) {
@@ -5853,6 +6023,10 @@ async function respondToSceneRequest(from) {
       rotation: obj.quaternion.toArray(),
       scale: obj.scale.toArray(),
     };
+    const clock = serializeObjectClockForSceneSync(obj);
+    if (clock) {
+      entry.clock = clock;
+    }
 
     const bounds = computeWorldBoundsForExternalUse(obj);
     if (bounds) {
@@ -6036,6 +6210,7 @@ function handleHandoff(data) {
         }
       }
       notifySceneStateChanged('scene-state-handoff');
+      publishSharedObjectClockBaselines('scene-state-baseline');
       break;
     }
     case 'scene-request': {
@@ -6105,6 +6280,7 @@ function handleHandoff(data) {
             position: Array.isArray(payload.position) ? payload.position : obj.position.toArray(),
             rotation: Array.isArray(payload.rotation) ? payload.rotation : obj.quaternion.toArray(),
             scale: Array.isArray(payload.scale) ? payload.scale : obj.scale.toArray(),
+            clock: payload.clock,
             asset: payload.asset,
             metadata: hasPayloadMetadata
               ? cloneJsonSafe(payload.metadata)
@@ -6142,6 +6318,7 @@ function handleHandoff(data) {
           }
 
           notifySceneStateChanged('scene-delta-content-replace');
+          publishSharedObjectClockBaselines('scene-delta-baseline');
           break;
         }
         applyAssetDelta(obj, payload.asset);
@@ -6213,6 +6390,7 @@ function handleHandoff(data) {
       if (shouldRebaseObjectClock) {
         rebaseObjectClock(obj, {
           resetPhysicsMotion: shouldResetPhysicsMotion,
+          sharedEpochTime: readSharedEpochTime(payload.clock),
           reason: 'scene-delta',
         });
       }
@@ -6232,6 +6410,7 @@ function handleHandoff(data) {
         presenceState.historyManager.push(historyEntry);
       }
       notifySceneStateChanged('scene-delta-handoff');
+      publishSharedObjectClockBaselines('scene-delta-baseline');
       break;
     }
     case 'scene-add': {
@@ -6250,6 +6429,7 @@ function handleHandoff(data) {
         presenceState.historyManager.push(historyEntry);
       }
       notifySceneStateChanged('scene-add-handoff');
+      publishSharedObjectClockBaselines('scene-add-baseline');
       break;
     }
     case 'scene-remove': {
@@ -6289,6 +6469,7 @@ function handleHandoff(data) {
         reason: 'scene-physics-handoff',
       });
       notifySceneStateChanged('scene-physics-handoff');
+      publishSharedObjectClockBaselines('scene-physics-baseline');
       break;
     }
     case 'scene-mesh': {
@@ -6427,6 +6608,7 @@ function handleHandoff(data) {
         handleHandoff({ ...data, payload: child, __batchIndex: index });
       }
       notifySceneStateChanged('scene-batch-handoff');
+      publishSharedObjectClockBaselines('scene-batch-baseline');
       break;
     }
     case 'ai-command': {
@@ -7048,6 +7230,10 @@ function serializeSceneObjectForExternalUse(objectId, obj) {
     metadata: obj.userData?.metadata || null,
     meshPath: obj.userData?.meshPath || obj.userData?.asset?.meshPath || null,
   };
+  const clock = serializeObjectClockForSceneSync(obj);
+  if (clock) {
+    result.clock = clock;
+  }
 
   const bounds = computeWorldBoundsForExternalUse(obj);
   if (bounds) {
@@ -7593,6 +7779,7 @@ function addOrUpdateObject(objectId, info, options = {}) {
   rebaseObjectClock(existing, {
     resetPhysicsMotion: info.resetPhysicsMotion === true ||
       Boolean(info.position || info.rotation || info.scale),
+    sharedEpochTime: readSharedEpochTime(info.clock),
     reason: 'managed-object-updated',
   });
   notifySceneStateChanged('managed-object-updated');
@@ -8648,6 +8835,7 @@ function replaceManagedObject(objectId, nextObject, info) {
 
   rebaseObjectClock(nextObject, {
     resetPhysicsMotion: info?.resetPhysicsMotion === true,
+    sharedEpochTime: readSharedEpochTime(info?.clock),
     reason: 'managed-object-replaced',
   });
   markScenePhysicsRuntimeDirty();
@@ -9075,10 +9263,53 @@ function applyOperationToScene(operation) {
 
 // ── broadcast 送信ヘルパー（次 Step 以降で使用） ─────────
 
+function attachSharedClockToSceneMutationPayload(payload, now = performance.now()) {
+  if (!payload || typeof payload !== 'object') return payload;
+
+  if (payload.kind === 'scene-batch') {
+    if (Array.isArray(payload.actions)) {
+      payload.actions = payload.actions.map((action) =>
+        attachSharedClockToSceneMutationPayload(action, now));
+    }
+    if (Array.isArray(payload.ops)) {
+      payload.ops = payload.ops.map((op) =>
+        attachSharedClockToSceneMutationPayload(op, now));
+    }
+    return payload;
+  }
+
+  if (payload.kind !== 'scene-add' && payload.kind !== 'scene-delta') return payload;
+  if (typeof payload.objectId !== 'string' || !payload.objectId) return payload;
+
+  const existingClock = readSharedEpochTime(payload.clock);
+  if (Number.isFinite(existingClock)) {
+    payload.clock = {
+      ...(payload.clock || {}),
+      sharedEpochTime: existingClock,
+    };
+    return payload;
+  }
+
+  const obj = managedObjects.get(payload.objectId);
+  const clock = obj
+    ? serializeObjectClockForSceneSync(obj, now)
+    : { sharedEpochTime: getSharedEpochTimeForCurrentState(now) };
+  if (clock) {
+    payload.clock = {
+      ...(payload.clock || {}),
+      ...clock,
+    };
+  }
+  return payload;
+}
+
 function broadcast(payload) {
   const ws = presenceState.ws;
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
-  ws.send(JSON.stringify({ type: 'broadcast', payload }));
+  ws.send(JSON.stringify({
+    type: 'broadcast',
+    payload: attachSharedClockToSceneMutationPayload(payload),
+  }));
 }
 
 function sendHandoff({ targetId, payload }) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -61,8 +61,19 @@ import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from
 import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
 import { calculateScenePlaybackDuration } from './runtime/playback-duration.js';
 import {
+  CLOCK_MODE_LABELS,
+  CLOCK_MODES,
+  createClockState,
+  getActiveClockTime,
+  getObjectAge as getObjectAgeFromClock,
+  normalizeClockMode,
   normalizeSceneClockDeactivateArgs,
   preserveLocalSceneClockTimeline,
+  pauseClockState,
+  resumeClockState,
+  seekClockState,
+  setClockMode as setActiveClockMode,
+  setClockRate as setActiveClockRate,
 } from './runtime/scene-clock-transport.js';
 import {
   createScenePhysicsRuntime,
@@ -1036,6 +1047,10 @@ transformCtrl.addEventListener('dragging-changed', (e) => {
           );
           presenceState.historyManager.push(historyEntry);
         }
+        rebaseObjectClock(obj, {
+          resetPhysicsMotion: true,
+          reason: 'transform-drag-end',
+        });
       }
       dragStartState = null;
     }
@@ -1336,6 +1351,12 @@ function endMultiTransformHistory() {
   }
 
   if (entries.length > 0) {
+    for (const { objectId } of entries) {
+      rebaseObjectClockById(objectId, {
+        resetPhysicsMotion: true,
+        reason: 'multi-transform-end',
+      });
+    }
     const modeLabel = multiTransformMode === 'rotate' ? 'Rotated' :
       multiTransformMode === 'scale' ? 'Scaled' : 'Moved';
     pushMultiTransformHistory(entries, modeLabel);
@@ -1378,7 +1399,9 @@ const scenePhysicsRuntime = createScenePhysicsRuntime({
     object,
     physics: object.userData?.physics,
   })),
-  isClockActive: (clockState) => clockState?.transportActive === true && clockState?.mode === 'local',
+  isClockActive: (clockState) => clockState?.active === true,
+  getObjectAge: (objectId, clockState) => getObjectAge(objectId, performance.now(), clockState),
+  isObjectPaused: (objectId, clockState) => shouldFreezeRuntimeForEditor(objectId, clockState),
 });
 const removedObjectIds = new Set();
 
@@ -1584,9 +1607,9 @@ function updateTransformTweens(now = performance.now()) {
 // objectId → { mixer, clips, action, clipIndex }
 const glbAnimationMixers = new Map();
 
-// ── Runtime Time Model ───────────────────────────────────
-// Selected objects evaluate at t=0 (edit mode).
-// Unselected objects advance runtime time from 0.
+// ── Runtime Time Model / ObjectAge ───────────────────────
+// Runtime code evaluates ObjectAge, not raw host or room time.
+// ObjectAge = ActiveTime - object.userData.clock.epochTime.
 
 function ensureObjectRuntime(obj) {
   if (!obj) return null;
@@ -1601,6 +1624,85 @@ function ensureObjectRuntime(obj) {
   };
 
   return obj.userData.runtime;
+}
+
+function getLocalNowSeconds(now = performance.now()) {
+  return now / 1000;
+}
+
+function getRoomNowSeconds() {
+  return Date.now() / 1000 + (Number.isFinite(sceneClockState?.roomTimeOffset)
+    ? sceneClockState.roomTimeOffset
+    : 0);
+}
+
+function getActiveClockSources(now = performance.now()) {
+  return {
+    localNow: getLocalNowSeconds(now),
+    roomNow: getRoomNowSeconds(),
+  };
+}
+
+function getActiveClockNow(now = performance.now()) {
+  return getActiveClockTime(sceneClockState, getActiveClockSources(now));
+}
+
+function ensureObjectClock(obj, now = performance.now()) {
+  if (!obj) return null;
+  const activeTime = getActiveClockNow(now);
+  const current = obj.userData?.clock;
+  obj.userData.clock = {
+    epochTime: Number.isFinite(current?.epochTime) ? current.epochTime : activeTime,
+  };
+  return obj.userData.clock;
+}
+
+function resetObjectPhysicsMotion(obj) {
+  const physics = normalizeObjectPhysics(obj?.userData?.physics);
+  if (!obj || !physics) return null;
+
+  obj.userData.physics = {
+    ...physics,
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+    initialTransform: {
+      position: obj.position?.toArray?.() || [0, 0, 0],
+      rotation: obj.quaternion?.toArray?.() || [0, 0, 0, 1],
+      scale: obj.scale?.toArray?.() || [1, 1, 1],
+    },
+  };
+  return obj.userData.physics;
+}
+
+function rebaseObjectClock(obj, {
+  now = performance.now(),
+  resetPhysicsMotion = false,
+  reason = 'object-rebased',
+} = {}) {
+  if (!obj) return null;
+  const runtime = ensureObjectRuntime(obj);
+  runtime.startLocalTime = now;
+  runtime.startHostTime = null;
+  runtime.selectedTime = 0;
+  obj.userData.runtime = runtime;
+
+  const clock = {
+    epochTime: getActiveClockNow(now),
+  };
+  obj.userData.clock = clock;
+
+  if (resetPhysicsMotion) {
+    resetObjectPhysicsMotion(obj);
+  }
+
+  markScenePhysicsRuntimeDirty();
+  notifySceneSyncShellStateChanged?.(`object-clock:${reason}`);
+  return clock;
+}
+
+function rebaseObjectClockById(objectId, options = {}) {
+  const obj = managedObjects.get(objectId);
+  return rebaseObjectClock(obj, options);
 }
 
 function shouldFreezeRuntimeForEditor(objectId, clockState = null) {
@@ -1619,25 +1721,31 @@ function getObjectRuntimeTime(objectId, now = performance.now(), clockState = nu
   if (!obj) return 0;
 
   const runtime = ensureObjectRuntime(obj);
+  const objectClock = ensureObjectClock(obj, now);
   if (!runtime?.enabled) return 0;
 
-  // Freeze selected/actively edited objects, except selection-only freeze is
-  // disabled while the Player transport explicitly owns scene time.
+  // Freeze actively edited objects. Local Preview is active by default, so
+  // selection alone no longer prevents placed objects from animating.
   if (shouldFreezeRuntimeForEditor(objectId, clockState)) {
     return runtime.selectedTime ?? 0;
   }
 
-  // normal object: use Scene Clock time if available, else object runtime time
-  if (clockState) {
-    return clockState.t;
-  }
-
+  const activeTime = Number.isFinite(clockState?.t)
+    ? clockState.t
+    : getActiveClockNow(now);
+  const objectAge = getObjectAgeFromClock(activeTime, objectClock);
   const speed = Number.isFinite(runtime.speed) ? runtime.speed : 1;
-  const start = Number.isFinite(runtime.startLocalTime)
-    ? runtime.startLocalTime
-    : now;
+  return Math.max(0, objectAge * speed);
+}
 
-  return Math.max(0, ((now - start) / 1000) * speed);
+function getObjectAge(objectId, now = performance.now(), clockState = null) {
+  const obj = managedObjects.get(objectId);
+  if (!obj) return 0;
+  const clock = ensureObjectClock(obj, now);
+  const activeTime = Number.isFinite(clockState?.t)
+    ? clockState.t
+    : getActiveClockNow(now);
+  return getObjectAgeFromClock(activeTime, clock);
 }
 
 // The host owns the clock source used for shared runtime behavior.
@@ -1659,11 +1767,7 @@ function resetObjectRuntimeOrigin(objectId, now = performance.now()) {
   const obj = managedObjects.get(objectId);
   if (!obj) return;
 
-  const runtime = ensureObjectRuntime(obj);
-  runtime.startLocalTime = now;
-  runtime.selectedTime = 0;
-
-  obj.userData.runtime = runtime;
+  rebaseObjectClock(obj, { now, reason: 'runtime-origin-reset' });
 }
 
 let previousSelectedRuntimeObjectIds = new Set();
@@ -2555,6 +2659,7 @@ function applyObjectAnimationDelta(obj, animationDelta) {
   };
 
   updateObjectGlbAnimationClip(obj.userData.objectId, next.clip);
+  rebaseObjectClock(obj, { reason: 'animation-delta' });
 }
 
 function serializeObjectAnimationState(obj) {
@@ -2585,6 +2690,7 @@ function registerLoadedGlbAnimation(objectId, model, reason = 'unknown') {
   model.userData.objectId = objectId;
   managedObjects.set(objectId, model);
   setupObjectGlbAnimation(objectId, model);
+  rebaseObjectClock(model, { reason: `glb-animation:${reason}` });
 
   const clips = model.userData?.scenesync?.animations;
   if (Array.isArray(clips) && clips.length > 0) {
@@ -2723,6 +2829,13 @@ function resetScenePhysicsRuntimeBeforePersistence() {
 
 function applyScenePhysics(physics, options = {}) {
   scenePhysicsState = normalizeScenePhysics(physics);
+  if (options.rebaseObjects !== false) {
+    for (const obj of managedObjects.values()) {
+      if (normalizeObjectPhysics(obj?.userData?.physics)) {
+        rebaseObjectClock(obj, { reason: 'scene-physics' });
+      }
+    }
+  }
   markScenePhysicsRuntimeDirty();
   if (options.broadcastChange) {
     const serialized = getScenePhysicsForSerialize({ enableWhenObjectsExist: false });
@@ -2752,6 +2865,7 @@ function applyObjectPhysicsDelta(obj, physics) {
     delete obj.userData.physics;
   }
   markScenePhysicsRuntimeDirty();
+  rebaseObjectClock(obj, { reason: 'object-physics' });
   return next;
 }
 
@@ -4654,73 +4768,115 @@ const sceneInspectorState = {
   },
 };
 
-// ── Scene Clock 状態 ────────────────────────────────
-// Host 所有のグローバル時刻制御システム
-// local-only: broadcast しない、room history に記録しない
-// 用途: Loomlet behavior の可制御なアニメーション
-// time.t = object graph の実評価時刻（選択中は 0、通常は Scene Clock time）
-// time.sceneT = Scene Clock のグローバル時刻（通常は time.t と同じ）
-// time.delta = object evaluation delta
-// time.sceneDelta = Scene Clock global delta
+// ── Active Clock 状態 ────────────────────────────────
+// Editor Shell default: local-preview. Time operations are local unless the
+// Player UI switches to shared-playback and broadcasts operation events.
 const sceneClockState = {
-  mode: 'host-follow',          // 'host-follow' | 'local'
-  paused: false,
-  localTime: 0,                 // local mode でのみ使用
-  pausedAt: null,               // 一時停止時の冷凍時刻
+  ...createClockState({
+    mode: CLOCK_MODES.LOCAL_PREVIEW,
+    offset: -getLocalNowSeconds(),
+    paused: false,
+    rate: 1,
+  }),
+  roomTimeOffset: 0,
+  localTime: 0,
+  pausedAt: null,
   seekOffset: 0,
   lastUpdateNow: performance.now(),
-  lastHostNow: Date.now() / 1000,    // host-follow mode の delta 計算用
-  rate: 1,                       // 再生速度倍率
-  transportActive: false,         // Player transport UI がScene Clockを明示制御中
+  lastHostNow: Date.now() / 1000,
+  lastTickTime: null,
+  transportActive: true,
+  active: true,
+  controller: null,
+  sharedRevision: 0,
+  sharedUpdatedAt: 0,
 };
 
+function getSceneClockSources(now = performance.now()) {
+  return getActiveClockSources(now);
+}
+
 function getSceneClockTime(now = performance.now()) {
-  if (sceneClockState.paused) {
-    return sceneClockState.pausedAt ?? 0;
-  }
+  return getActiveClockTime(sceneClockState, getSceneClockSources(now));
+}
 
-  if (sceneClockState.mode === 'local') {
-    const elapsed = (now - sceneClockState.lastUpdateNow) / 1000;
-    return Math.max(0, sceneClockState.localTime + elapsed * sceneClockState.rate);
-  }
-
-  // host-follow mode: host-provided wall-clock seconds
-  return Date.now() / 1000;
+function consumeSceneClockDelta(t) {
+  const previous = sceneClockState.lastTickTime;
+  sceneClockState.lastTickTime = t;
+  if (sceneClockState.paused || sceneClockState.rate === 0) return 0;
+  if (!Number.isFinite(previous)) return 0;
+  return Math.max(0, t - previous);
 }
 
 function getSceneClockDelta(now = performance.now()) {
-  if (sceneClockState.paused) {
-    return 0;
-  }
+  return consumeSceneClockDelta(getSceneClockTime(now));
+}
 
-  if (sceneClockState.mode === 'local') {
-    const elapsed = Math.max(0, (now - sceneClockState.lastUpdateNow) / 1000);
-    const delta = elapsed * sceneClockState.rate;
-    // Accumulate localTime so getSceneClockTime() sees continuous progression
-    sceneClockState.localTime = Math.max(0, sceneClockState.localTime + delta);
-    sceneClockState.lastUpdateNow = now;
-    return delta;
-  }
+function getSceneClockController() {
+  return sceneClockState.controller || null;
+}
 
-  // host-follow mode: delta from last host time sample
-  const currentHostNow = Date.now() / 1000;
-  const delta = currentHostNow - sceneClockState.lastHostNow;
-  sceneClockState.lastHostNow = currentHostNow;
-  return Math.max(0, delta);
+function isSceneClockControllerSelf() {
+  const controller = getSceneClockController();
+  return Boolean(controller?.id && presenceState.id && controller.id === presenceState.id);
+}
+
+function getLocalClockControllerInfo() {
+  return {
+    id: presenceState.id || 'local',
+    nickname: presenceState.nickname || 'Local',
+  };
+}
+
+function preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime) {
+  if (!Number.isFinite(previousActiveTime) || !Number.isFinite(nextActiveTime)) return;
+  for (const obj of managedObjects.values()) {
+    const clock = ensureObjectClock(obj);
+    const age = getObjectAgeFromClock(previousActiveTime, clock);
+    obj.userData.clock = {
+      epochTime: nextActiveTime - age,
+    };
+  }
+}
+
+function updateClockLegacyFields(now = performance.now()) {
+  const t = getSceneClockTime(now);
+  sceneClockState.localTime = t;
+  sceneClockState.pausedAt = sceneClockState.paused ? t : null;
+  sceneClockState.lastUpdateNow = now;
+  sceneClockState.lastHostNow = getRoomNowSeconds();
+}
+
+function setRoomTimeOffsetFromServer(serverTimeMs) {
+  if (!Number.isFinite(serverTimeMs)) return;
+  sceneClockState.roomTimeOffset = (serverTimeMs / 1000) - (Date.now() / 1000);
 }
 
 function getSceneClockStateForLoomlet(now = performance.now()) {
   const t = getSceneClockTime(now);
-  const delta = getSceneClockDelta(now);
+  const delta = consumeSceneClockDelta(t);
+  const localNow = getLocalNowSeconds(now);
+  const roomNow = getRoomNowSeconds();
+  const controller = getSceneClockController();
 
   return {
     t,
+    time: t,
+    activeTime: t,
     delta,
     isPaused: sceneClockState.paused,
     mode: sceneClockState.mode,
+    source: sceneClockState.source,
+    offset: sceneClockState.offset,
     rate: sceneClockState.rate,
-    hostNow: Date.now() / 1000,
+    hostNow: roomNow,
+    roomNow,
+    localNow,
+    active: sceneClockState.active,
     transportActive: sceneClockState.transportActive,
+    controller,
+    isController: sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK || isSceneClockControllerSelf(),
+    modeLabel: CLOCK_MODE_LABELS[sceneClockState.mode] || sceneClockState.mode,
   };
 }
 
@@ -4731,6 +4887,9 @@ function applySceneGraphOperation(operation) {
     return false;
   }
   loomIntegration.handlePayload(operation);
+  if (operation.scope && typeof operation.scope === 'object' && typeof operation.scope.object === 'string') {
+    rebaseObjectClockById(operation.scope.object, { reason: 'loomlet-graph' });
+  }
   notifySceneStateChanged('scene-graph-operation-applied');
   return true;
 }
@@ -4787,84 +4946,167 @@ function tryHandleLoomletGraphPaste(text) {
   return true;
 }
 
-function setSceneClockMode(mode, now = performance.now()) {
-  if (mode === sceneClockState.mode) return;
+function canControlSceneClock() {
+  return sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK || isSceneClockControllerSelf();
+}
 
-  if (mode === 'local') {
-    // host-follow -> local: 現在時刻を localTime として記録
-    const currentTime = getSceneClockTime(now);
-    sceneClockState.localTime = currentTime;
-    sceneClockState.lastUpdateNow = now;
+function broadcastSceneClockEvent(action, extra = {}) {
+  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (!presenceState.ws || presenceState.ws.readyState !== WebSocket.OPEN) return;
+  sceneClockState.sharedRevision += 1;
+  broadcast({
+    kind: 'scene-clock',
+    action,
+    mode: sceneClockState.mode,
+    source: sceneClockState.source,
+    offset: sceneClockState.offset,
+    paused: sceneClockState.paused,
+    pausedTime: sceneClockState.paused ? getSceneClockTime() : undefined,
+    rate: sceneClockState.rate,
+    controller: getSceneClockController(),
+    revision: sceneClockState.sharedRevision,
+    roomNow: getRoomNowSeconds(),
+    sentAt: Date.now(),
+    ...extra,
+  });
+}
+
+function requestSceneClockControl(now = performance.now()) {
+  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) {
+    setSceneClockMode(CLOCK_MODES.SHARED_PLAYBACK, now, { requestControl: true });
+    return;
+  }
+  sceneClockState.controller = getLocalClockControllerInfo();
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('controller');
+  notifySceneSyncShellStateChanged('scene-clock-controller-requested');
+}
+
+function releaseSceneClockControl(now = performance.now()) {
+  if (!isSceneClockControllerSelf()) return;
+  sceneClockState.controller = null;
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('controller-release');
+  notifySceneSyncShellStateChanged('scene-clock-controller-released');
+}
+
+function applyRemoteSceneClock(payload, from = null) {
+  if (!payload || typeof payload !== 'object') return;
+  const nextMode = normalizeClockMode(payload.mode, CLOCK_MODES.SHARED_PLAYBACK);
+  if (nextMode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+
+  sceneClockState.mode = CLOCK_MODES.SHARED_PLAYBACK;
+  sceneClockState.source = 'room';
+  sceneClockState.offset = Number.isFinite(payload.offset) ? payload.offset : sceneClockState.offset;
+  sceneClockState.rate = Number.isFinite(payload.rate) && payload.rate >= 0 ? payload.rate : sceneClockState.rate;
+  sceneClockState.paused = payload.paused === true;
+  sceneClockState.pausedTime = Number.isFinite(payload.pausedTime) ? payload.pausedTime : undefined;
+  sceneClockState.controller = Object.prototype.hasOwnProperty.call(payload, 'controller')
+    ? payload.controller
+    : (from ? {
+        id: from.id,
+        nickname: from.nickname || 'Controller',
+      } : null);
+  sceneClockState.sharedRevision = Math.max(sceneClockState.sharedRevision, Number(payload.revision) || 0);
+  sceneClockState.sharedUpdatedAt = Date.now();
+  sceneClockState.transportActive = true;
+  sceneClockState.active = true;
+  updateClockLegacyFields();
+  notifySceneSyncShellStateChanged(`scene-clock-remote-${payload.action || 'update'}`);
+}
+
+function setSceneClockMode(mode, now = performance.now(), options = {}) {
+  const nextMode = normalizeClockMode(mode, sceneClockState.mode);
+  const previousActiveTime = getSceneClockTime(now);
+  const sources = getSceneClockSources(now);
+
+  if (nextMode === CLOCK_MODES.ROOM_TIME) {
+    sceneClockState.mode = CLOCK_MODES.ROOM_TIME;
+    sceneClockState.source = 'room';
+    sceneClockState.offset = Number.isFinite(options.offset) ? options.offset : 0;
     sceneClockState.paused = false;
-    sceneClockState.pausedAt = null;
-  } else if (mode === 'host-follow') {
-    // local -> host-follow: ローカル状態をクリア
-    sceneClockState.localTime = 0;
-    sceneClockState.paused = false;
-    sceneClockState.pausedAt = null;
-    sceneClockState.lastHostNow = Date.now() / 1000;
-    sceneClockState.lastUpdateNow = now;
+    sceneClockState.pausedTime = undefined;
+    sceneClockState.rate = 1;
+  } else {
+    setActiveClockMode(sceneClockState, nextMode, sources, {
+      preserveTime: options.preserveTime !== false,
+      resetToZero: options.resetToZero === true,
+    });
   }
 
-  sceneClockState.mode = mode;
+  if (nextMode !== CLOCK_MODES.SHARED_PLAYBACK) {
+    sceneClockState.controller = null;
+  } else if (options.requestControl === true || !sceneClockState.controller) {
+    sceneClockState.controller = getLocalClockControllerInfo();
+  }
+
+  const nextActiveTime = getSceneClockTime(now);
+  if (nextMode === CLOCK_MODES.ROOM_TIME) {
+    preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime);
+  }
+
+  sceneClockState.transportActive = true;
+  sceneClockState.active = true;
+  updateClockLegacyFields(now);
+  if (nextMode === CLOCK_MODES.SHARED_PLAYBACK && isSceneClockControllerSelf()) {
+    broadcastSceneClockEvent('mode');
+  }
+  notifySceneSyncShellStateChanged('scene-clock-mode-changed');
 }
 
 function pauseSceneClock(now = performance.now()) {
-  if (sceneClockState.paused) return;
-
-  const currentTime = getSceneClockTime(now);
-
-  sceneClockState.paused = true;
-  sceneClockState.pausedAt = currentTime;
-  sceneClockState.localTime = currentTime;
-  sceneClockState.lastUpdateNow = now;
+  if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
+  if (!canControlSceneClock()) return;
+  pauseClockState(sceneClockState, getSceneClockSources(now));
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('pause');
+  notifySceneSyncShellStateChanged('scene-clock-paused');
 }
 
 function resumeSceneClock(now = performance.now()) {
-  if (!sceneClockState.paused) return;
-
-  const pausedAt = sceneClockState.pausedAt ?? getSceneClockTime(now);
-
-  sceneClockState.mode = 'local';
-  sceneClockState.localTime = pausedAt;
-  sceneClockState.lastUpdateNow = now;
-  sceneClockState.paused = false;
-  sceneClockState.pausedAt = null;
+  if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
+  if (!canControlSceneClock()) return;
+  resumeClockState(sceneClockState, getSceneClockSources(now));
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('play');
+  notifySceneSyncShellStateChanged('scene-clock-playing');
 }
 
 function seekSceneClock(t, now = performance.now()) {
-  t = Math.max(0, t);
-
-  if (sceneClockState.mode !== 'local') {
-    setSceneClockMode('local', now);
-  }
-
-  const wasPaused = sceneClockState.paused;
-
-  sceneClockState.localTime = t;
-  sceneClockState.lastUpdateNow = now;
-
-  if (wasPaused) {
-    sceneClockState.paused = true;
-    sceneClockState.pausedAt = t;
-  } else {
-    sceneClockState.paused = false;
-    sceneClockState.pausedAt = null;
-  }
+  if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
+  if (!canControlSceneClock()) return;
+  seekClockState(sceneClockState, Math.max(0, Number(t) || 0), getSceneClockSources(now));
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('seek');
+  notifySceneSyncShellStateChanged('scene-clock-seek');
 }
 
 function resetSceneClock(now = performance.now()) {
   seekSceneClock(0, now);
+  for (const obj of managedObjects.values()) {
+    rebaseObjectClock(obj, { now, resetPhysicsMotion: true, reason: 'player-reset' });
+  }
+  scenePhysicsRuntime.resetToInitialPose();
+  broadcastSceneClockEvent('reset');
 }
 
 function followHostClock(now = performance.now()) {
-  setSceneClockMode('host-follow', now);
+  setSceneClockMode(CLOCK_MODES.ROOM_TIME, now);
 }
 
-function activateSceneClockTransport(now = performance.now()) {
-  setSceneClockRate(1, now);
-  stopSceneClock(now);
+function activateSceneClockTransport(nowOrOptions = performance.now(), maybeOptions = {}) {
+  const options = typeof nowOrOptions === 'object' ? nowOrOptions : maybeOptions;
+  const now = typeof nowOrOptions === 'number' ? nowOrOptions : performance.now();
   sceneClockState.transportActive = true;
+  sceneClockState.active = true;
+  if (options?.mode) {
+    setSceneClockMode(options.mode, now, {
+      requestControl: options.requestControl === true,
+      preserveTime: options.preserveTime !== false,
+    });
+  } else {
+    updateClockLegacyFields(now);
+  }
   notifySceneSyncShellStateChanged('scene-clock-transport-activated');
 }
 
@@ -4873,62 +5115,69 @@ function deactivateSceneClockTransport(nowOrOptions = performance.now(), maybeOp
     normalizeSceneClockDeactivateArgs(nowOrOptions, maybeOptions);
 
   setSceneClockRate(1, now);
-  sceneClockState.transportActive = false;
+  sceneClockState.transportActive = true;
+  sceneClockState.active = true;
   if (preserveLocalTimeline) {
     preserveLocalSceneClockTimeline(sceneClockState, {
       now,
       getSceneClockTime,
       resume: resumeLocalTimeline,
     });
-  } else {
-    followHostClock(now);
   }
+  updateClockLegacyFields(now);
   notifySceneSyncShellStateChanged('scene-clock-transport-deactivated');
 }
 
 function setSceneClockRate(rate, now = performance.now()) {
-  const nextRate = Number(rate);
-  if (!Number.isFinite(nextRate) || nextRate < 0) return;
-  // rate 変更時に time jump を避けるため現在時刻を localTime に焼く
-  if (sceneClockState.mode === 'local') {
-    sceneClockState.localTime = getSceneClockTime(now);
-    sceneClockState.lastUpdateNow = now;
-  }
-  sceneClockState.rate = nextRate;
+  if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
+  if (!canControlSceneClock()) return;
+  if (!setActiveClockRate(sceneClockState, rate, getSceneClockSources(now))) return;
+  updateClockLegacyFields(now);
+  broadcastSceneClockEvent('rate');
+  notifySceneSyncShellStateChanged('scene-clock-rate');
 }
 
 function playSceneClock(now = performance.now()) {
-  // seekSceneClock(0) ensures we are in local mode starting from a sensible
-  // position rather than baking the host-follow wall-clock epoch into localTime.
-  if (sceneClockState.mode !== 'local') {
-    seekSceneClock(0, now);
-  }
-  if (sceneClockState.paused) {
-    resumeSceneClock(now);
-  }
+  resumeSceneClock(now);
 }
 
 function stopSceneClock(now = performance.now()) {
-  seekSceneClock(0, now); // seek clears pause; then we re-pause at t=0
+  resetSceneClock(now);
   pauseSceneClock(now);
 }
 
-// Side-effect-free getter for shell UI (does not update delta/lastUpdateNow).
-// In host-follow mode, raw time is wall-clock epoch (>1 billion seconds).
-// Player Shell transport always starts from 0, so display 0 until local mode.
-function getSceneClockStateForShell() {
-  const rawTime = getSceneClockTime();
-  const displayTime = sceneClockState.mode === 'host-follow' ? 0 : rawTime;
-  const duration = getScenePlaybackDuration();
+function getPrimarySelectedObjectAgeForShell(now = performance.now()) {
+  const objectId = transformCtrl.object?.userData?.objectId || getPrimarySelectedObjectId();
+  if (!objectId) return null;
   return {
-    time: displayTime,
-    t: displayTime,
+    objectId,
+    age: getObjectAge(objectId, now, { t: getSceneClockTime(now) }),
+  };
+}
+
+// Side-effect-free getter for shell UI.
+function getSceneClockStateForShell() {
+  const now = performance.now();
+  const time = getSceneClockTime(now);
+  const duration = getScenePlaybackDuration();
+  const controller = getSceneClockController();
+  const selectedObjectAge = getPrimarySelectedObjectAgeForShell(now);
+  return {
+    time,
+    t: time,
     isPaused: sceneClockState.paused,
-    playing: !sceneClockState.paused && sceneClockState.mode === 'local',
+    playing: !sceneClockState.paused && sceneClockState.rate > 0,
     mode: sceneClockState.mode,
+    modeLabel: CLOCK_MODE_LABELS[sceneClockState.mode] || sceneClockState.mode,
+    source: sceneClockState.source,
     rate: sceneClockState.rate,
     duration,
     transportActive: sceneClockState.transportActive,
+    active: sceneClockState.active,
+    controller,
+    isController: sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK || isSceneClockControllerSelf(),
+    selectedObjectAge,
+    roomNow: getRoomNowSeconds(),
   };
 }
 
@@ -4962,6 +5211,7 @@ function applyObjectAudioSourcesPatch(objectId, patch) {
   const merged = mergeAudioSourcesPatch(obj.userData.audioSources, patch);
   obj.userData.audioSources = merged;
   audioSourceController.setObjectAudioSources(objectId, merged);
+  rebaseObjectClock(obj, { reason: 'object-audio-sources' });
   notifySceneStateChanged('object-audio-sources-updated');
   return merged;
 }
@@ -4987,6 +5237,7 @@ function setObjectAudioSourcesFull(objectId, map) {
   const normalized = normalizeAudioSourcesMap(map);
   obj.userData.audioSources = normalized;
   audioSourceController.setObjectAudioSources(objectId, normalized);
+  rebaseObjectClock(obj, { reason: 'object-audio-sources-full' });
   return normalized;
 }
 
@@ -5088,7 +5339,7 @@ sceneClockTogglePauseBtn?.addEventListener('click', () => {
 });
 
 sceneClockFollowBtn?.addEventListener('click', () => {
-  setSceneClockMode('host-follow');
+  setSceneClockMode(CLOCK_MODES.ROOM_TIME);
   updateSceneClockUI();
 });
 
@@ -5106,14 +5357,7 @@ sceneClockRateInput?.addEventListener('change', (e) => {
     return;
   }
 
-  // rate 変更時に time jump を避ける
-  // 現在時刻を localTime に焼いてから rate を変更
-  if (sceneClockState.mode === 'local') {
-    sceneClockState.localTime = getSceneClockTime(now);
-    sceneClockState.lastUpdateNow = now;
-  }
-
-  sceneClockState.rate = nextRate;
+  setSceneClockRate(nextRate, now);
   sceneClockRateInput.value = sceneClockState.rate;
   updateSceneClockUI();
 });
@@ -5128,7 +5372,7 @@ function updateSceneClockUI() {
 
   if (sceneClockModeEl) {
     sceneClockModeEl.textContent = sceneClockState.mode;
-    sceneClockModeEl.classList.toggle('local', sceneClockState.mode === 'local');
+    sceneClockModeEl.classList.toggle('local', sceneClockState.mode === CLOCK_MODES.LOCAL_PREVIEW);
   }
 
   if (sceneClockStatusEl) {
@@ -5425,6 +5669,7 @@ function connectPresence() {
       case 'welcome':
         presenceState.id = data.id;
         presenceState.room = data.room;
+        setRoomTimeOffsetFromServer(data.serverTime);
         updateStatus(true);
         updatePeersList();
         notifyConnectionStateChanged('presence-welcome');
@@ -5745,6 +5990,11 @@ function handleHandoff(data) {
   }
 
   switch (payload.kind) {
+    case 'scene-clock': {
+      if (isOwn) break;
+      applyRemoteSceneClock(payload, data.from);
+      break;
+    }
     case 'scene-state': {
       sceneReceived = true;
       clearTimeout(sceneRequestTimer);
@@ -5763,7 +6013,7 @@ function handleHandoff(data) {
       const objects = payload.objects || {};
       removeSampleCube('scene-state-received');
       for (const [objectId, info] of Object.entries(objects)) {
-        addOrUpdateObject(objectId, info);
+        addOrUpdateObject(objectId, info, { resetPhysicsMotion: true });
       }
       ensureSampleCubeForEmptyRoom('scene-state-applied');
 
@@ -5826,6 +6076,8 @@ function handleHandoff(data) {
       const targetScl = Array.isArray(payload.scale)
         ? payload.scale.slice()
         : beforeScl;
+      let shouldRebaseObjectClock = false;
+      let shouldResetPhysicsMotion = false;
 
       // Check if this should animate (AI/GPT-originated)
       const shouldAnimateTransform =
@@ -5833,8 +6085,14 @@ function handleHandoff(data) {
         Boolean(data.from?.id?.startsWith?.('api-'));
 
       // Apply non-transform updates immediately
-      if (typeof payload.name === 'string') applyObjectName(obj, payload.name);
-      if (typeof payload.visible === 'boolean') applyObjectVisibility(obj, payload.visible);
+      if (typeof payload.name === 'string') {
+        applyObjectName(obj, payload.name);
+        shouldRebaseObjectClock = true;
+      }
+      if (typeof payload.visible === 'boolean') {
+        applyObjectVisibility(obj, payload.visible);
+        shouldRebaseObjectClock = true;
+      }
       if (payload.asset) {
         const newAssetType = payload.asset.type;
         if (newAssetType === 'image' || newAssetType === 'video' || newAssetType === 'text') {
@@ -5887,9 +6145,11 @@ function handleHandoff(data) {
           break;
         }
         applyAssetDelta(obj, payload.asset);
+        shouldRebaseObjectClock = true;
       }
       if (payload.animation && typeof payload.animation === 'object') {
         applyObjectAnimationDelta(obj, payload.animation);
+        shouldRebaseObjectClock = true;
         console.debug('[scene-delta] animation applied', {
           objectId: payload.objectId,
           animation: payload.animation,
@@ -5897,6 +6157,7 @@ function handleHandoff(data) {
       }
       if (payload.audioSources !== undefined) {
         applyIncomingAudioSources(payload.objectId, payload.audioSources);
+        shouldRebaseObjectClock = true;
         console.debug('[scene-delta] audioSources applied', {
           objectId: payload.objectId,
           audioSources: payload.audioSources,
@@ -5904,6 +6165,7 @@ function handleHandoff(data) {
       }
       if (Object.prototype.hasOwnProperty.call(payload, 'physics')) {
         applyObjectPhysicsDelta(obj, payload.physics);
+        shouldRebaseObjectClock = true;
         console.debug('[scene-delta] physics applied', {
           objectId: payload.objectId,
           physics: payload.physics,
@@ -5922,6 +6184,8 @@ function handleHandoff(data) {
         animateObjectTransform(payload.objectId, obj, payload, {
           delay: batchIndex * AI_TRANSFORM_TWEEN_STAGGER_MS,
         });
+        shouldRebaseObjectClock = true;
+        shouldResetPhysicsMotion = true;
         console.debug('[scene-delta] transform tween queued', {
           objectId: payload.objectId,
           targetPosition: payload.position || null,
@@ -5935,12 +6199,21 @@ function handleHandoff(data) {
         if (payload.scale) obj.scale.fromArray(payload.scale);
         if (payload.position || payload.rotation || payload.scale) {
           markScenePhysicsRuntimeDirty();
+          shouldRebaseObjectClock = true;
+          shouldResetPhysicsMotion = true;
         }
         console.debug('[scene-delta] applied', {
           objectId: payload.objectId,
           position: obj.position.toArray(),
           rotation: obj.quaternion.toArray(),
           scale: obj.scale.toArray(),
+        });
+      }
+
+      if (shouldRebaseObjectClock) {
+        rebaseObjectClock(obj, {
+          resetPhysicsMotion: shouldResetPhysicsMotion,
+          reason: 'scene-delta',
         });
       }
 
@@ -6462,6 +6735,7 @@ async function uploadGlbFromUrl(url, params = {}) {
   model.userData.name = file.name;
   managedObjects.set(model.userData.objectId, model);
   setupObjectGlbAnimation(objectId, model);
+  rebaseObjectClock(model, { reason: 'glb-url-upload' });
   selectManagedObject(model);
   notifySceneStateChanged('glb-uploaded-from-url');
 
@@ -7249,6 +7523,10 @@ function cleanupPreviewForLoadedObject(options = {}) {
 
 function addOrUpdateObject(objectId, info, options = {}) {
   removedObjectIds.delete(objectId);
+  info = {
+    ...(info || {}),
+    resetPhysicsMotion: options.resetPhysicsMotion === true || info?.resetPhysicsMotion === true,
+  };
   const existing = managedObjects.get(objectId);
   if (!isSampleCubeObjectId(objectId)) {
     removeSampleCube('object-added');
@@ -7312,6 +7590,11 @@ function addOrUpdateObject(objectId, info, options = {}) {
   if (info.physics !== undefined) {
     applyObjectPhysicsDelta(existing, info.physics);
   }
+  rebaseObjectClock(existing, {
+    resetPhysicsMotion: info.resetPhysicsMotion === true ||
+      Boolean(info.position || info.rotation || info.scale),
+    reason: 'managed-object-updated',
+  });
   notifySceneStateChanged('managed-object-updated');
 }
 
@@ -8362,6 +8645,11 @@ function replaceManagedObject(objectId, nextObject, info) {
   } else {
     delete nextObject.userData.physics;
   }
+
+  rebaseObjectClock(nextObject, {
+    resetPhysicsMotion: info?.resetPhysicsMotion === true,
+    reason: 'managed-object-replaced',
+  });
   markScenePhysicsRuntimeDirty();
 
   console.debug('[scene-add] applied transform', {
@@ -8536,6 +8824,7 @@ function applyAssetDelta(obj, asset) {
   if (textRoot?.userData?.asset?.type === 'text' || nextAsset.type === 'text') {
     textRoot.userData.asset = nextAsset;
     rerenderTextPanelObject(textRoot, nextAsset);
+    rebaseObjectClock(textRoot, { reason: 'text-asset-delta' });
     notifySceneStateChanged('asset-delta-applied');
     return;
   }
@@ -8543,6 +8832,7 @@ function applyAssetDelta(obj, asset) {
   if (asset.color) {
     applyObjectColor(obj, asset.color);
   }
+  rebaseObjectClock(obj, { reason: 'asset-delta' });
   notifySceneStateChanged('asset-delta-applied');
 }
 
@@ -8949,6 +9239,10 @@ async function loadGlbBlobForObject(objectId, blob, options = {}) {
     if (preservedAudioSources !== undefined) {
       setObjectAudioSourcesFull(objectId, preservedAudioSources);
     }
+    rebaseObjectClock(wrapper, {
+      resetPhysicsMotion: info?.resetPhysicsMotion === true,
+      reason: 'glb-blob-loaded',
+    });
     markScenePhysicsRuntimeDirty();
     notifySceneStateChanged('glb-blob-loaded');
     markCrashProbe('glb-scene-attach-success', { objectId });
@@ -9857,6 +10151,7 @@ const dragDropManager = new DragDropManager({
   onLoaded: async (model, file) => {
     managedObjects.set(model.userData.objectId, model);
     setupObjectGlbAnimation(model.userData.objectId, model);
+    rebaseObjectClock(model, { reason: 'drag-drop-loaded' });
     selectManagedObject(model);
     notifySelectionChanged('drag-drop-object-selected');
 
@@ -12745,6 +13040,7 @@ function restoreSnapshotObject(entry, options = {}) {
   addOrUpdateObject(objectId, payload, {
     skipFallbackOnFailure: true,
     suppressSnapshotSaveOnFailure: true,
+    resetPhysicsMotion: true,
   });
 }
 
@@ -13321,8 +13617,11 @@ mountSceneSyncShellFromDom({
     stopSceneClock,
     seekSceneClock,
     setSceneClockRate,
+    setSceneClockMode,
     resetSceneClock,
     followSceneClock: followHostClock,
+    requestSceneClockControl,
+    releaseSceneClockControl,
     activateSceneClockTransport,
     deactivateSceneClockTransport,
   },

--- a/html/assets/js/scenesync/shells/player/player-actions.js
+++ b/html/assets/js/scenesync/shells/player/player-actions.js
@@ -15,5 +15,14 @@ export function createPlayerActions(core) {
     setRate(rate) {
       core?.commands?.setSceneClockRate?.(rate);
     },
+    setMode(mode) {
+      core?.commands?.setSceneClockMode?.(mode);
+    },
+    requestControl() {
+      core?.commands?.requestSceneClockControl?.();
+    },
+    releaseControl() {
+      core?.commands?.releaseSceneClockControl?.();
+    },
   };
 }

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -80,10 +80,16 @@
   border: 1px solid rgba(99, 102, 241, 0.22);
 }
 
-.player-badge-mode[data-mode="host-follow"] {
+.player-badge-mode[data-mode="shared-playback"] {
   background: rgba(16, 185, 129, 0.15);
   color: rgba(110, 231, 183, 0.9);
   border-color: rgba(16, 185, 129, 0.22);
+}
+
+.player-badge-mode[data-mode="room-time"] {
+  background: rgba(14, 165, 233, 0.15);
+  color: rgba(125, 211, 252, 0.9);
+  border-color: rgba(14, 165, 233, 0.24);
 }
 
 .player-badge-status {
@@ -117,6 +123,80 @@
   color: #fff;
 }
 
+/* ── Clock mode ─────────────────────────────────────── */
+.player-mode-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.player-mode-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.player-mode-detail {
+  margin-top: 2px;
+  font-size: 11px;
+  color: rgba(203, 213, 225, 0.72);
+}
+
+.player-controller-btn,
+.player-mode-btn {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(226, 232, 240, 0.82);
+  font: inherit;
+  cursor: pointer;
+  outline: none;
+}
+
+.player-controller-btn {
+  flex: none;
+  min-width: 76px;
+  padding: 6px 10px;
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.player-mode-switch {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.player-mode-btn {
+  min-width: 0;
+  padding: 7px 8px;
+  border-radius: 7px;
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.player-mode-btn[data-active="true"] {
+  background: rgba(99, 102, 241, 0.24);
+  color: rgba(238, 242, 255, 0.96);
+  border-color: rgba(129, 140, 248, 0.46);
+}
+
+.player-controller-btn:hover,
+.player-mode-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.player-controller-btn:disabled,
+.player-mode-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* ── Time display ────────────────────────────────────── */
 .player-time-display {
   text-align: center;
@@ -130,6 +210,15 @@
   letter-spacing: 0.03em;
   color: #f1f5f9;
   font-variant-numeric: tabular-nums;
+}
+
+.player-object-age {
+  display: block;
+  margin-top: 8px;
+  min-height: 14px;
+  color: rgba(203, 213, 225, 0.58);
+  font-size: 11px;
+  line-height: 1.2;
 }
 
 /* ── Seek bar ────────────────────────────────────────── */
@@ -207,6 +296,13 @@
 
 .player-btn:active {
   transform: scale(0.91);
+}
+
+.player-btn:disabled,
+.player-rate-btn:disabled,
+.player-seek:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 .player-btn-stop {
@@ -305,5 +401,13 @@
 
   .player-rate-row {
     flex-wrap: wrap;
+  }
+
+  .player-mode-switch {
+    grid-template-columns: 1fr;
+  }
+
+  .player-mode-summary {
+    align-items: flex-start;
   }
 }

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -25,6 +25,10 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
         activateOnMount: true,
       });
       await transport.mount({ core, root: root || document.body });
+      core?.commands?.activateSceneClockTransport?.({
+        mode: 'shared-playback',
+        requestControl: true,
+      });
     },
 
     unmount() {

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -2,6 +2,14 @@ import { createPlayerActions } from './player-actions.js';
 
 const STYLE_ID = 'scene-sync-player-shell-style';
 const DEFAULT_DURATION = 60;
+const CLOCK_MODES = ['local-preview', 'shared-playback', 'room-time'];
+const CLOCK_MODE_LABELS = {
+  'local-preview': 'Local Preview',
+  'shared-playback': 'Shared Playback',
+  'room-time': 'Room Time',
+  local: 'Local Preview',
+  'host-follow': 'Room Time',
+};
 
 export async function ensurePlayerTransportStylesheet() {
   if (document.getElementById(STYLE_ID)) return;
@@ -24,6 +32,38 @@ function formatTime(seconds) {
   return `${String(mins).padStart(2, '0')}:${secs}`;
 }
 
+function normalizeUiClockMode(mode) {
+  if (mode === 'local') return 'local-preview';
+  if (mode === 'host-follow') return 'room-time';
+  return CLOCK_MODES.includes(mode) ? mode : 'local-preview';
+}
+
+function describeClockState(state = {}) {
+  const mode = normalizeUiClockMode(state.mode);
+  const controllerName = state.controller?.nickname || state.controller?.id || 'Unknown';
+  if (mode === 'shared-playback') {
+    return {
+      title: CLOCK_MODE_LABELS[mode],
+      detail: state.isController === false
+        ? `Following ${controllerName}`
+        : `Controller: ${controllerName}`,
+      scope: '全員に反映',
+    };
+  }
+  if (mode === 'room-time') {
+    return {
+      title: CLOCK_MODE_LABELS[mode],
+      detail: '現在時刻に同期',
+      scope: 'pause / seek 無効',
+    };
+  }
+  return {
+    title: CLOCK_MODE_LABELS[mode],
+    detail: '自分だけに反映',
+    scope: 'ローカル確認用',
+  };
+}
+
 function createPanelHtml({ title, closeable }) {
   return `
     <header class="player-header">
@@ -34,8 +74,21 @@ function createPanelHtml({ title, closeable }) {
         ${closeable ? '<button class="player-close-btn" data-player-close type="button" title="Close">x</button>' : ''}
       </div>
     </header>
+    <div class="player-mode-summary">
+      <div>
+        <div class="player-mode-title" data-player-mode-title>Local Preview</div>
+        <div class="player-mode-detail" data-player-mode-detail>自分だけに反映</div>
+      </div>
+      <button class="player-controller-btn" data-player-controller type="button" hidden>Control</button>
+    </div>
+    <div class="player-mode-switch" role="group" aria-label="Clock mode">
+      <button class="player-mode-btn" data-player-mode-switch="local-preview" type="button">Local Preview</button>
+      <button class="player-mode-btn" data-player-mode-switch="shared-playback" type="button">Shared Playback</button>
+      <button class="player-mode-btn" data-player-mode-switch="room-time" type="button">Room Time</button>
+    </div>
     <div class="player-time-display">
       <span class="player-current-time" data-player-current-time>00:00.00</span>
+      <span class="player-object-age" data-player-object-age>ObjectAge —</span>
     </div>
     <div class="player-seek-wrap">
       <input class="player-seek" data-player-seek type="range" min="0" max="60" step="0.01" value="0" />
@@ -92,18 +145,44 @@ export function createPlayerTransportPanel({
     const state = getClockState(core);
     const time = Number.isFinite(state.time) ? state.time : (state.t ?? 0);
     const isPaused = state.isPaused === true || state.playing === false;
-    const mode = state.mode ?? 'local';
+    const mode = normalizeUiClockMode(state.mode);
+    const modeInfo = describeClockState({ ...state, mode });
     const rate = state.rate ?? 1;
     const duration = resolvePlayerDuration(core, state);
+    const roomTimeMode = mode === 'room-time';
+    const sharedFollower = mode === 'shared-playback' && state.isController === false;
+    const controlsDisabled = roomTimeMode || sharedFollower;
 
     const timeEl = panel.querySelector('[data-player-current-time]');
     if (timeEl) timeEl.textContent = formatTime(time);
+
+    const objectAgeEl = panel.querySelector('[data-player-object-age]');
+    if (objectAgeEl) {
+      const objectAge = state.selectedObjectAge;
+      objectAgeEl.textContent = Number.isFinite(objectAge?.age)
+        ? `ObjectAge ${objectAge.objectId}: ${objectAge.age.toFixed(2)}s`
+        : 'ObjectAge —';
+    }
+
+    const modeTitleEl = panel.querySelector('[data-player-mode-title]');
+    if (modeTitleEl) modeTitleEl.textContent = modeInfo.title;
+
+    const modeDetailEl = panel.querySelector('[data-player-mode-detail]');
+    if (modeDetailEl) modeDetailEl.textContent = `${modeInfo.detail} · ${modeInfo.scope}`;
+
+    const controllerBtn = panel.querySelector('[data-player-controller]');
+    if (controllerBtn) {
+      controllerBtn.hidden = mode !== 'shared-playback';
+      controllerBtn.textContent = state.isController === false ? 'Control' : 'Release';
+      controllerBtn.disabled = mode !== 'shared-playback';
+    }
 
     if (!isSeeking) {
       const seekEl = panel.querySelector('[data-player-seek]');
       if (seekEl) {
         if (parseFloat(seekEl.max) !== duration) seekEl.max = duration;
         seekEl.value = Math.min(time, duration);
+        seekEl.disabled = controlsDisabled;
       }
     }
 
@@ -114,11 +193,15 @@ export function createPlayerTransportPanel({
         playPauseBtn.dataset.playerPlaying = playing ? '1' : '0';
         playPauseBtn.title = playing ? 'Pause' : 'Play';
       }
+      playPauseBtn.disabled = controlsDisabled;
     }
 
+    const stopBtn = panel.querySelector('[data-player-stop]');
+    if (stopBtn) stopBtn.disabled = controlsDisabled;
+
     const modeEl = panel.querySelector('[data-player-clock-mode]');
-    if (modeEl && modeEl.textContent !== mode) {
-      modeEl.textContent = mode;
+    if (modeEl && modeEl.textContent !== modeInfo.title) {
+      modeEl.textContent = modeInfo.title;
       modeEl.dataset.mode = mode;
     }
 
@@ -134,6 +217,12 @@ export function createPlayerTransportPanel({
     panel.querySelectorAll('[data-player-rate]').forEach(btn => {
       const active = String(parseFloat(btn.dataset.playerRate) === rate);
       if (btn.dataset.active !== active) btn.dataset.active = active;
+      btn.disabled = controlsDisabled;
+    });
+
+    panel.querySelectorAll('[data-player-mode-switch]').forEach(btn => {
+      const active = btn.dataset.playerModeSwitch === mode;
+      if (btn.dataset.active !== String(active)) btn.dataset.active = String(active);
     });
   }
 
@@ -197,6 +286,18 @@ export function createPlayerTransportPanel({
         }),
         addListener(panel.querySelector('[data-player-stop]'), 'click', () => actions.stop())
       );
+
+      panel.querySelectorAll('[data-player-mode-switch]').forEach(btn => {
+        disposers.push(addListener(btn, 'click', () => {
+          actions.setMode(btn.dataset.playerModeSwitch);
+        }));
+      });
+
+      disposers.push(addListener(panel.querySelector('[data-player-controller]'), 'click', () => {
+        const state = getClockState(core);
+        if (state.isController === false) actions.requestControl();
+        else actions.releaseControl();
+      }));
 
       panel.querySelectorAll('[data-player-rate]').forEach(btn => {
         disposers.push(addListener(btn, 'click', () => {

--- a/html/assets/js/scenesync/shells/viewer/viewer-shell.js
+++ b/html/assets/js/scenesync/shells/viewer/viewer-shell.js
@@ -74,6 +74,7 @@ export function createSceneSyncShell({ id = 'viewer', requestedId = 'viewer', av
 
       // 鑑賞は Play（interact）既定。クリックでオブジェクトを activate できる。
       core?.commands?.setInputRoutingMode?.('interact');
+      core?.commands?.activateSceneClockTransport?.({ mode: 'shared-playback' });
 
       root = document.createElement('div');
       root.className = 'viewer-shell';


### PR DESCRIPTION
## Summary

- Add the Scene Sync clock abstraction with Local Preview, Shared Playback, and Room Time modes.
- Introduce ObjectAge rebasing for placement, reload, transform edits, and component changes so runtime effects start from age 0.
- Route animation, Loomlet timing, and physics runtime behavior through ActiveClock/ObjectAge instead of raw host time.
- Expand the Player UI with clock mode switching, controller/follower state, ObjectAge display, and shared playback controls.
- Add presence-server validation for scene-clock events and document the new time model, Player UI policy, and editor runtime behavior.

## Impact

Editor Shell now keeps collaborative editing synchronized while leaving playback time local by default. Shared Playback uses RoomNow plus shared offsets for synchronized viewing, and Room Time follows the room clock without treating XR entry as a time-mode transition.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/player/player-transport.js`
- `node --check html/assets/js/scenesync/runtime/scene-clock-transport.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `node --check apps/presence-server/src/scenesync/message-schema.mjs`
- `node --test html/assets/js/scenesync/runtime/scene-clock-transport.test.js`
- `npm run test:physics`
- `npm run test:audio-source-controller`
- `npm run test:editing-state`

Presence-server guard assertions reached OK output, but the test process did not exit in the sandbox after completion; process termination was blocked by sandbox process-list restrictions.