### PR TITLE
feat: Runtime Schedule仕様化 + Physics Plugin境界導入

### DIFF
--- a/docs/runtime-plugins.md
+++ b/docs/runtime-plugins.md
@@ -1,0 +1,147 @@
+# Scene Sync Runtime Plugins
+
+Scene Sync Runtime Plugin の設計方針と責務境界を定義するドキュメント。
+
+## 目的
+
+- Physics / Loomlet / Audio / Animation / Interaction / Replay を内部設計の境界として分離する
+- 「外部拡張API」ではなく「内部モジュール境界」として使う
+- 将来的に Plugin を安全に追加・削除・テストできる土台を作る
+
+## 非目標
+
+- Plugin Manager の大規模実装
+- 動的な Plugin 登録・削除
+- Plugin 間の依存解決システム
+- サードパーティ向け拡張API
+
+---
+
+## Plugin 候補
+
+| Plugin名 | 状態 | 説明 |
+|---|---|---|
+| `SceneSyncPhysicsPlugin` | **実装済み**（wrapper） | Rapier物理シミュレーション |
+| `SceneSyncLoomletPlugin` | 将来の課題 | Behavior Graph（Loomlet）評価 |
+| `SceneSyncAudioPlugin` | 将来の課題 | 空間オーディオ・BGM管理 |
+| `SceneSyncAnimationPlugin` | 将来の課題 | Animation sampling |
+| `SceneSyncInteractionPlugin` | 将来の課題 | XR / pointer interaction |
+| `SceneSyncReplayPlugin` | 将来の課題 | 録画・再生・rollback |
+
+---
+
+## Plugin Interface
+
+```js
+/**
+ * @typedef {Object} SceneSyncRuntimePlugin
+ * @property {string} name - プラグイン名（'physics' / 'loomlet' / 'audio' 等）
+ * @property {function(SceneSyncRuntimeContext): void} [init] - 初期化
+ * @property {function(unknown): void} [onSceneLoaded] - シーンロード後
+ * @property {function(unknown): void} [onObjectAdded] - オブジェクト追加時
+ * @property {function(unknown, unknown): void} [onObjectChanged] - オブジェクト変更時
+ * @property {function(string): void} [onObjectRemoved] - オブジェクト削除時
+ * @property {function(SceneClockState, SceneSyncScheduleContext): void} [update] - フレーム更新
+ * @property {function(): void} [dispose] - 破棄
+ */
+
+/**
+ * @typedef {Object} SceneSyncRuntimeContext
+ * @property {unknown} [scene] - Three.js Scene 等
+ * @property {unknown} [renderer] - Three.js Renderer 等
+ * @property {unknown} [camera] - Three.js Camera 等
+ * @property {unknown} [clock] - SceneClock インスタンス
+ */
+
+/**
+ * @typedef {Object} SceneSyncScheduleContext
+ * @property {Array} events - Physics / collision event 等（将来用）
+ * @property {Array} diagnostics - Runtime 診断情報（将来用）
+ */
+```
+
+すべてのメソッドはオプショナル（`?`）。Plugin が実装しないメソッドは呼ばれてもエラーにならない。
+
+---
+
+## Plugin Runner
+
+複数 Plugin を順番に実行する軽量ヘルパー。
+
+```js
+const runner = createRuntimePluginRunner([
+  physicsPlugin,
+  // 将来: loomletPlugin, audioPlugin, ...
+]);
+
+runner.init(context);      // 全Plugin の init を順番に呼ぶ
+runner.update(clockState, scheduleContext);  // 全Plugin の update を順番に呼ぶ
+runner.dispose();           // 全Plugin の dispose を逆順に呼ぶ
+```
+
+実装: `html/assets/js/scenesync/runtime/runtime-plugin-runner.js`
+
+---
+
+## SceneSyncPhysicsPlugin
+
+### 責務
+
+- Physics component / scene physics settings を読む
+- Rapier world を生成・更新・破棄する
+- ClockState に基づいて fixed step を進める
+- 結果 Transform を Three.js Object へ反映する
+- 将来: collision event を `scheduleContext.events` に積む
+
+### やらないこと
+
+- Clock を進める
+- UI を直接所有する
+- Loomlet graph を評価する
+- Audio を鳴らす
+- Network 同期ポリシーを決める
+
+### API
+
+```js
+const physicsPlugin = createSceneSyncPhysicsPlugin({
+  physicsRuntime,  // 既存の createScenePhysicsRuntime() の戻り値
+});
+
+physicsPlugin.init(context);
+physicsPlugin.update(clockState, scheduleContext);
+physicsPlugin.hasBodies();   // Physics body が存在するか
+physicsPlugin.getRuntime();  // 内部の physicsRuntime を返す（直接アクセスが必要な場合）
+physicsPlugin.dispose();
+```
+
+実装: `html/assets/js/scenesync/plugins/scene-sync-physics-plugin.js`
+
+### 接続状況
+
+| 場所 | 状態 |
+|---|---|
+| Export Viewer (`create-viewer-core.js`) | Plugin 経由に移行済み |
+| Editor Shell (`scene.js`) | 直接呼び出しのまま（将来の課題） |
+
+Editor Shell はまだいくつかの箇所で Physics を直接参照している。
+Physics Plugin wrapper が安定した後、段階的に移行する。
+
+---
+
+## 将来の Plugin 追加ガイドライン
+
+新しい Plugin を追加する際は以下に従う。
+
+1. `html/assets/js/scenesync/plugins/` 以下に `scene-sync-{name}-plugin.js` を追加する
+2. Plugin Interface を実装する（全メソッドオプショナル）
+3. `update(clockState, scheduleContext)` でフレーム更新する
+4. `scheduleContext` を通じて Plugin 間データを受け渡す（イベント等）
+5. このドキュメントの「Plugin 候補」テーブルを更新する
+
+---
+
+## 参照
+
+- [runtime-schedule.md](./runtime-schedule.md) - Runtime 実行順序
+- [scene-sync-physics.md](./scene-sync-physics.md) - Physics仕様詳細

