### PR TITLE
Add scene behavior graph import support to Scene Sync Export

### DIFF
--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.js
@@ -1,0 +1,75 @@
+function isBehaviorGraph(value) {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Array.isArray(value.nodes) &&
+    Array.isArray(value.edges)
+  );
+}
+
+export function applySceneDocumentBehaviors(behaviors, {
+  managedObjects,
+  applySceneGraphOperation,
+  broadcast,
+  source = 'scene-sync-export-import',
+} = {}) {
+  if (!behaviors || typeof behaviors !== 'object' || Array.isArray(behaviors)) {
+    return { applied: 0, skipped: 0, operations: [] };
+  }
+  if (typeof applySceneGraphOperation !== 'function') {
+    return { applied: 0, skipped: 0, operations: [] };
+  }
+
+  let applied = 0;
+  let skipped = 0;
+  const operations = [];
+
+  function applyOperation(operation) {
+    const ok = applySceneGraphOperation(operation);
+    if (ok === false) {
+      skipped += 1;
+      return;
+    }
+    broadcast?.(operation);
+    operations.push(operation);
+    applied += 1;
+  }
+
+  if (isBehaviorGraph(behaviors.scene)) {
+    applyOperation({
+      type: 'scene-graph-set',
+      scope: 'scene',
+      graph: behaviors.scene,
+      source,
+    });
+  }
+
+  const objectGraphs =
+    behaviors.objects &&
+    typeof behaviors.objects === 'object' &&
+    !Array.isArray(behaviors.objects)
+      ? behaviors.objects
+      : null;
+
+  if (objectGraphs) {
+    for (const [objectId, graph] of Object.entries(objectGraphs)) {
+      if (!isBehaviorGraph(graph)) {
+        skipped += 1;
+        continue;
+      }
+      if (managedObjects instanceof Map && !managedObjects.has(objectId)) {
+        skipped += 1;
+        continue;
+      }
+      applyOperation({
+        type: 'scene-graph-set',
+        scope: { object: objectId },
+        graph,
+        source,
+      });
+    }
+  }
+
+  return { applied, skipped, operations };
+}

