### PR TITLE
[codex] Compact player transport UI

### DIFF
--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -19,22 +19,22 @@
   transform: translateX(-50%);
   z-index: 220;
   width: clamp(320px, 70vw, 560px);
-  padding: 8px 10px;
-  border-radius: 18px;
-  background: rgba(8, 8, 20, 0.90);
-  border: 1px solid rgba(99, 102, 241, 0.28);
+  padding: 6px 8px;
+  border-radius: 14px;
+  background: rgba(8, 8, 20, 0.62);
+  border: 1px solid rgba(99, 102, 241, 0.22);
   color: #e2e8f0;
   font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', ui-monospace, monospace;
   font-size: 13px;
   backdrop-filter: blur(20px) saturate(1.4);
   -webkit-backdrop-filter: blur(20px) saturate(1.4);
   box-shadow:
-    0 12px 40px rgba(0, 0, 0, 0.55),
+    0 10px 32px rgba(0, 0, 0, 0.42),
     0 0 0 1px rgba(99, 102, 241, 0.06) inset,
     0 1px 0 rgba(255, 255, 255, 0.06) inset;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 5px;
   pointer-events: auto;
   user-select: none;
   -webkit-user-select: none;
@@ -50,13 +50,18 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 4px;
+  gap: 8px;
+  margin-bottom: 0;
 }
 
 .player-title {
-  font-size: 12px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.1em;
   line-height: 1.1;
   color: rgba(129, 140, 248, 0.85);
 }
@@ -64,34 +69,80 @@
 .player-badges {
   display: flex;
   align-items: center;
-  gap: 4px;
+  flex: none;
+  gap: 3px;
 }
 
 .player-badge {
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 600;
-  padding: 2px 6px;
+  padding: 2px 5px;
   border-radius: 100px;
   letter-spacing: 0.04em;
   line-height: 1.2;
 }
 
-.player-badge-mode {
+.player-mode-select-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 100px;
   background: rgba(99, 102, 241, 0.15);
   color: rgba(165, 180, 252, 0.9);
   border: 1px solid rgba(99, 102, 241, 0.22);
 }
 
-.player-badge-mode[data-mode="shared-playback"] {
+.player-mode-select-wrap::after {
+  content: "";
+  position: absolute;
+  right: 7px;
+  top: 50%;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  border-left: 3.5px solid transparent;
+  border-right: 3.5px solid transparent;
+  border-top: 4px solid currentColor;
+  transform: translateY(-35%);
+  opacity: 0.8;
+}
+
+.player-mode-select-wrap[data-mode="shared-playback"] {
   background: rgba(16, 185, 129, 0.15);
   color: rgba(110, 231, 183, 0.9);
   border-color: rgba(16, 185, 129, 0.22);
 }
 
-.player-badge-mode[data-mode="room-time"] {
+.player-mode-select-wrap[data-mode="room-time"] {
   background: rgba(14, 165, 233, 0.15);
   color: rgba(125, 211, 252, 0.9);
   border-color: rgba(14, 165, 233, 0.24);
+}
+
+.player-mode-select {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 122px;
+  height: 20px;
+  padding: 1px 17px 1px 7px;
+  border: 0;
+  border-radius: 100px;
+  background: transparent;
+  color: currentColor;
+  font: 700 9px/1.2 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', ui-monospace, monospace;
+  letter-spacing: 0.02em;
+  outline: none;
+  cursor: pointer;
+}
+
+.player-mode-select:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.68);
+  outline-offset: 2px;
+}
+
+.player-mode-select option {
+  color: #111827;
+  background: #f8fafc;
 }
 
 .player-badge-status {
@@ -110,13 +161,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.06);
   color: rgba(226, 232, 240, 0.82);
-  font: 13px/1 monospace;
+  font: 12px/1 monospace;
   cursor: pointer;
 }
 
