### PR TITLE
[codex] Add staged Rapier parity fixtures

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -115,17 +115,29 @@ bytes.
 
 ### Cross-Host Parity Fixture
 
-The first Unity/Browser parity fixture lives at:
+The Unity/Browser parity fixtures live under:
 
 ```text
-fixtures/rapier/parity-basic-001.json
+fixtures/rapier/
 ```
 
-It defines the `SceneSyncRapierParity-0.30` profile, Rapier core `0.30.0`,
-fixed timestep, gravity, stable object ids, one fixed floor, one dynamic box,
-and sample ticks through tick 600. Browser-side fixture support is implemented
-by `html/assets/js/scenesync/physics/rapier-parity-fixture.js` and covered by
+They define the `SceneSyncRapierParity-0.30` profile, Rapier core `0.30.0`,
+fixed timestep, gravity, stable object ids, body/collider material fields, and
+sample ticks through tick 600. Browser-side fixture support is implemented by
+`html/assets/js/scenesync/physics/rapier-parity-fixture.js` and covered by
 `rapier-parity-fixture.test.js`.
+
+The staged fixtures provide narrower parity coverage for regression isolation:
+
+- `parity-freefall-001.json` removes contacts through tick 600 and exercises
+  free rigid-body integration.
+- `parity-contact-basic-001.json` uses a fixed floor plus one vertically falling
+  dynamic box with zero friction, zero restitution, zero angular velocity, no
+  damping, and explicit combine rules.
+- `parity-basic-001.json` is the original floor + moving/rotating box case. It
+  has been manually validated in Unity 6000 and matches the Browser hashes
+  through tick 600. Keep the staged fixtures around to isolate future
+  contact/material/solver regressions from initial-state setup issues.
 
 The `bodies` array order is the fixture creation order. Hashes and dumps still
 compare bodies/colliders by `stableIdHash(objectId)` so handle order does not

--- a/fixtures/rapier/parity-contact-basic-001.json
+++ b/fixtures/rapier/parity-contact-basic-001.json
@@ -1,0 +1,41 @@
+{
+  "profile": "SceneSyncRapierParity-0.30",
+  "rapierCoreVersion": "0.30.0",
+  "timestep": 0.016666666666666666,
+  "gravity": [0, -9.81, 0],
+  "bodies": [
+    {
+      "id": "floor",
+      "type": "fixed",
+      "shape": "box",
+      "position": [0, -0.5, 0],
+      "rotation": [0, 0, 0, 1],
+      "halfExtents": [6, 0.5, 6],
+      "density": 0,
+      "friction": 0,
+      "restitution": 0,
+      "frictionCombineRule": 0,
+      "restitutionCombineRule": 0
+    },
+    {
+      "id": "box-1",
+      "type": "dynamic",
+      "shape": "box",
+      "position": [0, 5, 0],
+      "rotation": [0, 0, 0, 1],
+      "halfExtents": [0.5, 0.5, 0.5],
+      "density": 1,
+      "linearVelocity": [0, 0, 0],
+      "angularVelocity": [0, 0, 0],
+      "linearDamping": 0,
+      "angularDamping": 0,
+      "canSleep": false,
+      "ccd": false,
+      "friction": 0,
+      "restitution": 0,
+      "frictionCombineRule": 0,
+      "restitutionCombineRule": 0
+    }
+  ],
+  "sampleTicks": [0, 1, 2, 10, 30, 55, 56, 57, 58, 60, 120, 300, 600]
+}

--- a/fixtures/rapier/parity-freefall-001.json
+++ b/fixtures/rapier/parity-freefall-001.json
@@ -1,0 +1,28 @@
+{
+  "profile": "SceneSyncRapierParity-0.30",
+  "rapierCoreVersion": "0.30.0",
+  "timestep": 0.016666666666666666,
+  "gravity": [0, -9.81, 0],
+  "bodies": [
+    {
+      "id": "box-1",
+      "type": "dynamic",
+      "shape": "box",
+      "position": [-0.75, 5, 0],
+      "rotation": [0, 0, 0, 1],
+      "halfExtents": [0.5, 0.5, 0.5],
+      "density": 1,
+      "linearVelocity": [0.75, 0, 0.15],
+      "angularVelocity": [0.35, 1.25, 0.55],
+      "linearDamping": 0.02,
+      "angularDamping": 0.02,
+      "canSleep": false,
+      "ccd": false,
+      "friction": 0.5,
+      "restitution": 0.2,
+      "frictionCombineRule": 0,
+      "restitutionCombineRule": 0
+    }
+  ],
+  "sampleTicks": [0, 1, 2, 10, 60, 120, 300, 600]
+}

