### PR TITLE
Add Loomlet collision event audio hooks

### DIFF
--- a/docs/runtime-events.md
+++ b/docs/runtime-events.md
@@ -81,6 +81,25 @@ scheduleContext.collisionEvents  // collision event の便利配列（events の
 
 `emitScheduleEvent()` は type が `physics.collision.*` の場合に `collisionEvents` にも自動で積む。
 
+## Loomlet event input
+
+Export Viewer では、`scheduleContext.events` が Loomlet evaluation context の `events` として渡される。
+`scheduleContext.collisionEvents` も adapter 境界では `collisionEvents` として渡すが、v0 の Loomlet input node は `events` を主入力として扱う。
+
+Object Behavior Graph では、その object が `objectIdA` または `objectIdB` に含まれる collision event のみを受け取る。
+Scene Behavior Graph では、すべての Runtime Event を受け取る。
+
+v0 の最小 input node:
+
+- `event.exists(type)` - 該当 type の event が現在 frame に存在するか
+- `event.count(type)` - 該当 type の event 数
+- `event.first(type)` - 該当 type の最初の event、なければ `null`
+- `event.field(event, field)` - event field 参照
+- `event.otherObject(event)` - object scope で collision 相手 object id を返す
+
+正規の collision type は `physics.collision.enter` / `physics.collision.exit`。
+Export Viewer adapter では `collision.enter` / `collision.exit` も alias として扱う。
+
 ## 参照
 
 - [runtime-schedule.md](./runtime-schedule.md) - Runtime 実行順序

--- a/docs/runtime-plugins.md
+++ b/docs/runtime-plugins.md
@@ -141,7 +141,9 @@ Physics Plugin wrapper が安定した後、段階的に移行する。
 - Loomlet / Behavior Graph adapter を保持する
 - ClockState に基づいて behavior graph を評価する
 - `scheduleContext.events` / `scheduleContext.collisionEvents` を受け取る
-- 将来、collision event を Behavior Graph の input として扱う
+- Export Viewer では `scheduleContext.events` を Loomlet evaluation context に渡す
+- Object scope では関連する Runtime Event のみを Behavior Graph input として渡す
+- `audioSource.playOneShot` effect を Host AudioSource API へ渡す
 - 将来、`prePhysics` / `postPhysics` phase に分割する入口になる
 
 ### やらないこと
@@ -156,6 +158,9 @@ Physics Plugin wrapper が安定した後、段階的に移行する。
 
 Export Viewer では、既存の `loomAdapter.tick(clockState, now)` を `SceneSyncLoomletPlugin.update(clockState, scheduleContext)` 経由に移行している。
 現時点では単一 phase のみで、実際の呼び出し位置は既存どおり Physics 後 / Audio 前。
+`loomAdapter.setScheduleContext(scheduleContext)` によって、`scheduleContext.events` / `scheduleContext.collisionEvents` が Export Viewer の Loomlet evaluation context に渡る。
+Object Behavior Graph は、自分に関係する collision event のみを受け取る。
+Scene Behavior Graph は、すべての Runtime Event を受け取る。
 将来 `prePhysics` / `postPhysics` に分割する。
 
 ### API
@@ -187,7 +192,7 @@ loomletPlugin.dispose();
 Loomlet は Scene Sync 本体の Audio 実装を直接所有しない。
 Host が提供する AudioSource operation API を呼ぶ。
 
