### PR TITLE
[codex] Sync export viewer audio with player clock

### DIFF
--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -637,31 +637,52 @@ export async function createViewerCore({
     physicsRuntime.update(clockState);
   }
 
+  function syncObjectAudioAtClock(clockState, now = performance.now()) {
+    objectAudioController.tick(now, clockState);
+  }
+
+  function evaluateAndSyncClock(clockState, now = performance.now()) {
+    evaluateSceneAtClock(clockState);
+    syncObjectAudioAtClock(clockState, now);
+  }
+
   const commands = {
     playSceneClock() {
-      sceneClock.play();
+      const now = performance.now();
+      sceneClock.play(now);
+      const clockState = sceneClock.getState();
+      evaluateAndSyncClock(clockState, now);
+      return objectAudioController.playPlaybackTargets(clockState, now);
     },
     pauseSceneClock() {
-      sceneClock.pause();
+      const now = performance.now();
+      sceneClock.pause(now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
     stopSceneClock() {
-      sceneClock.stop();
-      evaluateSceneAtClock(sceneClock.getState());
+      const now = performance.now();
+      sceneClock.stop(now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
     seekSceneClock(seconds) {
-      sceneClock.seek(seconds);
-      evaluateSceneAtClock(sceneClock.getState());
+      const now = performance.now();
+      sceneClock.seek(seconds, now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
     setSceneClockRate(rate) {
-      sceneClock.setRate(rate);
+      const now = performance.now();
+      sceneClock.setRate(rate, now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
     activateSceneClockTransport() {
-      sceneClock.activateTransport();
-      evaluateSceneAtClock(sceneClock.getState());
+      const now = performance.now();
+      sceneClock.activateTransport(now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
     deactivateSceneClockTransport() {
-      sceneClock.deactivateTransport();
-      evaluateSceneAtClock(sceneClock.getState());
+      const now = performance.now();
+      sceneClock.deactivateTransport(now);
+      evaluateAndSyncClock(sceneClock.getState(), now);
     },
   };
 
@@ -673,7 +694,7 @@ export async function createViewerCore({
       if (loomAdapter) {
         loomAdapter.tick(clockState, now);
       }
-      objectAudioController.tick(now);
+      syncObjectAudioAtClock(clockState, now);
     },
 
     getSceneClockState() {
@@ -740,7 +761,7 @@ export async function createViewerCore({
     },
 
     playObjectAudioPlaybackTargets() {
-      return objectAudioController.playPlaybackTargets();
+      return objectAudioController.playPlaybackTargets(sceneClock.getState(), performance.now());
     },
 
     pauseObjectAudioPlaybackTargets() {

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -71,6 +71,17 @@ function audioDuration(audio) {
   return Number.isFinite(audio?.duration) && audio.duration > 0 ? audio.duration : null;
 }
 
+function clockTime(clockState) {
+  if (Number.isFinite(clockState?.t)) return Math.max(0, clockState.t);
+  if (Number.isFinite(clockState?.time)) return Math.max(0, clockState.time);
+  return null;
+}
+
+function isTransportPaused(clockState) {
+  if (!clockState) return false;
+  return clockState.isPaused === true || clockState.playing === false || clockState.rate === 0;
+}
+
 function animationTargetTime(audio, sampleTime, offset, loop) {
   const duration = audioDuration(audio);
   let target = sampleTime + offset;
@@ -80,6 +91,35 @@ function animationTargetTime(audio, sampleTime, offset, loop) {
     target = 0;
   }
   return target;
+}
+
+function timelineTargetTime(entry, clockState, nowMs, startMs) {
+  const timelineTime = clockTime(clockState);
+  let target = timelineTime;
+
+  if (!Number.isFinite(target)) {
+    if (entry.started) return null;
+    target = Math.max(0, (nowMs - startMs) / 1000);
+  }
+
+  target += finiteNumber(entry.source.offset, 0);
+  const duration = audioDuration(entry.audio);
+  if (duration) {
+    target = entry.source.loop === true
+      ? ((target % duration) + duration) % duration
+      : Math.min(Math.max(0, target), duration);
+  }
+
+  return Math.max(0, target);
+}
+
+function applyTransportPlaybackRate(audio, source, clockState) {
+  if (!audio) return;
+  const sourceRate = positiveNumber(source.playbackRate, 1);
+  const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0
+    ? clockState.rate
+    : 1;
+  try { audio.playbackRate = sourceRate * transportRate; } catch {}
 }
 
 function applyAudioElementConfig(audio, source) {
@@ -228,11 +268,23 @@ export function createObjectAudioController({
     return true;
   }
 
-  function tickEntry(entry, nowMs) {
+  function syncTimelineEntry(entry, nowMs, clockState, driftThreshold = 0.15) {
+    const target = timelineTargetTime(entry, clockState, nowMs, startMs);
+    if (!Number.isFinite(target)) return false;
+
+    const drift = Math.abs((entry.audio.currentTime || 0) - target);
+    if (drift > driftThreshold) {
+      safeSeek(entry.audio, target);
+    }
+    return true;
+  }
+
+  function tickEntry(entry, nowMs, clockState = null) {
     if (!entry.audio) return;
     if (entry.oneShotActive) return;
 
     applyAudioElementConfig(entry.audio, entry.source);
+    applyTransportPlaybackRate(entry.audio, entry.source, clockState);
 
     if (entry.desiredState === 'stopped') {
       if (entry.audio.paused === false) safePause(entry.audio);
@@ -242,16 +294,19 @@ export function createObjectAudioController({
       if (entry.audio.paused === false) safePause(entry.audio);
       return;
     }
-    if (entry.userPaused) return;
 
     const syncedToAnimation = syncAnimationEntry(entry);
-    if (!syncedToAnimation && !entry.started) {
-      const elapsed = Math.max(0, (nowMs - startMs) / 1000);
-      const target = (entry.source.offset || 0) + elapsed;
-      const duration = audioDuration(entry.audio);
-      safeSeek(entry.audio, duration && entry.source.loop
-        ? ((target % duration) + duration) % duration
-        : target);
+
+    if (isTransportPaused(clockState) || entry.userPaused) {
+      if (entry.audio.paused === false) safePause(entry.audio);
+      if (!syncedToAnimation) {
+        syncTimelineEntry(entry, nowMs, clockState, 0);
+      }
+      return;
+    }
+
+    if (!syncedToAnimation) {
+      syncTimelineEntry(entry, nowMs, clockState, entry.started ? 0.15 : 0);
     }
 
     entry.started = true;
@@ -406,9 +461,11 @@ export function createObjectAudioController({
       return getPlaybackTargetEntries().map((entry) => entry.audio);
     },
 
-    playPlaybackTargets() {
+    playPlaybackTargets(clockState = null, nowMs = now()) {
       return Promise.allSettled(getPlaybackTargetEntries().map((entry) => {
         entry.userPaused = false;
+        tickEntry(entry, nowMs, clockState);
+        if (isTransportPaused(clockState)) return Promise.resolve(true);
         return tryPlay(entry, { force: true });
       }));
     },
@@ -431,7 +488,6 @@ export function createObjectAudioController({
         cancelEntryOneShot(entry);
         entry.desiredState = 'playing';
         entry.userPaused = false;
-        tryPlay(entry, { force: true });
       } else if (effect.type === 'audioSource.pause') {
         cancelEntryOneShot(entry);
         entry.desiredState = 'paused';
@@ -492,8 +548,8 @@ export function createObjectAudioController({
       }
     },
 
-    tick(nowMs = now()) {
-      for (const entry of entries) tickEntry(entry, nowMs);
+    tick(nowMs = now(), clockState = null) {
+      for (const entry of entries) tickEntry(entry, nowMs, clockState);
     },
 
     dispose() {

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createObjectAudioController } from './object-audio-controller.js';
+
+class FakeAudio {
+  constructor({ duration = 10, currentTime = 0 } = {}) {
+    this.currentTime = currentTime;
+    this.duration = duration;
+    this.loop = false;
+    this.muted = false;
+    this.paused = true;
+    this.playbackRate = 1;
+    this.preload = '';
+    this.src = '';
+    this.volume = 1;
+    this.pauseCount = 0;
+    this.playCount = 0;
+  }
+
+  addEventListener() {}
+
+  load() {}
+
+  pause() {
+    this.paused = true;
+    this.pauseCount += 1;
+  }
+
+  play() {
+    this.paused = false;
+    this.playCount += 1;
+    return Promise.resolve();
+  }
+}
+
+function createSceneDoc(source = {}) {
+  return {
+    objects: [{
+      id: 'speaker',
+      audioSources: {
+        default: {
+          url: 'https://example.test/audio.mp3',
+          state: 'playing',
+          loop: true,
+          ...source,
+        },
+      },
+    }],
+  };
+}
+
+function createHarness({
+  audio = new FakeAudio(),
+  source = {},
+  getAnimationSample = null,
+} = {}) {
+  const controller = createObjectAudioController({
+    sceneDoc: createSceneDoc(source),
+    resolver: { resolveAsset: () => null },
+    createAudio: (url) => {
+      audio.src = url;
+      return audio;
+    },
+    getAnimationSample,
+    now: () => 1000,
+  });
+  return { audio, controller };
+}
+
+test('seeks object audio to the paused player timeline without playing', () => {
+  const { audio, controller } = createHarness({ source: { offset: 0.5 } });
+
+  controller.tick(1000, { t: 4, isPaused: true, playing: false, rate: 1 });
+
+  assert.equal(audio.paused, true);
+  assert.equal(audio.currentTime, 4.5);
+  assert.equal(audio.playCount, 0);
+});
+
+test('plays object audio from the player timeline and applies transport rate', () => {
+  const { audio, controller } = createHarness({ source: { playbackRate: 1.25 } });
+
+  controller.tick(1000, { t: 3, isPaused: false, playing: true, rate: 2 });
+
+  assert.equal(audio.paused, false);
+  assert.equal(audio.currentTime, 3);
+  assert.equal(audio.playbackRate, 2.5);
+});
+
+test('resyncs object audio when the player timeline seeks while playing', () => {
+  const { audio, controller } = createHarness();
+
+  controller.tick(1000, { t: 1, isPaused: false, playing: true, rate: 1 });
+  audio.currentTime = 1.05;
+
+  controller.tick(1100, { t: 7, isPaused: false, playing: true, rate: 1 });
+
+  assert.equal(audio.currentTime, 7);
+});
+

--- a/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
+++ b/html/assets/js/scenesync-export/viewer/static-viewer-entry.js
@@ -215,38 +215,7 @@ async function main() {
   const hasPlaybackTargets = viewerCore.hasObjectAudioPlaybackTargets?.()
     ?? (viewerCore.getObjectAudioPlaybackElements?.() || []).length > 0;
 
-  if (hasObjectAudioSources && hasPlaybackTargets && controlsEl) {
-    const audioBtn = document.createElement('button');
-    audioBtn.className = 'viewer-btn';
-    audioBtn.textContent = '▶ Play Audio';
-    let playing = false;
-    let pending = false;
-    audioBtn.addEventListener('click', async () => {
-      if (pending) return;
-      if (playing) {
-        viewerCore.pauseObjectAudioPlaybackTargets?.();
-        audioBtn.textContent = '▶ Play Audio';
-        playing = false;
-      } else {
-        const playbackElements = viewerCore.getObjectAudioPlaybackElements?.() || [];
-        if (playbackElements.length > 0) {
-          pending = true;
-          audioBtn.disabled = true;
-          await Promise.resolve(viewerCore.unlockObjectAudio?.()).catch(() => false);
-          const results = await Promise.resolve(viewerCore.playObjectAudioPlaybackTargets?.()).catch(() => []);
-          if (Array.isArray(results) && results.some((result) => (
-            result.status === 'fulfilled' && result.value === true
-          ))) {
-            audioBtn.textContent = '⏸ Pause Audio';
-            playing = true;
-          }
-          audioBtn.disabled = false;
-          pending = false;
-        }
-      }
-    });
-    controlsEl.appendChild(audioBtn);
-  } else if (hasObjectAudioSources && controlsEl) {
+  if (hasObjectAudioSources && !hasPlaybackTargets && controlsEl) {
     const enableBtn = document.createElement('button');
     enableBtn.className = 'viewer-btn';
     enableBtn.textContent = 'Enable Audio';


### PR DESCRIPTION
## Summary

Export Viewer object audio now follows the Player transport clock instead of running from a separate `Play Audio` control.

## Root Cause

The Viewer created HTMLAudioElement instances independently from the Player transport. The old `Play Audio` button directly played and paused object audio targets, while Player UI controls updated only the Scene Clock. That let audio playback drift away from Player time, especially after play, pause, seek, stop, or rate changes.

## Changes

- Pass Scene Clock state into the export viewer object audio controller on every frame.
- Seek object audio to `Player time + source offset` when paused, started, or drifting.
- Apply Player transport rate to object audio playback rate.
- Remove the exported Viewer `Play Audio` button for object audio playback targets; playback now starts from the Player transport controls.
- Add regression coverage for paused timeline seek, playback rate sync, and seek resync.

## Impact

AudioSource playback in exported Scene Sync viewers stays aligned with Player UI time and transport operations. The Viewer no longer shows a separate `Play Audio` button for object audio that should be controlled by the Player timeline. Existing animation sync behavior remains supported.

## Validation

- `npm run test:scene-sync-export-import`
- `git diff --check`

Note: Browser-level verification was attempted locally, but this environment could not start the in-app browser or Playwright Chromium due host/browser availability and macOS sandbox permission errors.