--- a/html/assets/js/scenesync/physics/rapier-parity-fixture.test.js
+++ b/html/assets/js/scenesync/physics/rapier-parity-fixture.test.js
@@ -1,6 +1,6 @@
 import test, { before } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 
 import {
   CANONICAL_PHYSICS_HASH_VERSION,
@@ -12,16 +12,72 @@ import {
   createRapierParityWorldFromFixture,
 } from './rapier-parity-fixture.js';
 
-const FIXTURE_URL = new URL('../../../../../fixtures/rapier/parity-basic-001.json', import.meta.url);
+const FIXTURE_DIR_URL = new URL('../../../../../fixtures/rapier/', import.meta.url);
+const EXPECTED_HASHES = {
+  'parity-basic-001.json': {
+    0: '02bbfcc85e21a236',
+    1: 'cb8f1992d35076c7',
+    2: 'b2b7e98db862dabb',
+    10: '1a77e988f4c3b903',
+    60: '0f91006661518595',
+    120: '78f4dbb6435f7ccb',
+    300: '9a6399672d2eddd1',
+    600: '9a6399672d2eddd1',
+  },
+  'parity-contact-basic-001.json': {
+    0: '9ecb260d2bf78356',
+    1: '2bef43f5fdcc5db2',
+    2: '862ceba743bd1a15',
+    10: 'c7b5725488784681',
+    30: 'aa4e2cf669d0a13e',
+    55: 'dc8dae299b6badc3',
+    56: 'e47e0580936645d3',
+    57: 'eb65430cfd43231c',
+    58: 'de65709d75fa9f39',
+    60: '0d78a29829f3e8d4',
+    120: '3c5b2e079372d657',
+    300: 'ecfb6297a05463a8',
+    600: '48af1add55c90f76',
+  },
+  'parity-freefall-001.json': {
+    0: 'bfab2fb4f911bac6',
+    1: 'e83ec7c2f6ed2b8b',
+    2: '5c60df3ce3409ffb',
+    10: 'c9f66903fbb86fdb',
+    60: '50551696bd305d52',
+    120: '016928d21c8bfcbc',
+    300: '2335b3ab4bfe8943',
+    600: '3e8eec1943f444e5',
+  },
+};
 
-let fixture;
+const fixtures = new Map();
 
 before(async () => {
   await initRapierPhysics();
-  fixture = JSON.parse(await readFile(FIXTURE_URL, 'utf8'));
+  const names = (await readdir(FIXTURE_DIR_URL))
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+  for (const name of names) {
+    fixtures.set(name, JSON.parse(await readFile(new URL(name, FIXTURE_DIR_URL), 'utf8')));
+  }
 });
 
-test('loads the shared Rapier parity fixture into a browser Rapier world', () => {
+function assertHashesEqualWithDumps(name, result, expected) {
+  try {
+    assert.deepEqual(result.hashes, expected);
+  } catch (error) {
+    error.message = `${error.message}\n\nCanonical dumps for ${name}:\n${JSON.stringify(result.dumps, null, 2)}`;
+    throw error;
+  }
+}
+
+test('loads all shared Rapier parity fixtures', () => {
+  assert.deepEqual([...fixtures.keys()], Object.keys(EXPECTED_HASHES).sort());
+});
+
+test('loads the basic Rapier parity fixture into a browser Rapier world', () => {
+  const fixture = fixtures.get('parity-basic-001.json');
   const world = createRapierParityWorldFromFixture(fixture);
   try {
     assert.equal(world.options.ground, null);
@@ -33,50 +89,48 @@ test('loads the shared Rapier parity fixture into a browser Rapier world', () =>
   }
 });
 
-test('browser parity fixture records canonical hashes and dumps at sample ticks', () => {
-  const result = createRapierParityResult(fixture);
-  const sampleTickKeys = fixture.sampleTicks.map((tick) => String(tick));
+for (const [fixtureName, expectedHashes] of Object.entries(EXPECTED_HASHES)) {
+  test(`browser parity fixture records canonical hashes and dumps for ${fixtureName}`, () => {
+    const fixture = fixtures.get(fixtureName);
+    const fixturePath = `fixtures/rapier/${fixtureName}`;
+    const result = createRapierParityResult(fixture, { fixturePath });
+    const sampleTickKeys = fixture.sampleTicks.map((tick) => String(tick));
 
-  assert.equal(result.host, 'browser');
-  assert.equal(result.profile, 'SceneSyncRapierParity-0.30');
-  assert.equal(result.rapierCoreVersion, RAPIER_CORE_VERSION);
-  assert.equal(result.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
-  assert.equal(result.fixture, 'fixtures/rapier/parity-basic-001.json');
-  assert.deepEqual(Object.keys(result.hashes), sampleTickKeys);
-  assert.deepEqual(Object.keys(result.dumps), sampleTickKeys);
-  assert.deepEqual(result.hashes, {
-    0: '02bbfcc85e21a236',
-    1: 'cb8f1992d35076c7',
-    2: 'b2b7e98db862dabb',
-    10: '1a77e988f4c3b903',
-    60: '0f91006661518595',
-    120: '78f4dbb6435f7ccb',
-    300: '9a6399672d2eddd1',
-    600: '9a6399672d2eddd1',
+    assert.equal(result.host, 'browser');
+    assert.equal(result.profile, 'SceneSyncRapierParity-0.30');
+    assert.equal(result.rapierCoreVersion, RAPIER_CORE_VERSION);
+    assert.equal(result.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
+    assert.equal(result.fixture, fixturePath);
+    assert.deepEqual(Object.keys(result.hashes), sampleTickKeys);
+    assert.deepEqual(Object.keys(result.dumps), sampleTickKeys);
+    assertHashesEqualWithDumps(fixtureName, result, expectedHashes);
+
+    for (const hash of Object.values(result.hashes)) {
+      assert.match(hash, /^[0-9a-f]{16}$/);
+    }
+
+    const fixtureIds = fixture.bodies.map((body) => body.id);
+    const initialDump = result.dumps['0'];
+    assert.equal(initialDump.tick, 0);
+    assert.equal(initialDump.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
+    assert.deepEqual(new Set(initialDump.bodies.map((body) => body.id)), new Set(fixtureIds));
+    assert.deepEqual(new Set(initialDump.colliders.map((collider) => collider.id)), new Set(fixtureIds));
+
+    const boxFixture = fixture.bodies.find((body) => body.id === 'box-1');
+    const boxBody = initialDump.bodies.find((body) => body.id === 'box-1');
+    const boxCollider = initialDump.colliders.find((collider) => collider.id === 'box-1');
+    assert.deepEqual(boxBody.position, boxFixture.position);
+    assert.deepEqual(boxBody.linvel.map(Math.fround), boxFixture.linearVelocity.map(Math.fround));
+    assert.equal(boxCollider.shape, 'box');
+    assert.deepEqual(boxCollider.halfExtents, boxFixture.halfExtents);
+    assert.equal(boxCollider.density, boxFixture.density);
+    assert.equal(Math.fround(boxCollider.friction), Math.fround(boxFixture.friction));
+    assert.equal(Math.fround(boxCollider.restitution), Math.fround(boxFixture.restitution));
   });
-
-  for (const hash of Object.values(result.hashes)) {
-    assert.match(hash, /^[0-9a-f]{16}$/);
-  }
-
-  const initialDump = result.dumps['0'];
-  assert.equal(initialDump.tick, 0);
-  assert.equal(initialDump.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
-  assert.deepEqual(new Set(initialDump.bodies.map((body) => body.id)), new Set(['box-1', 'floor']));
-  assert.deepEqual(new Set(initialDump.colliders.map((collider) => collider.id)), new Set(['box-1', 'floor']));
-
-  const boxBody = initialDump.bodies.find((body) => body.id === 'box-1');
-  const boxCollider = initialDump.colliders.find((collider) => collider.id === 'box-1');
-  assert.deepEqual(boxBody.position, [-0.75, 5, 0]);
-  assert.deepEqual(boxBody.linvel.map(Math.fround), [0.75, 0, 0.15].map(Math.fround));
-  assert.equal(boxCollider.shape, 'box');
-  assert.deepEqual(boxCollider.halfExtents, [0.5, 0.5, 0.5]);
-  assert.equal(boxCollider.density, 1);
-  assert.equal(boxCollider.friction, 0.5);
-  assert.equal(Math.fround(boxCollider.restitution), Math.fround(0.2));
-});
+}
 
 test('browser parity fixture result reports the supplied fixture path', () => {
+  const fixture = fixtures.get('parity-basic-001.json');
   const result = createRapierParityResult(fixture, {
     fixturePath: 'fixtures/rapier/custom.json',
     includeDumps: false,


### PR DESCRIPTION
## Summary
- add staged cross-host parity fixtures for freefall and simplified contact debugging
- run every shared parity fixture in the browser baseline test and include canonical dumps on mismatch
- document that `parity-basic-001` now matches Unity through tick 600 and keep the staged fixtures for future regression isolation

## Why
The original parity fixture now matches across Unity and Browser, so the next useful step is a smaller staged fixture set that can isolate future contact, material, or solver regressions without changing the shared parity schema.

## Impact
- Browser parity coverage now includes `parity-basic-001`, `parity-freefall-001`, and `parity-contact-basic-001`
- Fixture mismatches surface canonical dumps directly from the test failure
- Physics parity docs reflect the current measured cross-host result

## Test
- npm run test:physics