--- a/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js
@@ -1,0 +1,259 @@
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { applySceneDocumentBehaviors } from './apply-scene-behaviors.js';
+
+const validGraph = { nodes: [], edges: [] };
+const validGraphWithNodes = {
+  nodes: [{ id: 'collisionEnter', type: 'event.exists', params: { type: 'collision.enter' } }],
+  edges: [],
+};
+
+test('returns empty result for null behaviors', () => {
+  const result = applySceneDocumentBehaviors(null, {
+    managedObjects: new Map(),
+    applySceneGraphOperation: () => true,
+    broadcast: () => {},
+  });
+  deepStrictEqual(result, { applied: 0, skipped: 0, operations: [] });
+});
+
+test('returns empty result for array behaviors', () => {
+  const result = applySceneDocumentBehaviors([], {
+    managedObjects: new Map(),
+    applySceneGraphOperation: () => true,
+    broadcast: () => {},
+  });
+  deepStrictEqual(result, { applied: 0, skipped: 0, operations: [] });
+});
+
+test('returns empty result when applySceneGraphOperation is not a function', () => {
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    { managedObjects: new Map([['ball', {}]]), broadcast: () => {} }
+  );
+  deepStrictEqual(result, { applied: 0, skipped: 0, operations: [] });
+});
+
+test('applies object behavior for existing object', () => {
+  const calls = { operations: [], broadcasts: [] };
+  const managedObjects = new Map([['ball', {}]]);
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      managedObjects,
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: (op) => calls.broadcasts.push(op),
+    }
+  );
+
+  strictEqual(result.applied, 1);
+  strictEqual(result.skipped, 0);
+  strictEqual(calls.operations.length, 1);
+  strictEqual(calls.operations[0].type, 'scene-graph-set');
+  deepStrictEqual(calls.operations[0].scope, { object: 'ball' });
+  deepStrictEqual(calls.operations[0].graph, validGraph);
+  strictEqual(calls.broadcasts.length, 1);
+  deepStrictEqual(calls.broadcasts[0], calls.operations[0]);
+});
+
+test('skips object behavior for missing object', () => {
+  const calls = { operations: [] };
+  const managedObjects = new Map();
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { 'deleted-object': validGraph } },
+    {
+      managedObjects,
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 0);
+  strictEqual(result.skipped, 1);
+  strictEqual(calls.operations.length, 0);
+});
+
+test('applies scene-scope behavior', () => {
+  const calls = { operations: [], broadcasts: [] };
+
+  const result = applySceneDocumentBehaviors(
+    { scene: validGraphWithNodes },
+    {
+      managedObjects: new Map(),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: (op) => calls.broadcasts.push(op),
+    }
+  );
+
+  strictEqual(result.applied, 1);
+  strictEqual(result.skipped, 0);
+  strictEqual(calls.operations[0].type, 'scene-graph-set');
+  strictEqual(calls.operations[0].scope, 'scene');
+  deepStrictEqual(calls.operations[0].graph, validGraphWithNodes);
+  deepStrictEqual(calls.broadcasts[0], calls.operations[0]);
+});
+
+test('skips invalid graph (non-object)', () => {
+  const calls = { operations: [] };
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: 'not-a-graph' } },
+    {
+      managedObjects: new Map([['ball', {}]]),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 0);
+  strictEqual(result.skipped, 1);
+  strictEqual(calls.operations.length, 0);
+});
+
+test('skips graph without nodes/edges arrays', () => {
+  const calls = { operations: [] };
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: { nodes: 'bad', edges: [] } } },
+    {
+      managedObjects: new Map([['ball', {}]]),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 0);
+  strictEqual(result.skipped, 1);
+  strictEqual(calls.operations.length, 0);
+});
+
+test('counts skipped when applySceneGraphOperation returns false', () => {
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      managedObjects: new Map([['ball', {}]]),
+      applySceneGraphOperation: () => false,
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 0);
+  strictEqual(result.skipped, 1);
+});
+
+test('broadcasts applied operations', () => {
+  const broadcasts = [];
+  const managedObjects = new Map([['ball', {}], ['cube', {}]]);
+
+  applySceneDocumentBehaviors(
+    { objects: { ball: validGraph, cube: validGraphWithNodes } },
+    {
+      managedObjects,
+      applySceneGraphOperation: () => true,
+      broadcast: (op) => broadcasts.push(op),
+    }
+  );
+
+  strictEqual(broadcasts.length, 2);
+  deepStrictEqual(broadcasts[0].scope, { object: 'ball' });
+  deepStrictEqual(broadcasts[1].scope, { object: 'cube' });
+});
+
+test('uses default source in operation', () => {
+  const calls = { operations: [] };
+
+  applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      managedObjects: new Map([['ball', {}]]),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(calls.operations[0].source, 'scene-sync-export-import');
+});
+
+test('uses custom source when provided', () => {
+  const calls = { operations: [] };
+
+  applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      managedObjects: new Map([['ball', {}]]),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+      source: 'custom-source',
+    }
+  );
+
+  strictEqual(calls.operations[0].source, 'custom-source');
+});
+
+test('applies both scene and object behaviors', () => {
+  const calls = { operations: [] };
+  const managedObjects = new Map([['ball', {}]]);
+
+  const result = applySceneDocumentBehaviors(
+    { scene: validGraph, objects: { ball: validGraphWithNodes } },
+    {
+      managedObjects,
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 2);
+  strictEqual(calls.operations[0].scope, 'scene');
+  deepStrictEqual(calls.operations[1].scope, { object: 'ball' });
+});
+
+test('skips non-graph scene value', () => {
+  const calls = { operations: [] };
+
+  const result = applySceneDocumentBehaviors(
+    { scene: null },
+    {
+      managedObjects: new Map(),
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 0);
+  strictEqual(calls.operations.length, 0);
+});
+
+test('does not check managedObjects when it is not a Map', () => {
+  const calls = { operations: [] };
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      applySceneGraphOperation: (op) => { calls.operations.push(op); return true; },
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.applied, 1);
+  strictEqual(calls.operations.length, 1);
+});
+
+test('includes applied operations in result', () => {
+  const managedObjects = new Map([['ball', {}]]);
+
+  const result = applySceneDocumentBehaviors(
+    { objects: { ball: validGraph } },
+    {
+      managedObjects,
+      applySceneGraphOperation: () => true,
+      broadcast: () => {},
+    }
+  );
+
+  strictEqual(result.operations.length, 1);
+  strictEqual(result.operations[0].type, 'scene-graph-set');
+  deepStrictEqual(result.operations[0].scope, { object: 'ball' });
+});

--- a/html/assets/js/scenesync/importers/scene-sync-export/index.js
+++ b/html/assets/js/scenesync/importers/scene-sync-export/index.js
@@ -6,6 +6,17 @@ import { resolveSceneDocumentAssetsFromUrl } from './resolve-url-assets.js';
 import { applySceneDocument } from './apply-scene-document.js';
 import { applySceneDocumentSettings } from './apply-scene-settings.js';
 
+async function applyImportedBehaviorsIfNeeded(resolvedDocument, context) {
+  if (!resolvedDocument.behaviors) return null;
+  if (typeof context.applySceneBehaviors !== 'function') return null;
+
+  return await context.applySceneBehaviors(resolvedDocument.behaviors, {
+    source: 'scene-sync-export-import',
+    notify: true,
+    broadcast: true,
+  });
+}
+
 export { isZipFile };
 
 function cloneJson(value) {
@@ -171,6 +182,7 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
     uploadBlobToStore,
     applySceneBgm,
     applyScenePhysics,
+    applySceneBehaviors,
   } = context;
 
   const result = await loadExportPackageFromBlob(file);
@@ -219,6 +231,7 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
   let completed = false;
   let stats;
   let settingsResult;
+  let behaviorsResult = null;
   try {
     stats = await applySceneDocument(resolvedDocument, {
       managedObjects,
@@ -244,16 +257,20 @@ export async function tryOpenSceneSyncExportFile(file, context = {}) {
       zip: result.zip,
       uploadBlobToStore,
     });
+
+    behaviorsResult = await applyImportedBehaviorsIfNeeded(resolvedDocument, { applySceneBehaviors });
     completed = true;
   } finally {
     if (completed) preview.dispose();
   }
 
+  const behaviorCount = behaviorsResult?.applied || 0;
+  const toastSuffix = behaviorCount > 0 ? ` / Behavior: ${behaviorCount}` : '';
   showToast?.(
-    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}）`
+    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}${toastSuffix}）`
   );
 
-  return { handled: true, stats, settings: settingsResult };
+  return { handled: true, stats, settings: settingsResult, behaviors: behaviorsResult };
 }
 
 export async function tryOpenSceneSyncExportUrl(url, context = {}) {
@@ -268,6 +285,7 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
     uploadBlobToStore,
     applySceneBgm,
     applyScenePhysics,
+    applySceneBehaviors,
     fetchImpl,
   } = context;
 
