### PR TITLE
Add SceneSyncLoomletPlugin wrapper and route Export Viewer through plugin boundary

### DIFF
--- a/docs/runtime-plugins.md
+++ b/docs/runtime-plugins.md
@@ -22,7 +22,7 @@ Scene Sync Runtime Plugin の設計方針と責務境界を定義するドキュ
 | Plugin名 | 状態 | 説明 |
 |---|---|---|
 | `SceneSyncPhysicsPlugin` | **実装済み**（wrapper） | Rapier物理シミュレーション |
-| `SceneSyncLoomletPlugin` | 将来の課題 | Behavior Graph（Loomlet）評価 |
+| `SceneSyncLoomletPlugin` | **実装済み**（wrapper） | Behavior Graph（Loomlet）評価 |
 | `SceneSyncAudioPlugin` | 将来の課題 | 空間オーディオ・BGM管理 |
 | `SceneSyncAnimationPlugin` | 将来の課題 | Animation sampling |
 | `SceneSyncInteractionPlugin` | 将来の課題 | XR / pointer interaction |
@@ -126,6 +126,53 @@ physicsPlugin.dispose();
 
 Editor Shell はまだいくつかの箇所で Physics を直接参照している。
 Physics Plugin wrapper が安定した後、段階的に移行する。
+
+---
+
+## SceneSyncLoomletPlugin
+
+### 責務
+
+- Loomlet / Behavior Graph adapter を保持する
+- ClockState に基づいて behavior graph を評価する
+- 将来、`scheduleContext.events` から input / collision event を受け取る
+- 将来、`prePhysics` / `postPhysics` phase に分割する入口になる
+
+### やらないこと
+
+- Clock を進める
+- Physics step を進める
+- Audio system を直接所有する
+- Animation sampling を行う
+- Network 同期ポリシーを決める
+
+### 現在の扱い
+
+Export Viewer では、既存の `loomAdapter.tick(clockState, now)` を `SceneSyncLoomletPlugin.update(clockState, scheduleContext)` 経由に移行している。
+現時点では単一 phase のみで、実際の呼び出し位置は既存どおり Physics 後 / Audio 前。
+将来 `prePhysics` / `postPhysics` に分割する。
+
+### API
+
+```js
+const loomletPlugin = createSceneSyncLoomletPlugin({
+  loomAdapter,  // 既存の createExportBehaviorRuntime() の戻り値
+});
+
+loomletPlugin.init(context);
+loomletPlugin.update(clockState, scheduleContext);
+loomletPlugin.getAdapter();  // 内部の loomAdapter を返す（直接アクセスが必要な場合）
+loomletPlugin.dispose();
+```
+
+実装: `html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.js`
+
+### 接続状況
+
+| 場所 | 状態 |
+|---|---|
+| Export Viewer (`create-viewer-core.js`) | Plugin 経由に移行済み |
+| Editor Shell | 直接呼び出しのまま（将来の課題） |
 
 ---
 

--- a/docs/runtime-schedule.md
+++ b/docs/runtime-schedule.md
@@ -57,9 +57,9 @@ Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義�
 
 ### Loomlet pre-physics phase
 
-- 現時点では Loomlet（Behavior Runtime）は単一フェーズで評価される
-- Export Viewer: `loomAdapter.tick(clockState, now)` が animation/physics の後に呼ばれている
-- **将来の課題**: `prePhysics` / `postPhysics` に分割する
+- 未実装
+- 現時点では Loomlet は単一 phase で評価される
+- **将来の課題**: `prePhysics` phase を追加する
 
 ### Physics fixed step
 
@@ -76,8 +76,11 @@ Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義�
 
 ### Loomlet post-physics phase
 
-- **将来の課題**: Physics 後の Loomlet 評価フェーズ
-- collision event を Loomlet graph が消費できるようになる設計にする
+- Export Viewer では `SceneSyncLoomletPlugin.update(clockState, scheduleContext)` 経由で評価する
+- 現在は既存の `loomAdapter.tick(clockState, now)` を薄く包んでいる
+- `scheduleContext.phase = 'postPhysics'` として渡す
+- collision event 消費は未実装
+- **将来の課題**: `prePhysics` / `postPhysics` に分割する
 
 ### Animation / Audio sampling
 
@@ -104,7 +107,7 @@ Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義�
 | Clock update | フレーム先頭で `sceneClock.tick(now)` | `sceneClockStateForTick` を計算 | どちらも Clock が基準 |
 | Physics step | `clockState.transportActive` でアクティブ判定 | `clockState.active` でアクティブ判定 | isClockActive の実装が異なる |
 | Animation | Physics より先に評価（現実装） | 概念順序と同様 | 将来的に整合させる |
