### PR TITLE
[codex] Force recreate staging nginx on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,4 +37,4 @@ jobs:
             docker compose up -d --build presence-server
             docker compose up -d mediamtx
             docker compose up -d --force-recreate https-portal
-            docker compose -p afjkjp-staging -f docker-compose.staging.yml up -d
+            docker compose -p afjkjp-staging -f docker-compose.staging.yml up -d --force-recreate


### PR DESCRIPTION
## Summary
- Force-recreate the staging static nginx service during deploy.

## Root Cause
PR #404 updated `nginx/default.conf` to serve `.mjs` as `application/javascript`, but staging still returns Rapier `.mjs` as `application/octet-stream`. The static nginx service uses a bind-mounted config, and the current deploy command only runs `docker compose ... up -d`, so an unchanged running nginx container can keep serving with the old in-memory config.

## Validation
- Confirmed with Playwright on `https://staging.afjk.jp/scenesync/?codex-check=20260614b` that Chromium still reports: `Failed to load module script... MIME type of "application/octet-stream"`.
- Confirmed with `curl -I 'https://staging.afjk.jp/assets/vendor/rapier/0.19.3/rapier.mjs?codex-check=20260614e'` that staging still returns `content-type: application/octet-stream` after #404.
- Confirmed `origin/main` contains #404, so this is deploy/reload behavior rather than missing code in main.

## Operational Note
For the already-running staging instance, restarting/reloading `www-service-staging` should clear the issue immediately. This PR makes future deploys do that automatically.