### PR TITLE
[codex] Add export title card thumbnail

### DIFF
--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -2,6 +2,11 @@ import { createSceneDocumentFromSceneSyncState } from './export-scene-document.j
 import { collectExportAssets } from './collect-export-assets.js';
 import { generateManifest } from './export-manifest.js';
 import { generateReadme, generateReadmeHtml } from './export-readme.js';
+import {
+  collectExportSceneStats,
+  generateExportThumbnail,
+  resolveExportThumbnailTitle,
+} from './export-thumbnail.js';
 
 // These viewer source files are fetched from the current origin and bundled into the ZIP
 export const VIEWER_SOURCES = [
@@ -184,6 +189,8 @@ export async function buildExportPackage({
     exportedAt,
     cdnDependent: true,
   });
+  const filename = `scene-sync-export-${formatTimestamp()}.zip`;
+  const filenameTitle = filename.replace(/\.zip$/i, '');
 
   // 5. Load JSZip
   const JSZip = await loadJSZip();
@@ -195,6 +202,20 @@ export async function buildExportPackage({
   zip.file('README.html', generateReadmeHtml());
   zip.file('manifest.json', JSON.stringify(manifest, null, 2));
   zip.file('scene.json', JSON.stringify(updatedDoc, null, 2));
+
+  try {
+    const thumbnail = await generateExportThumbnail({
+      title: resolveExportThumbnailTitle({
+        sceneDocument: updatedDoc,
+        manifest,
+        fallbackTitle: filenameTitle,
+      }),
+      stats: collectExportSceneStats(updatedDoc),
+    });
+    zip.file('thumbnail.png', thumbnail.blob);
+  } catch (error) {
+    console.warn('[Export] thumbnail generation failed:', error);
+  }
 
   // 7. Add viewer files
   for (const [dest, content] of Object.entries(viewerFiles)) {
@@ -215,7 +236,6 @@ export async function buildExportPackage({
   }
 
   // 10. Trigger download
-  const filename = `scene-sync-export-${formatTimestamp()}.zip`;
   const url = URL.createObjectURL(zipBlob);
   const a = document.createElement('a');
   a.href = url;

--- a/html/assets/js/scenesync-export/export/build-export-package.test.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildExportPackage } from './build-export-package.js';
+
+function vec(values) {
+  return { toArray: () => [...values] };
+}
+
+function createManagedObjects() {
+  return new Map([
+    ['box', {
+      name: 'Box',
+      visible: true,
+      position: vec([0, 0, 0]),
+      quaternion: vec([0, 0, 0, 1]),
+      scale: vec([1, 1, 1]),
+      userData: {
+        name: 'Box',
+        asset: {
+          type: 'primitive',
+          primitive: 'box',
+          color: '#4488ff',
+        },
+      },
+    }],
+  ]);
+}
+
+function createMockCanvas() {
+  const context = {
+    fillStyle: '',
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    fillRect() {},
+    fillText() {},
+    measureText(text) {
+      return { width: String(text).length * 20 };
+    },
+    createLinearGradient() {
+      return { addColorStop() {} };
+    },
+  };
+  return {
+    width: 0,
+    height: 0,
+    getContext(type) {
+      return type === '2d' ? context : null;
+    },
+    toBlob(callback, type) {
+      callback(new Blob(['thumbnail'], { type }));
+    },
+  };
+}
+
+test('builds export ZIP with generated root thumbnail', async () => {
+  const original = {
+    JSZip: globalThis.JSZip,
+    fetch: globalThis.fetch,
+    document: globalThis.document,
+    URL: globalThis.URL,
+    setTimeout: globalThis.setTimeout,
+  };
+  const zipFiles = new Map();
+
+  class MockJSZip {
+    file(name, content) {
+      zipFiles.set(name, content);
+      return this;
+    }
+
+    async generateAsync() {
+      return new Blob(['zip'], { type: 'application/zip' });
+    }
+  }
+
+  try {
+    globalThis.JSZip = MockJSZip;
+    globalThis.fetch = async () => ({
+      ok: true,
+      text: async () => 'export default {};',
+    });
+    globalThis.document = {
+      createElement(tagName) {
+        if (tagName === 'canvas') return createMockCanvas();
+        return {
+          href: '',
+          download: '',
+          click() {},
+        };
+      },
+      body: {
+        appendChild() {},
+        removeChild() {},
+      },
+      head: {
+        appendChild() {},
+      },
+    };
+    globalThis.URL = {
+      createObjectURL() {
+        return 'blob:scene-sync-export-test';
+      },
+      revokeObjectURL() {},
+    };
+    globalThis.setTimeout = (callback) => {
+      callback();
+      return 0;
+    };
+
+    await buildExportPackage({
+      managedObjects: createManagedObjects(),
+      bgmState: null,
+      envId: null,
+      blobBase: '',
+      envOrigin: 'https://example.test',
+      behaviorState: null,
+      physicsState: null,
+    });
+
+    assert(zipFiles.has('scene.json'));
+    assert(zipFiles.has('manifest.json'));
+    assert(zipFiles.has('thumbnail.png'));
+    assert.equal(zipFiles.get('thumbnail.png').type, 'image/png');
+  } finally {
+    globalThis.JSZip = original.JSZip;
+    globalThis.fetch = original.fetch;
+    globalThis.document = original.document;
+    globalThis.URL = original.URL;
+    globalThis.setTimeout = original.setTimeout;
+  }
+});

--- a/html/assets/js/scenesync-export/export/export-thumbnail.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.js
@@ -1,0 +1,197 @@
+export const EXPORT_THUMBNAIL_WIDTH = 1200;
+export const EXPORT_THUMBNAIL_HEIGHT = 630;
+
+const FALLBACK_TITLE = 'Scene Sync Export';
+const FALLBACK_STATS_LABEL = 'Scene Sync world';
+
+function normalizeText(value, fallback = '') {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return text || fallback;
+}
+
+export function colorFromString(input) {
+  const text = normalizeText(input, FALLBACK_TITLE);
+  let hash = 0;
+  for (const ch of text) {
+    hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 64%, 42%)`;
+}
+
+export function collectExportSceneStats(sceneDocument = {}) {
+  const objects = Array.isArray(sceneDocument.objects) ? sceneDocument.objects : [];
+  const stats = {
+    objects: objects.length,
+    images: 0,
+    videos: 0,
+    audios: sceneDocument.bgm ? 1 : 0,
+    texts: 0,
+    glbs: 0,
+    loomlets: sceneDocument.behaviors ? 1 : 0,
+    physics: 0,
+  };
+
+  for (const obj of objects) {
+    const type = obj?.asset?.type;
+    if (type === 'image') stats.images += 1;
+    else if (type === 'video') stats.videos += 1;
+    else if (type === 'text') stats.texts += 1;
+    else if (type === 'mesh') stats.glbs += 1;
+
+    if (obj?.audioSources && typeof obj.audioSources === 'object' && !Array.isArray(obj.audioSources)) {
+      stats.audios += Object.keys(obj.audioSources).length;
+    }
+    if (obj?.physics?.enabled) stats.physics += 1;
+  }
+
+  return stats;
+}
+
+export function buildExportThumbnailStatsLabel(stats = {}) {
+  const parts = [];
+  const objectCount = Number.isFinite(stats.objects) ? Math.max(0, stats.objects) : 0;
+  parts.push(`${objectCount} object${objectCount === 1 ? '' : 's'}`);
+  if (stats.glbs > 0) parts.push('glb');
+  if (stats.images > 0) parts.push('image');
+  if (stats.videos > 0) parts.push('video');
+  if (stats.audios > 0) parts.push('audio');
+  if (stats.texts > 0) parts.push('text');
+  if (stats.loomlets > 0) parts.push('interactive');
+  if (stats.physics > 0) parts.push('physics');
+  return parts.filter(Boolean).slice(0, 5).join(' · ') || FALLBACK_STATS_LABEL;
+}
+
+export function resolveExportThumbnailTitle({
+  sceneDocument = null,
+  manifest = null,
+  fallbackTitle = FALLBACK_TITLE,
+} = {}) {
+  return normalizeText(
+    sceneDocument?.title || manifest?.title || fallbackTitle,
+    FALLBACK_TITLE,
+  );
+}
+
+export function wrapCanvasText(ctx, text, maxWidth, maxLines = 3) {
+  const normalized = normalizeText(text, FALLBACK_TITLE);
+  const words = normalized.split(/\s+/).filter(Boolean);
+  const lines = [];
+
+  function pushBrokenWord(word) {
+    let current = '';
+    for (const ch of word) {
+      const next = `${current}${ch}`;
+      if (current && ctx.measureText(next).width > maxWidth) {
+        lines.push(current);
+        current = ch;
+        if (lines.length >= maxLines) break;
+      } else {
+        current = next;
+      }
+    }
+    if (current && lines.length < maxLines) lines.push(current);
+  }
+
+  for (const word of words) {
+    if (lines.length >= maxLines) break;
+    const current = lines.pop() || '';
+    const next = current ? `${current} ${word}` : word;
+    if (!current || ctx.measureText(next).width <= maxWidth) {
+      lines.push(next);
+      continue;
+    }
+    lines.push(current);
+    if (ctx.measureText(word).width <= maxWidth) {
+      lines.push(word);
+    } else {
+      pushBrokenWord(word);
+    }
+  }
+
+  if (lines.length > maxLines) lines.length = maxLines;
+  if (lines.length === maxLines && words.join(' ') !== lines.join(' ')) {
+    const last = lines[maxLines - 1];
+    let clipped = last;
+    while (clipped.length > 1 && ctx.measureText(`${clipped}…`).width > maxWidth) {
+      clipped = clipped.slice(0, -1);
+    }
+    lines[maxLines - 1] = `${clipped}…`;
+  }
+  return lines;
+}
+
+function createThumbnailCanvas(width, height) {
+  if (typeof OffscreenCanvas === 'function') {
+    return new OffscreenCanvas(width, height);
+  }
+  const doc = globalThis.document;
+  if (!doc?.createElement) {
+    throw new Error('Canvas is not available');
+  }
+  const canvas = doc.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+async function canvasToPngBlob(canvas) {
+  if (typeof canvas.convertToBlob === 'function') {
+    return await canvas.convertToBlob({ type: 'image/png' });
+  }
+  if (typeof canvas.toBlob === 'function') {
+    return await new Promise((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('Canvas returned an empty thumbnail blob'));
+      }, 'image/png');
+    });
+  }
+  throw new Error('Canvas PNG export is not available');
+}
+
+export async function generateExportThumbnail({
+  title,
+  stats = null,
+  width = EXPORT_THUMBNAIL_WIDTH,
+  height = EXPORT_THUMBNAIL_HEIGHT,
+  canvasFactory = createThumbnailCanvas,
+} = {}) {
+  const safeTitle = normalizeText(title, FALLBACK_TITLE);
+  const canvas = canvasFactory(width, height);
+  const ctx = canvas.getContext?.('2d');
+  if (!ctx) throw new Error('2D canvas context is not available');
+
+  ctx.fillStyle = colorFromString(safeTitle);
+  ctx.fillRect(0, 0, width, height);
+
+  const gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, 'rgba(255,255,255,0.18)');
+  gradient.addColorStop(1, 'rgba(0,0,0,0.28)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.font = '700 76px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const titleLines = wrapCanvasText(ctx, safeTitle, width - 200, 3);
+  const lineHeight = 86;
+  const firstY = height / 2 - ((titleLines.length - 1) * lineHeight) / 2 - 24;
+  titleLines.forEach((line, index) => {
+    ctx.fillText(line, width / 2, firstY + index * lineHeight);
+  });
+
+  ctx.font = '500 32px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+  ctx.fillStyle = 'rgba(255,255,255,0.78)';
+  ctx.fillText(buildExportThumbnailStatsLabel(stats || {}), width / 2, height - 130);
+
+  ctx.font = '700 30px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+  ctx.fillStyle = 'rgba(255,255,255,0.88)';
+  ctx.fillText('Scene Sync', width / 2, height - 74);
+
+  return {
+    blob: await canvasToPngBlob(canvas),
+    mode: 'title-card',
+  };
+}

--- a/html/assets/js/scenesync-export/export/export-thumbnail.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.js
@@ -97,7 +97,15 @@ export function wrapCanvasText(ctx, text, maxWidth, maxLines = 3) {
     if (lines.length >= maxLines) break;
     const current = lines.pop() || '';
     const next = current ? `${current} ${word}` : word;
-    if (!current || ctx.measureText(next).width <= maxWidth) {
+    if (!current) {
+      if (ctx.measureText(word).width <= maxWidth) {
+        lines.push(word);
+      } else {
+        pushBrokenWord(word);
+      }
+      continue;
+    }
+    if (ctx.measureText(next).width <= maxWidth) {
       lines.push(next);
       continue;
     }

--- a/html/assets/js/scenesync-export/export/export-thumbnail.test.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.test.js
@@ -105,3 +105,16 @@ test('wraps long title text to a bounded number of lines', () => {
   assert(lines.every((line) => line.length > 0));
   assert(lines[2].endsWith('…'));
 });
+
+test('wraps long unspaced title text', () => {
+  const lines = wrapCanvasText(
+    measureTextByChars(10),
+    'これはとても長いSceneSyncの日本語タイトルです',
+    120,
+    3,
+  );
+
+  assert(lines.length <= 3);
+  assert(lines.every((line) => line.length > 0));
+  assert(lines.some((line) => line.endsWith('…')) || lines.length > 1);
+});

--- a/html/assets/js/scenesync-export/export/export-thumbnail.test.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildExportThumbnailStatsLabel,
+  collectExportSceneStats,
+  colorFromString,
+  resolveExportThumbnailTitle,
+  wrapCanvasText,
+} from './export-thumbnail.js';
+
+function measureTextByChars(charWidth = 10) {
+  return {
+    measureText(text) {
+      return { width: String(text).length * charWidth };
+    },
+  };
+}
+
+test('collects scene stats for generated export thumbnails', () => {
+  const stats = collectExportSceneStats({
+    bgm: { url: 'assets/bgm.mp3' },
+    behaviors: { graphs: { box: {} } },
+    physics: { enabled: true },
+    objects: [
+      { asset: { type: 'image' } },
+      { asset: { type: 'video' } },
+      { asset: { type: 'text' } },
+      { asset: { type: 'mesh' }, audioSources: { default: {}, click: {} } },
+      { asset: { type: 'primitive' }, physics: { enabled: true } },
+      { asset: { type: 'primitive' }, physics: { enabled: false } },
+    ],
+  });
+
+  assert.deepEqual(stats, {
+    objects: 6,
+    images: 1,
+    videos: 1,
+    audios: 3,
+    texts: 1,
+    glbs: 1,
+    loomlets: 1,
+    physics: 1,
+  });
+});
+
+test('builds compact stats labels for thumbnail cards', () => {
+  assert.equal(
+    buildExportThumbnailStatsLabel({
+      objects: 12,
+      glbs: 1,
+      images: 3,
+      videos: 0,
+      audios: 1,
+      texts: 2,
+      loomlets: 1,
+      physics: 1,
+    }),
+    '12 objects · glb · image · audio · text',
+  );
+  assert.equal(buildExportThumbnailStatsLabel({ objects: 1 }), '1 object');
+});
+
+test('uses scene or manifest title before fallback title', () => {
+  assert.equal(
+    resolveExportThumbnailTitle({
+      sceneDocument: { title: 'Scene Title' },
+      manifest: { title: 'Manifest Title' },
+      fallbackTitle: 'Fallback',
+    }),
+    'Scene Title',
+  );
+  assert.equal(
+    resolveExportThumbnailTitle({
+      sceneDocument: {},
+      manifest: { title: 'Manifest Title' },
+      fallbackTitle: 'Fallback',
+    }),
+    'Manifest Title',
+  );
+  assert.equal(
+    resolveExportThumbnailTitle({
+      sceneDocument: {},
+      manifest: {},
+      fallbackTitle: 'Fallback',
+    }),
+    'Fallback',
+  );
+});
+
+test('generates stable title-card background colors', () => {
+  const color = colorFromString('First Sample');
+  assert.equal(color, colorFromString('First Sample'));
+  assert.match(color, /^hsl\(\d+, 64%, 42%\)$/);
+});
+
+test('wraps long title text to a bounded number of lines', () => {
+  const lines = wrapCanvasText(
+    measureTextByChars(10),
+    'A very long Scene Sync export title that needs wrapping',
+    180,
+    3,
+  );
+
+  assert.equal(lines.length, 3);
+  assert(lines.every((line) => line.length > 0));
+  assert(lines[2].endsWith('…'));
+});


### PR DESCRIPTION
## Summary
- Add generated `thumbnail.png` to Scene Sync Export ZIPs.
- Generate a deterministic title-card thumbnail from the export title and scene stats.
- Keep export resilient: thumbnail generation failures warn but do not fail the ZIP export.

## Why
Scene Sync exports should be distinguishable when published through `scenesync-template` without requiring a hand-authored thumbnail for every ZIP.

## Details
- No `metadata.json` is added.
- The existing ZIP structure is preserved.
- `thumbnail.png` is written at the ZIP root.

## Validation
- `npm run test:scene-sync-export-import`
- `node --check html/assets/js/scenesync-export/export/build-export-package.js`
- `node --check html/assets/js/scenesync-export/export/export-thumbnail.js`
- `node --check html/assets/js/scenesync-export/export/build-export-package.test.js`
- `git diff --check`