### PR TITLE
[codex] Preserve physics velocity on player reset

### DIFF
--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5118,7 +5118,7 @@ function applyScenePhysicsResetBaseline(physicsBaseline = null, now = performanc
 function resetAllObjectClocksForSceneClock(now = performance.now(), {
   objectClocks = null,
   reason = 'player-reset',
-  resetPhysicsMotion = true,
+  resetPhysicsMotion = false,
   capturePhysicsInitialTransform = false,
   physicsBaseline = null,
 } = {}) {
@@ -5253,7 +5253,6 @@ function applyRemoteSceneClock(payload, from = null) {
     resetAllObjectClocksForSceneClock(now, {
       objectClocks: payload.objectClocks,
       reason: payload.action === 'seek' ? 'remote-player-seek-zero' : 'remote-player-reset',
-      resetPhysicsMotion: true,
       physicsBaseline: payload.physicsBaseline || createPhysicsResetBaseline({
         time: 0,
         worldEpochTime: activeTime,
@@ -5307,7 +5306,6 @@ function setSceneClockMode(mode, now = performance.now(), options = {}) {
     physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'player-mode-zero');
     resetAllObjectClocksForSceneClock(now, {
       reason: 'player-mode-zero',
-      resetPhysicsMotion: true,
       physicsBaseline,
     });
   } else {
@@ -5366,7 +5364,6 @@ function seekSceneClock(t, now = performance.now(), options = {}) {
     physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'player-seek-zero');
     resetAllObjectClocksForSceneClock(now, {
       reason: 'player-seek-zero',
-      resetPhysicsMotion: true,
       physicsBaseline,
     });
   }
@@ -5392,7 +5389,6 @@ function resetSceneClock(now = performance.now()) {
     : null;
   resetAllObjectClocksForSceneClock(now, {
     reason: 'player-reset',
-    resetPhysicsMotion: true,
     physicsBaseline,
   });
   broadcastSceneClockEvent('reset', {


### PR DESCRIPTION
## Summary
- Keep authored object physics velocity and angularVelocity values when Player UI reset / seek(0) rebases scene clocks.
- Continue using the Rapier shared zero-baseline reset with preserveMotion:false so runtime body motion is discarded without mutating object physics settings.

## Why
Player UI time 0 was calling the object physics motion reset path, which rewrote the saved Physics velocity fields to [0, 0, 0]. That made configured launch velocities disappear from the inspector after reset/seek(0).

## Impact
Shared Playback reset still rebuilds the Rapier world from the synchronized zero baseline, but authored Physics settings remain intact.

## Validation
- node --check html/assets/js/scenesync/scene.js
- npm run test:physics
- git diff --check