### PR TITLE
[codex] Recreate production web service on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
             cd ~/github/afjk.jp
             git fetch origin
             git reset --hard origin/main
+            docker compose up -d --force-recreate www-service
             docker compose up -d --build presence-server
             docker compose up -d mediamtx
             docker compose up -d --force-recreate https-portal


### PR DESCRIPTION
## Summary
- Recreate the production `www-service` nginx container during production deploy.

## Why
`https://afjk.jp/assets/vendor/rapier/0.19.3/rapier.mjs` is currently served as `application/octet-stream`, so browsers reject it as a module script. The repository already has the `.mjs` MIME mapping in `nginx/default.conf`, but production deploy was not recreating/reloading `www-service`, so nginx could keep running with the old parsed config.

Staging already force-recreates its web nginx service on deploy; this brings production in line with that behavior.

## Validation
- Confirmed live `rapier.mjs` currently returns `content-type: application/octet-stream`.
- Confirmed live `scene.js` returns `content-type: application/javascript`.
- `git diff --check`