### PR TITLE
[codex] Add SceneSync export metadata form

### DIFF
--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -127,6 +127,7 @@ const THUMBNAIL_EXTENSION_BY_MIME = new Map([
   ['image/webp', '.webp'],
 ]);
 
+export const EXPORT_THUMBNAIL_FILE_LIMIT_BYTES = 10 * 1024 * 1024;
 const SUPPORTED_THUMBNAIL_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
 
 export function getExportThumbnailExtension(file) {
@@ -139,6 +140,16 @@ export function getExportThumbnailExtension(file) {
   const dotIndex = name.lastIndexOf('.');
   const ext = dotIndex >= 0 ? name.slice(dotIndex) : '';
   return SUPPORTED_THUMBNAIL_EXTENSIONS.has(ext) ? ext : null;
+}
+
+export function validateExportThumbnailFile(file) {
+  if (!getExportThumbnailExtension(file)) {
+    return 'PNG / JPEG / WebP の画像を選択してください';
+  }
+  if (Number.isFinite(file?.size) && file.size > EXPORT_THUMBNAIL_FILE_LIMIT_BYTES) {
+    return 'Thumbnail画像は10MB以下にしてください';
+  }
+  return null;
 }
 
 function getCustomThumbnailFile(exportOptions) {
@@ -154,10 +165,11 @@ async function addExportThumbnail(zip, {
 }) {
   const customThumbnail = getCustomThumbnailFile(exportOptions);
   if (customThumbnail) {
-    const extension = getExportThumbnailExtension(customThumbnail);
-    if (!extension) {
-      throw new Error('Thumbnail image must be PNG, JPEG, or WebP');
+    const validationError = validateExportThumbnailFile(customThumbnail);
+    if (validationError) {
+      throw new Error(validationError);
     }
+    const extension = getExportThumbnailExtension(customThumbnail);
     const path = `thumbnail${extension}`;
     zip.file(path, customThumbnail);
     return { path, mode: 'custom' };

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -7,6 +7,7 @@ import {
   generateExportThumbnail,
   resolveExportThumbnailTitle,
 } from './export-thumbnail.js';
+import { normalizeExportMetadata } from './export-metadata.js';
 
 // These viewer source files are fetched from the current origin and bundled into the ZIP
 export const VIEWER_SOURCES = [
@@ -120,6 +121,60 @@ function formatTimestamp(date = new Date()) {
   return `${y}${mo}${d}-${h}${mi}${s}`;
 }
 
+const THUMBNAIL_EXTENSION_BY_MIME = new Map([
+  ['image/png', '.png'],
+  ['image/jpeg', '.jpg'],
+  ['image/webp', '.webp'],
+]);
+
+const SUPPORTED_THUMBNAIL_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+export function getExportThumbnailExtension(file) {
+  const mime = String(file?.type || '').toLowerCase().split(';')[0].trim();
+  if (THUMBNAIL_EXTENSION_BY_MIME.has(mime)) {
+    return THUMBNAIL_EXTENSION_BY_MIME.get(mime);
+  }
+
+  const name = String(file?.name || '').toLowerCase();
+  const dotIndex = name.lastIndexOf('.');
+  const ext = dotIndex >= 0 ? name.slice(dotIndex) : '';
+  return SUPPORTED_THUMBNAIL_EXTENSIONS.has(ext) ? ext : null;
+}
+
+function getCustomThumbnailFile(exportOptions) {
+  const file = exportOptions?.thumbnailFile || exportOptions?.thumbnail || null;
+  return file && typeof file === 'object' ? file : null;
+}
+
+async function addExportThumbnail(zip, {
+  exportOptions,
+  sceneDocument,
+  manifest,
+  filenameTitle,
+}) {
+  const customThumbnail = getCustomThumbnailFile(exportOptions);
+  if (customThumbnail) {
+    const extension = getExportThumbnailExtension(customThumbnail);
+    if (!extension) {
+      throw new Error('Thumbnail image must be PNG, JPEG, or WebP');
+    }
+    const path = `thumbnail${extension}`;
+    zip.file(path, customThumbnail);
+    return { path, mode: 'custom' };
+  }
+
+  const thumbnail = await generateExportThumbnail({
+    title: resolveExportThumbnailTitle({
+      sceneDocument,
+      manifest,
+      fallbackTitle: filenameTitle,
+    }),
+    stats: collectExportSceneStats(sceneDocument),
+  });
+  zip.file('thumbnail.png', thumbnail.blob);
+  return { path: 'thumbnail.png', mode: thumbnail.mode };
+}
+
 async function fetchViewerSources() {
   const results = {};
   const failures = [];
@@ -149,7 +204,10 @@ export async function buildExportPackage({
   assetCache = null,
   behaviorState = null,
   physicsState = null,
+  exportMetadata = null,
 }) {
+  const metadata = normalizeExportMetadata(exportMetadata);
+
   // 1. Build SceneDocument from current state
   let sceneDocument;
   try {
@@ -159,6 +217,7 @@ export async function buildExportPackage({
       envId,
       behaviorState,
       physicsState,
+      exportMetadata: metadata,
     });
   } catch (err) {
     throw new Error(`SceneDocument generation failed: ${err.message}`);
@@ -188,6 +247,7 @@ export async function buildExportPackage({
     missingAssets,
     exportedAt,
     cdnDependent: true,
+    metadata,
   });
   const filename = `scene-sync-export-${formatTimestamp()}.zip`;
   const filenameTitle = filename.replace(/\.zip$/i, '');
@@ -203,17 +263,18 @@ export async function buildExportPackage({
   zip.file('manifest.json', JSON.stringify(manifest, null, 2));
   zip.file('scene.json', JSON.stringify(updatedDoc, null, 2));
 
+  const hasCustomThumbnail = Boolean(getCustomThumbnailFile(exportMetadata));
   try {
-    const thumbnail = await generateExportThumbnail({
-      title: resolveExportThumbnailTitle({
-        sceneDocument: updatedDoc,
-        manifest,
-        fallbackTitle: filenameTitle,
-      }),
-      stats: collectExportSceneStats(updatedDoc),
+    await addExportThumbnail(zip, {
+      exportOptions: exportMetadata,
+      sceneDocument: updatedDoc,
+      manifest,
+      filenameTitle,
     });
-    zip.file('thumbnail.png', thumbnail.blob);
   } catch (error) {
+    if (hasCustomThumbnail) {
+      throw error;
+    }
     console.warn('[Export] thumbnail generation failed:', error);
   }
 

--- a/html/assets/js/scenesync-export/export/build-export-package.test.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildExportPackage } from './build-export-package.js';
+import {
+  buildExportPackage,
+  EXPORT_THUMBNAIL_FILE_LIMIT_BYTES,
+} from './build-export-package.js';
 
 function vec(values) {
   return { toArray: () => [...values] };
@@ -172,5 +175,50 @@ test('builds export ZIP with metadata and custom root thumbnail', async () => {
     assert.equal(manifest.author, 'afjk');
     assert.equal(zipFiles.get('thumbnail.webp'), thumbnail);
     assert.equal(zipFiles.has('thumbnail.png'), false);
+  });
+});
+
+test('omits blank export title so filename fallback remains available', async () => {
+  await withMockExportEnvironment(async (zipFiles) => {
+    await buildExportPackage({
+      managedObjects: createManagedObjects(),
+      bgmState: null,
+      envId: null,
+      blobBase: '',
+      envOrigin: 'https://example.test',
+      behaviorState: null,
+      physicsState: null,
+      exportMetadata: { title: '   ' },
+    });
+
+    const sceneDocument = JSON.parse(zipFiles.get('scene.json'));
+    const manifest = JSON.parse(zipFiles.get('manifest.json'));
+    assert.equal(Object.hasOwn(sceneDocument, 'title'), false);
+    assert.equal(Object.hasOwn(manifest, 'title'), false);
+  });
+});
+
+test('rejects oversized custom root thumbnail', async () => {
+  await withMockExportEnvironment(async () => {
+    const thumbnail = new Blob([
+      new Uint8Array(EXPORT_THUMBNAIL_FILE_LIMIT_BYTES + 1),
+    ], { type: 'image/png' });
+    Object.defineProperty(thumbnail, 'name', { value: 'too-large.png' });
+
+    await assert.rejects(
+      buildExportPackage({
+        managedObjects: createManagedObjects(),
+        bgmState: null,
+        envId: null,
+        blobBase: '',
+        envOrigin: 'https://example.test',
+        behaviorState: null,
+        physicsState: null,
+        exportMetadata: {
+          thumbnailFile: thumbnail,
+        },
+      }),
+      /10MB/,
+    );
   });
 });

--- a/html/assets/js/scenesync-export/export/build-export-package.test.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.test.js
@@ -53,7 +53,7 @@ function createMockCanvas() {
   };
 }
 
-test('builds export ZIP with generated root thumbnail', async () => {
+async function withMockExportEnvironment(run) {
   const original = {
     JSZip: globalThis.JSZip,
     fetch: globalThis.fetch,
@@ -108,6 +108,18 @@ test('builds export ZIP with generated root thumbnail', async () => {
       return 0;
     };
 
+    await run(zipFiles);
+  } finally {
+    globalThis.JSZip = original.JSZip;
+    globalThis.fetch = original.fetch;
+    globalThis.document = original.document;
+    globalThis.URL = original.URL;
+    globalThis.setTimeout = original.setTimeout;
+  }
+}
+
+test('builds export ZIP with generated root thumbnail', async () => {
+  await withMockExportEnvironment(async (zipFiles) => {
     await buildExportPackage({
       managedObjects: createManagedObjects(),
       bgmState: null,
@@ -122,11 +134,43 @@ test('builds export ZIP with generated root thumbnail', async () => {
     assert(zipFiles.has('manifest.json'));
     assert(zipFiles.has('thumbnail.png'));
     assert.equal(zipFiles.get('thumbnail.png').type, 'image/png');
-  } finally {
-    globalThis.JSZip = original.JSZip;
-    globalThis.fetch = original.fetch;
-    globalThis.document = original.document;
-    globalThis.URL = original.URL;
-    globalThis.setTimeout = original.setTimeout;
-  }
+  });
+});
+
+test('builds export ZIP with metadata and custom root thumbnail', async () => {
+  await withMockExportEnvironment(async (zipFiles) => {
+    const thumbnail = new Blob(['custom-thumbnail'], { type: 'image/webp' });
+    Object.defineProperty(thumbnail, 'name', { value: 'cover.webp' });
+
+    await buildExportPackage({
+      managedObjects: createManagedObjects(),
+      bgmState: null,
+      envId: null,
+      blobBase: '',
+      envOrigin: 'https://example.test',
+      behaviorState: null,
+      physicsState: null,
+      exportMetadata: {
+        title: 'Candy Rock Star',
+        description: 'Unity-chan stage',
+        tags: 'music, unity-chan, music',
+        author: 'afjk',
+        thumbnailFile: thumbnail,
+      },
+    });
+
+    const sceneDocument = JSON.parse(zipFiles.get('scene.json'));
+    const manifest = JSON.parse(zipFiles.get('manifest.json'));
+
+    assert.equal(sceneDocument.title, 'Candy Rock Star');
+    assert.equal(sceneDocument.description, 'Unity-chan stage');
+    assert.deepEqual(sceneDocument.tags, ['music', 'unity-chan']);
+    assert.equal(sceneDocument.author, 'afjk');
+    assert.equal(manifest.title, 'Candy Rock Star');
+    assert.equal(manifest.description, 'Unity-chan stage');
+    assert.deepEqual(manifest.tags, ['music', 'unity-chan']);
+    assert.equal(manifest.author, 'afjk');
+    assert.equal(zipFiles.get('thumbnail.webp'), thumbnail);
+    assert.equal(zipFiles.has('thumbnail.png'), false);
+  });
 });

--- a/html/assets/js/scenesync-export/export/export-manifest.js
+++ b/html/assets/js/scenesync-export/export/export-manifest.js
@@ -1,8 +1,15 @@
+import { normalizeExportMetadata } from './export-metadata.js';
+
 export function generateManifest({
   assetManifest = [],
   missingAssets = [],
   exportedAt = new Date().toISOString(),
   cdnDependent = true,
+  title = '',
+  description = '',
+  tags = [],
+  author = '',
+  metadata = null,
 }) {
   const notes = [
     'This is a read-only exported scene.',
@@ -22,6 +29,7 @@ export function generateManifest({
     format: 'scene-sync-export',
     version: 1,
     exportedAt,
+    ...normalizeExportMetadata(metadata || { title, description, tags, author }),
     viewer: { entry: 'index.html' },
     assets: assetManifest,
     missingAssets,

--- a/html/assets/js/scenesync-export/export/export-metadata.js
+++ b/html/assets/js/scenesync-export/export/export-metadata.js
@@ -1,0 +1,56 @@
+const TAG_SEPARATOR_RE = /[,\n、]+/u;
+
+function normalizeSingleLineText(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeMultilineText(value) {
+  return String(value ?? '')
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .join('\n')
+    .trim();
+}
+
+export function normalizeExportTags(value) {
+  const rawTags = Array.isArray(value)
+    ? value
+    : String(value ?? '').split(TAG_SEPARATOR_RE);
+  const seen = new Set();
+  const tags = [];
+
+  for (const rawTag of rawTags) {
+    const tag = normalizeSingleLineText(rawTag);
+    if (!tag) continue;
+    const key = tag.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    tags.push(tag);
+  }
+
+  return tags;
+}
+
+export function normalizeExportMetadata(value = {}) {
+  const metadata = {};
+  const title = normalizeSingleLineText(value?.title);
+  const description = normalizeMultilineText(value?.description);
+  const tags = normalizeExportTags(value?.tags);
+  const author = normalizeSingleLineText(value?.author ?? value?.credit ?? value?.credits);
+
+  if (title) metadata.title = title;
+  if (description) metadata.description = description;
+  if (tags.length > 0) metadata.tags = tags;
+  if (author) metadata.author = author;
+
+  return metadata;
+}
+
+export function applyExportMetadata(target, metadataInput = {}) {
+  const metadata = normalizeExportMetadata(metadataInput);
+  for (const [key, value] of Object.entries(metadata)) {
+    target[key] = value;
+  }
+  return target;
+}

--- a/html/assets/js/scenesync-export/export/export-scene-document.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.js
@@ -1,6 +1,7 @@
 import { SCENE_DOCUMENT_FORMAT, SCENE_DOCUMENT_VERSION } from '../viewer/scene-document.js';
 import { LOOMLET_RUNTIME_METADATA } from '../../scenesync/loomlet-runtime-integration.js';
 import { normalizeAudioSourcesMap } from '../../scenesync/audio/audio-source.js';
+import { applyExportMetadata } from './export-metadata.js';
 
 const SKIP_ROLES = new Set([
   'multi-transform-pivot',
@@ -16,6 +17,88 @@ function cloneJson(value) {
 function clonePlainObject(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return cloneJson(value);
+}
+
+export function isExportBehaviorGraph(value) {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Array.isArray(value.nodes) &&
+    Array.isArray(value.edges)
+  );
+}
+
+export function hasExportBehaviorGraph(value) {
+  return isExportBehaviorGraph(value) && value.nodes.length > 0;
+}
+
+export function countExportBehaviorGraphs(behaviorState) {
+  if (!behaviorState || typeof behaviorState !== 'object' || Array.isArray(behaviorState)) {
+    return 0;
+  }
+
+  let count = hasExportBehaviorGraph(behaviorState.scene) ? 1 : 0;
+
+  if (behaviorState.objects && typeof behaviorState.objects === 'object' && !Array.isArray(behaviorState.objects)) {
+    for (const graph of Object.values(behaviorState.objects)) {
+      if (hasExportBehaviorGraph(graph)) count += 1;
+    }
+  }
+
+  if (behaviorState.graphs && typeof behaviorState.graphs === 'object' && !Array.isArray(behaviorState.graphs)) {
+    for (const graph of Object.values(behaviorState.graphs)) {
+      if (hasExportBehaviorGraph(graph)) count += 1;
+    }
+  }
+
+  return count;
+}
+
+export function normalizeExportBehaviorState(behaviorState) {
+  if (!behaviorState || typeof behaviorState !== 'object' || Array.isArray(behaviorState)) {
+    return null;
+  }
+
+  const normalized = {
+    scene: null,
+    objects: {},
+  };
+
+  if (hasExportBehaviorGraph(behaviorState.scene)) {
+    normalized.scene = cloneJson(behaviorState.scene);
+  }
+
+  if (behaviorState.objects && typeof behaviorState.objects === 'object' && !Array.isArray(behaviorState.objects)) {
+    for (const [objectId, graph] of Object.entries(behaviorState.objects)) {
+      if (hasExportBehaviorGraph(graph)) {
+        normalized.objects[objectId] = cloneJson(graph);
+      }
+    }
+  }
+
+  if (behaviorState.graphs && typeof behaviorState.graphs === 'object' && !Array.isArray(behaviorState.graphs)) {
+    normalized.graphs = {};
+    for (const [graphId, graph] of Object.entries(behaviorState.graphs)) {
+      if (hasExportBehaviorGraph(graph)) {
+        normalized.graphs[graphId] = cloneJson(graph);
+      }
+    }
+    if (Object.keys(normalized.graphs).length === 0) {
+      delete normalized.graphs;
+    }
+  }
+
+  if (countExportBehaviorGraphs(normalized) === 0) {
+    return null;
+  }
+
+  const bases = clonePlainObject(behaviorState.bases);
+  if (bases) {
+    normalized.bases = bases;
+  }
+
+  return normalized;
 }
 
 function copyStringField(target, source, key) {
@@ -175,6 +258,7 @@ export function createSceneDocumentFromSceneSyncState({
   envId,
   behaviorState = null,
   physicsState = null,
+  exportMetadata = null,
 }) {
   if (!(managedObjects instanceof Map)) {
     throw new Error('managedObjects must be a Map');
@@ -237,8 +321,11 @@ export function createSceneDocumentFromSceneSyncState({
     bgm: buildBgmEntry(bgmState),
   };
 
-  if (behaviorState) {
-    doc.behaviors = JSON.parse(JSON.stringify(behaviorState));
+  applyExportMetadata(doc, exportMetadata);
+
+  const behaviors = normalizeExportBehaviorState(behaviorState);
+  if (behaviors) {
+    doc.behaviors = behaviors;
   }
 
   const physics = clonePlainObject(physicsState);

--- a/html/assets/js/scenesync-export/export/export-scene-document.test.js
+++ b/html/assets/js/scenesync-export/export/export-scene-document.test.js
@@ -54,3 +54,67 @@ test('exports scene and object physics state', () => {
   assert.equal(doc.objects.length, 1);
   assert.deepEqual(doc.objects[0].physics, managedObjects.get('ball').userData.physics);
 });
+
+test('omits empty exported behavior state', () => {
+  const doc = createSceneDocumentFromSceneSyncState({
+    managedObjects: new Map(),
+    behaviorState: {
+      scene: null,
+      objects: {},
+      bases: {
+        'scene:box': {
+          target: 'box',
+          position: { x: 0, y: 0, z: 0 },
+        },
+      },
+    },
+  });
+
+  assert.equal(Object.hasOwn(doc, 'behaviors'), false);
+});
+
+test('exports only behavior graphs with nodes', () => {
+  const sceneGraph = {
+    nodes: [{ id: 'time', type: 'time' }],
+    edges: [],
+  };
+  const objectGraph = {
+    nodes: [{ id: 'move', type: 'scene.setPosition' }],
+    edges: [],
+  };
+
+  const doc = createSceneDocumentFromSceneSyncState({
+    managedObjects: new Map(),
+    behaviorState: {
+      scene: sceneGraph,
+      objects: {
+        empty: { nodes: [], edges: [] },
+        box: objectGraph,
+      },
+    },
+  });
+
+  assert.deepEqual(doc.behaviors, {
+    scene: sceneGraph,
+    objects: {
+      box: objectGraph,
+    },
+  });
+});
+
+test('exports provided scene metadata', () => {
+  const doc = createSceneDocumentFromSceneSyncState({
+    managedObjects: new Map(),
+    exportMetadata: {
+      title: 'Candy Rock Star',
+      description: 'Unity-chan stage',
+      tags: 'unity-chan, music, scene-sync',
+      author: 'afjk',
+    },
+  });
+
+  assert.equal(doc.title, 'Candy Rock Star');
+  assert.equal(doc.description, 'Unity-chan stage');
+  assert.deepEqual(doc.tags, ['unity-chan', 'music', 'scene-sync']);
+  assert.equal(doc.author, 'afjk');
+});

--- a/html/assets/js/scenesync-export/export/export-thumbnail.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.js
@@ -1,3 +1,5 @@
+import { countExportBehaviorGraphs } from './export-scene-document.js';
+
 export const EXPORT_THUMBNAIL_WIDTH = 1200;
 export const EXPORT_THUMBNAIL_HEIGHT = 630;
 
@@ -28,7 +30,7 @@ export function collectExportSceneStats(sceneDocument = {}) {
     audios: sceneDocument.bgm ? 1 : 0,
     texts: 0,
     glbs: 0,
-    loomlets: sceneDocument.behaviors ? 1 : 0,
+    loomlets: countExportBehaviorGraphs(sceneDocument.behaviors),
     physics: 0,
   };
 

--- a/html/assets/js/scenesync-export/export/export-thumbnail.test.js
+++ b/html/assets/js/scenesync-export/export/export-thumbnail.test.js
@@ -19,7 +19,7 @@ function measureTextByChars(charWidth = 10) {
 test('collects scene stats for generated export thumbnails', () => {
   const stats = collectExportSceneStats({
     bgm: { url: 'assets/bgm.mp3' },
-    behaviors: { graphs: { box: {} } },
+    behaviors: { graphs: { box: { nodes: [{ id: 'n1', type: 'time' }], edges: [] } } },
     physics: { enabled: true },
     objects: [
       { asset: { type: 'image' } },
@@ -41,6 +41,16 @@ test('collects scene stats for generated export thumbnails', () => {
     loomlets: 1,
     physics: 1,
   });
+});
+
+test('does not count empty behavior export state as interactive', () => {
+  const stats = collectExportSceneStats({
+    behaviors: { scene: null, objects: {} },
+    objects: [],
+  });
+
+  assert.equal(stats.loomlets, 0);
+  assert.equal(buildExportThumbnailStatsLabel(stats).includes('interactive'), false);
 });
 
 test('builds compact stats labels for thumbnail cards', () => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -86,7 +86,7 @@ import {
   serializeScenePhysics,
   shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
-import { buildExportPackage, getExportThumbnailExtension } from '../scenesync-export/export/build-export-package.js';
+import { buildExportPackage, validateExportThumbnailFile } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
 
@@ -14113,6 +14113,8 @@ function closeExportMetadataDialog(result = null) {
   revokeExportThumbnailPreviewUrl();
   const resolve = exportDialogResolve;
   exportDialogResolve = null;
+  exportThumbnailFile = null;
+  if (exportThumbnailInput) exportThumbnailInput.value = '';
   if (resolve) resolve(result);
 }
 
@@ -14149,8 +14151,9 @@ exportThumbnailInput?.addEventListener('change', () => {
     setExportThumbnailFile(null);
     return;
   }
-  if (!getExportThumbnailExtension(file)) {
-    showToast('PNG / JPEG / WebP の画像を選択してください');
+  const validationError = validateExportThumbnailFile(file);
+  if (validationError) {
+    showToast(validationError);
     setExportThumbnailFile(null);
     return;
   }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -86,7 +86,7 @@ import {
   serializeScenePhysics,
   shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
-import { buildExportPackage } from '../scenesync-export/export/build-export-package.js';
+import { buildExportPackage, getExportThumbnailExtension } from '../scenesync-export/export/build-export-package.js';
 
 const ABSOLUTE_IMAGE_FILE_LIMIT_BYTES = 80 * 1024 * 1024;
 
@@ -14034,7 +14034,154 @@ window.addEventListener('pageshow', (e) => {
 });
 // ── Export ────────────────────────────────────────────────
 
+const exportDialog = document.getElementById('export-dialog');
+const exportForm = document.getElementById('export-form');
+const exportDialogCloseBtn = document.getElementById('export-dialog-close');
+const exportCancelBtn = document.getElementById('export-cancel');
+const exportTitleInput = document.getElementById('export-title-input');
+const exportDescriptionInput = document.getElementById('export-description-input');
+const exportTagsInput = document.getElementById('export-tags-input');
+const exportAuthorInput = document.getElementById('export-author-input');
+const exportThumbnailSelectBtn = document.getElementById('export-thumbnail-select');
+const exportThumbnailClearBtn = document.getElementById('export-thumbnail-clear');
+const exportThumbnailInput = document.getElementById('export-thumbnail-input');
+const exportThumbnailName = document.getElementById('export-thumbnail-name');
+const exportThumbnailPreview = document.getElementById('export-thumbnail-preview');
+let exportDialogResolve = null;
+let exportThumbnailFile = null;
+let exportThumbnailPreviewUrl = null;
+
+function isExportDialogOpen() {
+  return Boolean(exportDialog && !exportDialog.hidden);
+}
+
+function revokeExportThumbnailPreviewUrl() {
+  if (!exportThumbnailPreviewUrl) return;
+  if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(exportThumbnailPreviewUrl);
+  }
+  exportThumbnailPreviewUrl = null;
+}
+
+function setExportThumbnailFile(file) {
+  exportThumbnailFile = file || null;
+  revokeExportThumbnailPreviewUrl();
+
+  if (!exportThumbnailFile) {
+    if (exportThumbnailInput) exportThumbnailInput.value = '';
+    if (exportThumbnailName) exportThumbnailName.textContent = '未選択';
+    if (exportThumbnailClearBtn) exportThumbnailClearBtn.hidden = true;
+    if (exportThumbnailPreview) {
+      exportThumbnailPreview.removeAttribute('src');
+      exportThumbnailPreview.classList.remove('is-visible');
+    }
+    return;
+  }
+
+  if (exportThumbnailName) {
+    exportThumbnailName.textContent = exportThumbnailFile.name || '選択済み';
+  }
+  if (exportThumbnailClearBtn) exportThumbnailClearBtn.hidden = false;
+  if (
+    exportThumbnailPreview &&
+    typeof URL !== 'undefined' &&
+    typeof URL.createObjectURL === 'function'
+  ) {
+    exportThumbnailPreviewUrl = URL.createObjectURL(exportThumbnailFile);
+    exportThumbnailPreview.src = exportThumbnailPreviewUrl;
+    exportThumbnailPreview.classList.add('is-visible');
+  }
+}
+
+function resetExportDialogForm() {
+  exportForm?.reset?.();
+  setExportThumbnailFile(null);
+}
+
+function buildExportDialogResult() {
+  return {
+    title: exportTitleInput?.value || '',
+    description: exportDescriptionInput?.value || '',
+    tags: exportTagsInput?.value || '',
+    author: exportAuthorInput?.value || '',
+    thumbnailFile: exportThumbnailFile,
+  };
+}
+
+function closeExportMetadataDialog(result = null) {
+  if (exportDialog) exportDialog.hidden = true;
+  revokeExportThumbnailPreviewUrl();
+  const resolve = exportDialogResolve;
+  exportDialogResolve = null;
+  if (resolve) resolve(result);
+}
+
+function openExportMetadataDialog() {
+  if (!exportDialog || !exportForm) {
+    return Promise.resolve({});
+  }
+  if (exportDialogResolve) {
+    closeExportMetadataDialog(null);
+  }
+
+  resetExportDialogForm();
+  exportDialog.hidden = false;
+  requestAnimationFrame(() => {
+    focusTextInputIfSafe(exportTitleInput);
+  });
+
+  return new Promise((resolve) => {
+    exportDialogResolve = resolve;
+  });
+}
+
+exportThumbnailSelectBtn?.addEventListener('click', () => {
+  exportThumbnailInput?.click();
+});
+
+exportThumbnailClearBtn?.addEventListener('click', () => {
+  setExportThumbnailFile(null);
+});
+
+exportThumbnailInput?.addEventListener('change', () => {
+  const file = exportThumbnailInput.files?.[0] || null;
+  if (!file) {
+    setExportThumbnailFile(null);
+    return;
+  }
+  if (!getExportThumbnailExtension(file)) {
+    showToast('PNG / JPEG / WebP の画像を選択してください');
+    setExportThumbnailFile(null);
+    return;
+  }
+  setExportThumbnailFile(file);
+});
+
+exportDialogCloseBtn?.addEventListener('click', () => closeExportMetadataDialog(null));
+exportCancelBtn?.addEventListener('click', () => closeExportMetadataDialog(null));
+
+exportDialog?.addEventListener('click', (event) => {
+  if (event.target === exportDialog) {
+    closeExportMetadataDialog(null);
+  }
+});
+
+exportForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  closeExportMetadataDialog(buildExportDialogResult());
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && isExportDialogOpen()) {
+    event.preventDefault();
+    closeExportMetadataDialog(null);
+  }
+});
+
 async function triggerExport() {
+  const exportMetadata = await openExportMetadataDialog();
+  if (!exportMetadata) return;
+
   showToast('Exporting...');
 
   try {
@@ -14049,6 +14196,7 @@ async function triggerExport() {
       assetCache,
       behaviorState,
       physicsState: getScenePhysicsForSerialize(),
+      exportMetadata,
     });
 
     if (missingAssets.length > 0) {

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -996,6 +996,90 @@
       color: #ff6666;
       margin-top: 4px;
     }
+    .export-dialog {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.72);
+      z-index: 520;
+      font-family: monospace;
+      padding: 16px;
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+    }
+    .export-dialog[hidden] {
+      display: none;
+    }
+    .export-content {
+      width: min(520px, 100%);
+      max-height: calc(100dvh - 32px);
+      overflow-y: auto;
+      padding: 24px;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(20, 20, 20, 0.96);
+      color: #fff;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    }
+    .export-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .export-header h3 {
+      margin: 0;
+      font-size: 18px;
+      line-height: 1.3;
+    }
+    .export-form {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .export-form .form-input {
+      width: 100%;
+    }
+    .export-textarea {
+      min-height: 88px;
+      resize: vertical;
+    }
+    .export-thumbnail-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .export-thumbnail-name {
+      min-width: 0;
+      flex: 1;
+      color: #aaa;
+      font-size: 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .export-thumbnail-preview {
+      display: none;
+      width: 100%;
+      aspect-ratio: 1200 / 630;
+      object-fit: cover;
+      border-radius: 6px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(255, 255, 255, 0.05);
+    }
+    .export-thumbnail-preview.is-visible {
+      display: block;
+    }
+    .export-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 8px;
+    }
     .welcome-actions {
       display: flex;
       flex-direction: column;
@@ -1121,12 +1205,31 @@
 
     body.scene-sync-device-mobile .room-input,
     body.scene-sync-device-mobile .form-input,
+    body.scene-sync-device-mobile .export-textarea,
     body.scene-sync-device-mobile .scene-inspector-editor,
     body.scene-sync-device-mobile .scene-inspector-number-input,
     body.scene-sync-device-mobile #clipboard-paste-target,
     body.scene-sync-device-mobile #mobile-env-select,
     body.scene-sync-device-mobile #env-select {
       font-size: 16px !important;
+    }
+
+    @media (max-width: 560px) {
+      .export-content {
+        padding: 20px;
+      }
+      .export-actions {
+        flex-direction: column-reverse;
+      }
+      .export-actions .chip,
+      .export-thumbnail-row .chip {
+        width: 100%;
+        justify-content: center;
+      }
+      .export-thumbnail-name {
+        flex-basis: 100%;
+        text-align: center;
+      }
     }
 
     /* ── Viewport layout adjustments (PC narrow and mobile) ── */
@@ -1356,6 +1459,46 @@
         <button id="btn-room-full-retry" class="chip" type="button">もう一度試す</button>
         <button id="btn-room-full-new" class="chip primary" type="button">新しいルームを作る</button>
       </div>
+    </div>
+  </div>
+  <div id="export-dialog" class="export-dialog" hidden>
+    <div class="export-content" role="dialog" aria-modal="true" aria-labelledby="export-dialog-title">
+      <div class="export-header">
+        <h3 id="export-dialog-title">Export</h3>
+        <button id="export-dialog-close" class="chip" type="button" title="閉じる">✕</button>
+      </div>
+      <form id="export-form" class="export-form">
+        <label class="form-group">
+          <span class="form-label">タイトル</span>
+          <input id="export-title-input" class="form-input" type="text" maxlength="120" placeholder="scene-sync-export-YYYYMMDD-HHMMSS" autocomplete="off">
+        </label>
+        <label class="form-group">
+          <span class="form-label">説明</span>
+          <textarea id="export-description-input" class="form-input export-textarea" maxlength="2000" rows="4"></textarea>
+        </label>
+        <label class="form-group">
+          <span class="form-label">タグ</span>
+          <input id="export-tags-input" class="form-input" type="text" maxlength="240" placeholder="scene-sync, audio" autocomplete="off">
+        </label>
+        <label class="form-group">
+          <span class="form-label">クレジット</span>
+          <input id="export-author-input" class="form-input" type="text" maxlength="120" autocomplete="off">
+        </label>
+        <div class="form-group">
+          <span class="form-label">Thumbnail画像</span>
+          <div class="export-thumbnail-row">
+            <button id="export-thumbnail-select" class="chip" type="button">画像を選択</button>
+            <button id="export-thumbnail-clear" class="chip" type="button" hidden>クリア</button>
+            <span id="export-thumbnail-name" class="export-thumbnail-name">未選択</span>
+          </div>
+          <input id="export-thumbnail-input" type="file" accept="image/png,image/jpeg,image/webp" hidden>
+          <img id="export-thumbnail-preview" class="export-thumbnail-preview" alt="">
+        </div>
+        <div class="export-actions">
+          <button id="export-cancel" class="chip" type="button">キャンセル</button>
+          <button class="chip primary" type="submit">Export ZIP</button>
+        </div>
+      </form>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Add an Export metadata dialog for SceneSync with title, description, tags, credit, and thumbnail image inputs.
- Write entered metadata into both `scene.json` and `manifest.json`, while leaving blank title values to fall back to the existing generated title behavior.
- Store custom thumbnails at the ZIP root as `thumbnail.png`, `thumbnail.jpg`, `thumbnail.jpeg`, or `thumbnail.webp`.
- Validate custom thumbnails in both the UI and package builder, including a 10MB size limit.
- Omit empty Loomlet behavior export state so empty `{ scene: null, objects: {} }` payloads no longer count as interactions.

## Why

SceneSync Template publishing uses `scene.json.title` first, then `manifest.json.title`, then falls back to a title derived from the ZIP file name. This makes the exported ZIP carry the intended display title and thumbnail metadata directly, while preserving the previous ZIP-name fallback when the form is left blank.

## Validation

- `npm run test:scene-sync-export-import`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync-export/export/build-export-package.js`
- `git diff --check`

Note: local browser automation could not be completed because the in-app browser was unavailable and Playwright Chromium was blocked by macOS process permissions in this environment.