@@ -130,15 +181,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 5px 8px;
+  gap: 6px;
+  padding: 4px 6px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.045);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .player-mode-title {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   line-height: 1.15;
   color: #f8fafc;
@@ -146,13 +197,12 @@
 
 .player-mode-detail {
   margin-top: 0;
-  font-size: 10px;
+  font-size: 9px;
   line-height: 1.15;
   color: rgba(203, 213, 225, 0.72);
 }
 
-.player-controller-btn,
-.player-mode-btn {
+.player-controller-btn {
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.06);
   color: rgba(226, 232, 240, 0.82);
@@ -164,53 +214,31 @@
 .player-controller-btn {
   flex: none;
   min-width: 64px;
-  padding: 4px 8px;
+  padding: 3px 7px;
   border-radius: 7px;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
 }
 
-.player-mode-switch {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 4px;
-  margin-top: 5px;
-}
-
-.player-mode-btn {
-  min-width: 0;
-  padding: 5px 6px;
-  border-radius: 7px;
-  font-size: 10px;
-  line-height: 1.1;
-}
-
-.player-mode-btn[data-active="true"] {
-  background: rgba(99, 102, 241, 0.24);
-  color: rgba(238, 242, 255, 0.96);
-  border-color: rgba(129, 140, 248, 0.46);
-}
-
-.player-controller-btn:hover,
-.player-mode-btn:hover {
+.player-controller-btn:hover {
   background: rgba(255, 255, 255, 0.12);
 }
 
-.player-controller-btn:disabled,
-.player-mode-btn:disabled {
+.player-controller-btn:disabled {
   opacity: 0.45;
   cursor: default;
 }
 
 /* ── Time display ────────────────────────────────────── */
 .player-time-display {
-  text-align: center;
+  min-width: 0;
+  text-align: left;
   line-height: 1;
-  margin: 6px 0 4px;
+  margin: 0;
 }
 
 .player-current-time {
-  font-size: 24px;
+  font-size: 19px;
   font-weight: 200;
   letter-spacing: 0.03em;
   line-height: 1;
@@ -220,23 +248,23 @@
 
 .player-object-age {
   display: block;
-  margin-top: 3px;
-  min-height: 11px;
+  margin-top: 2px;
+  min-height: 10px;
   color: rgba(203, 213, 225, 0.58);
-  font-size: 10px;
+  font-size: 9px;
   line-height: 1.1;
 }
 
 /* ── Seek bar ────────────────────────────────────────── */
 .player-seek-wrap {
-  padding: 2px 4px;
+  padding: 1px 2px 0;
 }
 
 .player-seek {
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 18px;
+  height: 14px;
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.1);
   outline: none;
@@ -246,13 +274,13 @@
 
 .player-seek:hover,
 .player-seek:focus-visible {
-  height: 6px;
+  height: 5px;
 }
 
 .player-seek::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: #6366f1;
   cursor: pointer;
@@ -267,8 +295,8 @@
 }
 
 .player-seek::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: #6366f1;
   cursor: pointer;
@@ -277,20 +305,27 @@
 }
 
 /* ── Transport controls ──────────────────────────────── */
+.player-transport-row {
+  display: grid;
+  grid-template-columns: minmax(96px, 1fr) auto minmax(130px, 1fr);
+  align-items: center;
+  gap: 8px;
+}
+
 .player-controls {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  margin-top: 4px;
+  gap: 6px;
+  margin: 0;
 }
 
 .player-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   border: none;
   border-radius: 50%;
   cursor: pointer;
@@ -315,8 +350,8 @@
 }
 
 .player-btn-stop {
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(148, 163, 184, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -328,8 +363,8 @@
 }
 
 .player-btn-play-pause {
-  width: 42px;
-  height: 42px;
+  width: 36px;
+  height: 36px;
   background: linear-gradient(145deg, #6366f1, #4f46e5);
   color: #fff;
   box-shadow: 0 4px 16px rgba(99, 102, 241, 0.42);
@@ -350,25 +385,26 @@
 .player-rate-row {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 4px;
-  margin-top: 5px;
+  min-width: 0;
+  margin: 0;
 }
 
 .player-rate-label {
-  font-size: 10px;
+  font-size: 9px;
   letter-spacing: 0.08em;
   color: rgba(255, 255, 255, 0.35);
   margin-right: 2px;
 }
 
 .player-rate-btn {
-  padding: 4px 7px;
+  padding: 3px 6px;
   border-radius: 7px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.48);
-  font-size: 10px;
+  font-size: 9px;
   font-family: inherit;
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
@@ -397,7 +433,7 @@
   .scene-sync-player-shell {
     bottom: calc(18px + var(--mobile-safe-bottom, 0px));
     width: min(560px, calc(100vw - 24px));
-    padding: 8px 10px;
+    padding: 6px 8px;
     border-radius: 14px;
   }
 
@@ -406,43 +442,56 @@
   }
 
   .player-current-time {
-    font-size: 24px;
+    font-size: 19px;
   }
 
-  .player-rate-row {
-    flex-wrap: wrap;
+  .player-title {
+    font-size: 10px;
   }
 
-  .player-mode-switch {
-    grid-template-columns: 1fr;
+  .player-mode-select {
+    width: 112px;
   }
 
   .player-mode-summary {
     align-items: flex-start;
   }
+
+  .player-transport-row {
+    grid-template-columns: minmax(86px, 1fr) auto minmax(116px, 1fr);
+    gap: 6px;
+  }
+
+  .player-rate-label {
+    display: none;
+  }
+
+  .player-rate-row {
+    gap: 3px;
+  }
 }
 
 @media (max-width: 640px) {
   .scene-sync-player-shell {
-    padding: 7px 8px;
+    padding: 6px 7px;
   }
 
   .player-mode-summary {
-    padding: 5px 7px;
+    padding: 4px 6px;
   }
 
   .player-current-time {
-    font-size: 22px;
+    font-size: 18px;
   }
 
   .player-btn {
-    width: 32px;
-    height: 32px;
+    width: 30px;
+    height: 30px;
   }
 
   .player-btn-play-pause {
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
   }
 
   .player-rate-row {

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -69,7 +69,13 @@ function createPanelHtml({ title, closeable }) {
     <header class="player-header">
       <span class="player-title">${title}</span>
       <div class="player-badges">
-        <span class="player-badge player-badge-mode" data-player-clock-mode data-mode="local">local</span>
+        <span class="player-mode-select-wrap" data-player-clock-mode data-mode="local-preview">
+          <select class="player-mode-select" data-player-mode-select aria-label="Clock mode">
+            <option value="local-preview">Local Preview</option>
+            <option value="shared-playback">Shared Playback</option>
+            <option value="room-time">Room Time</option>
+          </select>
+        </span>
         <span class="player-badge player-badge-status" data-player-clock-status data-paused="1">paused</span>
         ${closeable ? '<button class="player-close-btn" data-player-close type="button" title="Close">x</button>' : ''}
       </div>
@@ -81,40 +87,37 @@ function createPanelHtml({ title, closeable }) {
       </div>
       <button class="player-controller-btn" data-player-controller type="button" hidden>Control</button>
     </div>
-    <div class="player-mode-switch" role="group" aria-label="Clock mode">
-      <button class="player-mode-btn" data-player-mode-switch="local-preview" type="button">Local Preview</button>
-      <button class="player-mode-btn" data-player-mode-switch="shared-playback" type="button">Shared Playback</button>
-      <button class="player-mode-btn" data-player-mode-switch="room-time" type="button">Room Time</button>
-    </div>
-    <div class="player-time-display">
-      <span class="player-current-time" data-player-current-time>00:00.00</span>
-      <span class="player-object-age" data-player-object-age>ObjectAge —</span>
-    </div>
     <div class="player-seek-wrap">
       <input class="player-seek" data-player-seek type="range" min="0" max="60" step="0.01" value="0" />
     </div>
-    <div class="player-controls">
-      <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <rect x="3" y="3" width="10" height="10" rx="2"/>
-        </svg>
-      </button>
-      <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
-        <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
-          <polygon points="5,2 16,9 5,16"/>
-        </svg>
-        <svg class="icon-pause" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
-          <rect x="3" y="2" width="4" height="14" rx="1.5"/>
-          <rect x="11" y="2" width="4" height="14" rx="1.5"/>
-        </svg>
-      </button>
-    </div>
-    <div class="player-rate-row">
-      <span class="player-rate-label">Rate</span>
-      <button class="player-rate-btn" data-player-rate="0.25" type="button">1/4x</button>
-      <button class="player-rate-btn" data-player-rate="0.5" type="button">1/2x</button>
-      <button class="player-rate-btn" data-player-rate="1" type="button" data-active="true">1x</button>
-      <button class="player-rate-btn" data-player-rate="2" type="button">2x</button>
+    <div class="player-transport-row">
+      <div class="player-time-display">
+        <span class="player-current-time" data-player-current-time>00:00.00</span>
+        <span class="player-object-age" data-player-object-age>ObjectAge —</span>
+      </div>
+      <div class="player-controls">
+        <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <rect x="3" y="3" width="10" height="10" rx="2"/>
+          </svg>
+        </button>
+        <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
+          <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+            <polygon points="5,2 16,9 5,16"/>
+          </svg>
+          <svg class="icon-pause" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+            <rect x="3" y="2" width="4" height="14" rx="1.5"/>
+            <rect x="11" y="2" width="4" height="14" rx="1.5"/>
+          </svg>
+        </button>
+      </div>
+      <div class="player-rate-row">
+        <span class="player-rate-label">Rate</span>
+        <button class="player-rate-btn" data-player-rate="0.25" type="button">1/4x</button>
+        <button class="player-rate-btn" data-player-rate="0.5" type="button">1/2x</button>
+        <button class="player-rate-btn" data-player-rate="1" type="button" data-active="true">1x</button>
+        <button class="player-rate-btn" data-player-rate="2" type="button">2x</button>
+      </div>
     </div>
   `;
 }
@@ -200,9 +203,13 @@ export function createPlayerTransportPanel({
     if (stopBtn) stopBtn.disabled = controlsDisabled;
 
     const modeEl = panel.querySelector('[data-player-clock-mode]');
-    if (modeEl && modeEl.textContent !== modeInfo.title) {
-      modeEl.textContent = modeInfo.title;
+    if (modeEl) {
       modeEl.dataset.mode = mode;
+    }
+
+    const modeSelect = panel.querySelector('[data-player-mode-select]');
+    if (modeSelect && modeSelect.value !== mode) {
+      modeSelect.value = mode;
     }
 
     const statusEl = panel.querySelector('[data-player-clock-status]');
@@ -218,11 +225,6 @@ export function createPlayerTransportPanel({
       const active = String(parseFloat(btn.dataset.playerRate) === rate);
       if (btn.dataset.active !== active) btn.dataset.active = active;
       btn.disabled = controlsDisabled;
-    });
-
-    panel.querySelectorAll('[data-player-mode-switch]').forEach(btn => {
-      const active = btn.dataset.playerModeSwitch === mode;
-      if (btn.dataset.active !== String(active)) btn.dataset.active = String(active);
     });
   }
 
@@ -302,11 +304,9 @@ export function createPlayerTransportPanel({
         addListener(panel.querySelector('[data-player-stop]'), 'click', () => actions.stop())
       );
 
-      panel.querySelectorAll('[data-player-mode-switch]').forEach(btn => {
-        disposers.push(addListener(btn, 'click', () => {
-          actions.setMode(btn.dataset.playerModeSwitch);
-        }));
-      });
+      disposers.push(addListener(panel.querySelector('[data-player-mode-select]'), 'change', (event) => {
+        actions.setMode(event.target.value);
+      }));
 
       disposers.push(addListener(panel.querySelector('[data-player-controller]'), 'click', () => {
         const state = getClockState(core);


### PR DESCRIPTION
## Summary

Compacts the Scene Sync Player UI and consolidates Clock Mode selection into the existing mode status area.

- Replaces the separate Local Preview / Shared Playback / Room Time button row with a compact dropdown in the top-right mode badge.
- Applies the same shared transport changes to both Player Shell and the Editor Shell player panel.
- Reduces panel padding, gaps, control sizes, and time typography.
- Places time, transport controls, and rate controls on one row to reduce vertical height.
- Makes the panel background more transparent while keeping backdrop blur and contrast.

## Impact

The Player UI takes less vertical space and leaves more of the scene visible. Clock Mode selection remains available in the status area instead of duplicating controls.

## Validation

- `node --check html/assets/js/scenesync/shells/player/player-transport.js`
- `node --test html/assets/js/scenesync/shells/editor/editor-player-transport.test.js`
- `git diff --check`
- Playwright verification for Player Shell desktop/mobile and Editor Shell player panel:
  - mode dropdown exists with Local Preview / Shared Playback / Room Time
  - old mode button row is removed
  - background is rendered as transparent rgba
  - dropdown mode changes apply
  - panel height is about 141px on desktop and mobile test viewports