### PR TITLE
[codex] Use audio as export viewer playback clock

### DIFF
--- a/apps/presence-server/tests/object-audio-controller.test.mjs
+++ b/apps/presence-server/tests/object-audio-controller.test.mjs
@@ -209,6 +209,39 @@ test('static object AudioSource controller', async (t) => {
     assert.ok(Math.abs(created[0].currentTime - 1.3) < 0.001);
   });
 
+  await t.test('uses playing timeline audio as a media clock source', () => {
+    const { controller, created } = makeController({
+      audioSources: {
+        default: {
+          name: 'default',
+          url: 'music.mp3',
+          state: 'playing',
+          loop: true,
+          offset: 0.5,
+        },
+      },
+    });
+
+    controller.tick(1000, { t: 4, isPaused: false, playing: true, rate: 1, duration: 10 });
+    created[0].currentTime = 4.25;
+
+    const clockState = controller.getMediaClockState({
+      t: 4.5,
+      time: 4.5,
+      isPaused: false,
+      playing: true,
+      rate: 1,
+      duration: 10,
+    });
+
+    assert.equal(clockState.mediaClockActive, true);
+    assert.deepEqual(clockState.mediaClockSource, { objectId: 'speaker-1', name: 'default' });
+    assert.equal(clockState.time, 3.75);
+
+    controller.tick(1100, clockState);
+    assert.equal(created[0].currentTime, 4.25);
+  });
+
   await t.test('routes syncToAnimation and unsync effects', () => {
     let sampleTime = 4;
     const { controller, created } = makeController({

--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -485,6 +485,13 @@ export async function createViewerCore({
     objectAudioController.tick(now, clockState);
   }
 
+  function alignClockToObjectAudio(clockState, now = performance.now()) {
+    const mediaClockState = objectAudioController.getMediaClockState(clockState);
+    if (!mediaClockState) return clockState;
+    sceneClock.syncPlaybackTime(mediaClockState.time, now);
+    return mediaClockState;
+  }
+
   function evaluateAndSyncClock(clockState, now = performance.now()) {
     evaluateSceneAtClock(clockState);
     syncObjectAudioAtClock(clockState, now);
@@ -533,7 +540,7 @@ export async function createViewerCore({
   const api = {
     update() {
       const now = performance.now();
-      const clockState = sceneClock.tick(now);
+      const clockState = alignClockToObjectAudio(sceneClock.tick(now), now);
       const scheduleContext = createSceneSyncScheduleContext({
         now,
         frameId: ++runtimeFrameId,
@@ -548,7 +555,7 @@ export async function createViewerCore({
     },
 
     getSceneClockState() {
-      return sceneClock.getState();
+      return alignClockToObjectAudio(sceneClock.getState());
     },
 
     onStateChange(listener) {
@@ -562,7 +569,7 @@ export async function createViewerCore({
     },
 
     getPhysicsPlaybackState() {
-      const state = sceneClock.getState();
+      const state = alignClockToObjectAudio(sceneClock.getState());
       return { time: state.time, duration: state.duration, playing: state.playing };
     },
 

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -166,6 +166,23 @@ function timelineTargetTime(entry, clockState, nowMs, startMs) {
   return Math.max(0, target);
 }
 
+function timelineTimeFromAudio(entry, clockState = null) {
+  const audioTime = Number.isFinite(entry?.audio?.currentTime) ? entry.audio.currentTime : null;
+  if (!Number.isFinite(audioTime)) return null;
+
+  const offset = finiteNumber(entry.source.offset, 0);
+  const duration = Number.isFinite(clockState?.duration) && clockState.duration > 0
+    ? clockState.duration
+    : null;
+  let time = audioTime - offset;
+
+  if (duration) {
+    time = Math.min(Math.max(0, time), duration);
+  }
+
+  return Math.max(0, time);
+}
+
 function applyTransportPlaybackRate(audio, source, clockState) {
   if (!audio) return;
   const sourceRate = positiveNumber(source.playbackRate, 1);
@@ -207,6 +224,25 @@ export function createObjectAudioController({
 
   function getPlaybackTargetEntries() {
     return entries.filter((entry) => entry.desiredState === 'playing');
+  }
+
+  function getMediaClockEntry() {
+    return entries.find((entry) => (
+      entry.desiredState === 'playing'
+      && entry.userPaused !== true
+      && entry.oneShotActive !== true
+      && !entry.sync
+      && entry.source.clockMaster !== false
+      && entry.audio?.paused === false
+      && entry.audio?.seeking !== true
+      && Number.isFinite(entry.audio?.currentTime)
+    )) || null;
+  }
+
+  function resetMediaClockTracking() {
+    for (const entry of entries) {
+      entry.lastMediaClockTime = null;
+    }
   }
 
   function cancelEntryOneShot(entry) {
@@ -462,6 +498,7 @@ export function createObjectAudioController({
       lastAutoSeekAtMs: null,
       lastAutoTargetTime: null,
       lastAutoTargetAtMs: null,
+      lastMediaClockTime: null,
       oneShotActive: false,
       oneShotToken: 0,
     };
@@ -519,8 +556,40 @@ export function createObjectAudioController({
       return getPlaybackTargetEntries().map((entry) => entry.audio);
     },
 
+    getMediaClockState(clockState = null) {
+      if (isTransportPaused(clockState)) {
+        resetMediaClockTracking();
+        return null;
+      }
+
+      const entry = getMediaClockEntry();
+      if (!entry) {
+        resetMediaClockTracking();
+        return null;
+      }
+
+      const time = timelineTimeFromAudio(entry, clockState);
+      if (!Number.isFinite(time)) return null;
+
+      const previous = Number.isFinite(entry.lastMediaClockTime) ? entry.lastMediaClockTime : time;
+      entry.lastMediaClockTime = time;
+
+      return {
+        ...(clockState || {}),
+        time,
+        t: time,
+        delta: Math.max(0, time - previous),
+        mediaClockActive: true,
+        mediaClockSource: {
+          objectId: entry.objectId,
+          name: entry.name,
+        },
+      };
+    },
+
     playPlaybackTargets(clockState = null, nowMs = now()) {
       return Promise.allSettled(getPlaybackTargetEntries().map((entry) => {
+        entry.lastMediaClockTime = null;
         entry.userPaused = false;
         tickEntry(entry, nowMs, clockState);
         if (isTransportPaused(clockState)) return Promise.resolve(true);
@@ -531,6 +600,7 @@ export function createObjectAudioController({
     pausePlaybackTargets() {
       for (const entry of getPlaybackTargetEntries()) {
         cancelEntryOneShot(entry);
+        entry.lastMediaClockTime = null;
         entry.userPaused = true;
         safePause(entry.audio);
       }
@@ -544,20 +614,24 @@ export function createObjectAudioController({
 
       if (effect.type === 'audioSource.play') {
         cancelEntryOneShot(entry);
+        entry.lastMediaClockTime = null;
         entry.desiredState = 'playing';
         entry.userPaused = false;
       } else if (effect.type === 'audioSource.pause') {
         cancelEntryOneShot(entry);
+        entry.lastMediaClockTime = null;
         entry.desiredState = 'paused';
         entry.userPaused = false;
         safePause(entry.audio);
       } else if (effect.type === 'audioSource.stop') {
         cancelEntryOneShot(entry);
+        entry.lastMediaClockTime = null;
         entry.desiredState = 'stopped';
         entry.userPaused = false;
         safePause(entry.audio);
         safeSeek(entry.audio, 0);
       } else if (effect.type === 'audioSource.seek') {
+        entry.lastMediaClockTime = null;
         safeSeek(entry.audio, Math.max(0, finiteNumber(effect.time, 0)));
       } else if (effect.type === 'audioSource.playOneShot') {
         const options = effect.options || {};
@@ -595,6 +669,7 @@ export function createObjectAudioController({
         entry.source.url = effect.url;
         entry.audio.src = effect.url;
         entry.started = false;
+        entry.lastMediaClockTime = null;
         entry.autoplayBlocked = false;
         safeLoad(entry.audio);
       } else if (effect.type === 'audioSource.syncToAnimation') {

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
@@ -89,6 +89,58 @@ test('plays object audio from the player timeline and applies transport rate', (
   assert.equal(audio.playbackRate, 2.5);
 });
 
+test('exposes playing timeline audio as the media clock', () => {
+  const { audio, controller } = createHarness({ source: { offset: 0.5 } });
+
+  controller.tick(1000, { t: 4, isPaused: false, playing: true, rate: 1, duration: 10 });
+  audio.currentTime = 4.25;
+
+  const clockState = controller.getMediaClockState({
+    t: 4.5,
+    time: 4.5,
+    isPaused: false,
+    playing: true,
+    rate: 1,
+    duration: 10,
+  });
+
+  assert.equal(clockState.mediaClockActive, true);
+  assert.deepEqual(clockState.mediaClockSource, { objectId: 'speaker', name: 'default' });
+  assert.equal(clockState.time, 3.75);
+  assert.equal(clockState.t, 3.75);
+
+  controller.tick(1100, clockState);
+  assert.equal(audio.currentTime, 4.25);
+});
+
+test('does not expose event-only or animation-synced audio as the media clock', () => {
+  const eventOnly = createHarness({ source: { state: 'stopped' } });
+  eventOnly.audio.paused = false;
+  eventOnly.audio.currentTime = 2;
+  assert.equal(eventOnly.controller.getMediaClockState({
+    t: 2,
+    isPaused: false,
+    playing: true,
+    rate: 1,
+  }), null);
+
+  const animationSynced = createHarness({
+    source: {
+      sync: { mode: 'animation', offset: 0 },
+    },
+    getAnimationSample: () => ({ time: 2, duration: 10 }),
+  });
+  animationSynced.controller.tick(1000, { t: 2, isPaused: false, playing: true, rate: 1 });
+  animationSynced.audio.currentTime = 2;
+
+  assert.equal(animationSynced.controller.getMediaClockState({
+    t: 2,
+    isPaused: false,
+    playing: true,
+    rate: 1,
+  }), null);
+});
+
 test('resyncs object audio when the player timeline seeks while playing', () => {
   const { audio, controller } = createHarness();
 

--- a/html/assets/js/scenesync-export/viewer/viewer-scene-clock.js
+++ b/html/assets/js/scenesync-export/viewer/viewer-scene-clock.js
@@ -176,6 +176,13 @@ export function createViewerSceneClock({
     emit();
   }
 
+  function syncPlaybackTime(seconds, nowMs = now()) {
+    const nextTime = clampTime(seconds, state.duration);
+    state.localTime = nextTime;
+    state.lastUpdateNow = nowMs;
+    state.pausedAt = state.paused ? nextTime : null;
+  }
+
   function setRate(rate, nowMs = now()) {
     const nextRate = Number(rate);
     if (!Number.isFinite(nextRate) || nextRate < 0) return;
@@ -212,6 +219,7 @@ export function createViewerSceneClock({
     pause,
     stop,
     seek,
+    syncPlaybackTime,
     setRate,
     activateTransport,
     deactivateTransport,

--- a/html/assets/js/scenesync-export/viewer/viewer-scene-clock.test.js
+++ b/html/assets/js/scenesync-export/viewer/viewer-scene-clock.test.js
@@ -57,6 +57,26 @@ test('viewer scene clock clamps to duration and restarts when played from the en
   assert.equal(clock.getState().playing, true);
 });
 
+test('viewer scene clock can be aligned to media time without emitting transport events', () => {
+  let now = 0;
+  let changeCount = 0;
+  const clock = createViewerSceneClock({ duration: 10, now: () => now });
+  clock.onChange(() => { changeCount += 1; });
+
+  clock.play();
+  assert.equal(changeCount, 1);
+
+  now = 1000;
+  clock.syncPlaybackTime(4, now);
+
+  assert.equal(clock.getState().time, 4);
+  assert.equal(clock.getState().playing, true);
+  assert.equal(changeCount, 1);
+
+  now = 1500;
+  assert.equal(clock.tick().time, 4.5);
+});
+
 test('viewer playback duration includes animation and physics durations', () => {
   const duration = calculateViewerPlaybackDuration({
     defaultDuration: 1,


### PR DESCRIPTION
## Summary
- Use playing timeline AudioSources as the export viewer's media clock during normal playback.
- Keep explicit transport operations such as play, pause, stop, and seek clock-driven.
- Add tests covering media-clock alignment and excluding event-only or animation-synced audio.

## Root Cause
On Quest 3 WebXR, frame pressure can make the HTML audio element drift behind the Scene Clock. The previous viewer corrected that drift by seeking `currentTime` during playback, which can make Quest browser audio stutter or lag further.

## Validation
- `npm run test:scene-sync-export-import`
- `node --test apps/presence-server/tests/object-audio-controller.test.mjs`
- `node --check html/assets/js/scenesync-export/viewer/object-audio-controller.js`
- `node --check html/assets/js/scenesync-export/viewer/create-viewer-core.js`
- `node --check html/assets/js/scenesync-export/viewer/viewer-scene-clock.js`

Playwright browser launch was blocked locally by macOS sandbox permission errors, so Quest/manual browser verification was not performed.