### PR TITLE
[codex] Stabilize Scene Sync audio auto sync

### DIFF
--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -34,6 +34,60 @@ function safeSeek(audio, time) {
   try { audio.currentTime = time; } catch {}
 }
 
+function safeAutoSeek(entry, time, nowMs, { minIntervalMs = 250, force = false } = {}) {
+  const audio = entry?.audio;
+  if (!audio || !Number.isFinite(time) || time < 0) return false;
+  if (!force && audio.seeking === true) return false;
+  if (
+    !force
+    && Number.isFinite(entry.lastAutoSeekAtMs)
+    && Number.isFinite(nowMs)
+    && nowMs - entry.lastAutoSeekAtMs < minIntervalMs
+  ) {
+    return false;
+  }
+
+  try {
+    audio.currentTime = time;
+    entry.lastAutoSeekAtMs = Number.isFinite(nowMs) ? nowMs : defaultNow();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function wrappedDistance(a, b, duration) {
+  const direct = Math.abs(a - b);
+  return duration ? Math.min(direct, Math.max(0, duration - direct)) : direct;
+}
+
+function noteAutoSyncTarget(entry, target, nowMs, source, clockState) {
+  const previousTarget = entry.lastAutoTargetTime;
+  const previousNow = entry.lastAutoTargetAtMs;
+  let jumped = false;
+
+  if (Number.isFinite(previousTarget) && Number.isFinite(previousNow) && Number.isFinite(nowMs)) {
+    const elapsed = Math.max(0, (nowMs - previousNow) / 1000);
+    const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0 ? clockState.rate : 1;
+    const expectedRate = positiveNumber(source?.playbackRate, 1) * transportRate;
+    let expected = previousTarget + elapsed * expectedRate;
+    const duration = audioDuration(entry.audio);
+    if (duration && source?.loop === true) {
+      expected = ((expected % duration) + duration) % duration;
+    }
+    const distance = duration && source?.loop === true
+      ? wrappedDistance(target, expected, duration)
+      : Math.abs(target - expected);
+    jumped = distance > 0.3;
+  } else {
+    jumped = true;
+  }
+
+  entry.lastAutoTargetTime = target;
+  entry.lastAutoTargetAtMs = Number.isFinite(nowMs) ? nowMs : defaultNow();
+  return jumped;
+}
+
 function safeLoad(audio) {
   try { audio?.load?.(); } catch {}
 }
@@ -243,7 +297,7 @@ export function createObjectAudioController({
     safeSeek(entry.audio, duration ? Math.min(offset, duration) : offset);
   }
 
-  function syncAnimationEntry(entry) {
+  function syncAnimationEntry(entry, nowMs) {
     const sync = entry.sync;
     if (!sync || sync.mode !== 'animation' || typeof getAnimationSample !== 'function') return false;
 
@@ -259,10 +313,11 @@ export function createObjectAudioController({
     const driftThreshold = Number.isFinite(sync.driftThreshold) ? sync.driftThreshold : 0.05;
     const looped = entry.lastSampleTime != null && sample.time < entry.lastSampleTime;
     entry.lastSampleTime = sample.time;
+    const targetJumped = noteAutoSyncTarget(entry, target, nowMs, entry.source, null);
 
     const drift = Math.abs((entry.audio.currentTime || 0) - target);
     if (drift > driftThreshold && (sync.resyncOnLoop !== false || !looped)) {
-      safeSeek(entry.audio, target);
+      safeAutoSeek(entry, target, nowMs, { force: targetJumped });
     }
 
     return true;
@@ -271,10 +326,11 @@ export function createObjectAudioController({
   function syncTimelineEntry(entry, nowMs, clockState, driftThreshold = 0.15) {
     const target = timelineTargetTime(entry, clockState, nowMs, startMs);
     if (!Number.isFinite(target)) return false;
+    const targetJumped = noteAutoSyncTarget(entry, target, nowMs, entry.source, clockState);
 
     const drift = Math.abs((entry.audio.currentTime || 0) - target);
     if (drift > driftThreshold) {
-      safeSeek(entry.audio, target);
+      safeAutoSeek(entry, target, nowMs, { force: targetJumped });
     }
     return true;
   }
@@ -295,7 +351,7 @@ export function createObjectAudioController({
       return;
     }
 
-    const syncedToAnimation = syncAnimationEntry(entry);
+    const syncedToAnimation = syncAnimationEntry(entry, nowMs);
 
     if (isTransportPaused(clockState) || entry.userPaused) {
       if (entry.audio.paused === false) safePause(entry.audio);
@@ -404,6 +460,9 @@ export function createObjectAudioController({
       autoplayBlocked: false,
       warnedAutoplayBlocked: false,
       lastSampleTime: null,
+      lastAutoSeekAtMs: null,
+      lastAutoTargetTime: null,
+      lastAutoTargetAtMs: null,
       oneShotActive: false,
       oneShotToken: 0,
     };

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -69,8 +69,7 @@ function noteAutoSyncTarget(entry, target, nowMs, source, clockState) {
   if (Number.isFinite(previousTarget) && Number.isFinite(previousNow) && Number.isFinite(nowMs)) {
     const elapsed = Math.max(0, (nowMs - previousNow) / 1000);
     const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0 ? clockState.rate : 1;
-    const expectedRate = positiveNumber(source?.playbackRate, 1) * transportRate;
-    let expected = previousTarget + elapsed * expectedRate;
+    let expected = previousTarget + elapsed * transportRate;
     const duration = audioDuration(entry.audio);
     if (duration && source?.loop === true) {
       expected = ((expected % duration) + duration) % duration;
@@ -80,7 +79,7 @@ function noteAutoSyncTarget(entry, target, nowMs, source, clockState) {
       : Math.abs(target - expected);
     jumped = distance > 0.3;
   } else {
-    jumped = true;
+    jumped = false;
   }
 
   entry.lastAutoTargetTime = target;

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
@@ -113,3 +113,31 @@ test('does not restart an in-flight media seek during continuous auto sync', () 
 
   assert.equal(audio.currentTime, 0.8);
 });
+
+test('does not treat playbackRate progression as repeated timeline jumps', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 10, currentTime: 1 }),
+    source: { playbackRate: 2 },
+  });
+
+  controller.tick(1000, { t: 1, isPaused: false, playing: true, rate: 1 });
+  audio.currentTime = 0.8;
+  audio.seeking = true;
+
+  controller.tick(1100, { t: 1.1, isPaused: false, playing: true, rate: 1 });
+
+  assert.equal(audio.currentTime, 0.8);
+});
+
+test('forces auto seek when the player timeline jumps shortly after a resync', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 10, currentTime: 0 }),
+  });
+
+  controller.tick(1000, { t: 1, isPaused: false, playing: true, rate: 1 });
+  assert.equal(audio.currentTime, 1);
+
+  controller.tick(1100, { t: 7, isPaused: false, playing: true, rate: 1 });
+
+  assert.equal(audio.currentTime, 7);
+});

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
@@ -12,6 +12,7 @@ class FakeAudio {
     this.paused = true;
     this.playbackRate = 1;
     this.preload = '';
+    this.seeking = false;
     this.src = '';
     this.volume = 1;
     this.pauseCount = 0;
@@ -99,3 +100,16 @@ test('resyncs object audio when the player timeline seeks while playing', () => 
   assert.equal(audio.currentTime, 7);
 });
 
+test('does not restart an in-flight media seek during continuous auto sync', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 10, currentTime: 1 }),
+  });
+
+  controller.tick(1000, { t: 1, isPaused: false, playing: true, rate: 1 });
+  audio.currentTime = 0.8;
+  audio.seeking = true;
+
+  controller.tick(1100, { t: 1.1, isPaused: false, playing: true, rate: 1 });
+
+  assert.equal(audio.currentTime, 0.8);
+});

