### PR TITLE
[codex] Add shared playback physics baseline

### DIFF
--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -322,7 +322,7 @@ function finiteNonNegativeNumber(value, fallback = 0) {
   return Number.isFinite(number) ? Math.max(0, number) : fallback;
 }
 
-function isZeroTime(value) {
+export function isScenePhysicsZeroTime(value) {
   const number = Number(value);
   return Number.isFinite(number) && Math.abs(number) <= ZERO_TIME_EPSILON;
 }
@@ -346,7 +346,7 @@ export function shouldResetPhysicsForSceneClockPayload(payload, activeTime = nul
   if (!payload || typeof payload !== 'object') return false;
   const baseline = payload.physicsBaseline;
   if (baseline?.kind === 'reset') {
-    return isZeroTime(baseline.time ?? payload.targetTime ?? payload.time ?? activeTime);
+    return isScenePhysicsZeroTime(baseline.time ?? payload.targetTime ?? payload.time ?? activeTime);
   }
   if (payload.action === 'reset') return true;
   if (payload.action !== 'seek') return false;
@@ -355,7 +355,7 @@ export function shouldResetPhysicsForSceneClockPayload(payload, activeTime = nul
     payload.time,
     payload.pausedTime,
     activeTime,
-  ].some(isZeroTime);
+  ].some(isScenePhysicsZeroTime);
 }
 
 export function applyPhysicsResetBaseline(runtime, clockState = null, baseline = null) {

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -25,6 +25,7 @@ export const DEFAULT_SCENE_PHYSICS = Object.freeze({
 
 const BODY_TYPES = new Set(['dynamic', 'static']);
 const SHAPES = new Set(['box', 'sphere']);
+const ZERO_TIME_EPSILON = 1e-6;
 
 function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
@@ -58,6 +59,25 @@ function readVec3(value, fallback = [0, 0, 0]) {
 function readPositiveVec3(value, fallback) {
   const next = readVec3(value, fallback);
   return next.map((component, index) => positiveNumber(component, fallback[index] || 0.5));
+}
+
+function readQuaternion(value, fallback = [0, 0, 0, 1]) {
+  if (!Array.isArray(value) || value.length < 4) return [...fallback];
+  return [
+    finiteNumber(value[0], fallback[0] || 0),
+    finiteNumber(value[1], fallback[1] || 0),
+    finiteNumber(value[2], fallback[2] || 0),
+    finiteNumber(value[3], fallback[3] ?? 1),
+  ];
+}
+
+function normalizeInitialTransform(input) {
+  if (!input || typeof input !== 'object') return null;
+  return {
+    position: readVec3(input.position, [0, 0, 0]),
+    rotation: readQuaternion(input.rotation, [0, 0, 0, 1]),
+    scale: readPositiveVec3(input.scale, [1, 1, 1]),
+  };
 }
 
 function normalizeGround(input) {
@@ -142,6 +162,10 @@ export function normalizeObjectPhysics(input = null) {
   if (shape === 'box' && Array.isArray(input.halfExtents)) {
     physics.halfExtents = readPositiveVec3(input.halfExtents, [0.5, 0.5, 0.5]);
   }
+  const initialTransform = normalizeInitialTransform(input.initialTransform);
+  if (initialTransform) {
+    physics.initialTransform = initialTransform;
+  }
 
   return physics;
 }
@@ -176,23 +200,58 @@ function getRotationArray(object) {
   return [0, 0, 0, 1];
 }
 
+function applyTransformArrays(object, transform) {
+  if (!object || !transform) return;
+  if (Array.isArray(transform.position)) {
+    if (typeof object.position?.fromArray === 'function') {
+      object.position.fromArray(transform.position);
+    } else if (object.position) {
+      object.position.x = transform.position[0];
+      object.position.y = transform.position[1];
+      object.position.z = transform.position[2];
+    }
+  }
+  if (Array.isArray(transform.rotation)) {
+    if (typeof object.quaternion?.fromArray === 'function') {
+      object.quaternion.fromArray(transform.rotation);
+    } else if (object.quaternion) {
+      object.quaternion.x = transform.rotation[0];
+      object.quaternion.y = transform.rotation[1];
+      object.quaternion.z = transform.rotation[2];
+      object.quaternion.w = transform.rotation[3];
+    }
+  }
+  if (Array.isArray(transform.scale)) {
+    if (typeof object.scale?.fromArray === 'function') {
+      object.scale.fromArray(transform.scale);
+    } else if (object.scale) {
+      object.scale.x = transform.scale[0];
+      object.scale.y = transform.scale[1];
+      object.scale.z = transform.scale[2];
+    }
+  }
+  object.updateMatrixWorld?.(true);
+}
+
 function inferShape(physics, object) {
   if (physics?.shape === 'sphere') return 'sphere';
   if (physics?.shape === 'box') return 'box';
   return object?.userData?.asset?.primitive === 'sphere' ? 'sphere' : 'box';
 }
 
-export function buildPhysicsBodyDef({ objectId, object, physics }) {
+export function buildPhysicsBodyDef({ objectId, object, physics, useInitialTransform = false }) {
   const normalized = normalizeObjectPhysics(physics);
   if (!objectId || !object || !normalized) return null;
 
-  const scale = getScaleArray(object).map((component) => Math.abs(component || 1));
+  const initialTransform = useInitialTransform ? normalized.initialTransform : null;
+  const scale = (initialTransform?.scale || getScaleArray(object))
+    .map((component) => Math.abs(component || 1));
   const shape = inferShape(normalized, object);
   const body = {
     id: objectId,
     shape,
-    position: getPositionArray(object),
-    rotation: getRotationArray(object),
+    position: initialTransform?.position || getPositionArray(object),
+    rotation: initialTransform?.rotation || getRotationArray(object),
     velocity: normalized.bodyType === 'static'
       ? [0, 0, 0]
       : readVec3(normalized.velocity, [0, 0, 0]),
@@ -256,6 +315,65 @@ function collectRuntimeEntries(entries) {
     })
     .filter(Boolean)
     .sort((left, right) => left.objectId.localeCompare(right.objectId));
+}
+
+function finiteNonNegativeNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, number) : fallback;
+}
+
+function isZeroTime(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && Math.abs(number) <= ZERO_TIME_EPSILON;
+}
+
+export function createPhysicsResetBaseline({
+  time = 0,
+  worldEpochTime = time,
+  preserveMotion = false,
+  reason = 'reset',
+} = {}) {
+  return {
+    kind: 'reset',
+    time: finiteNonNegativeNumber(time, 0),
+    worldEpochTime: finiteNonNegativeNumber(worldEpochTime, 0),
+    preserveMotion: preserveMotion === true,
+    reason,
+  };
+}
+
+export function shouldResetPhysicsForSceneClockPayload(payload, activeTime = null) {
+  if (!payload || typeof payload !== 'object') return false;
+  const baseline = payload.physicsBaseline;
+  if (baseline?.kind === 'reset') {
+    return isZeroTime(baseline.time ?? payload.targetTime ?? payload.time ?? activeTime);
+  }
+  if (payload.action === 'reset') return true;
+  if (payload.action !== 'seek') return false;
+  return [
+    payload.targetTime,
+    payload.time,
+    payload.pausedTime,
+    activeTime,
+  ].some(isZeroTime);
+}
+
+export function applyPhysicsResetBaseline(runtime, clockState = null, baseline = null) {
+  if (!runtime) return false;
+  const worldEpochTime = finiteNonNegativeNumber(
+    baseline?.worldEpochTime,
+    finiteNonNegativeNumber(clockState?.t, 0),
+  );
+  const resetClockState = {
+    ...(clockState || {}),
+    t: worldEpochTime,
+  };
+  const reset = runtime.resetToInitialPose?.(resetClockState) === true;
+  runtime.markDirty?.({
+    preserveMotion: baseline?.preserveMotion === true,
+    worldEpochTime,
+  });
+  return reset;
 }
 
 export function createScenePhysicsRuntime({
@@ -359,14 +477,18 @@ export function createScenePhysicsRuntime({
     world = createWorld(scenePhysics.worldOptions);
     timestepSeconds = world.timestep || normalizeRapierWorldOptions(scenePhysics.worldOptions).timestep;
     entryMap = new Map();
+    const useInitialTransform = preserveMotionOnRebuild === false;
     worldEpochTime = Number.isFinite(pendingWorldEpochTime)
       ? pendingWorldEpochTime
       : getClockTime(clockState);
     pendingWorldEpochTime = null;
 
     for (const entry of entries) {
-      const body = buildPhysicsBodyDef(entry);
+      const body = buildPhysicsBodyDef({ ...entry, useInitialTransform });
       if (!body) continue;
+      if (useInitialTransform && entry.physics?.initialTransform) {
+        applyTransformArrays(entry.object, entry.physics.initialTransform);
+      }
       const motion = previousMotion.get(entry.objectId);
       if (motion && !body.static) {
         body.velocity = motion.velocity;

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -4,6 +4,7 @@ import {
   applyPhysicsResetBaseline,
   createPhysicsResetBaseline,
   createScenePhysicsRuntime,
+  isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
   shouldResetPhysicsForSceneClockPayload,
@@ -347,7 +348,10 @@ test('scene physics runtime applies remote reset payload as a zero baseline', ()
   };
   assert.equal(shouldResetPhysicsForSceneClockPayload(payload, 0), true);
   assert.equal(shouldResetPhysicsForSceneClockPayload({ action: 'seek', targetTime: 0 }, 0), true);
+  assert.equal(shouldResetPhysicsForSceneClockPayload({ action: 'seek', targetTime: 0.0000001 }, 0.0000001), true);
   assert.equal(shouldResetPhysicsForSceneClockPayload({ action: 'seek', targetTime: 2 }, 2), false);
+  assert.equal(isScenePhysicsZeroTime(0.0000001), true);
+  assert.equal(isScenePhysicsZeroTime(0.00001), false);
 
   applyPhysicsResetBaseline(controllerRuntime, { t: 0, mode: 'shared-playback', active: true }, payload.physicsBaseline);
   applyPhysicsResetBaseline(followerRuntime, { t: 0, mode: 'shared-playback', active: true }, payload.physicsBaseline);

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -1,9 +1,12 @@
 import test, { before } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  applyPhysicsResetBaseline,
+  createPhysicsResetBaseline,
   createScenePhysicsRuntime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
+  shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
 import { initRapierPhysics } from './physics/index.js';
 
@@ -49,6 +52,47 @@ function makeEntry(object) {
     objectId: object.userData.objectId,
     object,
     physics: object.userData.physics,
+  };
+}
+
+function makeRuntime({ scenePhysics, entries }) {
+  return createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => entries,
+    isClockActive: () => true,
+  });
+}
+
+function assertVectorClose(actual, expected, epsilon = 1e-6) {
+  assert.equal(actual.length, expected.length);
+  actual.forEach((value, index) => {
+    assert.ok(
+      Math.abs(value - expected[index]) <= epsilon,
+      `expected component ${index} ${value} to be within ${epsilon} of ${expected[index]}`,
+    );
+  });
+}
+
+function assertVectorNotClose(actual, expected, epsilon = 1e-3) {
+  assert.equal(actual.length, expected.length);
+  assert.ok(
+    actual.some((value, index) => Math.abs(value - expected[index]) > epsilon),
+    `expected ${JSON.stringify(actual)} to differ from ${JSON.stringify(expected)}`,
+  );
+}
+
+function physicsWithInitialTransform({
+  shape = 'sphere',
+  position = [0, 2, 0],
+  rotation = [0, 0, 0, 1],
+  scale = [1, 1, 1],
+  velocity = [0, 0, 0],
+} = {}) {
+  return {
+    enabled: true,
+    shape,
+    velocity,
+    initialTransform: { position, rotation, scale },
   };
 }
 
@@ -165,6 +209,155 @@ test('scene physics runtime keeps existing body motion when a new body rebases t
     yAfterRebuild - yNextFrame > 0.1,
     'existing body should keep falling with its pre-rebuild velocity',
   );
+});
+
+test('scene physics runtime resynchronizes from a shared playback zero baseline', () => {
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const objectA = makeObject({
+    objectId: 'shared-ball',
+    position: [0, 8, 0],
+    physics: { enabled: true, shape: 'sphere', velocity: [0.75, 0, 0] },
+  });
+  const objectB = makeObject({
+    objectId: 'shared-ball',
+    position: [0, 8, 0],
+    physics: { enabled: true, shape: 'sphere', velocity: [0.75, 0, 0] },
+  });
+  const runtimeA = makeRuntime({ scenePhysics, entries: [makeEntry(objectA)] });
+  const runtimeB = makeRuntime({ scenePhysics, entries: [makeEntry(objectB)] });
+
+  runtimeA.update({ t: 0, mode: 'shared-playback', active: true });
+  runtimeB.update({ t: 0, mode: 'shared-playback', active: true });
+  runtimeA.update({ t: 1.4, mode: 'shared-playback', active: true });
+  runtimeB.update({ t: 0.65, mode: 'shared-playback', active: true });
+  assertVectorNotClose(objectA.position.toArray(), objectB.position.toArray());
+
+  const baseline = createPhysicsResetBaseline({
+    time: 0,
+    worldEpochTime: 0,
+    preserveMotion: false,
+    reason: 'test-shared-reset',
+  });
+  applyPhysicsResetBaseline(runtimeA, { t: 0, mode: 'shared-playback', active: true }, baseline);
+  applyPhysicsResetBaseline(runtimeB, { t: 0, mode: 'shared-playback', active: true }, baseline);
+  runtimeA.update({ t: 0, mode: 'shared-playback', active: true });
+  runtimeB.update({ t: 0, mode: 'shared-playback', active: true });
+
+  assertVectorClose(objectA.position.toArray(), [0, 8, 0]);
+  assertVectorClose(objectB.position.toArray(), [0, 8, 0]);
+
+  runtimeA.update({ t: 1.1, mode: 'shared-playback', active: true });
+  runtimeB.update({ t: 1.1, mode: 'shared-playback', active: true });
+  assertVectorClose(objectA.position.toArray(), objectB.position.toArray());
+});
+
+test('scene physics shared zero baseline rebuilds from initial transforms after local drift', () => {
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const objectA = makeObject({
+    objectId: 'drift-a',
+    position: [0, 8, 0],
+    physics: physicsWithInitialTransform({
+      position: [0, 8, 0],
+      velocity: [0.5, 0, 0],
+    }),
+  });
+  const objectB = makeObject({
+    objectId: 'drift-b',
+    position: [2, 6, 0],
+    physics: physicsWithInitialTransform({
+      position: [2, 6, 0],
+      velocity: [-0.25, 0, 0],
+    }),
+  });
+  let entries = [makeEntry(objectA)];
+  const runtime = makeRuntime({ scenePhysics, entries });
+
+  runtime.update({ t: 0, mode: 'local-preview', active: true });
+  runtime.update({ t: 1, mode: 'local-preview', active: true });
+  entries = [makeEntry(objectA), makeEntry(objectB)];
+  runtime.markDirty();
+  runtime.update({ t: 1, mode: 'local-preview', active: true });
+  runtime.update({ t: 1.4, mode: 'local-preview', active: true });
+  assertVectorNotClose(objectA.position.toArray(), [0, 8, 0]);
+
+  const baseline = createPhysicsResetBaseline({
+    time: 0,
+    worldEpochTime: 0,
+    preserveMotion: false,
+    reason: 'test-shared-zero-after-drift',
+  });
+  applyPhysicsResetBaseline(runtime, { t: 0, mode: 'shared-playback', active: true }, baseline);
+  runtime.update({ t: 0, mode: 'shared-playback', active: true });
+
+  assertVectorClose(objectA.position.toArray(), [0, 8, 0]);
+  assertVectorClose(objectB.position.toArray(), [2, 6, 0]);
+});
+
+test('scene physics runtime applies remote reset payload as a zero baseline', () => {
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    duration: 4,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+    },
+  });
+  const controllerObject = makeObject({
+    objectId: 'remote-ball',
+    position: [0, 6, 0],
+    physics: { enabled: true, shape: 'sphere', velocity: [0.5, 0, 0] },
+  });
+  const followerObject = makeObject({
+    objectId: 'remote-ball',
+    position: [0, 6, 0],
+    physics: { enabled: true, shape: 'sphere', velocity: [0.5, 0, 0] },
+  });
+  const controllerRuntime = makeRuntime({ scenePhysics, entries: [makeEntry(controllerObject)] });
+  const followerRuntime = makeRuntime({ scenePhysics, entries: [makeEntry(followerObject)] });
+
+  controllerRuntime.update({ t: 0, mode: 'shared-playback', active: true });
+  followerRuntime.update({ t: 0, mode: 'shared-playback', active: true });
+  controllerRuntime.update({ t: 1.2, mode: 'shared-playback', active: true });
+  followerRuntime.update({ t: 0.35, mode: 'shared-playback', active: true });
+  assertVectorNotClose(controllerObject.position.toArray(), followerObject.position.toArray());
+
+  const payload = {
+    action: 'reset',
+    mode: 'shared-playback',
+    physicsBaseline: createPhysicsResetBaseline({
+      time: 0,
+      worldEpochTime: 0,
+      preserveMotion: false,
+      reason: 'remote-player-reset',
+    }),
+  };
+  assert.equal(shouldResetPhysicsForSceneClockPayload(payload, 0), true);
+  assert.equal(shouldResetPhysicsForSceneClockPayload({ action: 'seek', targetTime: 0 }, 0), true);
+  assert.equal(shouldResetPhysicsForSceneClockPayload({ action: 'seek', targetTime: 2 }, 2), false);
+
+  applyPhysicsResetBaseline(controllerRuntime, { t: 0, mode: 'shared-playback', active: true }, payload.physicsBaseline);
+  applyPhysicsResetBaseline(followerRuntime, { t: 0, mode: 'shared-playback', active: true }, payload.physicsBaseline);
+  controllerRuntime.update({ t: 0, mode: 'shared-playback', active: true });
+  followerRuntime.update({ t: 0, mode: 'shared-playback', active: true });
+  assertVectorClose(controllerObject.position.toArray(), followerObject.position.toArray());
+
+  controllerRuntime.update({ t: 0.9, mode: 'shared-playback', active: true });
+  followerRuntime.update({ t: 0.9, mode: 'shared-playback', active: true });
+  assertVectorClose(controllerObject.position.toArray(), followerObject.position.toArray());
 });
 
 test('scene physics runtime resets to initial pose when the clock becomes inactive', () => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -76,11 +76,14 @@ import {
   setClockRate as setActiveClockRate,
 } from './runtime/scene-clock-transport.js';
 import {
+  applyPhysicsResetBaseline,
+  createPhysicsResetBaseline,
   createScenePhysicsRuntime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
   serializeObjectPhysics,
   serializeScenePhysics,
+  shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
 import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
 
@@ -1688,19 +1691,37 @@ function serializeObjectClockForSceneSync(obj, now = performance.now()) {
   };
 }
 
-function resetObjectPhysicsMotion(obj) {
+function getObjectPhysicsInitialTransform(obj) {
+  return {
+    position: obj?.position?.toArray?.() || [0, 0, 0],
+    rotation: obj?.quaternion?.toArray?.() || [0, 0, 0, 1],
+    scale: obj?.scale?.toArray?.() || [1, 1, 1],
+  };
+}
+
+function captureObjectPhysicsInitialTransform(obj) {
   const physics = normalizeObjectPhysics(obj?.userData?.physics);
   if (!obj || !physics) return null;
 
   obj.userData.physics = {
     ...physics,
+    initialTransform: getObjectPhysicsInitialTransform(obj),
+  };
+  return obj.userData.physics;
+}
+
+function resetObjectPhysicsMotion(obj, { captureInitialTransform = true } = {}) {
+  const physics = normalizeObjectPhysics(obj?.userData?.physics);
+  if (!obj || !physics) return null;
+  const initialTransform = captureInitialTransform === false
+    ? physics.initialTransform
+    : getObjectPhysicsInitialTransform(obj);
+
+  obj.userData.physics = {
+    ...physics,
     velocity: [0, 0, 0],
     angularVelocity: [0, 0, 0],
-    initialTransform: {
-      position: obj.position?.toArray?.() || [0, 0, 0],
-      rotation: obj.quaternion?.toArray?.() || [0, 0, 0, 1],
-      scale: obj.scale?.toArray?.() || [1, 1, 1],
-    },
+    ...(initialTransform ? { initialTransform } : {}),
   };
   return obj.userData.physics;
 }
@@ -1708,6 +1729,7 @@ function resetObjectPhysicsMotion(obj) {
 function rebaseObjectClock(obj, {
   now = performance.now(),
   resetPhysicsMotion = false,
+  capturePhysicsInitialTransform = true,
   sharedEpochTime = null,
   reason = 'object-rebased',
 } = {}) {
@@ -1727,7 +1749,9 @@ function rebaseObjectClock(obj, {
   obj.userData.clock = clock;
 
   if (resetPhysicsMotion) {
-    resetObjectPhysicsMotion(obj);
+    resetObjectPhysicsMotion(obj, {
+      captureInitialTransform: capturePhysicsInitialTransform,
+    });
   }
 
   markScenePhysicsRuntimeDirty({
@@ -2885,8 +2909,10 @@ function applyScenePhysics(physics, options = {}) {
 function applyObjectPhysicsDelta(obj, physics) {
   if (!obj) return null;
   const next = normalizeObjectPhysics(physics);
+  let applied = null;
   if (next) {
     obj.userData.physics = next;
+    applied = captureObjectPhysicsInitialTransform(obj) || next;
     if (!scenePhysicsState.enabled) {
       scenePhysicsState = {
         ...normalizeScenePhysics(scenePhysicsState),
@@ -2900,7 +2926,7 @@ function applyObjectPhysicsDelta(obj, physics) {
     resetMotionObjectIds: obj.userData?.objectId ? [obj.userData.objectId] : null,
   });
   rebaseObjectClock(obj, { reason: 'object-physics' });
-  return next;
+  return applied;
 }
 
 function showTemporaryImagePreview(objectId, file, position, options = {}) {
@@ -5010,6 +5036,7 @@ function applySharedObjectClockBaseline(objectId, clockLike, {
   now = performance.now(),
   resetLocalEpoch = false,
   resetPhysicsMotion = false,
+  capturePhysicsInitialTransform = true,
 } = {}) {
   const obj = managedObjects.get(objectId);
   if (!obj) return false;
@@ -5024,7 +5051,9 @@ function applySharedObjectClockBaseline(objectId, clockLike, {
   };
 
   if (resetPhysicsMotion) {
-    resetObjectPhysicsMotion(obj);
+    resetObjectPhysicsMotion(obj, {
+      captureInitialTransform: capturePhysicsInitialTransform,
+    });
   }
   return true;
 }
@@ -5033,6 +5062,7 @@ function applySharedObjectClockBaselines(objectClocks, {
   now = performance.now(),
   resetLocalEpoch = false,
   resetPhysicsMotion = false,
+  capturePhysicsInitialTransform = true,
 } = {}) {
   if (!objectClocks || typeof objectClocks !== 'object') return false;
   let applied = false;
@@ -5041,6 +5071,7 @@ function applySharedObjectClockBaselines(objectClocks, {
       now,
       resetLocalEpoch,
       resetPhysicsMotion,
+      capturePhysicsInitialTransform,
     }) || applied;
   }
   if (applied) {
@@ -5053,10 +5084,42 @@ function applySharedObjectClockBaselines(objectClocks, {
   return applied;
 }
 
+function createSharedPlaybackPhysicsResetBaseline(now = performance.now(), reason = 'shared-playback-reset') {
+  return createPhysicsResetBaseline({
+    time: 0,
+    worldEpochTime: getSceneClockTime(now),
+    preserveMotion: false,
+    reason,
+  });
+}
+
+function applyScenePhysicsResetBaseline(physicsBaseline = null, now = performance.now()) {
+  const worldEpochTime = Number.isFinite(Number(physicsBaseline?.worldEpochTime))
+    ? Math.max(0, Number(physicsBaseline.worldEpochTime))
+    : getSceneClockTime(now);
+  return applyPhysicsResetBaseline(
+    scenePhysicsRuntime,
+    {
+      t: worldEpochTime,
+      mode: sceneClockState.mode,
+      active: sceneClockState.active,
+      transportActive: sceneClockState.transportActive,
+    },
+    physicsBaseline || createPhysicsResetBaseline({
+      time: 0,
+      worldEpochTime,
+      preserveMotion: false,
+      reason: 'shared-playback-reset',
+    }),
+  );
+}
+
 function resetAllObjectClocksForSceneClock(now = performance.now(), {
   objectClocks = null,
   reason = 'player-reset',
   resetPhysicsMotion = true,
+  capturePhysicsInitialTransform = false,
+  physicsBaseline = null,
 } = {}) {
   for (const [objectId, obj] of managedObjects.entries()) {
     const baseline = objectClocks && Object.prototype.hasOwnProperty.call(objectClocks, objectId)
@@ -5067,18 +5130,19 @@ function resetAllObjectClocksForSceneClock(now = performance.now(), {
           now,
           resetLocalEpoch: true,
           resetPhysicsMotion,
+          capturePhysicsInitialTransform,
         })
       : false;
     if (appliedBaseline) continue;
     rebaseObjectClock(obj, {
       now,
       resetPhysicsMotion,
+      capturePhysicsInitialTransform,
       reason,
     });
   }
 
-  scenePhysicsRuntime.resetToInitialPose();
-  markScenePhysicsRuntimeDirty({ preserveMotion: false });
+  applyScenePhysicsResetBaseline(physicsBaseline, now);
 }
 
 function publishSharedObjectClockBaselines(reason = 'baseline') {
@@ -5182,14 +5246,22 @@ function applyRemoteSceneClock(payload, from = null) {
   sceneClockState.active = true;
   updateClockLegacyFields();
 
-  if (payload.action === 'reset') {
-    resetAllObjectClocksForSceneClock(performance.now(), {
+  const now = performance.now();
+  const activeTime = getSceneClockTime(now);
+  if (shouldResetPhysicsForSceneClockPayload(payload, activeTime)) {
+    resetAllObjectClocksForSceneClock(now, {
       objectClocks: payload.objectClocks,
-      reason: 'remote-player-reset',
+      reason: payload.action === 'seek' ? 'remote-player-seek-zero' : 'remote-player-reset',
       resetPhysicsMotion: true,
+      physicsBaseline: payload.physicsBaseline || createPhysicsResetBaseline({
+        time: 0,
+        worldEpochTime: activeTime,
+        preserveMotion: false,
+        reason: `remote-${payload.action || 'scene-clock'}`,
+      }),
     });
   } else if (payload.objectClocks) {
-    applySharedObjectClockBaselines(payload.objectClocks);
+    applySharedObjectClockBaselines(payload.objectClocks, { now });
   }
 
   notifySceneSyncShellStateChanged(`scene-clock-remote-${payload.action || 'update'}`);
@@ -5200,6 +5272,10 @@ function setSceneClockMode(mode, now = performance.now(), options = {}) {
   const previousMode = sceneClockState.mode;
   const previousActiveTime = getSceneClockTime(now);
   const sources = getSceneClockSources(now);
+  const resetSharedPlaybackBaseline =
+    nextMode === CLOCK_MODES.SHARED_PLAYBACK &&
+    previousMode !== CLOCK_MODES.SHARED_PLAYBACK &&
+    options.resetPhysicsBaseline !== false;
 
   if (nextMode === CLOCK_MODES.ROOM_TIME) {
     sceneClockState.mode = CLOCK_MODES.ROOM_TIME;
@@ -5210,8 +5286,8 @@ function setSceneClockMode(mode, now = performance.now(), options = {}) {
     sceneClockState.rate = 1;
   } else {
     setActiveClockMode(sceneClockState, nextMode, sources, {
-      preserveTime: options.preserveTime !== false,
-      resetToZero: options.resetToZero === true,
+      preserveTime: resetSharedPlaybackBaseline ? false : options.preserveTime !== false,
+      resetToZero: options.resetToZero === true || resetSharedPlaybackBaseline,
     });
   }
 
@@ -5222,17 +5298,35 @@ function setSceneClockMode(mode, now = performance.now(), options = {}) {
   }
 
   const nextActiveTime = getSceneClockTime(now);
-  preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime, {
-    previousMode,
-    nextMode,
-    now,
-  });
+  let physicsBaseline = null;
 
   sceneClockState.transportActive = true;
   sceneClockState.active = true;
+  if (resetSharedPlaybackBaseline) {
+    physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'player-mode-zero');
+    resetAllObjectClocksForSceneClock(now, {
+      reason: 'player-mode-zero',
+      resetPhysicsMotion: true,
+      physicsBaseline,
+    });
+  } else {
+    preserveObjectAgesAcrossActiveTimeChange(previousActiveTime, nextActiveTime, {
+      previousMode,
+      nextMode,
+      now,
+    });
+  }
+
   updateClockLegacyFields(now);
   if (nextMode === CLOCK_MODES.SHARED_PLAYBACK && isSceneClockControllerSelf()) {
-    broadcastSceneClockEvent('mode');
+    broadcastSceneClockEvent('mode', {
+      ...(physicsBaseline ? {
+        targetTime: 0,
+        time: 0,
+        objectClocks: getSharedObjectClockPayload(now),
+        physicsBaseline,
+      } : {}),
+    });
   }
   notifySceneSyncShellStateChanged('scene-clock-mode-changed');
 }
@@ -5258,10 +5352,31 @@ function resumeSceneClock(now = performance.now()) {
 function seekSceneClock(t, now = performance.now(), options = {}) {
   if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
   if (!canControlSceneClock()) return;
-  seekClockState(sceneClockState, Math.max(0, Number(t) || 0), getSceneClockSources(now));
+  const targetTime = Math.max(0, Number(t) || 0);
+  seekClockState(sceneClockState, targetTime, getSceneClockSources(now));
   updateClockLegacyFields(now);
+  let physicsBaseline = null;
+  if (
+    sceneClockState.mode === CLOCK_MODES.SHARED_PLAYBACK &&
+    targetTime === 0 &&
+    options.resetPhysicsBaseline !== false
+  ) {
+    physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'player-seek-zero');
+    resetAllObjectClocksForSceneClock(now, {
+      reason: 'player-seek-zero',
+      resetPhysicsMotion: true,
+      physicsBaseline,
+    });
+  }
   if (options.broadcast !== false) {
-    broadcastSceneClockEvent('seek');
+    broadcastSceneClockEvent('seek', {
+      targetTime,
+      time: targetTime,
+      ...(physicsBaseline ? {
+        objectClocks: getSharedObjectClockPayload(now),
+        physicsBaseline,
+      } : {}),
+    });
   }
   notifySceneSyncShellStateChanged('scene-clock-seek');
 }
@@ -5269,13 +5384,18 @@ function seekSceneClock(t, now = performance.now(), options = {}) {
 function resetSceneClock(now = performance.now()) {
   if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
   if (!canControlSceneClock()) return;
-  seekSceneClock(0, now, { broadcast: false });
+  seekSceneClock(0, now, { broadcast: false, resetPhysicsBaseline: false });
+  const physicsBaseline = sceneClockState.mode === CLOCK_MODES.SHARED_PLAYBACK
+    ? createSharedPlaybackPhysicsResetBaseline(now, 'player-reset')
+    : null;
   resetAllObjectClocksForSceneClock(now, {
     reason: 'player-reset',
     resetPhysicsMotion: true,
+    physicsBaseline,
   });
   broadcastSceneClockEvent('reset', {
     objectClocks: getSharedObjectClockPayload(now),
+    ...(physicsBaseline ? { physicsBaseline } : {}),
   });
 }
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -79,6 +79,7 @@ import {
   applyPhysicsResetBaseline,
   createPhysicsResetBaseline,
   createScenePhysicsRuntime,
+  isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
   serializeObjectPhysics,
@@ -5352,13 +5353,14 @@ function resumeSceneClock(now = performance.now()) {
 function seekSceneClock(t, now = performance.now(), options = {}) {
   if (sceneClockState.mode === CLOCK_MODES.ROOM_TIME) return;
   if (!canControlSceneClock()) return;
-  const targetTime = Math.max(0, Number(t) || 0);
+  const rawTargetTime = Math.max(0, Number(t) || 0);
+  const targetTime = isScenePhysicsZeroTime(rawTargetTime) ? 0 : rawTargetTime;
   seekClockState(sceneClockState, targetTime, getSceneClockSources(now));
   updateClockLegacyFields(now);
   let physicsBaseline = null;
   if (
     sceneClockState.mode === CLOCK_MODES.SHARED_PLAYBACK &&
-    targetTime === 0 &&
+    isScenePhysicsZeroTime(targetTime) &&
     options.resetPhysicsBaseline !== false
   ) {
     physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'player-seek-zero');


### PR DESCRIPTION
## Summary

Adds a Shared Playback zero-time physics baseline for Scene Sync Rapier physics.

- Rebuilds Rapier worlds from stored initial transforms when Shared Playback enters zero-time reset paths.
- Broadcasts and consumes `physicsBaseline` data on scene-clock reset, seek(0), and Shared Playback mode entry.
- Handles remote reset / seek(0) payloads by resetting object clocks and rebuilding physics without preserving local velocity or angular velocity.
- Keeps Local Preview editing behavior permissive: mid-edit divergence can still happen, but zero-time Shared Playback reset returns clients to the same baseline.

## Impact

This makes Shared Playback stop/reset/seek(0) a deterministic synchronization point for Rapier physics. If clients drift during editing or after mid-play object additions, resetting to 0 seconds rebuilds from the same scene state and replaying from 0 produces matching physics results.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- `npm run test:physics`
- `npm run test:scene-sync-export-import`
- `git diff --check`
- Playwright Chromium 2-tab verification: created divergent local-preview physics timelines, applied Shared Playback zero baseline, confirmed reset positions and replayed physics matched across tabs.