@@ -320,6 +338,7 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
   let completed = false;
   let stats;
   let settingsResult;
+  let behaviorsResult = null;
   try {
     stats = await applySceneDocument(resolvedDocument, {
       managedObjects,
@@ -345,19 +364,24 @@ export async function tryOpenSceneSyncExportUrl(url, context = {}) {
       zip: result.zip,
       uploadBlobToStore,
     });
+
+    behaviorsResult = await applyImportedBehaviorsIfNeeded(resolvedDocument, { applySceneBehaviors });
     completed = true;
   } finally {
     if (completed) preview.dispose();
   }
 
+  const behaviorCount = behaviorsResult?.applied || 0;
+  const toastSuffix = behaviorCount > 0 ? ` / Behavior: ${behaviorCount}` : '';
   showToast?.(
-    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}）`
+    `Scene Sync Exportを読み込みました（追加: ${stats.added} / 更新: ${stats.updated} / GLB: ${stats.glbImported || 0}${toastSuffix}）`
   );
 
   return {
     handled: true,
     stats,
     settings: settingsResult,
+    behaviors: behaviorsResult,
     sourceUrl: result.sourceUrl || url,
     kind: result.kind,
   };

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -11,6 +11,7 @@ import { createThreeApp } from './core/three-app.js';
 import { createEnvironmentManager } from './core/environment.js';
 import { DragDropManager, SKY_DROP_UPNESS_THRESHOLD } from './components/drag-drop-manager.js';
 import { tryOpenSceneSyncExportFile, tryOpenSceneSyncExportUrl } from './importers/scene-sync-export/index.js';
+import { applySceneDocumentBehaviors } from './importers/scene-sync-export/apply-scene-behaviors.js';
 import { ClipboardImportManager } from './components/clipboard-import-manager.js';
 import { parseLoomletGraphClipboardText } from './components/loomlet-graph-clipboard.js';
 import { GLBFileLoader } from './loaders/glb-file-loader.js';
@@ -10380,6 +10381,12 @@ async function urlImporterCallback(url, position, context = {}) {
       uploadBlobToStore,
       applySceneBgm,
       applyScenePhysics,
+      applySceneBehaviors: (behaviors, options = {}) => applySceneDocumentBehaviors(behaviors, {
+        managedObjects,
+        applySceneGraphOperation,
+        broadcast,
+        source: options.source || 'scene-sync-export-import',
+      }),
     });
     if (sceneSyncExportResult?.handled) return;
   }
@@ -10482,6 +10489,12 @@ const dragDropManager = new DragDropManager({
     uploadBlobToStore,
     applySceneBgm,
     applyScenePhysics,
+    applySceneBehaviors: (behaviors, options = {}) => applySceneDocumentBehaviors(behaviors, {
+      managedObjects,
+      applySceneGraphOperation,
+      broadcast,
+      source: options.source || 'scene-sync-export-import',
+    }),
   }),
   onLoadStart: async ({
     objectId,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js",
     "test:plugins": "node --test html/assets/js/scenesync/plugins/scene-sync-physics-plugin.test.js html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
     "test:export-behavior-runtime": "node --test html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js",
+    "test:scene-sync-export-behaviors": "node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js",
     "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js html/assets/js/scenesync-export/viewer/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"


### PR DESCRIPTION
## 概要

Scene Sync Export ファイルからシーン内のオブジェクトおよびシーン全体に対する behavior graph（ノード・エッジベースのビジュアルスクリプト）をインポートできるようにしました。

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

### 新規ファイル
- `apply-scene-behaviors.js`: behavior graph をシーンに適用するコア関数
  - `isBehaviorGraph()`: グラフの妥当性検証（nodes/edges 配列の確認）
  - `applySceneDocumentBehaviors()`: behaviors オブジェクトを処理し、scene-graph-set 操作を生成・適用
  - 対象オブジェクトの存在確認、グラフ形式の検証、操作の成功/失敗カウント

- `apply-scene-behaviors.test.js`: 259行の包括的なユニットテスト
  - null/配列 behaviors の処理
  - オブジェクト存在確認（managedObjects Map チェック）
  - グラフ形式の検証（nodes/edges 配列の確認）
  - scene スコープと object スコープの両方に対応
  - applySceneGraphOperation の戻り値による成功/失敗判定
  - broadcast 通知の確認
  - source パラメータのカスタマイズ

### 既存ファイル修正
- `index.js` (importers/scene-sync-export)
  - `applyImportedBehaviorsIfNeeded()` 関数を追加
  - `tryOpenSceneSyncExportFile()` と `tryOpenSceneSyncExportUrl()` で behavior インポート処理を統合
  - toast メッセージに behavior 適用数を追加表示
  - 戻り値に `behaviors` フィールドを追加

- `scene.js`
  - `applySceneDocumentBehaviors` をインポート
  - `urlImporterCallback()` と `dragDropManager` の context に `applySceneBehaviors` コールバックを追加
  - managedObjects、applySceneGraphOperation、broadcast を渡して behavior 適用を実現

- `package.json`
  - test script に `apply-scene-behaviors.test.js` を追加

## 変更していないこと

- behavior graph の生成・エクスポート機能（別途実装予定）
- scene-graph-set 操作の実装詳細（既存の applySceneGraphOperation に委譲）
- 物理演算やアセット管理との統合

## staging確認

未確認（behavior graph エクスポート機能の実装待ち）

## テスト/チェック

- `npm run test:scene-sync-export` で 259行のユニットテストが全て pass
- 以下のシナリオをカバー:
  - null/配列 behaviors の拒否
  - 無効な applySceneGraphOperation の処理
  - オブジェクト存在確認
  - グラフ形式の検証
  - scene/object スコープの両対応
  - broadcast 通知
  - source パラメータのカスタマイズ
  - 複数オブジェクトの一括処理

## リスク

- behavior graph エクスポート機能がまだ実装されていないため、実際の動作確認は後続 PR で実施
- managedObjects が Map でない場合は存在確認をスキップ（既存の applySceneDocument

https://claude.ai/code/session_01RoPz4bNf5R1v3a7xRfKsP5