--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -41,6 +41,63 @@ function safeSeek(audio, time) {
   try { audio.currentTime = time; } catch { /* noop */ }
 }
 
+function safeAutoSeek(entry, time, nowMs, { minIntervalMs = 250, force = false } = {}) {
+  const audio = entry?.audio;
+  if (!audio) return false;
+  if (!Number.isFinite(time) || time < 0) return false;
+  if (!force && audio.seeking === true) return false;
+  if (
+    !force
+    && Number.isFinite(entry.lastAutoSeekAtMs)
+    && Number.isFinite(nowMs)
+    && nowMs - entry.lastAutoSeekAtMs < minIntervalMs
+  ) {
+    return false;
+  }
+
+  try {
+    audio.currentTime = time;
+    entry.lastAutoSeekAtMs = Number.isFinite(nowMs) ? nowMs : defaultNow();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function wrappedDistance(a, b, duration) {
+  const direct = Math.abs(a - b);
+  return duration ? Math.min(direct, Math.max(0, duration - direct)) : direct;
+}
+
+function noteAutoSyncTarget(entry, target, nowMs, config, clockState) {
+  const previousTarget = entry.lastAutoTargetTime;
+  const previousNow = entry.lastAutoTargetAtMs;
+  let jumped = false;
+
+  if (Number.isFinite(previousTarget) && Number.isFinite(previousNow) && Number.isFinite(nowMs)) {
+    const elapsed = Math.max(0, (nowMs - previousNow) / 1000);
+    const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0 ? clockState.rate : 1;
+    const sourceRate = typeof config?.playbackRate === 'number' && config.playbackRate > 0
+      ? config.playbackRate
+      : 1;
+    let expected = previousTarget + elapsed * sourceRate * transportRate;
+    const duration = Number.isFinite(entry.audio?.duration) && entry.audio.duration > 0 ? entry.audio.duration : null;
+    if (duration && config?.loop === true) {
+      expected = ((expected % duration) + duration) % duration;
+    }
+    const distance = duration && config?.loop === true
+      ? wrappedDistance(target, expected, duration)
+      : Math.abs(target - expected);
+    jumped = distance > 0.3;
+  } else {
+    jumped = true;
+  }
+
+  entry.lastAutoTargetTime = target;
+  entry.lastAutoTargetAtMs = Number.isFinite(nowMs) ? nowMs : defaultNow();
+  return jumped;
+}
+
 // アニメーション再生位置(sampleTime)を audio の再生時刻へ変換する。
 // offset を加算し、duration が判明していれば loop なら巻き戻し、非 loop ならクランプする。
 function animationTargetTime(audio, sampleTime, offset, loop) {
@@ -137,6 +194,9 @@ export function createAudioSourceController(deps = {}) {
           started: false,
           autoplayBlocked: false,
           lastSampleTime: null,
+          lastAutoSeekAtMs: null,
+          lastAutoTargetTime: null,
+          lastAutoTargetAtMs: null,
         };
         map.set(name, entry);
       } else {
@@ -374,9 +434,10 @@ export function createAudioSourceController(deps = {}) {
         const target = animationTargetTime(audio, sample.time, offset, config.loop);
         const looped = entry.lastSampleTime != null && sample.time < entry.lastSampleTime;
         entry.lastSampleTime = sample.time;
+        const targetJumped = noteAutoSyncTarget(entry, target, nowMs, config, clockState);
         const drift = Math.abs((audio.currentTime || 0) - target);
         if (drift > driftThreshold && (sync.resyncOnLoop !== false || !looped)) {
-          safeSeek(audio, target);
+          safeAutoSeek(entry, target, nowMs, { force: targetJumped });
         }
       }
     }
@@ -402,16 +463,18 @@ export function createAudioSourceController(deps = {}) {
             const animTarget = animationTargetTime(audio, sample.time, config.offset || 0, config.loop);
             const drift = Math.abs((audio.currentTime || 0) - animTarget);
             if (drift > driftThreshold) {
-              safeSeek(audio, animTarget);
+              const targetJumped = noteAutoSyncTarget(entry, animTarget, nowMs, config, clockState);
+              safeAutoSeek(entry, animTarget, nowMs, { force: targetJumped });
             }
           }
         }
         tryPlay(entry, objectId, name);
         return;
       }
