### PR TITLE
[codex] Fix Rapier module MIME handling

### DIFF
--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -18,7 +18,7 @@ export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync/physics/index.js', dest: 'viewer/physics/index.js' },
   { src: '/assets/js/scenesync/physics/rapier-world.js', dest: 'viewer/physics/rapier-world.js' },
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },
-  { src: '/assets/vendor/rapier/0.19.3/rapier.mjs', dest: 'viewer/rapier/rapier.mjs' },
+  { src: '/assets/vendor/rapier/0.19.3/rapier.mjs', dest: 'viewer/rapier/rapier.js' },
   // Pinned Loomlet behavior graph runtime. Exported viewers must not depend on afjk.jp at runtime.
   {
     src: '/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js',
@@ -37,7 +37,7 @@ const INDEX_HTML_TEMPLATE = `<!DOCTYPE html>
     "imports": {
       "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
       "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/",
-      "@dimforge/rapier3d-compat": "./viewer/rapier/rapier.mjs"
+      "@dimforge/rapier3d-compat": "./viewer/rapier/rapier.js"
     }
   }
   <\/script>

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,6 +9,16 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  # Some nginx mime maps do not include .mjs. Module scripts require a
+  # JavaScript MIME type; otherwise browsers reject them before execution.
+  location ~* \.mjs$ {
+    types {
+      application/javascript mjs;
+    }
+    default_type application/javascript;
+    try_files $uri =404;
+  }
+
   # WHIP/WHEP WebRTC endpoints for /pipe streaming.
   # Keep this here as a fallback even though production https-portal also
   # proxies /stream/, so requests never fall through to static file handling.


### PR DESCRIPTION
## Summary
- Serve `.mjs` files from nginx with `application/javascript` so browser module loading works on staging/production.
- Bundle Rapier as `viewer/rapier/rapier.js` in Scene Sync Export ZIPs and point the export importmap at the `.js` path to avoid `.mjs` MIME issues on simple static servers.

## Root Cause
`https://staging.afjk.jp/assets/vendor/rapier/0.19.3/rapier.mjs` was served as `application/octet-stream`. Browsers reject module scripts unless the response has a JavaScript MIME type.

## Validation
- `npm run test:scene-sync-export-import`
- `git diff --check`
- Confirmed staging currently returns `content-type: application/octet-stream` before this deploy, matching the reported browser error.

## Notes
The generated sample export ZIP was regenerated locally with `viewer/rapier/rapier.js`, but the generated `exports/` directory is not included in this PR.