### PR TITLE
Keep editing while Player UI is open, and slim down Player UI height

### DIFF
--- a/html/assets/js/scenesync/shells/editor/editor-player-transport.js
+++ b/html/assets/js/scenesync/shells/editor/editor-player-transport.js
@@ -61,7 +61,6 @@ export function createEditorPlayerTransport() {
   let mobileButton = null;
   let mountedCore = null;
   let opened = false;
-  let inputRoutingModeBeforePlayerUi = null;
   const disposers = [];
 
   function renderToggleState() {
@@ -75,9 +74,6 @@ export function createEditorPlayerTransport() {
   function open(core) {
     if (opened) return;
     opened = true;
-    const state = core?.getEditorState?.();
-    inputRoutingModeBeforePlayerUi = state?.inputRoutingMode ?? 'edit';
-    core?.commands?.setInputRoutingMode?.('interact');
     core?.commands?.activateSceneClockTransport?.();
     transport?.setHidden(false);
     renderToggleState();
@@ -88,9 +84,6 @@ export function createEditorPlayerTransport() {
     opened = false;
     transport?.setHidden(true);
     core?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
-    const restoreMode = inputRoutingModeBeforePlayerUi ?? 'edit';
-    inputRoutingModeBeforePlayerUi = null;
-    core?.commands?.setInputRoutingMode?.(restoreMode);
     renderToggleState();
   }
 
@@ -135,9 +128,6 @@ export function createEditorPlayerTransport() {
     unmount() {
       if (opened) {
         mountedCore?.commands?.deactivateSceneClockTransport?.(getEditorPlayerDeactivateSceneClockOptions());
-        const restoreMode = inputRoutingModeBeforePlayerUi ?? 'edit';
-        inputRoutingModeBeforePlayerUi = null;
-        mountedCore?.commands?.setInputRoutingMode?.(restoreMode);
       }
       opened = false;
       for (const dispose of disposers.splice(0)) dispose();

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -19,7 +19,7 @@
   transform: translateX(-50%);
   z-index: 220;
   width: clamp(320px, 70vw, 560px);
-  padding: 16px 20px 18px;
+  padding: 8px 10px;
   border-radius: 18px;
   background: rgba(8, 8, 20, 0.90);
   border: 1px solid rgba(99, 102, 241, 0.28);
@@ -34,7 +34,7 @@
     0 1px 0 rgba(255, 255, 255, 0.06) inset;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   pointer-events: auto;
   user-select: none;
   -webkit-user-select: none;
@@ -50,28 +50,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: 4px;
 }
 
 .player-title {
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.14em;
+  line-height: 1.1;
   color: rgba(129, 140, 248, 0.85);
 }
 
 .player-badges {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
 }
 
 .player-badge {
   font-size: 10px;
   font-weight: 600;
-  padding: 2px 8px;
+  padding: 2px 6px;
   border-radius: 100px;
   letter-spacing: 0.04em;
-  line-height: 1.4;
+  line-height: 1.2;
 }
 
 .player-badge-mode {
@@ -128,22 +130,24 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 8px 10px;
+  gap: 8px;
+  padding: 5px 8px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.045);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .player-mode-title {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 700;
+  line-height: 1.15;
   color: #f8fafc;
 }
 
 .player-mode-detail {
-  margin-top: 2px;
-  font-size: 11px;
+  margin-top: 0;
+  font-size: 10px;
+  line-height: 1.15;
   color: rgba(203, 213, 225, 0.72);
 }
 
@@ -159,25 +163,26 @@
 
 .player-controller-btn {
   flex: none;
-  min-width: 76px;
-  padding: 6px 10px;
+  min-width: 64px;
+  padding: 4px 8px;
   border-radius: 7px;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
 }
 
 .player-mode-switch {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
+  gap: 4px;
+  margin-top: 5px;
 }
 
 .player-mode-btn {
   min-width: 0;
-  padding: 7px 8px;
+  padding: 5px 6px;
   border-radius: 7px;
-  font-size: 11px;
-  line-height: 1.2;
+  font-size: 10px;
+  line-height: 1.1;
 }
 
 .player-mode-btn[data-active="true"] {
@@ -201,36 +206,37 @@
 .player-time-display {
   text-align: center;
   line-height: 1;
-  padding: 4px 0 2px;
+  margin: 6px 0 4px;
 }
 
 .player-current-time {
-  font-size: 42px;
+  font-size: 24px;
   font-weight: 200;
   letter-spacing: 0.03em;
+  line-height: 1;
   color: #f1f5f9;
   font-variant-numeric: tabular-nums;
 }
 
 .player-object-age {
   display: block;
-  margin-top: 8px;
-  min-height: 14px;
+  margin-top: 3px;
+  min-height: 11px;
   color: rgba(203, 213, 225, 0.58);
-  font-size: 11px;
-  line-height: 1.2;
+  font-size: 10px;
+  line-height: 1.1;
 }
 
 /* ── Seek bar ────────────────────────────────────────── */
 .player-seek-wrap {
-  padding: 0 4px;
+  padding: 2px 4px;
 }
 
 .player-seek {
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 4px;
+  height: 18px;
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.1);
   outline: none;
@@ -275,13 +281,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 14px;
+  gap: 8px;
+  margin-top: 4px;
 }
 
 .player-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 34px;
+  height: 34px;
   border: none;
   border-radius: 50%;
   cursor: pointer;
@@ -306,8 +315,8 @@
 }
 
 .player-btn-stop {
-  width: 40px;
-  height: 40px;
+  width: 34px;
+  height: 34px;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(148, 163, 184, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -319,8 +328,8 @@
 }
 
 .player-btn-play-pause {
-  width: 54px;
-  height: 54px;
+  width: 42px;
+  height: 42px;
   background: linear-gradient(145deg, #6366f1, #4f46e5);
   color: #fff;
   box-shadow: 0 4px 16px rgba(99, 102, 241, 0.42);
@@ -342,7 +351,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 4px;
+  margin-top: 5px;
 }
 
 .player-rate-label {
@@ -353,17 +363,17 @@
 }
 
 .player-rate-btn {
-  padding: 4px 11px;
+  padding: 4px 7px;
   border-radius: 7px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.48);
-  font-size: 12px;
+  font-size: 10px;
   font-family: inherit;
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
   outline: none;
-  line-height: 1.5;
+  line-height: 1.1;
 }
 
 .player-rate-btn:hover {
@@ -387,7 +397,7 @@
   .scene-sync-player-shell {
     bottom: calc(18px + var(--mobile-safe-bottom, 0px));
     width: min(560px, calc(100vw - 24px));
-    padding: 14px 14px 16px;
+    padding: 8px 10px;
     border-radius: 14px;
   }
 
@@ -396,7 +406,7 @@
   }
 
   .player-current-time {
-    font-size: 34px;
+    font-size: 24px;
   }
 
   .player-rate-row {
@@ -409,5 +419,33 @@
 
   .player-mode-summary {
     align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .scene-sync-player-shell {
+    padding: 7px 8px;
+  }
+
+  .player-mode-summary {
+    padding: 5px 7px;
+  }
+
+  .player-current-time {
+    font-size: 22px;
+  }
+
+  .player-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .player-btn-play-pause {
+    width: 40px;
+    height: 40px;
+  }
+
+  .player-rate-row {
+    gap: 4px;
   }
 }

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -255,6 +255,21 @@ export function createPlayerTransportPanel({
       panel.hidden = hidden;
       panel.innerHTML = createPanelHtml({ title, closeable });
 
+      // Player UI 内部の操作が背後の Scene 選択 / TransformControls に流れないようにする
+      const stopPanelEvent = (event) => event.stopPropagation();
+      [
+        'pointerdown',
+        'pointermove',
+        'pointerup',
+        'click',
+        'dblclick',
+        'touchstart',
+        'touchmove',
+        'wheel',
+      ].forEach((type) => {
+        disposers.push(addListener(panel, type, stopPanelEvent, { passive: false }));
+      });
+
       const seekEl = panel.querySelector('[data-player-seek]');
       disposers.push(
         addListener(seekEl, 'pointerdown', () => { isSeeking = true; }),


### PR DESCRIPTION
- Editor Shell の Player UI 表示/非表示で inputRoutingMode を変更しないように
  し、Player UI を開いたまま選択・移動・回転・スケール等の編集操作を継続できる
  ようにする
- Player UI パネル内のpointer/click/touch/wheelイベントが背後のScene選択や
  TransformControlsへ伝播しないようにstopPropagationを追加
- Player UIのpadding/margin/gap/フォントサイズ/ボタンサイズを調整し、既存の
  レイアウト構成を保ったまま縦幅を圧縮