--- a/docs/runtime-schedule.md
+++ b/docs/runtime-schedule.md
@@ -1,0 +1,138 @@
+# Scene Sync Runtime Schedule
+
+Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義するドキュメント。
+
+## 目的
+
+- Clock / Loomlet / Physics / Animation / Audio の実行順序を明文化する
+- 将来的なPhase分割・Plugin追加の設計基準にする
+- Editor / Player / Export Viewer 間の意図的な順序差分を記録する
+
+## 非目標
+
+- 完全なECS実装
+- rollback / replay の完全設計
+- collision event の実装（将来の課題）
+- Loomlet phase分割の実装（将来の課題）
+- Plugin Managerの大規模導入
+
+---
+
+## 概念上の実行順序
+
+1 frame / 1 tick は概念上、以下の順序で進む。
+
+```
+1. Clock update
+2. Input / scheduled command collection
+3. Tick boundary command apply
+4. Loomlet pre-physics phase
+5. Physics fixed step
+6. Collision / physics events collection
+7. Loomlet post-physics phase
+8. Animation / Audio sampling
+9. Apply runtime outputs to view
+10. Record / sync / diagnostics
+```
+
+---
+
+## Current implementation mapping
+
+### Clock update
+
+- Export Viewer: `sceneClock.tick(now)` がフレーム先頭で呼ばれ、`clockState` を返す
+- Editor Shell: `sceneClockStateForTick` が update ループで計算される
+- Physics / Animation / Audio はこの `clockState` を参照して動作する
+
+### Input / scheduled command collection
+
+- 現時点では明示的なコマンドキューはない
+- Editor / Player のUI操作が都度 `physicsRuntime.markDirty()` などを呼ぶ形で実装されている
+
+### Tick boundary command apply
+
+- `physicsRuntime.rebuild()` がこのフェーズに対応する（dirty フラグで制御）
+- 毎フレームの `update()` 内で dirty チェックが行われ、必要なら rebuild する
+
+### Loomlet pre-physics phase
+
+- 現時点では Loomlet（Behavior Runtime）は単一フェーズで評価される
+- Export Viewer: `loomAdapter.tick(clockState, now)` が animation/physics の後に呼ばれている
+- **将来の課題**: `prePhysics` / `postPhysics` に分割する
+
+### Physics fixed step
+
+- `physicsRuntime.update(clockState)` → 内部で `world.stepTo(targetTick)` を実行
+- fixed timestep: デフォルト `1/60` 秒
+- ClockState の `t` から `targetTick = floor(worldAge / timestep)` を計算して固定刻みで進める
+- Step 上限（step-limit）を超えた場合はシミュレーションを停止する
+- 現在は `SceneSyncPhysicsPlugin.update(clockState, scheduleContext)` 経由で呼び出す（後述）
+
+### Collision / physics events collection
+
+- **未実装**（将来の課題）
+- 将来ここで生成された collision event を `scheduleContext.events` に積む
+
+### Loomlet post-physics phase
+
+- **将来の課題**: Physics 後の Loomlet 評価フェーズ
+- collision event を Loomlet graph が消費できるようになる設計にする
+
+### Animation / Audio sampling
+
+- Export Viewer: `animationRuntime.sampleAt(time)` が Physics より先に呼ばれている
+  - 現状の実装では Physics と Animation の順序が逆転している（下記「意図的な差分」参照）
+- `objectAudioController.tick(now, clockState)` が毎フレーム実行される
+
+### Apply runtime outputs to view
+
+- `physicsRuntime.update()` 内の `applyWorldToObjects()` が Three.js Object の Transform を更新する
+- Animation runtime の `sampleAt()` も同様に Object の Transform を直接更新する
+
+### Record / sync / diagnostics
+
+- `scheduleContext.diagnostics` に記録する設計（将来の課題）
+- 現時点は `scheduleContext = { events: [], diagnostics: [] }` を空で渡す
+
+---
+
+## 意図的な差分（Editor / Player / Export Viewer）
+
+| フェーズ | Export Viewer | Editor Shell | 備考 |
+|---|---|---|---|
+| Clock update | フレーム先頭で `sceneClock.tick(now)` | `sceneClockStateForTick` を計算 | どちらも Clock が基準 |
+| Physics step | `clockState.transportActive` でアクティブ判定 | `clockState.active` でアクティブ判定 | isClockActive の実装が異なる |
+| Animation | Physics より先に評価（現実装） | 概念順序と同様 | 将来的に整合させる |
+| Loomlet | Physics の後に `loomAdapter.tick()` | 別の実装 | prePhysics/postPhysics 分割が将来の課題 |
+| Audio | `objectAudioController.tick()` | 独自実装 | Clock に従う点は共通 |
+
+これらの差分は現時点では意図した差分として記録する。
+段階的にこのドキュメントの概念順序に整合させていく。
+
+---
+
+## scheduleContext
+
+Runtime の各フェーズ間でデータを受け渡す軽量な context オブジェクト。
+
+```js
+const scheduleContext = {
+  events: [],       // 将来: collision event / physics event を積む
+  diagnostics: [],  // 将来: runtime diagnostics を記録する
+  // 将来追加候補:
+  // physicsEvents: [],
+  // collisionEvents: [],
+  // commandQueue: [],
+};
+```
+
+現時点では空で渡すが、将来 Plugin 間のデータ受け渡しに使う。
+
+---
+
+## 参照
+
+- [scene-sync-physics.md](./scene-sync-physics.md) - Physics仕様詳細
+- [scene-sync-runtime-time-model.md](./scene-sync-runtime-time-model.md) - Time Model詳細
+- [runtime-plugins.md](./runtime-plugins.md) - Plugin設計

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -10,6 +10,7 @@ import {
   createScenePhysicsRuntime,
   normalizeScenePhysics,
 } from './scene-physics.js';