-| Loomlet | Physics の後に `loomAdapter.tick()` | 別の実装 | prePhysics/postPhysics 分割が将来の課題 |
+| Loomlet | Physics の後に `SceneSyncLoomletPlugin.update()` 経由 | 別の実装 | prePhysics/postPhysics 分割が将来の課題 |
 | Audio | `objectAudioController.tick()` | 独自実装 | Clock に従う点は共通 |
 
 これらの差分は現時点では意図した差分として記録する。

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -11,6 +11,7 @@ import {
   normalizeScenePhysics,
 } from './scene-physics.js';
 import { createSceneSyncPhysicsPlugin } from '../../scenesync/plugins/scene-sync-physics-plugin.js';
+import { createSceneSyncLoomletPlugin } from '../../scenesync/plugins/scene-sync-loomlet-plugin.js';
 import {
   calculateViewerPlaybackDuration,
   clipTimeForMode,
@@ -611,6 +612,7 @@ export async function createViewerCore({
   if (sceneDoc.behaviors) {
     loomAdapter = createExportBehaviorRuntime(sceneDoc.behaviors, objectMap, objectAudioController);
   }
+  const loomletPlugin = createSceneSyncLoomletPlugin({ loomAdapter });
 
   const physicsState = normalizeScenePhysics(sceneDoc.physics);
   const sceneClock = createViewerSceneClock({
@@ -630,6 +632,7 @@ export async function createViewerCore({
   });
   const physicsPlugin = createSceneSyncPhysicsPlugin({ physicsRuntime });
   physicsPlugin.init({ clock: sceneClock });
+  loomletPlugin.init({ clock: sceneClock });
 
   function evaluateSceneAtClock(clockState) {
     const time = Number.isFinite(clockState?.t) ? clockState.t : 0;
@@ -695,9 +698,12 @@ export async function createViewerCore({
       const now = performance.now();
       const clockState = sceneClock.tick(now);
       evaluateSceneAtClock(clockState);
-      if (loomAdapter) {
-        loomAdapter.tick(clockState, now);
-      }
+      loomletPlugin.update(clockState, {
+        phase: 'postPhysics',
+        events: [],
+        diagnostics: [],
+        now,
+      });
       syncObjectAudioAtClock(clockState, now);
     },
 
@@ -776,7 +782,7 @@ export async function createViewerCore({
       dracoLoader.dispose();
       bgmAudio?.pause();
       objectAudioController.dispose();
-      loomAdapter?.dispose?.();
+      loomletPlugin.dispose();
       physicsPlugin.dispose();
     },
   };

--- a/html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.js
+++ b/html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.js
@@ -1,0 +1,71 @@
+/**
+ * Thin wrapper that exposes an Export/Scene Loomlet adapter as a SceneSyncRuntimePlugin.
+ *
+ * The plugin boundary keeps Loomlet behavior evaluation isolated from
+ * Clock, Physics, Audio, Animation, and shell-specific update loops.
+ *
+ * Current implementation is a single post-physics phase wrapper.
+ * Future work: split into prePhysics/postPhysics phases.
+ *
+ * @typedef {Object} SceneSyncRuntimePlugin
+ * @property {string} name
+ * @property {(context: Object) => void} [init]
+ * @property {(clockState: Object, scheduleContext: Object) => void} [update]
+ * @property {() => void} [dispose]
+ */
+
+/**
+ * @typedef {Object} SceneSyncLoomletPluginOptions
+ * @property {Object} [loomAdapter] - Existing adapter from createExportBehaviorRuntime()
+ * @property {Function} [createLoomAdapter] - Factory called during init() if no adapter is pre-built
+ * @property {Function} [now] - Optional time source for tests
+ */
+
+/**
+ * @param {SceneSyncLoomletPluginOptions} [options]
+ * @returns {SceneSyncRuntimePlugin & { getAdapter(): Object|null }}
+ */
+export function createSceneSyncLoomletPlugin(options = {}) {
+  const {
+    loomAdapter: prebuiltAdapter,
+    createLoomAdapter,
+    now = () => performance.now(),
+  } = options;
+  let adapter = prebuiltAdapter || null;
+
+  return {
+    name: 'loomlet',
+
+    init(context) {
+      if (!adapter && typeof createLoomAdapter === 'function') {
+        adapter = createLoomAdapter(context);
+      }
+    },
+
+    /**
+     * Current behavior:
+     * - Single phase only
+     * - Called after evaluateSceneAtClock(), which currently includes animation + physics
+     * - Does not consume scheduleContext.events yet
+     *
+     * @param {Object} clockState
+     * @param {{ phase?: string, events: Array, diagnostics: Array, now?: number }} [scheduleContext]
+     */
+    update(clockState, scheduleContext = {}) {
+      if (!adapter || typeof adapter.tick !== 'function') return;
+      const currentNow = Number.isFinite(scheduleContext.now)
+        ? scheduleContext.now
+        : now();
+      adapter.tick(clockState, currentNow);
+    },
+
+    dispose() {
+      adapter?.dispose?.();
+      adapter = null;
+    },
+
+    getAdapter() {
+      return adapter;
+    },
+  };
+}

--- a/html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js
+++ b/html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSceneSyncLoomletPlugin } from './scene-sync-loomlet-plugin.js';
+
+test('SceneSyncLoomletPlugin delegates update to loomAdapter.tick', () => {
+  const calls = [];
+  const adapter = {
+    tick(clockState, now) {
+      calls.push({ clockState, now });
+    },
+  };
+  const plugin = createSceneSyncLoomletPlugin({ loomAdapter: adapter });
+  const clockState = { t: 1.25 };
+  plugin.update(clockState, { now: 1234, events: [], diagnostics: [] });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].clockState, clockState);
+  assert.equal(calls[0].now, 1234);
+});
+
+test('SceneSyncLoomletPlugin update is safe without adapter', () => {
+  const plugin = createSceneSyncLoomletPlugin();
+  assert.doesNotThrow(() => {
+    plugin.update({ t: 0 }, { now: 0, events: [], diagnostics: [] });
+  });
+});
+
+test('SceneSyncLoomletPlugin dispose delegates to adapter', () => {
+  let disposed = false;
+  const adapter = {
+    dispose() {
+      disposed = true;
+    },
+  };
+  const plugin = createSceneSyncLoomletPlugin({ loomAdapter: adapter });
+  plugin.dispose();
+  assert.equal(disposed, true);
+  assert.equal(plugin.getAdapter(), null);
+});
+
+test('SceneSyncLoomletPlugin init can create adapter lazily', () => {
+  const context = { clock: {} };
+  const adapter = { tick() {} };
+  const plugin = createSceneSyncLoomletPlugin({
+    createLoomAdapter(receivedContext) {
+      assert.equal(receivedContext, context);
+      return adapter;
+    },
+  });
+  plugin.init(context);
+  assert.equal(plugin.getAdapter(), adapter);
+});
+
+test('SceneSyncLoomletPlugin uses scheduleContext.now when provided', () => {
+  const calls = [];
+  const adapter = {
+    tick(clockState, now) {
+      calls.push({ clockState, now });
+    },
+  };
+  const plugin = createSceneSyncLoomletPlugin({ loomAdapter: adapter });
+  const clockState = { t: 2.0 };
+  plugin.update(clockState, { now: 9999, events: [], diagnostics: [] });
+  assert.equal(calls[0].now, 9999);
+});
+
+test('SceneSyncLoomletPlugin falls back to now() when scheduleContext.now is absent', () => {
+  const calls = [];
+  const adapter = {
+    tick(clockState, now) {
+      calls.push({ clockState, now });
+    },
+  };
+  const fakeNow = () => 42;
+  const plugin = createSceneSyncLoomletPlugin({ loomAdapter: adapter, now: fakeNow });
+  plugin.update({ t: 0 }, { events: [], diagnostics: [] });
+  assert.equal(calls[0].now, 42);
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
     "test:physics": "node --test html/assets/js/scenesync/physics/rapier-world.test.js html/assets/js/scenesync/scene-physics.test.js html/assets/js/scenesync/history/history-manager.test.js",
+    "test:loomlet-plugin": "node --test html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
     "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js html/assets/js/scenesync-export/viewer/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"


### PR DESCRIPTION
Wraps the existing loomAdapter.tick() call in a thin SceneSyncLoomletPlugin
so Loomlet behavior evaluation sits behind the same plugin boundary as Physics.
Evaluation order in Export Viewer is unchanged (animation → physics → loomlet → audio).
Adds scheduleContext with phase:'postPhysics' as the entry point for future
collision-event consumption. pre/post physics phase split is explicitly deferred.

https://claude.ai/code/session_01Dmou6KK3uV6FqCBgmvr47z