+      const targetJumped = noteAutoSyncTarget(entry, target, nowMs, config, clockState);
       const drift = Math.abs((audio.currentTime || 0) - target);
       if (drift > driftThreshold) {
-        safeSeek(audio, target);
+        safeAutoSeek(entry, target, nowMs, { force: targetJumped });
       }
     }
 

--- a/html/assets/js/scenesync/audio/audio-source-controller.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.js
@@ -77,10 +77,7 @@ function noteAutoSyncTarget(entry, target, nowMs, config, clockState) {
   if (Number.isFinite(previousTarget) && Number.isFinite(previousNow) && Number.isFinite(nowMs)) {
     const elapsed = Math.max(0, (nowMs - previousNow) / 1000);
     const transportRate = Number.isFinite(clockState?.rate) && clockState.rate > 0 ? clockState.rate : 1;
-    const sourceRate = typeof config?.playbackRate === 'number' && config.playbackRate > 0
-      ? config.playbackRate
-      : 1;
-    let expected = previousTarget + elapsed * sourceRate * transportRate;
+    let expected = previousTarget + elapsed * transportRate;
     const duration = Number.isFinite(entry.audio?.duration) && entry.audio.duration > 0 ? entry.audio.duration : null;
     if (duration && config?.loop === true) {
       expected = ((expected % duration) + duration) % duration;
@@ -90,7 +87,7 @@ function noteAutoSyncTarget(entry, target, nowMs, config, clockState) {
       : Math.abs(target - expected);
     jumped = distance > 0.3;
   } else {
-    jumped = true;
+    jumped = false;
   }
 
   entry.lastAutoTargetTime = target;

--- a/html/assets/js/scenesync/audio/audio-source-controller.test.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.test.js
@@ -10,6 +10,7 @@ class FakeAudio {
     this.loop = false;
     this.paused = true;
     this.playbackRate = 1;
+    this.seeking = false;
     this.volume = 1;
     this.seekLog = [];
     this.pauseCount = 0;
@@ -148,4 +149,17 @@ test('resyncs audio to animation position after deselect in host-follow mode', (
   controller.tick(16, hostFollowClock);
   assert.ok(Math.abs(audio.currentTime - 7.3) < 0.001, `expected ~7.3, got ${audio.currentTime}`);
   assert.equal(audio.paused, false);
+});
+
+test('does not restart an in-flight media seek during continuous auto sync', () => {
+  const audio = new FakeAudio({ duration: 10, currentTime: 1 });
+  const { controller } = createHarness({ audio });
+
+  controller.tick(1000, { mode: 'local', t: 1, isPaused: false, rate: 1 });
+  audio.currentTime = 0.8;
+  audio.seeking = true;
+
+  controller.tick(1100, { mode: 'local', t: 1.1, isPaused: false, rate: 1 });
+
+  assert.equal(audio.currentTime, 0.8);
 });

--- a/html/assets/js/scenesync/audio/audio-source-controller.test.js
+++ b/html/assets/js/scenesync/audio/audio-source-controller.test.js
@@ -31,7 +31,14 @@ class FakeAudio {
   load() {}
 }
 
-function createHarness({ audio = new FakeAudio(), offset = 0, loop = true, getAnimationSample = null, isObjectBeingEdited = () => false } = {}) {
+function createHarness({
+  audio = new FakeAudio(),
+  offset = 0,
+  loop = true,
+  playbackRate = 1,
+  getAnimationSample = null,
+  isObjectBeingEdited = () => false,
+} = {}) {
   const controller = createAudioSourceController({
     createAudio: () => audio,
     getObjectRuntimeTime: (_objectId, _nowMs, clockState) => clockState?.t ?? 0,
@@ -45,6 +52,7 @@ function createHarness({ audio = new FakeAudio(), offset = 0, loop = true, getAn
       state: 'playing',
       loop,
       offset,
+      playbackRate,
     },
   });
 
@@ -162,4 +170,29 @@ test('does not restart an in-flight media seek during continuous auto sync', () 
   controller.tick(1100, { mode: 'local', t: 1.1, isPaused: false, rate: 1 });
 
   assert.equal(audio.currentTime, 0.8);
+});
+
+test('does not treat playbackRate progression as repeated timeline jumps', () => {
+  const audio = new FakeAudio({ duration: 10, currentTime: 1 });
+  const { controller } = createHarness({ audio, playbackRate: 2 });
+
+  controller.tick(1000, { mode: 'local', t: 1, isPaused: false, rate: 1 });
+  audio.currentTime = 0.8;
+  audio.seeking = true;
+
+  controller.tick(1100, { mode: 'local', t: 1.1, isPaused: false, rate: 1 });
+
+  assert.equal(audio.currentTime, 0.8);
+});
+
+test('forces auto seek when the player timeline jumps shortly after a resync', () => {
+  const audio = new FakeAudio({ duration: 10, currentTime: 0 });
+  const { controller } = createHarness({ audio });
+
+  controller.tick(1000, { mode: 'local', t: 1, isPaused: false, rate: 1 });
+  assert.equal(audio.currentTime, 1);
+
+  controller.tick(1100, { mode: 'local', t: 7, isPaused: false, rate: 1 });
+
+  assert.equal(audio.currentTime, 7);
 });


### PR DESCRIPTION
## Summary
- Prevent automatic audio sync from repeatedly assigning `currentTime` while a media seek is already in progress.
- Throttle continuous automatic resync seeks, while still forcing an immediate seek when the timeline jumps.
- Add regression coverage for in-flight media seek handling in the Scene Sync runtime and export viewer audio controllers.

## Root Cause
Scene Sync corrected audio drift by seeking during normal frame updates. In WebXR or other high-load playback, repeated `audio.currentTime` writes can interrupt browser media seeking and cause audible stutter or delayed playback.

## Validation
- `npm run test:audio-source-controller`
- `node --test html/assets/js/scenesync-export/viewer/object-audio-controller.test.js`
- `npm run test:scene-sync-export-import`
- `node --check html/assets/js/scenesync-export/viewer/object-audio-controller.js`
- `node --check html/assets/js/scenesync/audio/audio-source-controller.js`