+import { createSceneSyncPhysicsPlugin } from '../../scenesync/plugins/scene-sync-physics-plugin.js';
 import {
   calculateViewerPlaybackDuration,
   clipTimeForMode,
@@ -627,6 +628,8 @@ export async function createViewerCore({
     })),
     isClockActive: (clockState) => clockState?.transportActive === true,
   });
+  const physicsPlugin = createSceneSyncPhysicsPlugin({ physicsRuntime });
+  physicsPlugin.init({ clock: sceneClock });
 
   function evaluateSceneAtClock(clockState) {
     const time = Number.isFinite(clockState?.t) ? clockState.t : 0;
@@ -634,7 +637,8 @@ export async function createViewerCore({
       runtime.sampleAt(time);
     }
     if (!physicsState.enabled) return;
-    physicsRuntime.update(clockState);
+    const scheduleContext = { events: [], diagnostics: [] };
+    physicsPlugin.update(clockState, scheduleContext);
   }
 
   function syncObjectAudioAtClock(clockState, now = performance.now()) {
@@ -708,7 +712,7 @@ export async function createViewerCore({
     commands,
 
     hasPhysics() {
-      return physicsState.enabled && physicsRuntime.hasBodies();
+      return physicsState.enabled && physicsPlugin.hasBodies();
     },
 
     getPhysicsPlaybackState() {
@@ -773,7 +777,7 @@ export async function createViewerCore({
       bgmAudio?.pause();
       objectAudioController.dispose();
       loomAdapter?.dispose?.();
-      physicsRuntime.dispose();
+      physicsPlugin.dispose();
     },
   };
 

--- a/html/assets/js/scenesync/plugins/scene-sync-physics-plugin.js
+++ b/html/assets/js/scenesync/plugins/scene-sync-physics-plugin.js
@@ -1,0 +1,65 @@
+/**
+ * Thin wrapper that exposes a ScenePhysicsRuntime as a SceneSyncRuntimePlugin.
+ *
+ * The plugin boundary keeps Physics isolated from Clock, UI, Loomlet, Audio,
+ * and Network concerns. Only update() and dispose() are wired to the runtime;
+ * lifecycle hooks (onSceneLoaded, onObjectAdded, …) are stubs for future use.
+ *
+ * @param {Object} options
+ * @param {Object} [options.physicsRuntime] - Existing runtime from createScenePhysicsRuntime()
+ * @param {Function} [options.createPhysicsRuntime] - Factory called during init() if no runtime is pre-built
+ * @returns {SceneSyncRuntimePlugin & { hasBodies(): boolean, getRuntime(): Object|null }}
+ */
+export function createSceneSyncPhysicsPlugin(options = {}) {
+  const { createPhysicsRuntime, physicsRuntime: prebuiltRuntime } = options;
+  let runtime = prebuiltRuntime || null;
+
+  return {
+    name: 'physics',
+
+    init(context) {
+      if (!runtime && typeof createPhysicsRuntime === 'function') {
+        runtime = createPhysicsRuntime(context);
+      }
+    },
+
+    onSceneLoaded(nextScene) {
+      runtime?.onSceneLoaded?.(nextScene);
+    },
+
+    onObjectAdded(object) {
+      runtime?.onObjectAdded?.(object);
+    },
+
+    onObjectChanged(object, changes) {
+      runtime?.onObjectChanged?.(object, changes);
+    },
+
+    onObjectRemoved(objectId) {
+      runtime?.onObjectRemoved?.(objectId);
+    },
+
+    /**
+     * @param {Object} clockState
+     * @param {{ events: Array, diagnostics: Array }} scheduleContext
+     */
+    update(clockState, scheduleContext) {
+      if (!runtime || typeof runtime.update !== 'function') return;
+      runtime.update(clockState);
+      // Future: push collision/physics events into scheduleContext.events
+    },
+
+    hasBodies() {
+      return runtime?.hasBodies?.() ?? false;
+    },
+
+    dispose() {
+      runtime?.dispose?.();
+      runtime = null;
+    },
+
+    getRuntime() {
+      return runtime;
+    },
+  };
+}

--- a/html/assets/js/scenesync/runtime/runtime-plugin-runner.js
+++ b/html/assets/js/scenesync/runtime/runtime-plugin-runner.js
@@ -1,0 +1,53 @@
+/**
+ * Lightweight runner that dispatches lifecycle calls to an ordered list of plugins.
+ * dispose() runs plugins in reverse order so later-registered plugins clean up first.
+ *
+ * @param {Array<import('../plugins/scene-sync-physics-plugin.js').SceneSyncRuntimePlugin>} plugins
+ */
+export function createRuntimePluginRunner(plugins = []) {
+  return {
+    plugins,
+
+    init(context) {
+      for (const plugin of plugins) {
+        plugin.init?.(context);
+      }
+    },
+
+    onSceneLoaded(scene) {
+      for (const plugin of plugins) {
+        plugin.onSceneLoaded?.(scene);
+      }
+    },
+
+    onObjectAdded(object) {
+      for (const plugin of plugins) {
+        plugin.onObjectAdded?.(object);
+      }
+    },
+
+    onObjectChanged(object, changes) {
+      for (const plugin of plugins) {
+        plugin.onObjectChanged?.(object, changes);
+      }
+    },
+
+    onObjectRemoved(objectId) {
+      for (const plugin of plugins) {
+        plugin.onObjectRemoved?.(objectId);
+      }
+    },
+
+    update(clockState, scheduleContext) {
+      for (const plugin of plugins) {
+        plugin.update?.(clockState, scheduleContext);
+      }
+    },
+
+    dispose() {
+      for (const plugin of [...plugins].reverse()) {
+        plugin.dispose?.();
+      }
+    },
+  };
+}


### PR DESCRIPTION
- docs/runtime-schedule.md: Clock/Loomlet/Physics/Animation/Audioの
  概念上の実行順序を定義。現状実装のマッピングと意図的な差分も記録。
- docs/runtime-plugins.md: Plugin設計の責務境界を明文化。
  PhysicsPlugin の責務と「やらないこと」を記述。
- html/assets/js/scenesync/plugins/scene-sync-physics-plugin.js:
  createSceneSyncPhysicsPlugin() を追加。既存 ScenePhysicsRuntime を
  薄く包み、Plugin interface 経由で update/dispose を委譲する。
- html/assets/js/scenesync/runtime/runtime-plugin-runner.js:
  複数 Plugin を順番に実行する軽量ヘルパーを追加。
- html/assets/js/scenesync-export/viewer/create-viewer-core.js:
  physicsRuntime.update() を physicsPlugin.update() 経由に切り替え。
  scheduleContext を空で渡し、将来のイベント受け渡しの足場を作る。

既存の Physics 挙動は変更していない。
Plugin Manager の大規模実装・collision event 実装はこのPRの対象外。

https://claude.ai/code/session_01TWgVDwQrq7WRJUGvYnXf4z