-v0 では以下を目標にする。
+v0 で実装済み:
 
 ```js
 audioSource.play(objectId, name?)
@@ -199,6 +204,9 @@ audioSource.playOneShot(objectId, name?, options?)
 
 Host API は `objectAudioController.applyEffect()` をラップして提供する。
 Loomlet adapter の `setScheduleContext()` 経由で scheduleContext も渡す。
+Object Behavior Graph では、`objectId` 省略時に scope object を target として使う。
+Scene Behavior Graph で `objectId` が省略された場合は no-op。
+今回の Export Viewer v0 では、collision reaction 用に `audioSource.playOneShot` の trigger / options 経路をテスト対象にする。
 
 `scene.setAudio` は削除しない。非推奨（deprecated）扱いにする。
 `audioSource.*` を推奨に移行する。

--- a/docs/runtime-schedule.md
+++ b/docs/runtime-schedule.md
@@ -12,7 +12,7 @@ Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義�
 
 - 完全なECS実装
 - rollback / replay の完全設計
-- collision event の実装（将来の課題）
+- collision impulse / normal / point など詳細 collision payload の実装
 - Loomlet phase分割の実装（将来の課題）
 - Plugin Managerの大規模導入
 
@@ -81,9 +81,12 @@ Scene Sync Runtime の 1 frame / 1 tick 内の概念上の実行順序を定義�
 - Export Viewer では `SceneSyncLoomletPlugin.update(clockState, scheduleContext)` 経由で評価する
 - 現在は既存の `loomAdapter.tick(clockState, now)` を薄く包んでいる
 - `scheduleContext.phase = 'postPhysics'` として渡す
-- `scheduleContext.collisionEvents` から physics collision event を参照できる
-- 現時点では、Loomlet runtime 本体がすべての event を直接消費する必要はない
-- まずは host API / adapter 経由で必要な event を渡す
+- Export Viewer では `scheduleContext.events` が Loomlet evaluation context の `events` として渡る
+- `scheduleContext.collisionEvents` も adapter 境界で渡る
+- collision enter/exit を Behavior Graph input として扱える
+- Object Behavior Graph では関連する collision event のみを受け取る
+- Scene Behavior Graph ではすべての Runtime Event を受け取る
+- `audioSource.playOneShot` effect により、collision reaction sound を表現できる
 - **将来の課題**: `prePhysics` / `postPhysics` に分割する
 
 ### Animation / Audio sampling

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -4,7 +4,7 @@ import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
 import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 import { isValidSceneDocument } from './scene-document.js';
 import { createStaticAssetResolver } from './static-asset-resolver.js';
-import { createSceneSyncRuntime } from './loomlet/loomlet-scenesync-runtime.browser.js';
+import { createExportBehaviorRuntime } from './export-behavior-runtime.js';
 import { createObjectAudioController } from './object-audio-controller.js';
 import {
   createScenePhysicsRuntime,
@@ -21,18 +21,6 @@ import { createSceneSyncScheduleContext } from '../../scenesync/runtime/schedule
 
 const DRACO_DECODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/libs/draco/gltf/';
 
-const AUDIO_SOURCE_EFFECT_TYPES = new Set([
-  'audioSource.play',
-  'audioSource.pause',
-  'audioSource.stop',
-  'audioSource.seek',
-  'audioSource.playOneShot',
-  'audioSource.setVolume',
-  'audioSource.setClip',
-  'audioSource.syncToAnimation',
-  'audioSource.unsync',
-]);
-
 const TEXT_LAYOUT_DEFAULTS = Object.freeze({
   width: 2.4,
   height: 1.6,
@@ -44,207 +32,12 @@ function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
 
-function setVector3(target, values) {
-  if (!target) return;
-  if (typeof target.set === 'function') {
-    target.set(values[0], values[1], values[2]);
-  } else {
-    target.x = values[0];
-    target.y = values[1];
-    target.z = values[2];
-  }
-}
-
-function setQuaternion(target, values) {
-  if (!target) return;
-  if (typeof target.set === 'function') {
-    target.set(values[0], values[1], values[2], values[3]);
-  } else {
-    target.x = values[0];
-    target.y = values[1];
-    target.z = values[2];
-    target.w = values[3];
-  }
-}
-
-function clonePosition(position) {
-  if (!position) return null;
-  if (typeof position.clone === 'function') return position.clone();
-  return {
-    x: Number(position.x || 0),
-    y: Number(position.y || 0),
-    z: Number(position.z || 0),
-  };
-}
-
 function finiteNumber(value, fallback) {
   return Number.isFinite(value) ? value : fallback;
 }
 
 function positiveNumber(value, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
-}
-
-const OBJECT_TARGET_NODE_TYPES = new Set([
-  'sceneSetPosition',
-  'sceneOffsetPosition',
-  'sceneSetRotation',
-  'sceneSetScale',
-  'sceneSetColor',
-  'sceneSetVisible',
-  'scene.setPosition',
-  'scene.offsetPosition',
-  'scene.setRotation',
-  'scene.setScale',
-  'scene.setColor',
-  'scene.setVisible',
-]);
-
-function graphForRuntime(graph, scopeObjectId) {
-  const cloned = cloneJson(graph);
-  if (!scopeObjectId) return cloned;
-
-  return {
-    ...cloned,
-    nodes: cloned.nodes.map((node) => {
-      if (!OBJECT_TARGET_NODE_TYPES.has(node.type)) return node;
-      const params = { ...(node.params || {}) };
-      if (!params.target && !params.objectId) {
-        params.target = scopeObjectId;
-      }
-      return { ...node, params };
-    }),
-  };
-}
-
-function createExportBehaviorRuntime(behaviorState, objectMap, audioController = null) {
-  const runtimes = [];
-  const behaviorBases = new Map();
-  let currentScheduleContext = null;
-
-  // AudioSource Host API v0 — wraps objectAudioController.applyEffect()
-  // Loomlet uses this to play/pause/stop/seek audio without owning Audio system
-  const audioSource = {
-    play(objectId, name = 'default') {
-      audioController?.applyEffect({ type: 'audioSource.play', objectId, name });
-    },
-    pause(objectId, name = 'default') {
-      audioController?.applyEffect({ type: 'audioSource.pause', objectId, name });
-    },
-    stop(objectId, name = 'default') {
-      audioController?.applyEffect({ type: 'audioSource.stop', objectId, name });
-    },
-    seek(objectId, seconds, name = 'default') {
-      audioController?.applyEffect({ type: 'audioSource.seek', objectId, name, time: seconds });
-    },
-    playOneShot(objectId, name = 'default', options = {}) {
-      audioController?.applyEffect({ type: 'audioSource.playOneShot', objectId, name, options });
-    },
-  };
-
-  function applySceneEffect(effect, scopeKey) {
-    if (effect?.type && AUDIO_SOURCE_EFFECT_TYPES.has(effect.type)) {
-      audioController?.applyEffect(effect);
-      return;
-    }
-
-    const objectId = effect?.objectId;
-    if (!objectId) return;
-
-    const object = objectMap.get(objectId);
-    if (!object) return;
-
-    if (effect.type === 'scene.setPosition' && Array.isArray(effect.position)) {
-      setVector3(object.position, effect.position);
-    } else if (effect.type === 'scene.offsetPosition' && Array.isArray(effect.offset)) {
-      const baseKey = `${scopeKey}:${objectId}`;
-      if (!behaviorBases.has(baseKey)) {
-        const position = clonePosition(object.position);
-        if (position) behaviorBases.set(baseKey, { target: objectId, position });
-      }
-      const base = behaviorBases.get(baseKey)?.position;
-      if (base) {
-        setVector3(object.position, [
-          base.x + effect.offset[0],
-          base.y + effect.offset[1],
-          base.z + effect.offset[2],
-        ]);
-      }
-    } else if (effect.type === 'scene.setRotation' && Array.isArray(effect.rotation)) {
-      setQuaternion(object.quaternion || object.rotation, effect.rotation);
-    } else if (effect.type === 'scene.setScale' && Array.isArray(effect.scale)) {
-      setVector3(object.scale, effect.scale);
-    } else if (effect.type === 'scene.setVisible') {
-      object.visible = Boolean(effect.visible);
-    } else if (effect.type === 'scene.setColor' && Array.isArray(effect.color)) {
-      const material = Array.isArray(object.material) ? object.material[0] : object.material;
-      material?.color?.setRGB?.(effect.color[0], effect.color[1], effect.color[2]);
-    }
-  }
-
-  if (behaviorState?.bases && typeof behaviorState.bases === 'object') {
-    for (const [key, base] of Object.entries(behaviorState.bases)) {
-      if (!base?.position || !base.target) continue;
-      const object = objectMap.get(base.target);
-      if (object?.position) {
-        setVector3(object.position, [base.position.x, base.position.y, base.position.z]);
-      }
-      behaviorBases.set(key, {
-        target: base.target,
-        position: { ...base.position },
-      });
-    }
-  }
-
-  function addRuntime(scopeKey, scope, graph) {
-    const scopeObjectId = scope.type === 'object' ? scope.id : null;
-    runtimes.push({
-      scope,
-      runtime: createSceneSyncRuntime(graphForRuntime(graph, scopeObjectId), {
-        resolveTarget: (objectId) => objectMap.get(objectId) || null,
-        applySceneEffect: (effect) => applySceneEffect(effect, scopeKey),
-      }),
-    });
-  }
-
-  if (behaviorState?.scene) {
-    addRuntime('scene', { type: 'scene' }, behaviorState.scene);
-  }
-  if (behaviorState?.objects && typeof behaviorState.objects === 'object') {
-    for (const [objectId, graph] of Object.entries(behaviorState.objects)) {
-      if (graph) addRuntime(`object:${objectId}`, { type: 'object', id: objectId }, graph);
-    }
-  }
-
-  return {
-    tick(clockState = null, now = performance.now()) {
-      const time = Number.isFinite(clockState?.t) ? clockState.t : now / 1000;
-      for (const entry of runtimes) {
-        entry.runtime.evaluateAt({ time, scope: entry.scope, events: [] }, now);
-      }
-    },
-
-    setScheduleContext(scheduleContext) {
-      currentScheduleContext = scheduleContext || null;
-    },
-
-    getRuntimeEvents() {
-      return currentScheduleContext?.events || [];
-    },
-
-    getCollisionEvents() {
-      return currentScheduleContext?.collisionEvents || [];
-    },
-
-    // AudioSource Host API — exposed so Loomlet nodes can trigger audio
-    audioSource,
-
-    dispose() {
-      runtimes.length = 0;
-      behaviorBases.clear();
-      currentScheduleContext = null;
-    },
-  };
 }
 
 function buildPrimitive(assetDef) {

--- a/html/assets/js/scenesync-export/viewer/export-behavior-runtime.js
+++ b/html/assets/js/scenesync-export/viewer/export-behavior-runtime.js
@@ -1,0 +1,454 @@
+import { createSceneSyncRuntime } from './loomlet/loomlet-scenesync-runtime.browser.js';
+
+const AUDIO_SOURCE_EFFECT_TYPES = new Set([
+  'audioSource.play',
+  'audioSource.pause',
+  'audioSource.stop',
+  'audioSource.seek',
+  'audioSource.playOneShot',
+  'audioSource.setVolume',
+  'audioSource.setClip',
+  'audioSource.syncToAnimation',
+  'audioSource.unsync',
+]);
+
+const OBJECT_TARGET_NODE_TYPES = new Set([
+  'sceneSetPosition',
+  'sceneOffsetPosition',
+  'sceneSetRotation',
+  'sceneSetScale',
+  'sceneSetColor',
+  'sceneSetVisible',
+  'scene.setPosition',
+  'scene.offsetPosition',
+  'scene.setRotation',
+  'scene.setScale',
+  'scene.setColor',
+  'scene.setVisible',
+]);
+
+const EVENT_TYPE_ALIASES = new Map([
+  ['collision.enter', 'physics.collision.enter'],
+  ['collision.exit', 'physics.collision.exit'],
+]);
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function stringifyText(value) {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function setVector3(target, values) {
+  if (!target) return;
+  if (typeof target.set === 'function') {
+    target.set(values[0], values[1], values[2]);
+  } else {
+    target.x = values[0];
+    target.y = values[1];
+    target.z = values[2];
+  }
+}
+
+function setQuaternion(target, values) {
+  if (!target) return;
+  if (typeof target.set === 'function') {
+    target.set(values[0], values[1], values[2], values[3]);
+  } else {
+    target.x = values[0];
+    target.y = values[1];
+    target.z = values[2];
+    target.w = values[3];
+  }
+}
+
+function clonePosition(position) {
+  if (!position) return null;
+  if (typeof position.clone === 'function') return position.clone();
+  return {
+    x: Number(position.x || 0),
+    y: Number(position.y || 0),
+    z: Number(position.z || 0),
+  };
+}
+
+function normalizeEventType(type) {
+  const value = stringifyText(type).trim();
+  return EVENT_TYPE_ALIASES.get(value) || value;
+}
+
+function finiteOption(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function triggerIsActive(value) {
+  if (Array.isArray(value)) return value.length > 0;
+  return Boolean(value);
+}
+
+function graphForRuntime(graph, scopeObjectId) {
+  const cloned = cloneJson(graph);
+  if (!scopeObjectId || !Array.isArray(cloned?.nodes)) return cloned;
+
+  return {
+    ...cloned,
+    nodes: cloned.nodes.map((node) => {
+      if (!OBJECT_TARGET_NODE_TYPES.has(node.type)) return node;
+      const params = { ...(node.params || {}) };
+      if (!params.target && !params.objectId) {
+        params.target = scopeObjectId;
+      }
+      return { ...node, params };
+    }),
+  };
+}
+
+export function eventMatchesScope(event, scope) {
+  if (!event || !scope) return false;
+  if (scope.type === 'scene') return true;
+  if (scope.type !== 'object') return true;
+
+  const objectId = stringifyText(scope.id);
+  if (!objectId) return false;
+
+  return event.objectIdA === objectId ||
+    event.objectIdB === objectId ||
+    event.objectId === objectId ||
+    event.target === objectId ||
+    (Array.isArray(event.targets) && event.targets.includes(objectId));
+}
+
+export function filterRuntimeEventsForScope(events, scope) {
+  if (!Array.isArray(events)) return [];
+  return events.filter((event) => eventMatchesScope(event, scope));
+}
+
+export function toLoomletRuntimeEvent(event) {
+  if (!isObject(event)) return null;
+  const eventType = normalizeEventType(event.type ?? event.channel);
+  const timestamp = Number.isFinite(event.timestamp)
+    ? event.timestamp
+    : Number.isFinite(event.time)
+      ? event.time
+      : 0;
+  return {
+    ...event,
+    type: event.type ?? eventType,
+    channel: typeof event.channel === 'string' ? event.channel : eventType,
+    timestamp,
+  };
+}
+
+function prepareLoomletEvents(events) {
+  if (!Array.isArray(events)) return [];
+  return events.map(toLoomletRuntimeEvent).filter(Boolean);
+}
+
+function eventsForType(events, type) {
+  const requestedType = normalizeEventType(type);
+  if (!requestedType) return events;
+  return events.filter((event) => (
+    normalizeEventType(event.type ?? event.channel) === requestedType ||
+    normalizeEventType(event.channel) === requestedType
+  ));
+}
+
+function runtimeEvents(ctx, type) {
+  return eventsForType(Array.isArray(ctx.env?.events) ? ctx.env.events : [], type);
+}
+
+function optionBag(inputs) {
+  const options = {};
+  const volume = finiteOption(inputs.volume);
+  const playbackRate = finiteOption(inputs.playbackRate);
+  const offset = finiteOption(inputs.offset);
+  const url = stringifyText(inputs.url).trim();
+  if (volume !== undefined) options.volume = volume;
+  if (playbackRate !== undefined) options.playbackRate = playbackRate;
+  if (offset !== undefined) options.offset = offset;
+  if (url) options.url = url;
+  return options;
+}
+
+export function createExportBehaviorNodeTypes() {
+  const audioSourcePlayOneShot = {
+    inputs: [
+      { name: 'trigger', default: true },
+      { name: 'objectId', default: '' },
+      { name: 'name', default: 'default' },
+      { name: 'volume', default: undefined },
+      { name: 'playbackRate', default: undefined },
+      { name: 'offset', default: undefined },
+      { name: 'url', default: '' },
+    ],
+    params: [
+      { name: 'trigger', default: true },
+      { name: 'objectId', default: '' },
+      { name: 'name', default: 'default' },
+      { name: 'volume', default: undefined },
+      { name: 'playbackRate', default: undefined },
+      { name: 'offset', default: undefined },
+      { name: 'url', default: '' },
+      { name: 'target', default: '' },
+    ],
+    evaluate: (inputs, params, ctx) => {
+      if (!triggerIsActive(inputs.trigger)) return {};
+      const inputObjectId = stringifyText(inputs.objectId ?? params.objectId).trim();
+      const targetObjectId = stringifyText(params.target).trim();
+      const objectId = inputObjectId || targetObjectId || stringifyText(ctx.scopeObjectId).trim();
+      if (!objectId) return {};
+
+      const name = stringifyText(inputs.name ?? params.name).trim() || 'default';
+      ctx.recordEffect({
+        type: 'audioSource.playOneShot',
+        objectId,
+        name,
+        options: optionBag(inputs),
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId,
+      });
+      return {};
+    },
+  };
+
+  return {
+    'event.exists': {
+      inputs: [{ name: 'type', default: '' }],
+      outputs: [{ name: 'out', default: false }],
+      params: [{ name: 'type', default: '' }],
+      evaluate: (inputs, params, ctx) => ({
+        out: runtimeEvents(ctx, inputs.type ?? params.type).length > 0,
+      }),
+    },
+    'event.count': {
+      inputs: [{ name: 'type', default: '' }],
+      outputs: [{ name: 'out', default: 0 }],
+      params: [{ name: 'type', default: '' }],
+      evaluate: (inputs, params, ctx) => ({
+        out: runtimeEvents(ctx, inputs.type ?? params.type).length,
+      }),
+    },
+    'event.first': {
+      inputs: [{ name: 'type', default: '' }],
+      outputs: [{ name: 'out', default: null }],
+      params: [{ name: 'type', default: '' }],
+      evaluate: (inputs, params, ctx) => ({
+        out: runtimeEvents(ctx, inputs.type ?? params.type)[0] || null,
+      }),
+    },
+    'event.field': {
+      inputs: [
+        { name: 'event', default: null },
+        { name: 'field', default: '' },
+        { name: 'default', default: null },
+      ],
+      outputs: [{ name: 'out' }],
+      params: [
+        { name: 'field', default: '' },
+        { name: 'default', default: null },
+      ],
+      evaluate: (inputs, params) => {
+        const event = inputs.event;
+        const field = stringifyText(inputs.field ?? params.field);
+        if (!isObject(event) || !field || !Object.prototype.hasOwnProperty.call(event, field)) {
+          return { out: inputs.default ?? params.default ?? null };
+        }
+        return { out: event[field] };
+      },
+    },
+    'event.otherObject': {
+      inputs: [{ name: 'event', default: null }],
+      outputs: [{ name: 'out', default: null }],
+      evaluate: (inputs, params, ctx) => {
+        const event = inputs.event;
+        const scopeObjectId = stringifyText(ctx.env?.scope?.id ?? ctx.scopeObjectId);
+        if (!isObject(event) || !scopeObjectId) return { out: null };
+        if (event.objectIdA === scopeObjectId) return { out: event.objectIdB ?? null };
+        if (event.objectIdB === scopeObjectId) return { out: event.objectIdA ?? null };
+        return { out: null };
+      },
+    },
+    'audioSource.playOneShot': audioSourcePlayOneShot,
+    audioSourcePlayOneShot,
+  };
+}
+
+function normalizeAudioSourceEffect(effect, scope) {
+  const directObjectId = stringifyText(effect?.objectId).trim();
+  const targetObjectId = effect?.target === 'scenesync' ? '' : stringifyText(effect?.target).trim();
+  const scopeObjectId = scope?.type === 'object' ? stringifyText(scope.id).trim() : '';
+  const objectId = directObjectId || targetObjectId || scopeObjectId;
+  if (!objectId) return null;
+
+  const name = stringifyText(effect?.name).trim() || 'default';
+  const normalized = { ...effect, objectId, name };
+  if (effect?.type === 'audioSource.playOneShot') {
+    normalized.options = isObject(effect.options) ? { ...effect.options } : {};
+    for (const key of ['volume', 'playbackRate', 'offset']) {
+      const value = finiteOption(effect[key]);
+      if (value !== undefined) normalized.options[key] = value;
+    }
+    const url = stringifyText(effect.url).trim();
+    if (url) normalized.options.url = url;
+  }
+  return normalized;
+}
+
+export function createExportBehaviorRuntime(behaviorState, objectMap, audioController = null, options = {}) {
+  const runtimes = [];
+  const behaviorBases = new Map();
+  const createRuntime = options.createRuntime || createSceneSyncRuntime;
+  const nodeTypes = {
+    ...createExportBehaviorNodeTypes(),
+    ...(options.nodeTypes || {}),
+  };
+  let currentScheduleContext = null;
+
+  const audioSource = {
+    play(objectId, name = 'default') {
+      audioController?.applyEffect({ type: 'audioSource.play', objectId, name });
+    },
+    pause(objectId, name = 'default') {
+      audioController?.applyEffect({ type: 'audioSource.pause', objectId, name });
+    },
+    stop(objectId, name = 'default') {
+      audioController?.applyEffect({ type: 'audioSource.stop', objectId, name });
+    },
+    seek(objectId, seconds, name = 'default') {
+      audioController?.applyEffect({ type: 'audioSource.seek', objectId, name, time: seconds });
+    },
+    playOneShot(objectId, name = 'default', options = {}) {
+      audioController?.applyEffect({ type: 'audioSource.playOneShot', objectId, name, options });
+    },
+  };
+
+  function applySceneEffect(effect, scopeKey, scope) {
+    if (effect?.type && AUDIO_SOURCE_EFFECT_TYPES.has(effect.type)) {
+      const normalizedEffect = normalizeAudioSourceEffect(effect, scope);
+      if (normalizedEffect) audioController?.applyEffect(normalizedEffect);
+      return;
+    }
+
+    const objectId = effect?.objectId;
+    if (!objectId) return;
+
+    const object = objectMap.get(objectId);
+    if (!object) return;
+
+    if (effect.type === 'scene.setPosition' && Array.isArray(effect.position)) {
+      setVector3(object.position, effect.position);
+    } else if (effect.type === 'scene.offsetPosition' && Array.isArray(effect.offset)) {
+      const baseKey = `${scopeKey}:${objectId}`;
+      if (!behaviorBases.has(baseKey)) {
+        const position = clonePosition(object.position);
+        if (position) behaviorBases.set(baseKey, { target: objectId, position });
+      }
+      const base = behaviorBases.get(baseKey)?.position;
+      if (base) {
+        setVector3(object.position, [
+          base.x + effect.offset[0],
+          base.y + effect.offset[1],
+          base.z + effect.offset[2],
+        ]);
+      }
+    } else if (effect.type === 'scene.setRotation' && Array.isArray(effect.rotation)) {
+      setQuaternion(object.quaternion || object.rotation, effect.rotation);
+    } else if (effect.type === 'scene.setScale' && Array.isArray(effect.scale)) {
+      setVector3(object.scale, effect.scale);
+    } else if (effect.type === 'scene.setVisible') {
+      object.visible = Boolean(effect.visible);
+    } else if (effect.type === 'scene.setColor' && Array.isArray(effect.color)) {
+      const material = Array.isArray(object.material) ? object.material[0] : object.material;
+      material?.color?.setRGB?.(effect.color[0], effect.color[1], effect.color[2]);
+    }
+  }
+
+  if (behaviorState?.bases && typeof behaviorState.bases === 'object') {
+    for (const [key, base] of Object.entries(behaviorState.bases)) {
+      if (!base?.position || !base.target) continue;
+      const object = objectMap.get(base.target);
+      if (object?.position) {
+        setVector3(object.position, [base.position.x, base.position.y, base.position.z]);
+      }
+      behaviorBases.set(key, {
+        target: base.target,
+        position: { ...base.position },
+      });
+    }
+  }
+
+  function addRuntime(scopeKey, scope, graph) {
+    const scopeObjectId = scope.type === 'object' ? scope.id : null;
+    runtimes.push({
+      scope,
+      runtime: createRuntime(graphForRuntime(graph, scopeObjectId), {
+        resolveTarget: (objectId) => objectMap.get(objectId) || null,
+        applySceneEffect: (effect) => applySceneEffect(effect, scopeKey, scope),
+        nodeTypes,
+      }),
+    });
+  }
+
+  if (behaviorState?.scene) {
+    addRuntime('scene', { type: 'scene' }, behaviorState.scene);
+  }
+  if (behaviorState?.objects && typeof behaviorState.objects === 'object') {
+    for (const [objectId, graph] of Object.entries(behaviorState.objects)) {
+      if (graph) addRuntime(`object:${objectId}`, { type: 'object', id: objectId }, graph);
+    }
+  }
+
+  return {
+    tick(clockState = null, now = performance.now()) {
+      const time = Number.isFinite(clockState?.t) ? clockState.t : now / 1000;
+      const runtimeEvents = Array.isArray(currentScheduleContext?.events) ? currentScheduleContext.events : [];
+      const collisionEvents = Array.isArray(currentScheduleContext?.collisionEvents)
+        ? currentScheduleContext.collisionEvents
+        : [];
+
+      for (const entry of runtimes) {
+        const scopedEvents = prepareLoomletEvents(filterRuntimeEventsForScope(runtimeEvents, entry.scope));
+        const scopedCollisionEvents = prepareLoomletEvents(filterRuntimeEventsForScope(collisionEvents, entry.scope));
+        entry.runtime.evaluateAt({
+          time,
+          scope: entry.scope,
+          events: scopedEvents,
+          collisionEvents: scopedCollisionEvents,
+        }, now);
+      }
+    },
+
+    setScheduleContext(scheduleContext) {
+      currentScheduleContext = scheduleContext || null;
+    },
+
+    getRuntimeEvents() {
+      return currentScheduleContext?.events || [];
+    },
+
+    getCollisionEvents() {
+      return currentScheduleContext?.collisionEvents || [];
+    },
+
+    audioSource,
+
+    dispose() {
+      runtimes.length = 0;
+      behaviorBases.clear();
+      currentScheduleContext = null;
+    },
+  };
+}

--- a/html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js
+++ b/html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js
@@ -1,0 +1,212 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createExportBehaviorNodeTypes,
+  createExportBehaviorRuntime,
+  eventMatchesScope,
+  filterRuntimeEventsForScope,
+  toLoomletRuntimeEvent,
+} from './export-behavior-runtime.js';
+
+function emptyGraph() {
+  return { nodes: [], edges: [] };
+}
+
+function collisionEvent(overrides = {}) {
+  return {
+    type: 'physics.collision.enter',
+    source: 'physics',
+    phase: 'postPhysics',
+    time: 0.5,
+    tick: 30,
+    frameId: 1,
+    objectIdA: 'ball',
+    objectIdB: 'platform',
+    pairKey: 'ball|platform',
+    payload: {},
+    ...overrides,
+  };
+}
+
+function makeCollisionOneShotGraph(soundParams = {}) {
+  return {
+    nodes: [
+      { id: 'exists', type: 'event.exists', params: { type: 'collision.enter' } },
+      { id: 'first', type: 'event.first', params: { type: 'physics.collision.enter' } },
+      { id: 'pairKey', type: 'event.field', params: { field: 'pairKey', default: 'hit' } },
+      { id: 'sound', type: 'audioSource.playOneShot', params: { ...soundParams } },
+    ],
+    edges: [
+      { from: 'exists.out', to: 'sound.trigger' },
+      { from: 'first.out', to: 'pairKey.event' },
+      { from: 'pairKey.out', to: 'sound.name' },
+    ],
+  };
+}
+
+test('eventMatchesScope matches scene and related object collision events', () => {
+  const event = collisionEvent();
+
+  assert.equal(eventMatchesScope(event, { type: 'scene' }), true);
+  assert.equal(eventMatchesScope(event, { type: 'object', id: 'ball' }), true);
+  assert.equal(eventMatchesScope(event, { type: 'object', id: 'platform' }), true);
+  assert.equal(eventMatchesScope(event, { type: 'object', id: 'other' }), false);
+});
+
+test('filterRuntimeEventsForScope filters object scoped events', () => {
+  const events = [
+    collisionEvent(),
+    collisionEvent({ objectIdA: 'other', objectIdB: 'platform', pairKey: 'other|platform' }),
+  ];
+
+  const scoped = filterRuntimeEventsForScope(events, { type: 'object', id: 'ball' });
+  assert.equal(scoped.length, 1);
+  assert.equal(scoped[0].pairKey, 'ball|platform');
+});
+
+test('toLoomletRuntimeEvent preserves runtime event fields and adds Loomlet channel/timestamp', () => {
+  const event = toLoomletRuntimeEvent(collisionEvent());
+
+  assert.equal(event.type, 'physics.collision.enter');
+  assert.equal(event.channel, 'physics.collision.enter');
+  assert.equal(event.timestamp, 0.5);
+  assert.equal(event.objectIdA, 'ball');
+  assert.equal(event.pairKey, 'ball|platform');
+});
+
+test('runtime passes scoped events and collisionEvents to Loomlet evaluateAt', () => {
+  const calls = [];
+  const runtime = createExportBehaviorRuntime(
+    {
+      scene: emptyGraph(),
+      objects: {
+        ball: emptyGraph(),
+        other: emptyGraph(),
+      },
+    },
+    new Map(),
+    null,
+    {
+      createRuntime(graph, options) {
+        assert.ok(options.nodeTypes['event.exists']);
+        return {
+          evaluateAt(env, now) {
+            calls.push({ env, now });
+          },
+        };
+      },
+    },
+  );
+
+  const related = collisionEvent();
+  const unrelated = collisionEvent({ objectIdA: 'crate', objectIdB: 'platform', pairKey: 'crate|platform' });
+  runtime.setScheduleContext({
+    events: [related, unrelated],
+    collisionEvents: [related, unrelated],
+  });
+  runtime.tick({ t: 0.5 }, 500);
+
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls[0].env.scope, { type: 'scene' });
+  assert.equal(calls[0].env.events.length, 2);
+  assert.equal(calls[0].env.collisionEvents.length, 2);
+  assert.deepEqual(calls[1].env.scope, { type: 'object', id: 'ball' });
+  assert.deepEqual(calls[1].env.events.map((event) => event.pairKey), ['ball|platform']);
+  assert.deepEqual(calls[1].env.collisionEvents.map((event) => event.pairKey), ['ball|platform']);
+  assert.deepEqual(calls[2].env.scope, { type: 'object', id: 'other' });
+  assert.equal(calls[2].env.events.length, 0);
+});
+
+test('event input nodes expose exists, count, first, field, and otherObject', () => {
+  const nodeTypes = createExportBehaviorNodeTypes();
+  const event = toLoomletRuntimeEvent(collisionEvent());
+  const ctx = {
+    env: {
+      scope: { type: 'object', id: 'ball' },
+      events: [event],
+    },
+    scopeObjectId: 'ball',
+  };
+
+  assert.equal(nodeTypes['event.exists'].evaluate({ type: 'collision.enter' }, {}, ctx).out, true);
+  assert.equal(nodeTypes['event.count'].evaluate({ type: 'physics.collision.enter' }, {}, ctx).out, 1);
+  assert.equal(nodeTypes['event.first'].evaluate({ type: 'physics.collision.enter' }, {}, ctx).out, event);
+  assert.equal(nodeTypes['event.field'].evaluate({ event, field: 'pairKey' }, {}, ctx).out, 'ball|platform');
+  assert.equal(nodeTypes['event.otherObject'].evaluate({ event }, {}, ctx).out, 'platform');
+});
+
+test('collision enter triggers object scoped audioSource.playOneShot', () => {
+  const effects = [];
+  const runtime = createExportBehaviorRuntime(
+    {
+      objects: {
+        ball: makeCollisionOneShotGraph({
+          volume: 0.5,
+          playbackRate: 1.25,
+          offset: 0.1,
+          url: 'https://example.test/hit.mp3',
+        }),
+      },
+    },
+    new Map(),
+    { applyEffect(effect) { effects.push(effect); } },
+  );
+
+  runtime.setScheduleContext({
+    events: [collisionEvent()],
+    collisionEvents: [collisionEvent()],
+  });
+  runtime.tick({ t: 0.5 }, 500);
+
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].type, 'audioSource.playOneShot');
+  assert.equal(effects[0].objectId, 'ball');
+  assert.equal(effects[0].name, 'ball|platform');
+  assert.deepEqual(effects[0].options, {
+    volume: 0.5,
+    playbackRate: 1.25,
+    offset: 0.1,
+    url: 'https://example.test/hit.mp3',
+  });
+});
+
+test('unrelated object collision does not trigger object scoped audioSource.playOneShot', () => {
+  const effects = [];
+  const runtime = createExportBehaviorRuntime(
+    {
+      objects: {
+        ball: makeCollisionOneShotGraph(),
+      },
+    },
+    new Map(),
+    { applyEffect(effect) { effects.push(effect); } },
+  );
+
+  runtime.setScheduleContext({
+    events: [collisionEvent({ objectIdA: 'crate', objectIdB: 'platform', pairKey: 'crate|platform' })],
+    collisionEvents: [collisionEvent({ objectIdA: 'crate', objectIdB: 'platform', pairKey: 'crate|platform' })],
+  });
+  runtime.tick({ t: 0.5 }, 500);
+
+  assert.equal(effects.length, 0);
+});
+
+test('scene scoped audioSource.playOneShot without objectId is a safe no-op', () => {
+  const effects = [];
+  const runtime = createExportBehaviorRuntime(
+    {
+      scene: {
+        nodes: [{ id: 'sound', type: 'audioSource.playOneShot', params: { name: 'hit' } }],
+        edges: [],
+      },
+    },
+    new Map(),
+    { applyEffect(effect) { effects.push(effect); } },
+  );
+
+  runtime.setScheduleContext({ events: [], collisionEvents: [] });
+  runtime.tick({ t: 0.5 }, 500);
+
+  assert.equal(effects.length, 0);
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:loomlet-plugin": "node --test html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
     "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js",
     "test:plugins": "node --test html/assets/js/scenesync/plugins/scene-sync-physics-plugin.test.js html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
+    "test:export-behavior-runtime": "node --test html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js",
     "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js html/assets/js/scenesync-export/viewer/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"


### PR DESCRIPTION
## Summary
- Passed `scheduleContext.events` / `collisionEvents` into Export Viewer Loomlet evaluation
- Added scoped runtime event filtering for scene/object behavior graphs
- Added minimal Loomlet event input support for runtime events
- Added `audioSource.playOneShot` trigger/options support for Export Viewer behaviors
- Added tests for collision event input and AudioSource one-shot effects

## Runtime flow
Current Export Viewer order remains:
1. Clock tick
2. Animation sampling
3. PhysicsPlugin update
4. LoomletPlugin update
5. Audio tick

Collision events now flow as:
PhysicsPlugin -> scheduleContext.events/collisionEvents -> Loomlet evaluation context -> audioSource.playOneShot effect -> objectAudioController.applyEffect()

## Implementation note
This PR keeps the change in `afjk.jp`. The Loomlet runtime already supports host-injected `nodeTypes`, so the Export Viewer can add the v0 event/audio nodes locally without changing the separate `loomlet` repo.

## Non-goals
- No Editor Shell migration
- No prePhysics phase implementation
- No network sync policy
- No full audio mixer
- No collision impulse/normal/point support
- No removal of scene.setAudio

## Test
- npm run test:runtime-schedule
- npm run test:plugins
- npm run test:physics
- npm run test:scene-sync-export-import
- npm run test:export-behavior-runtime
