### PR TITLE
[codex] Restore production deploy on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy Production
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add the `release: published` trigger back to the production deploy workflow.
- Keep manual `workflow_dispatch` support.

## Why
Creating release `v0.22.1` did not update production because `.github/workflows/deploy.yml` currently only runs via manual dispatch. The release only caused staging to deploy from the main push; the production workflow did not run.

## Impact
Future GitHub Releases will start the production deploy workflow again, including the existing `www-service` force-recreate step needed for the `.mjs` MIME config to take effect.

## Validation
- Confirmed `origin/main` contains #409 and tag `v0.22.1`.
- Confirmed live `rapier.mjs` still returns `application/octet-stream`.
- Confirmed GitHub Actions has a staging deploy for #409 but no recent production deploy run.
- `git diff --check`