### PR TITLE
[codex] Add Scene Sync Rapier Unity bridge

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -253,6 +253,36 @@ Editor Shell remains shared editing, not shared playback.
 XR does not change physics time. Entering or exiting XR must not change Clock
 Mode and must not reset ObjectAge.
 
+## Unity Rapier Bridge
+
+Unity support is implemented as an optional downstream package:
+
+```text
+unity/com.afjk.scene-sync-rapier
+```
+
+`com.afjk.scene-sync` stays free of a hard Rapier dependency. The base package
+only exposes incoming raw scene messages and preserves scene/object `physics`
+JSON through `SceneSyncPhysicsMetadata`, so Unity can round-trip `scene-state`
+without dropping physics fields. `com.afjk.scene-sync-rapier` depends on both
+`com.afjk.scene-sync` and `com.afjk.rapier` and maps those preserved physics
+fields into a Rapier world.
+
+While `com.afjk.rapier` is not yet published to `upm.afjk.jp`, sample projects
+should add it directly by Git URL:
+
+```json
+{
+  "dependencies": {
+    "com.afjk.rapier": "https://github.com/afjk/rapier-unity.git?path=Packages/com.afjk.rapier#v0.3.0"
+  }
+}
+```
+
+The Unity bridge uses Scene Sync wire coordinates as the canonical physics
+basis and converts poses only when applying them back to Unity `Transform`s.
+This keeps Web/Unity parity hashes meaningful within the same physics profile.
+
 ## Supported Shapes
 
 The current Scene Sync UI maps to Rapier sphere and cuboid colliders:

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -1,0 +1,38 @@
+# Scene Sync Rapier
+
+Optional Unity bridge that runs Scene Sync browser physics with
+`com.afjk.rapier`.
+
+This package intentionally sits downstream of both packages:
+
+- `com.afjk.scene-sync` owns network, objects, and wire metadata.
+- `com.afjk.rapier` owns Rapier world APIs and native plugins.
+- `com.afjk.scene-sync-rapier` maps Scene Sync `physics` JSON into Rapier bodies.
+
+## Install For Local Testing
+
+Add all three packages to the Unity project manifest while Rapier is not yet in
+`upm.afjk.jp`:
+
+```json
+{
+  "dependencies": {
+    "com.afjk.scene-sync": "file:/Users/afjk/github/SceneSyncWork/afjk.jp/unity/com.afjk.scene-sync",
+    "com.afjk.scene-sync-rapier": "file:/Users/afjk/github/SceneSyncWork/afjk.jp/unity/com.afjk.scene-sync-rapier",
+    "com.afjk.rapier": "https://github.com/afjk/rapier-unity.git?path=Packages/com.afjk.rapier#v0.3.0"
+  }
+}
+```
+
+For monorepo development you can replace the Rapier Git URL with a local
+`file:` path.
+
+## Usage
+
+1. Add `SceneSyncRapierBridge` to the same GameObject as `SceneSyncManager`.
+2. Connect to a room that has Scene Sync `physics` enabled in the Web client.
+3. When scene objects contain object-level `physics`, Unity creates a Rapier
+   world and applies dynamic body poses back to the corresponding GameObjects.
+
+The bridge uses Scene Sync wire coordinates as the physics basis, then converts
+body poses back to Unity coordinates when applying transforms.

--- a/unity/com.afjk.scene-sync-rapier/README.md.meta
+++ b/unity/com.afjk.scene-sync-rapier/README.md.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 33d071f5dedf42fe9e2d0120834318c7

--- a/unity/com.afjk.scene-sync-rapier/Runtime.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d20995a9e5e846f49f6ba3884803b0ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -1,0 +1,653 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using AFJK.Rapier;
+using Afjk.SceneSync;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Rapier
+{
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncRapierBridge : MonoBehaviour
+    {
+        private const float DefaultTimestep = 1f / 60f;
+        private const float GroundHalfExtent = 4096f;
+        private const float GroundThickness = 0.1f;
+        private const string GroundStableId = "__scenesync_ground__";
+
+        [SerializeField] private bool autoRun = true;
+        [SerializeField] private bool applyDynamicTransforms = true;
+        [SerializeField] private bool includeGround = true;
+        [SerializeField] private float metadataScanInterval = 0.5f;
+        [SerializeField] private float maxFrameStepSeconds = 0.25f;
+        [SerializeField] private bool logStateHash;
+
+        private readonly Dictionary<string, string> objectPhysicsJson = new Dictionary<string, string>(StringComparer.Ordinal);
+        private readonly Dictionary<string, BodyBinding> bindings = new Dictionary<string, BodyBinding>(StringComparer.Ordinal);
+
+        private RapierWorld world;
+        private ScenePhysicsDefinition scenePhysics = ScenePhysicsDefinition.Disabled;
+        private bool dirty = true;
+        private float accumulator;
+        private int tick;
+        private float nextMetadataScanAt;
+        private string lastStateHash;
+
+        public int Tick => tick;
+        public string LastStateHash => lastStateHash;
+        public bool HasWorld => world != null && world.IsCreated;
+
+        private void OnEnable()
+        {
+            SceneSyncMessageBus.MessageReceived += HandleSceneMessage;
+            dirty = true;
+            RefreshMetadataFromScene();
+        }
+
+        private void OnDisable()
+        {
+            SceneSyncMessageBus.MessageReceived -= HandleSceneMessage;
+            DisposeWorld();
+        }
+
+        private void Update()
+        {
+            if (Time.unscaledTime >= nextMetadataScanAt)
+            {
+                nextMetadataScanAt = Time.unscaledTime + Mathf.Max(0.05f, metadataScanInterval);
+                if (RefreshMetadataFromScene())
+                    dirty = true;
+            }
+
+            if (dirty)
+                RebuildWorld();
+
+            if (!autoRun || world == null) return;
+
+            var frameTime = Mathf.Min(Mathf.Max(0f, Time.unscaledDeltaTime), Mathf.Max(0f, maxFrameStepSeconds));
+            accumulator += frameTime;
+            var timestep = Mathf.Max(0.000001f, scenePhysics.Timestep);
+            var maxSteps = Mathf.Max(1, Mathf.CeilToInt(Mathf.Max(0.001f, maxFrameStepSeconds) / timestep));
+            var steps = 0;
+
+            while (accumulator + 0.0000001f >= timestep && steps < maxSteps)
+            {
+                if (!world.Step()) break;
+                accumulator -= timestep;
+                tick++;
+                steps++;
+            }
+
+            if (steps > 0)
+            {
+                ApplyWorldTransforms();
+                if (logStateHash)
+                {
+                    lastStateHash = world.StateHash().ToString("x16", CultureInfo.InvariantCulture);
+                    Debug.Log("[SceneSyncRapier] tick=" + tick + " stateHash=" + lastStateHash);
+                }
+            }
+        }
+
+        public void MarkDirty()
+        {
+            dirty = true;
+        }
+
+        public void RebuildWorld()
+        {
+            dirty = false;
+            accumulator = 0f;
+            tick = 0;
+            lastStateHash = null;
+            bindings.Clear();
+            DisposeWorld();
+
+            if (!scenePhysics.Enabled)
+                return;
+
+            var candidates = CollectBodyCandidates();
+            if (candidates.Count == 0)
+                return;
+
+            try
+            {
+                world = RapierWorld.Create();
+                world.SetGravity(scenePhysics.Gravity);
+                world.SetTimestep(scenePhysics.Timestep);
+
+                if (includeGround && scenePhysics.Ground != null)
+                    CreateGround(scenePhysics.Ground.Value);
+
+                foreach (var candidate in candidates.OrderBy(item => item.ObjectId, StringComparer.Ordinal))
+                {
+                    CreateBody(candidate);
+                }
+
+                ApplyWorldTransforms();
+            }
+            catch (Exception error)
+            {
+                Debug.LogWarning("[SceneSyncRapier] Failed to rebuild Rapier world: " + error.Message);
+                DisposeWorld();
+                bindings.Clear();
+            }
+        }
+
+        private bool RefreshMetadataFromScene()
+        {
+            var changed = false;
+
+            var localScenePhysics = GetComponent<SceneSyncPhysicsMetadata>();
+            if (localScenePhysics != null && !string.IsNullOrWhiteSpace(localScenePhysics.ScenePhysicsJson))
+            {
+                var next = ScenePhysicsDefinition.Parse(localScenePhysics.ScenePhysicsJson);
+                if (!scenePhysics.Equals(next))
+                {
+                    scenePhysics = next;
+                    changed = true;
+                }
+            }
+            else
+            {
+                foreach (var metadata in FindObjectsByType<SceneSyncPhysicsMetadata>(FindObjectsSortMode.None))
+                {
+                    if (metadata == null || string.IsNullOrWhiteSpace(metadata.ScenePhysicsJson)) continue;
+                    var next = ScenePhysicsDefinition.Parse(metadata.ScenePhysicsJson);
+                    if (!scenePhysics.Equals(next))
+                    {
+                        scenePhysics = next;
+                        changed = true;
+                    }
+                    break;
+                }
+            }
+
+            foreach (var identity in FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None))
+            {
+                if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
+                var metadata = identity.GetComponent<SceneSyncPhysicsMetadata>();
+                if (metadata == null) continue;
+
+                var raw = metadata.ObjectPhysicsJson;
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+
+                if (!objectPhysicsJson.TryGetValue(identity.ObjectId, out var previous) ||
+                    !string.Equals(previous, raw, StringComparison.Ordinal))
+                {
+                    objectPhysicsJson[identity.ObjectId] = raw;
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+
+        private List<BodyCandidate> CollectBodyCandidates()
+        {
+            var identities = FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None);
+            var byId = new Dictionary<string, SceneSyncIdentity>(StringComparer.Ordinal);
+            foreach (var identity in identities)
+            {
+                if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
+                if (!byId.ContainsKey(identity.ObjectId))
+                    byId.Add(identity.ObjectId, identity);
+            }
+
+            var result = new List<BodyCandidate>();
+            foreach (var pair in objectPhysicsJson)
+            {
+                if (!byId.TryGetValue(pair.Key, out var identity) || identity == null) continue;
+                var definition = ObjectPhysicsDefinition.Parse(pair.Value, identity.transform);
+                if (!definition.Enabled) continue;
+                result.Add(new BodyCandidate(pair.Key, identity.gameObject, definition));
+            }
+
+            return result;
+        }
+
+        private void HandleSceneMessage(SceneSyncRawMessage message)
+        {
+            var raw = message.RawJson;
+            if (string.IsNullOrWhiteSpace(raw)) return;
+
+            if (raw.Contains("\"kind\":\"scene-state\""))
+            {
+                if (SceneSyncWireJson.HasTopLevelField(raw, "physics"))
+                    scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
+
+                foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(raw, "objects"))
+                {
+                    ApplyObjectPhysicsJson(entry.Key, entry.Value);
+                }
+
+                dirty = true;
+                return;
+            }
+
+            if (raw.Contains("\"kind\":\"scene-physics\""))
+            {
+                scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
+                dirty = true;
+                return;
+            }
+
+            if (raw.Contains("\"kind\":\"scene-remove\"") || raw.Contains("\"kind\":\"scene-delete\""))
+            {
+                var objectId = SceneSyncWireJson.ExtractString(raw, "objectId");
+                if (!string.IsNullOrWhiteSpace(objectId) && objectPhysicsJson.Remove(objectId))
+                    dirty = true;
+                return;
+            }
+
+            if (!raw.Contains("\"kind\":\"scene-add\"") && !raw.Contains("\"kind\":\"scene-delta\""))
+                return;
+
+            var id = SceneSyncWireJson.ExtractString(raw, "objectId");
+            if (string.IsNullOrWhiteSpace(id)) return;
+            if (ApplyObjectPhysicsJson(id, raw))
+                dirty = true;
+        }
+
+        private bool ApplyObjectPhysicsJson(string objectId, string rawObjectJson)
+        {
+            if (!SceneSyncWireJson.HasTopLevelField(rawObjectJson, "physics")) return false;
+
+            var physicsJson = SceneSyncWireJson.ExtractTopLevelRawValue(rawObjectJson, "physics");
+            if (string.IsNullOrWhiteSpace(physicsJson) || physicsJson.Trim() == "null")
+            {
+                return objectPhysicsJson.Remove(objectId);
+            }
+
+            if (objectPhysicsJson.TryGetValue(objectId, out var previous) &&
+                string.Equals(previous, physicsJson, StringComparison.Ordinal))
+                return false;
+
+            objectPhysicsJson[objectId] = physicsJson;
+            return true;
+        }
+
+        private void CreateGround(GroundDefinition ground)
+        {
+            var body = world.CreateRigidBody(new RapierBodyDesc
+            {
+                BodyType = RapierRigidBodyType.Fixed,
+                Position = new Vector3(0f, ground.Y - GroundThickness / 2f, 0f),
+                Rotation = Quaternion.identity,
+                CanSleep = true
+            });
+            var stableId = RapierWorld.StableIdHash(GroundStableId);
+            world.SetRigidBodyStableId(body, stableId);
+
+            var collider = world.CreateBoxCollider(body, new RapierBoxColliderDesc
+            {
+                HalfExtents = new Vector3(GroundHalfExtent, GroundThickness / 2f, GroundHalfExtent),
+                Density = 1f,
+                Friction = ground.Friction,
+                HasFriction = true,
+                Restitution = ground.Restitution,
+                LocalRotation = Quaternion.identity
+            });
+            world.SetColliderStableId(collider, stableId);
+        }
+
+        private void CreateBody(BodyCandidate candidate)
+        {
+            var definition = candidate.Definition;
+            var body = world.CreateRigidBody(new RapierBodyDesc
+            {
+                BodyType = definition.IsStatic ? RapierRigidBodyType.Fixed : RapierRigidBodyType.Dynamic,
+                Position = definition.Position,
+                Rotation = definition.Rotation,
+                LinearVelocity = definition.IsStatic ? Vector3.zero : definition.LinearVelocity,
+                AngularVelocity = definition.IsStatic ? Vector3.zero : definition.AngularVelocity,
+                LinearDamping = definition.LinearDamping,
+                AngularDamping = definition.AngularDamping,
+                CanSleep = definition.CanSleep,
+                CcdEnabled = definition.CcdEnabled
+            });
+
+            var stableId = RapierWorld.StableIdHash(candidate.ObjectId);
+            world.SetRigidBodyStableId(body, stableId);
+
+            RapierColliderHandle collider;
+            if (definition.Shape == PhysicsShape.Sphere)
+            {
+                collider = world.CreateSphereCollider(body, new RapierSphereColliderDesc
+                {
+                    Radius = definition.Radius,
+                    Density = definition.Density,
+                    Friction = definition.Friction,
+                    HasFriction = true,
+                    Restitution = definition.Restitution,
+                    LocalRotation = Quaternion.identity
+                });
+            }
+            else
+            {
+                collider = world.CreateBoxCollider(body, new RapierBoxColliderDesc
+                {
+                    HalfExtents = definition.HalfExtents,
+                    Density = definition.Density,
+                    Friction = definition.Friction,
+                    HasFriction = true,
+                    Restitution = definition.Restitution,
+                    LocalRotation = Quaternion.identity
+                });
+            }
+
+            world.SetColliderStableId(collider, stableId);
+            bindings[candidate.ObjectId] = new BodyBinding(candidate.GameObject, body, definition.IsStatic);
+        }
+
+        private void ApplyWorldTransforms()
+        {
+            if (!applyDynamicTransforms || world == null) return;
+
+            foreach (var binding in bindings.Values)
+            {
+                if (binding.IsStatic || binding.GameObject == null) continue;
+                if (!world.TryGetTransform(binding.Body, out var transform)) continue;
+                binding.GameObject.transform.SetPositionAndRotation(
+                    WireToUnityPosition(transform.Position),
+                    WireToUnityRotation(transform.Rotation));
+            }
+        }
+
+        private void DisposeWorld()
+        {
+            if (world == null) return;
+            world.Dispose();
+            world = null;
+        }
+
+        private static Vector3 UnityToWirePosition(Vector3 value)
+        {
+            return new Vector3(value.x, value.y, -value.z);
+        }
+
+        private static Quaternion UnityToWireRotation(Quaternion value)
+        {
+            return new Quaternion(value.x, value.y, -value.z, -value.w);
+        }
+
+        private static Vector3 WireToUnityPosition(Vector3 value)
+        {
+            return new Vector3(value.x, value.y, -value.z);
+        }
+
+        private static Quaternion WireToUnityRotation(Quaternion value)
+        {
+            return new Quaternion(value.x, value.y, -value.z, -value.w);
+        }
+
+        private static Vector3 ReadVector3(string json, string field, Vector3 fallback)
+        {
+            var raw = SceneSyncWireJson.ExtractArray(json, field);
+            if (raw == null || raw.Length < 3) return fallback;
+            return new Vector3(raw[0], raw[1], raw[2]);
+        }
+
+        private static Quaternion ReadQuaternion(string json, string field, Quaternion fallback)
+        {
+            var raw = SceneSyncWireJson.ExtractArray(json, field);
+            if (raw == null || raw.Length < 4) return fallback;
+            var q = new Quaternion(raw[0], raw[1], raw[2], raw[3]);
+            return q == default ? fallback : Normalize(q);
+        }
+
+        private static Quaternion Normalize(Quaternion q)
+        {
+            var length = Mathf.Sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+            if (!IsFinite(length) || length <= 0f) return Quaternion.identity;
+            return new Quaternion(q.x / length, q.y / length, q.z / length, q.w / length);
+        }
+
+        private static float ReadFloat(string json, string field, float fallback)
+        {
+            var value = SceneSyncWireJson.ExtractFloat(json, field);
+            return value.HasValue && IsFinite(value.Value) ? value.Value : fallback;
+        }
+
+        private static bool ReadBool(string json, string field, bool fallback)
+        {
+            var value = SceneSyncWireJson.ExtractBoolean(json, field);
+            return value ?? fallback;
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private readonly struct BodyCandidate
+        {
+            public BodyCandidate(string objectId, GameObject gameObject, ObjectPhysicsDefinition definition)
+            {
+                ObjectId = objectId;
+                GameObject = gameObject;
+                Definition = definition;
+            }
+
+            public string ObjectId { get; }
+            public GameObject GameObject { get; }
+            public ObjectPhysicsDefinition Definition { get; }
+        }
+
+        private readonly struct BodyBinding
+        {
+            public BodyBinding(GameObject gameObject, RapierRigidBodyHandle body, bool isStatic)
+            {
+                GameObject = gameObject;
+                Body = body;
+                IsStatic = isStatic;
+            }
+
+            public GameObject GameObject { get; }
+            public RapierRigidBodyHandle Body { get; }
+            public bool IsStatic { get; }
+        }
+
+        private enum PhysicsShape
+        {
+            Box,
+            Sphere
+        }
+
+        private readonly struct ScenePhysicsDefinition : IEquatable<ScenePhysicsDefinition>
+        {
+            public static readonly ScenePhysicsDefinition Disabled = new ScenePhysicsDefinition(false, new Vector3(0f, -9.81f, 0f), DefaultTimestep, null);
+
+            public ScenePhysicsDefinition(bool enabled, Vector3 gravity, float timestep, GroundDefinition? ground)
+            {
+                Enabled = enabled;
+                Gravity = gravity;
+                Timestep = Mathf.Max(0.000001f, timestep);
+                Ground = ground;
+            }
+
+            public bool Enabled { get; }
+            public Vector3 Gravity { get; }
+            public float Timestep { get; }
+            public GroundDefinition? Ground { get; }
+
+            public static ScenePhysicsDefinition Parse(string json)
+            {
+                if (string.IsNullOrWhiteSpace(json) || json.Trim() == "null")
+                    return Disabled;
+
+                var enabled = ReadBool(json, "enabled", false);
+                var options = SceneSyncWireJson.ExtractTopLevelRawObject(json, "worldOptions") ?? json;
+                var gravityArray = SceneSyncWireJson.ExtractArray(options, "gravity");
+                var gravity = gravityArray != null && gravityArray.Length >= 3
+                    ? new Vector3(gravityArray[0], gravityArray[1], gravityArray[2])
+                    : new Vector3(0f, ReadFloat(options, "gravity", -9.81f), 0f);
+                var timestep = ReadFloat(options, "timestep", DefaultTimestep);
+                GroundDefinition? ground = null;
+                var groundRaw = SceneSyncWireJson.ExtractTopLevelRawValue(options, "ground");
+                if (!string.IsNullOrWhiteSpace(groundRaw) && groundRaw.Trim() != "null" && groundRaw.Trim() != "false")
+                {
+                    ground = new GroundDefinition(
+                        ReadFloat(groundRaw, "y", 0f),
+                        Mathf.Clamp(ReadFloat(groundRaw, "restitution", 0.2f), 0f, 1f),
+                        Mathf.Clamp(ReadFloat(groundRaw, "friction", 0.5f), 0f, 4f));
+                }
+
+                return new ScenePhysicsDefinition(enabled, gravity, timestep, ground);
+            }
+
+            public bool Equals(ScenePhysicsDefinition other)
+            {
+                return Enabled == other.Enabled
+                    && Gravity == other.Gravity
+                    && Mathf.Approximately(Timestep, other.Timestep)
+                    && ((!Ground.HasValue && !other.Ground.HasValue)
+                        || (Ground.HasValue && other.Ground.HasValue && Ground.Value.Equals(other.Ground.Value)));
+            }
+        }
+
+        private readonly struct GroundDefinition : IEquatable<GroundDefinition>
+        {
+            public GroundDefinition(float y, float restitution, float friction)
+            {
+                Y = y;
+                Restitution = restitution;
+                Friction = friction;
+            }
+
+            public float Y { get; }
+            public float Restitution { get; }
+            public float Friction { get; }
+
+            public bool Equals(GroundDefinition other)
+            {
+                return Mathf.Approximately(Y, other.Y)
+                    && Mathf.Approximately(Restitution, other.Restitution)
+                    && Mathf.Approximately(Friction, other.Friction);
+            }
+        }
+
+        private readonly struct ObjectPhysicsDefinition
+        {
+            public bool Enabled { get; }
+            public bool IsStatic { get; }
+            public PhysicsShape Shape { get; }
+            public Vector3 Position { get; }
+            public Quaternion Rotation { get; }
+            public Vector3 LinearVelocity { get; }
+            public Vector3 AngularVelocity { get; }
+            public Vector3 HalfExtents { get; }
+            public float Radius { get; }
+            public float Density { get; }
+            public float Friction { get; }
+            public float Restitution { get; }
+            public float LinearDamping { get; }
+            public float AngularDamping { get; }
+            public bool CanSleep { get; }
+            public bool CcdEnabled { get; }
+
+            private ObjectPhysicsDefinition(
+                bool enabled,
+                bool isStatic,
+                PhysicsShape shape,
+                Vector3 position,
+                Quaternion rotation,
+                Vector3 linearVelocity,
+                Vector3 angularVelocity,
+                Vector3 halfExtents,
+                float radius,
+                float density,
+                float friction,
+                float restitution,
+                float linearDamping,
+                float angularDamping,
+                bool canSleep,
+                bool ccdEnabled)
+            {
+                Enabled = enabled;
+                IsStatic = isStatic;
+                Shape = shape;
+                Position = position;
+                Rotation = rotation;
+                LinearVelocity = linearVelocity;
+                AngularVelocity = angularVelocity;
+                HalfExtents = halfExtents;
+                Radius = radius;
+                Density = density;
+                Friction = friction;
+                Restitution = restitution;
+                LinearDamping = linearDamping;
+                AngularDamping = angularDamping;
+                CanSleep = canSleep;
+                CcdEnabled = ccdEnabled;
+            }
+
+            public static ObjectPhysicsDefinition Parse(string json, Transform transform)
+            {
+                if (string.IsNullOrWhiteSpace(json) || json.Trim() == "null")
+                    return default;
+
+                var enabled = ReadBool(json, "enabled", true);
+                var bodyType = SceneSyncWireJson.ExtractString(json, "bodyType")
+                    ?? SceneSyncWireJson.ExtractString(json, "type")
+                    ?? "dynamic";
+                var mass = Mathf.Max(0f, ReadFloat(json, "mass", 1f));
+                var explicitStatic = ReadBool(json, "static", false);
+                var isStatic = explicitStatic
+                    || mass <= 0f
+                    || string.Equals(bodyType, "static", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(bodyType, "fixed", StringComparison.OrdinalIgnoreCase);
+                var shapeName = SceneSyncWireJson.ExtractString(json, "shape") ?? "box";
+                var shape = string.Equals(shapeName, "sphere", StringComparison.OrdinalIgnoreCase)
+                    ? PhysicsShape.Sphere
+                    : PhysicsShape.Box;
+
+                var initial = SceneSyncWireJson.ExtractTopLevelRawObject(json, "initialTransform");
+                var position = !string.IsNullOrWhiteSpace(initial)
+                    ? ReadVector3(initial, "position", Vector3.zero)
+                    : UnityToWirePosition(transform.position);
+                var rotation = !string.IsNullOrWhiteSpace(initial)
+                    ? ReadQuaternion(initial, "rotation", Quaternion.identity)
+                    : UnityToWireRotation(transform.rotation);
+                var scale = !string.IsNullOrWhiteSpace(initial)
+                    ? ReadVector3(initial, "scale", transform.localScale)
+                    : transform.localScale;
+                scale = new Vector3(Mathf.Abs(scale.x), Mathf.Abs(scale.y), Mathf.Abs(scale.z));
+
+                var defaultHalfExtents = new Vector3(
+                    Mathf.Max(0.01f, scale.x / 2f),
+                    Mathf.Max(0.01f, scale.y / 2f),
+                    Mathf.Max(0.01f, scale.z / 2f));
+                var halfExtents = ReadVector3(json, "halfExtents", defaultHalfExtents);
+                halfExtents = new Vector3(
+                    Mathf.Max(0.000001f, halfExtents.x),
+                    Mathf.Max(0.000001f, halfExtents.y),
+                    Mathf.Max(0.000001f, halfExtents.z));
+
+                var radius = Mathf.Max(
+                    0.000001f,
+                    ReadFloat(json, "radius", Mathf.Max(scale.x, Mathf.Max(scale.y, scale.z)) / 2f));
+                var density = isStatic ? 0f : Mathf.Max(0f, ReadFloat(json, "density", mass));
+
+                return new ObjectPhysicsDefinition(
+                    enabled,
+                    isStatic,
+                    shape,
+                    position,
+                    rotation,
+                    isStatic ? Vector3.zero : ReadVector3(json, "velocity", ReadVector3(json, "linearVelocity", Vector3.zero)),
+                    isStatic ? Vector3.zero : ReadVector3(json, "angularVelocity", Vector3.zero),
+                    halfExtents,
+                    radius,
+                    density,
+                    Mathf.Clamp(ReadFloat(json, "friction", 0.5f), 0f, 4f),
+                    Mathf.Clamp(ReadFloat(json, "restitution", 0.2f), 0f, 1f),
+                    Mathf.Max(0f, ReadFloat(json, "linearDamping", 0f)),
+                    Mathf.Max(0f, ReadFloat(json, "angularDamping", 0f)),
+                    ReadBool(json, "canSleep", true),
+                    ReadBool(json, "ccd", ReadBool(json, "ccdEnabled", false)));
+            }
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fb15cae625e4385b5c59f47753ae4c2

--- a/unity/com.afjk.scene-sync-rapier/Runtime/com.afjk.scene-sync-rapier.Runtime.asmdef
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/com.afjk.scene-sync-rapier.Runtime.asmdef
@@ -1,0 +1,17 @@
+{
+  "name": "com.afjk.scene-sync-rapier.Runtime",
+  "rootNamespace": "Afjk.SceneSync.Rapier",
+  "references": [
+    "com.afjk.scene-sync.Runtime",
+    "AFJK.Rapier.Runtime"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/com.afjk.scene-sync-rapier.Runtime.asmdef.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/com.afjk.scene-sync-rapier.Runtime.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc44fb7a177244f0a977ca6e0872b3f3

--- a/unity/com.afjk.scene-sync-rapier/package.json
+++ b/unity/com.afjk.scene-sync-rapier/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "com.afjk.scene-sync-rapier",
+  "version": "0.1.0",
+  "displayName": "Scene Sync Rapier",
+  "description": "Optional Rapier physics bridge for Scene Sync Unity clients.",
+  "unity": "2022.3",
+  "author": {
+    "name": "afjk"
+  },
+  "keywords": [
+    "scene-sync",
+    "rapier",
+    "physics",
+    "deterministic"
+  ],
+  "dependencies": {
+    "com.afjk.scene-sync": "0.1.0",
+    "com.afjk.rapier": "0.3.0"
+  }
+}

--- a/unity/com.afjk.scene-sync-rapier/package.json.meta
+++ b/unity/com.afjk.scene-sync-rapier/package.json.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b100db8d9e684c2bb195e0ad730a9d1c

--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -1378,6 +1378,7 @@ namespace Afjk.SceneSync.Editor
         private void DispatchSceneMessage(string raw, string fromId = null)
         {
             if (string.IsNullOrEmpty(raw)) return;
+            SceneSyncMessageBus.PublishReceived(raw, fromId, this);
 
             if (raw.Contains("\"type\":\"scene-graph-set\""))
             {
@@ -1401,6 +1402,10 @@ namespace Afjk.SceneSync.Editor
             else if (raw.Contains("\"kind\":\"scene-env\""))
             {
                 HandleSceneEnv(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-physics\""))
+            {
+                HandleScenePhysics(raw);
             }
             else if (raw.Contains("\"kind\":\"scene-batch\""))
             {
@@ -1542,6 +1547,8 @@ namespace Afjk.SceneSync.Editor
         {
             _sceneReceived = true;
             Debug.Log("[SceneSync] Received scene-state");
+
+            ApplyScenePhysicsMetadata(raw);
 
             var envId = SceneSyncWireJson.ExtractString(raw, "envId");
             if (!string.IsNullOrWhiteSpace(envId))
@@ -1711,6 +1718,62 @@ namespace Afjk.SceneSync.Editor
             Debug.Log("[SceneSync] scene-env received: envId=" + envId);
         }
 
+        private void HandleScenePhysics(string raw)
+        {
+            ApplyScenePhysicsMetadata(raw);
+        }
+
+        private void ApplyScenePhysicsMetadata(string raw)
+        {
+            if (!SceneSyncWireJson.HasTopLevelField(raw, "physics")) return;
+
+            var manager = FindSceneSyncManager();
+            if (manager == null) return;
+
+            var physicsJson = SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics");
+            var metadata = manager.GetComponent<SceneSyncPhysicsMetadata>();
+            if (metadata == null) metadata = manager.gameObject.AddComponent<SceneSyncPhysicsMetadata>();
+            metadata.ConfigureScenePhysics(physicsJson);
+            EditorUtility.SetDirty(metadata);
+            EditorUtility.SetDirty(manager);
+            EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+        }
+
+        private static string ExtractObjectPhysicsJson(string raw)
+        {
+            return SceneSyncWireJson.HasTopLevelField(raw, "physics")
+                ? SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics")
+                : null;
+        }
+
+        private static void ApplyObjectPhysicsMetadata(GameObject go, string physicsJson)
+        {
+            if (go == null) return;
+
+            var metadata = go.GetComponent<SceneSyncPhysicsMetadata>();
+            if (string.IsNullOrWhiteSpace(physicsJson) || physicsJson.Trim() == "null")
+            {
+                if (metadata != null)
+                {
+                    metadata.ClearObjectPhysics();
+                    EditorUtility.SetDirty(metadata);
+                }
+                return;
+            }
+
+            if (metadata == null) metadata = go.AddComponent<SceneSyncPhysicsMetadata>();
+            metadata.ConfigureObjectPhysics(physicsJson);
+            EditorUtility.SetDirty(metadata);
+        }
+
+        private static string GetObjectPhysicsJson(GameObject go)
+        {
+            var metadata = go != null ? go.GetComponent<SceneSyncPhysicsMetadata>() : null;
+            return metadata != null && !string.IsNullOrWhiteSpace(metadata.ObjectPhysicsJson)
+                ? metadata.ObjectPhysicsJson
+                : null;
+        }
+
         private void HandleSceneDelta(string raw)
         {
             // 簡易 JSON パース（scene-delta 専用）
@@ -1725,9 +1788,14 @@ namespace Afjk.SceneSync.Editor
             float[] scale = ExtractArray(raw, "\"scale\":");
             var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
             var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
 
             var go = FindManagedObject(objectId);
             if (go == null) return;
+
+            if (hasPhysics)
+                ApplyObjectPhysicsMetadata(go, physicsJson);
 
             if (!string.IsNullOrWhiteSpace(name))
                 go.name = name;
@@ -1895,7 +1963,8 @@ namespace Afjk.SceneSync.Editor
             bool? visible,
             float[] position,
             float[] rotation,
-            float[] scale)
+            float[] scale,
+            string physicsJson = null)
         {
             if (go == null) return;
 
@@ -1911,6 +1980,8 @@ namespace Afjk.SceneSync.Editor
             if (!string.IsNullOrEmpty(meshPath))
                 _meshPaths[objectId] = meshPath;
             SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            if (physicsJson != null)
+                ApplyObjectPhysicsMetadata(go, physicsJson);
             ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
             if (visible.HasValue) go.SetActive(visible.Value);
             ApplyTransform(go, position, rotation, scale);
@@ -2465,9 +2536,13 @@ namespace Afjk.SceneSync.Editor
                 raw, "\"objectId\":\"([^\"]+)\"");
             if (!objectIdMatch.Success) return;
             var objectId = objectIdMatch.Groups[1].Value;
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
 
             if (IsBoundUnityOriginObject(objectId))
             {
+                if (hasPhysics)
+                    ApplyObjectPhysicsMetadata(FindManagedObject(objectId), physicsJson);
                 Debug.Log("[SceneSync] scene-add received: objectId=" + objectId + " → bound Unity object, skipping remote creation");
                 return;
             }
@@ -2476,6 +2551,8 @@ namespace Afjk.SceneSync.Editor
             if (_managedObjects.ContainsKey(objectId))
             {
                 var existing = _managedObjects[objectId];
+                if (hasPhysics)
+                    ApplyObjectPhysicsMetadata(existing, physicsJson);
                 Debug.Log("[SceneSync] scene-add received: objectId=" + objectId
                     + " → already managed (name=" + (existing != null ? existing.name : "null")
                     + ", unityOrigin=" + IsBoundUnityOriginObject(objectId) + "), skipping");
@@ -2545,7 +2622,8 @@ namespace Afjk.SceneSync.Editor
                         visible,
                         position,
                         rotation,
-                        scale);
+                        scale,
+                        physicsJson);
                     Debug.Log("[SceneSync] scene-add resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + unityObject.name);
                     return;
                 }
@@ -2563,12 +2641,13 @@ namespace Afjk.SceneSync.Editor
             // メッシュがある場合は glB をダウンロードしてインポート
             if (hasMeshAsset)
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible, physicsJson);
             }
             else
             {
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                ApplyObjectPhysicsMetadata(go, physicsJson);
                 ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -2637,6 +2716,8 @@ namespace Afjk.SceneSync.Editor
 
             var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
             var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
@@ -2655,7 +2736,7 @@ namespace Afjk.SceneSync.Editor
                 go = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
                 if (go != null)
                 {
-                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null);
+                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null, physicsJson);
                     Debug.Log("[SceneSync] scene-mesh resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + go.name);
                     return;
                 }
@@ -2679,6 +2760,8 @@ namespace Afjk.SceneSync.Editor
                     EditorUtility.SetDirty(identity);
                 }
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                if (hasPhysics)
+                    ApplyObjectPhysicsMetadata(go, physicsJson);
                 ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 Debug.Log("[SceneSync] Received scene-mesh for Unity-authored object; keeping local GameObject: " + objectId);
                 return;
@@ -2697,11 +2780,11 @@ namespace Afjk.SceneSync.Editor
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId, visualBasis, assetJson, metadataJson);
+                    assetId, visualBasis, assetJson, metadataJson, null, physicsJson);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson, null, physicsJson);
             }
         }
 
@@ -2901,6 +2984,8 @@ namespace Afjk.SceneSync.Editor
                 var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
                 var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
                 var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                var physicsMetadata = go.GetComponent<SceneSyncPhysicsMetadata>();
+                var rawPhysicsJson = physicsMetadata != null ? physicsMetadata.ObjectPhysicsJson : null;
                 if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
                 {
                     rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
@@ -2924,7 +3009,8 @@ namespace Afjk.SceneSync.Editor
                     rawAssetJson,
                     rawMetadataJson,
                     identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
-                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null,
+                    rawPhysicsJson));
             }
 
             objectsJson.Append("}");
@@ -2933,8 +3019,13 @@ namespace Afjk.SceneSync.Editor
             var envJson = !string.IsNullOrWhiteSpace(_envId)
                 ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
                 : "";
+            var manager = FindSceneSyncManager();
+            var scenePhysics = manager != null ? manager.GetComponent<SceneSyncPhysicsMetadata>() : null;
+            var physicsJson = scenePhysics != null && !string.IsNullOrWhiteSpace(scenePhysics.ScenePhysicsJson)
+                ? ",\"physics\":" + scenePhysics.ScenePhysicsJson
+                : "";
             var loomGraphsJson = BuildLoomGraphsStateJson();
-            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson
+            var payload = "{\"kind\":\"scene-state\"" + envJson + physicsJson + ",\"objects\":" + objectsJson
                 + (!string.IsNullOrWhiteSpace(loomGraphsJson) ? ",\"loomGraphs\":" + loomGraphsJson : "")
                 + "}";
             await _client.SendHandoff(fromId, payload);
@@ -3128,7 +3219,7 @@ namespace Afjk.SceneSync.Editor
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
             float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
-            string assetJson = null, string metadataJson = null, bool? visible = null)
+            string assetJson = null, string metadataJson = null, bool? visible = null, string physicsJson = null)
         {
             try
             {
@@ -3137,6 +3228,7 @@ namespace Afjk.SceneSync.Editor
                     _meshPaths[objectId] = meshPath;
                 }
 
+                var effectivePhysicsJson = physicsJson ?? GetObjectPhysicsJson(FindManagedObject(objectId));
                 var assetUrl = SceneSyncWireJson.GetAssetSource(assetJson) == "url"
                     ? SceneSyncWireJson.GetAssetUrl(assetJson)
                     : null;
@@ -3162,6 +3254,8 @@ namespace Afjk.SceneSync.Editor
                         Debug.LogWarning("[SceneSync] Download failed: " + response.StatusCode);
                         var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                         ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                        if (effectivePhysicsJson != null)
+                            ApplyObjectPhysicsMetadata(fallback, effectivePhysicsJson);
                         ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
                         if (visible.HasValue) fallback.SetActive(visible.Value);
                         fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -3198,6 +3292,8 @@ namespace Afjk.SceneSync.Editor
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    if (effectivePhysicsJson != null)
+                        ApplyObjectPhysicsMetadata(go, effectivePhysicsJson);
                     ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                     if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -3232,6 +3328,8 @@ namespace Afjk.SceneSync.Editor
                     Debug.LogWarning("[SceneSync] glTF import failed for: " + name);
                     var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                     ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+                    if (effectivePhysicsJson != null)
+                        ApplyObjectPhysicsMetadata(fallback, effectivePhysicsJson);
                     ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
                     if (visible.HasValue) fallback.SetActive(visible.Value);
                     fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -199,6 +199,28 @@ https://github.com/KhronosGroup/UnityGLTF.git#release/2.19.5
 
 `Window > Scene Sync > Details & Advanced > Export Settings` の UnityGLTF セクションで状態を確認できます。
 
+## Rapier Physics（オプション）
+
+Scene Sync 本体は Rapier に hard dependency しません。Web 側の Rapier
+物理シーンを Unity 側でも動かす場合は、別 package
+`com.afjk.scene-sync-rapier` を追加します。
+
+開発中は `com.afjk.rapier` が registry 未登録のため、サンプル project では
+Rapier package を Git URL で明示的に追加してください。
+
+```json
+{
+  "dependencies": {
+    "com.afjk.scene-sync-rapier": "file:/Users/afjk/github/SceneSyncWork/afjk.jp/unity/com.afjk.scene-sync-rapier",
+    "com.afjk.rapier": "https://github.com/afjk/rapier-unity.git?path=Packages/com.afjk.rapier#v0.3.0"
+  }
+}
+```
+
+`SceneSyncRapierBridge` を `SceneSyncManager` と同じ GameObject に追加すると、
+Scene Sync の `physics` JSON を Rapier world に変換し、dynamic body の pose を
+Unity `Transform` に反映します。
+
 - `Install UnityGLTF`
   - UnityGLTF package を追加します
 - `Enable UnityGLTF Support`

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -982,6 +982,7 @@ namespace Afjk.SceneSync
         private void DispatchSceneMessage(string raw, string fromId = null)
         {
             if (string.IsNullOrEmpty(raw)) return;
+            SceneSyncMessageBus.PublishReceived(raw, fromId, this);
 
             if (raw.Contains("\"type\":\"scene-graph-set\""))
             {
@@ -1009,6 +1010,10 @@ namespace Afjk.SceneSync
             else if (raw.Contains("\"kind\":\"scene-env\""))
             {
                 HandleSceneEnv(raw);
+            }
+            else if (raw.Contains("\"kind\":\"scene-physics\""))
+            {
+                HandleScenePhysics(raw);
             }
             else if (raw.Contains("\"kind\":\"scene-batch\""))
             {
@@ -1313,6 +1318,8 @@ namespace Afjk.SceneSync
             _sceneReceived = true;
             Debug.Log("[SceneSync] Received scene-state");
 
+            ApplyScenePhysicsMetadata(raw);
+
             var envId = SceneSyncWireJson.ExtractString(raw, "envId");
             if (!string.IsNullOrWhiteSpace(envId))
                 _envId = envId;
@@ -1464,6 +1471,51 @@ namespace Afjk.SceneSync
             Debug.Log("[SceneSync] scene-env received: envId=" + envId);
         }
 
+        private void HandleScenePhysics(string raw)
+        {
+            ApplyScenePhysicsMetadata(raw);
+        }
+
+        private void ApplyScenePhysicsMetadata(string raw)
+        {
+            if (!SceneSyncWireJson.HasTopLevelField(raw, "physics")) return;
+
+            var physicsJson = SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics");
+            var metadata = GetComponent<SceneSyncPhysicsMetadata>();
+            if (metadata == null) metadata = gameObject.AddComponent<SceneSyncPhysicsMetadata>();
+            metadata.ConfigureScenePhysics(physicsJson);
+        }
+
+        private static string ExtractObjectPhysicsJson(string raw)
+        {
+            return SceneSyncWireJson.HasTopLevelField(raw, "physics")
+                ? SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics")
+                : null;
+        }
+
+        private static void ApplyObjectPhysicsMetadata(GameObject go, string physicsJson)
+        {
+            if (go == null) return;
+
+            var metadata = go.GetComponent<SceneSyncPhysicsMetadata>();
+            if (string.IsNullOrWhiteSpace(physicsJson) || physicsJson.Trim() == "null")
+            {
+                if (metadata != null) metadata.ClearObjectPhysics();
+                return;
+            }
+
+            if (metadata == null) metadata = go.AddComponent<SceneSyncPhysicsMetadata>();
+            metadata.ConfigureObjectPhysics(physicsJson);
+        }
+
+        private static string GetObjectPhysicsJson(GameObject go)
+        {
+            var metadata = go != null ? go.GetComponent<SceneSyncPhysicsMetadata>() : null;
+            return metadata != null && !string.IsNullOrWhiteSpace(metadata.ObjectPhysicsJson)
+                ? metadata.ObjectPhysicsJson
+                : null;
+        }
+
         private void HandleSceneDelta(string raw)
         {
             // 簡易 JSON パース（scene-delta 専用）
@@ -1478,9 +1530,14 @@ namespace Afjk.SceneSync
             float[] scale = ExtractArray(raw, "\"scale\":");
             var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
             var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
 
             var go = FindManagedObject(objectId);
             if (go == null) return;
+
+            if (hasPhysics)
+                ApplyObjectPhysicsMetadata(go, physicsJson);
 
             if (!string.IsNullOrWhiteSpace(name))
                 go.name = name;
@@ -1614,7 +1671,8 @@ namespace Afjk.SceneSync
             bool? visible,
             float[] position,
             float[] rotation,
-            float[] scale)
+            float[] scale,
+            string physicsJson = null)
         {
             if (go == null) return;
 
@@ -1630,6 +1688,8 @@ namespace Afjk.SceneSync
             if (!string.IsNullOrEmpty(meshPath))
                 _meshPaths[objectId] = meshPath;
             SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson, preserveMissing: true);
+            if (physicsJson != null)
+                ApplyObjectPhysicsMetadata(go, physicsJson);
             ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
             if (visible.HasValue) go.SetActive(visible.Value);
             ApplyTransform(go, position, rotation, scale);
@@ -1670,11 +1730,15 @@ namespace Afjk.SceneSync
                 raw, "\"objectId\":\"([^\"]+)\"");
             if (!objectIdMatch.Success) return;
             var objectId = objectIdMatch.Groups[1].Value;
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
 
             // 既に存在する場合はスキップ
             if (_managedObjects.ContainsKey(objectId))
             {
                 var existing = _managedObjects[objectId];
+                if (hasPhysics)
+                    ApplyObjectPhysicsMetadata(existing, physicsJson);
                 Debug.Log("[SceneSync] scene-add received: objectId=" + objectId
                     + " → already managed (name=" + (existing != null ? existing.name : "null")
                     + ", unityAuthored=" + (existing != null && IsUnityAuthoredObject(existing, objectId))
@@ -1746,7 +1810,8 @@ namespace Afjk.SceneSync
                         visible,
                         position,
                         rotation,
-                        scale);
+                        scale,
+                        physicsJson);
                     Debug.Log("[SceneSync] scene-add resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + unityObject.name);
                     return;
                 }
@@ -1766,6 +1831,8 @@ namespace Afjk.SceneSync
                     {
                         _managedObjects[objectId] = candidate;
                         _knownObjectIds.Add(objectId);
+                        if (hasPhysics)
+                            ApplyObjectPhysicsMetadata(candidate, physicsJson);
                         ApplyPendingObjectLoomGraph(objectId, candidate);
                         Debug.Log("[SceneSync] scene-add received for own Unity-authored object; skipping remote creation: " + objectId);
                         return;
@@ -1788,6 +1855,7 @@ namespace Afjk.SceneSync
                 placeholder.hideFlags = HideFlags.NotEditable;
                 ConfigureRemoteTemporaryIdentity(placeholder, objectId, meshPath, assetId);
                 SceneSyncPanelFactory.ConfigureWireMetadata(placeholder, assetJson, metadataJson);
+                ApplyObjectPhysicsMetadata(placeholder, physicsJson);
                 ApplyMetadataBehaviorGraph(placeholder, objectId, metadataJson);
                 if (visible.HasValue) placeholder.SetActive(visible.Value);
                 placeholder.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -1797,7 +1865,7 @@ namespace Afjk.SceneSync
                 _instanceToObjectId[placeholder.GetInstanceID()] = objectId;
 
                 // 非同期でダウンロード・インポート開始
-                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, position, rotation, scale, assetId, visualBasis, assetJson, metadataJson, visible, physicsJson);
             }
             else
             {
@@ -1805,6 +1873,7 @@ namespace Afjk.SceneSync
 
                 var go = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
                 ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
+                ApplyObjectPhysicsMetadata(go, physicsJson);
                 ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                 if (visible.HasValue) go.SetActive(visible.Value);
                 go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -1911,6 +1980,8 @@ namespace Afjk.SceneSync
 
             var assetJson = SceneSyncWireJson.ExtractRawObject(raw, "asset");
             var metadataJson = SceneSyncWireJson.ExtractRawObject(raw, "metadata");
+            var hasPhysics = SceneSyncWireJson.HasTopLevelField(raw, "physics");
+            var physicsJson = hasPhysics ? ExtractObjectPhysicsJson(raw) : null;
             if (string.IsNullOrEmpty(assetId) && !string.IsNullOrEmpty(assetJson))
                 assetId = SceneSyncWireJson.ExtractString(assetJson, "assetId");
 
@@ -1929,7 +2000,7 @@ namespace Afjk.SceneSync
                 go = ResolveUnityOriginObject(objectId, name, unityHierarchyPath);
                 if (go != null)
                 {
-                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null);
+                    BindUnityOriginObject(go, objectId, meshPath, assetId, assetJson, metadataJson, null, null, null, null, physicsJson);
                     Debug.Log("[SceneSync] scene-mesh resolved origin=unity to existing GameObject: objectId=" + objectId + ", name=" + go.name);
                     return;
                 }
@@ -1958,6 +2029,8 @@ namespace Afjk.SceneSync
                     identity.AssetId = assetId;
                 }
                 SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                if (hasPhysics)
+                    ApplyObjectPhysicsMetadata(go, physicsJson);
                 ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
 
                 _managedObjects[objectId] = go;
@@ -1981,11 +2054,11 @@ namespace Afjk.SceneSync
                     new float[] { pos.x, pos.y, -pos.z },
                     new float[] { rot.x, rot.y, -rot.z, -rot.w },
                     new float[] { scl.x, scl.y, scl.z },
-                    assetId, visualBasis, assetJson, metadataJson);
+                    assetId, visualBasis, assetJson, metadataJson, null, physicsJson);
             }
             else
             {
-                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson);
+                _ = DownloadAndCreateObject(objectId, name, meshPath, null, null, null, assetId, visualBasis, assetJson, metadataJson, null, physicsJson);
             }
         }
 
@@ -2117,6 +2190,8 @@ namespace Afjk.SceneSync
                 var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
                 var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
                 var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                var physicsMetadata = go.GetComponent<SceneSyncPhysicsMetadata>();
+                var rawPhysicsJson = physicsMetadata != null ? physicsMetadata.ObjectPhysicsJson : null;
                 if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
                 {
                     rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
@@ -2136,7 +2211,8 @@ namespace Afjk.SceneSync
                     rawAssetJson,
                     rawMetadataJson,
                     identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
-                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null,
+                    rawPhysicsJson));
                 sceneStateObjectCount++;
             }
 
@@ -2179,6 +2255,8 @@ namespace Afjk.SceneSync
                 var wireMetadata = go.GetComponent<SceneSyncWireMetadata>();
                 var rawAssetJson = wireMetadata != null ? wireMetadata.AssetJson : null;
                 var rawMetadataJson = wireMetadata != null ? wireMetadata.MetadataJson : null;
+                var physicsMetadata = go.GetComponent<SceneSyncPhysicsMetadata>();
+                var rawPhysicsJson = physicsMetadata != null ? physicsMetadata.ObjectPhysicsJson : null;
                 if (string.IsNullOrWhiteSpace(rawAssetJson) && path != null)
                 {
                     rawAssetJson = SceneSyncWireJson.BuildMeshAssetJson(
@@ -2198,7 +2276,8 @@ namespace Afjk.SceneSync
                     rawAssetJson,
                     rawMetadataJson,
                     identity != null && identity.Origin == SceneSyncOrigin.Unity ? "unity" : null,
-                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null));
+                    identity != null && identity.Origin == SceneSyncOrigin.Unity ? SceneSyncWireJson.GetUnityHierarchyPath(go) : null,
+                    rawPhysicsJson));
                 sceneStateObjectCount++;
             }
 
@@ -2210,8 +2289,12 @@ namespace Afjk.SceneSync
             var envJson = !string.IsNullOrWhiteSpace(_envId)
                 ? ",\"envId\":\"" + SceneSyncWireJson.JsonEscape(_envId) + "\""
                 : "";
+            var scenePhysics = GetComponent<SceneSyncPhysicsMetadata>();
+            var physicsJson = scenePhysics != null && !string.IsNullOrWhiteSpace(scenePhysics.ScenePhysicsJson)
+                ? ",\"physics\":" + scenePhysics.ScenePhysicsJson
+                : "";
             var loomGraphsJson = BuildLoomGraphsStateJson();
-            var payload = "{\"kind\":\"scene-state\"" + envJson + ",\"objects\":" + objectsJson
+            var payload = "{\"kind\":\"scene-state\"" + envJson + physicsJson + ",\"objects\":" + objectsJson
                 + (!string.IsNullOrWhiteSpace(loomGraphsJson) ? ",\"loomGraphs\":" + loomGraphsJson : "")
                 + "}";
             await _client.SendHandoff(fromId, payload);
@@ -2406,16 +2489,20 @@ namespace Afjk.SceneSync
             string assetId = null,
             string assetJson = null,
             string metadataJson = null,
-            bool? visible = null)
+            bool? visible = null,
+            string physicsJson = null)
         {
             var placeholder = _managedObjects[objectId];
             var placeholderInstanceId = placeholder.GetInstanceID();
             var placeholderGraphJson = GetObjectLoomGraphJson(placeholder);
+            var effectivePhysicsJson = physicsJson ?? GetObjectPhysicsJson(placeholder);
             if (!string.IsNullOrWhiteSpace(placeholderGraphJson))
                 _pendingObjectLoomGraphs[objectId] = placeholderGraphJson;
 
             var fallback = SceneSyncPanelFactory.CreateObjectForAsset(name, assetJson, metadataJson);
             ConfigureRemoteTemporaryIdentity(fallback, objectId, meshPath, assetId);
+            if (effectivePhysicsJson != null)
+                ApplyObjectPhysicsMetadata(fallback, effectivePhysicsJson);
             ApplyMetadataBehaviorGraph(fallback, objectId, metadataJson);
             if (visible.HasValue) fallback.SetActive(visible.Value);
             fallback.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -2439,7 +2526,7 @@ namespace Afjk.SceneSync
         private async System.Threading.Tasks.Task DownloadAndCreateObject(
             string objectId, string name, string meshPath,
             float[] position, float[] rotation, float[] scale, string assetId = null, string visualBasis = null,
-            string assetJson = null, string metadataJson = null, bool? visible = null)
+            string assetJson = null, string metadataJson = null, bool? visible = null, string physicsJson = null)
         {
             _knownObjectIds.Add(objectId);
 
@@ -2511,7 +2598,7 @@ namespace Afjk.SceneSync
                         HandleMissingGlb(objectId, meshPath, null, assetId);
                     }
 
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible, physicsJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }
@@ -2571,12 +2658,15 @@ namespace Afjk.SceneSync
                     var placeholder = _managedObjects[objectId];
                     var placeholderInstanceId = placeholder.GetInstanceID();
                     var placeholderGraphJson = GetObjectLoomGraphJson(placeholder);
+                    var effectivePhysicsJson = physicsJson ?? GetObjectPhysicsJson(placeholder);
                     if (!string.IsNullOrWhiteSpace(placeholderGraphJson))
                         _pendingObjectLoomGraphs[objectId] = placeholderGraphJson;
 
                     var go = new GameObject(name);
                     ConfigureRemoteTemporaryIdentity(go, objectId, meshPath, assetId);
                     SceneSyncPanelFactory.ConfigureWireMetadata(go, assetJson, metadataJson);
+                    if (effectivePhysicsJson != null)
+                        ApplyObjectPhysicsMetadata(go, effectivePhysicsJson);
                     ApplyMetadataBehaviorGraph(go, objectId, metadataJson);
                     if (visible.HasValue) go.SetActive(visible.Value);
                     go.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
@@ -2636,7 +2726,7 @@ namespace Afjk.SceneSync
                         + ", loadingError=" + gltf.LoadingError
                         + ", sceneCount=" + gltf.SceneCount
                         + ", defaultScene=" + (gltf.DefaultSceneIndex.HasValue ? gltf.DefaultSceneIndex.Value.ToString() : "null"));
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible, physicsJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                 }
 
@@ -2666,6 +2756,8 @@ namespace Afjk.SceneSync
                     if (replacements > 0)
                     {
                         currentObject.transform.SetParent(GetOrCreateTemporaryRoot(), worldPositionStays: false);
+                        if (physicsJson != null)
+                            ApplyObjectPhysicsMetadata(currentObject, physicsJson);
                         ApplyTransform(currentObject, position, rotation, scale);
 
                         OnObjectAdded?.Invoke(objectId, currentObject);
@@ -2675,7 +2767,7 @@ namespace Afjk.SceneSync
 
                 if (_managedObjects.ContainsKey(objectId))
                 {
-                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible);
+                    var fallback = ReplaceWithFallbackPrimitive(objectId, name, meshPath, position, rotation, scale, assetId, assetJson, metadataJson, visible, physicsJson);
                     OnObjectAdded?.Invoke(objectId, fallback);
                     return;
                 }

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Afjk.SceneSync
+{
+    public readonly struct SceneSyncRawMessage
+    {
+        public SceneSyncRawMessage(string rawJson, string fromPeerId, object source)
+        {
+            RawJson = rawJson;
+            FromPeerId = fromPeerId;
+            Source = source;
+        }
+
+        public string RawJson { get; }
+        public string FromPeerId { get; }
+        public object Source { get; }
+    }
+
+    public static class SceneSyncMessageBus
+    {
+        public static event Action<SceneSyncRawMessage> MessageReceived;
+
+        public static void PublishReceived(string rawJson, string fromPeerId = null, object source = null)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson)) return;
+            MessageReceived?.Invoke(new SceneSyncRawMessage(rawJson, fromPeerId, source));
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4eddceb324e54675a03197830d06162c

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncPhysicsMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncPhysicsMetadata.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace Afjk.SceneSync
+{
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncPhysicsMetadata : MonoBehaviour
+    {
+        [SerializeField] private string scenePhysicsJson;
+        [SerializeField] private string objectPhysicsJson;
+
+        public string ScenePhysicsJson
+        {
+            get => scenePhysicsJson;
+            set => scenePhysicsJson = Normalize(value);
+        }
+
+        public string ObjectPhysicsJson
+        {
+            get => objectPhysicsJson;
+            set => objectPhysicsJson = Normalize(value);
+        }
+
+        public bool HasScenePhysics => !string.IsNullOrWhiteSpace(scenePhysicsJson);
+        public bool HasObjectPhysics => !string.IsNullOrWhiteSpace(objectPhysicsJson);
+
+        public void ConfigureScenePhysics(string rawJson)
+        {
+            scenePhysicsJson = Normalize(rawJson);
+        }
+
+        public void ConfigureObjectPhysics(string rawJson)
+        {
+            objectPhysicsJson = Normalize(rawJson);
+        }
+
+        public void ClearObjectPhysics()
+        {
+            objectPhysicsJson = null;
+        }
+
+        private static string Normalize(string rawJson)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson)) return null;
+            var trimmed = rawJson.Trim();
+            return trimmed == "null" ? null : trimmed;
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncPhysicsMetadata.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncPhysicsMetadata.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 981f6677b52b40098ab8a82bc075fcc1

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncWireMetadata.cs
@@ -110,6 +110,91 @@ namespace Afjk.SceneSync
             return json.Substring(objectStart, objectEnd - objectStart + 1);
         }
 
+        public static bool HasField(string json, string fieldName)
+        {
+            return FindFieldValueStart(json, fieldName) >= 0;
+        }
+
+        public static bool HasTopLevelField(string json, string fieldName)
+        {
+            return FindFieldValueStart(json, fieldName, topLevelOnly: true) >= 0;
+        }
+
+        public static string ExtractRawValue(string json, string fieldName)
+        {
+            var valueStart = FindFieldValueStart(json, fieldName);
+            return ExtractRawValueAt(json, valueStart);
+        }
+
+        public static string ExtractTopLevelRawValue(string json, string fieldName)
+        {
+            var valueStart = FindFieldValueStart(json, fieldName, topLevelOnly: true);
+            return ExtractRawValueAt(json, valueStart);
+        }
+
+        public static string ExtractTopLevelRawObject(string json, string fieldName)
+        {
+            var raw = ExtractTopLevelRawValue(json, fieldName);
+            return !string.IsNullOrWhiteSpace(raw) && raw.TrimStart().StartsWith("{", StringComparison.Ordinal)
+                ? raw
+                : null;
+        }
+
+        private static string ExtractRawValueAt(string json, int valueStart)
+        {
+            if (valueStart < 0) return null;
+
+            var ch = json[valueStart];
+            if (ch == '{')
+            {
+                var end = FindMatching(json, valueStart, '{', '}');
+                return end >= 0 ? json.Substring(valueStart, end - valueStart + 1) : null;
+            }
+
+            if (ch == '[')
+            {
+                var end = FindMatching(json, valueStart, '[', ']');
+                return end >= 0 ? json.Substring(valueStart, end - valueStart + 1) : null;
+            }
+
+            if (ch == '"')
+            {
+                var end = FindStringEnd(json, valueStart);
+                return end >= 0 ? json.Substring(valueStart, end - valueStart + 1) : null;
+            }
+
+            var i = valueStart;
+            var inString = false;
+            var escape = false;
+            while (i < json.Length)
+            {
+                ch = json[i];
+                if (escape)
+                {
+                    escape = false;
+                    i++;
+                    continue;
+                }
+                if (ch == '\\')
+                {
+                    escape = true;
+                    i++;
+                    continue;
+                }
+                if (ch == '"')
+                {
+                    inString = !inString;
+                    i++;
+                    continue;
+                }
+                if (!inString && (ch == ',' || ch == '}'))
+                    break;
+                i++;
+            }
+
+            return json.Substring(valueStart, i - valueStart).Trim();
+        }
+
         public static List<KeyValuePair<string, string>> ExtractObjectMapEntries(string json, string fieldName)
         {
             var result = new List<KeyValuePair<string, string>>();
@@ -196,7 +281,8 @@ namespace Afjk.SceneSync
             string assetJson,
             string metadataJson,
             string origin = null,
-            string unityHierarchyPath = null)
+            string unityHierarchyPath = null,
+            string physicsJson = null)
         {
             var builder = new StringBuilder();
             builder.Append("\"").Append(JsonEscape(objectId)).Append("\":{");
@@ -227,6 +313,8 @@ namespace Afjk.SceneSync
                 builder.Append(",\"asset\":").Append(assetJson);
             if (!string.IsNullOrWhiteSpace(metadataJson))
                 builder.Append(",\"metadata\":").Append(metadataJson);
+            if (!string.IsNullOrWhiteSpace(physicsJson))
+                builder.Append(",\"physics\":").Append(physicsJson);
             builder.Append("}");
             return builder.ToString();
         }
@@ -269,6 +357,74 @@ namespace Afjk.SceneSync
         public static string GetAssetColor(string assetJson)
         {
             return ExtractString(assetJson, "color");
+        }
+
+        private static int FindFieldValueStart(string json, string fieldName, bool topLevelOnly = false)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(fieldName)) return -1;
+
+            var depth = 0;
+            var inString = false;
+            var escape = false;
+
+            for (var i = 0; i < json.Length; i++)
+            {
+                var ch = json[i];
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+
+                if (inString)
+                {
+                    if (ch == '\\')
+                    {
+                        escape = true;
+                    }
+                    else if (ch == '"')
+                    {
+                        inString = false;
+                    }
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    var keyStart = i;
+                    var keyEnd = FindStringEnd(json, keyStart);
+                    if (keyEnd < 0) return -1;
+
+                    if (!topLevelOnly || depth == 1)
+                    {
+                        var key = UnescapeJsonString(json.Substring(keyStart + 1, keyEnd - keyStart - 1));
+                        if (string.Equals(key, fieldName, StringComparison.Ordinal))
+                        {
+                            var colon = keyEnd + 1;
+                            SkipWhitespace(json, ref colon);
+                            if (colon >= json.Length || json[colon] != ':')
+                            {
+                                i = keyEnd;
+                                continue;
+                            }
+
+                            var valueStart = colon + 1;
+                            SkipWhitespace(json, ref valueStart);
+                            return valueStart < json.Length ? valueStart : -1;
+                        }
+                    }
+
+                    i = keyEnd;
+                    continue;
+                }
+
+                if (ch == '{' || ch == '[')
+                    depth++;
+                else if (ch == '}' || ch == ']')
+                    depth = Math.Max(0, depth - 1);
+            }
+
+            return -1;
         }
 
         private static int FindMatching(string text, int start, char open, char close)


### PR DESCRIPTION
## Summary

- Preserve Scene Sync physics metadata in the Unity SDK without adding a hard Rapier dependency to `com.afjk.scene-sync`.
- Add optional `com.afjk.scene-sync-rapier` package that consumes Scene Sync wire physics metadata and builds a Rapier world from Web-origin scene-state / scene-physics messages.
- Document the local Git/file install flow while `com.afjk.rapier` is not yet in OpenUPM or `upm.afjk.jp`.

## Implementation Notes

- Added `SceneSyncMessageBus` so optional downstream packages can observe raw Scene Sync messages.
- Added `SceneSyncPhysicsMetadata` and top-level JSON extraction helpers so scene-level physics and object-level physics stay distinct.
- Added `SceneSyncRapierBridge` with stable body/collider ids, wire-coordinate conversion, optional ground creation, fixed timestep stepping, and dynamic transform application back to Unity.
- Preserved existing object physics metadata when GLB/fallback replacement happens from a payload that omits `physics`; explicit `physics:null` still clears it.

## Validation

- `uloop compile` in `/Users/afjk/github/SceneSyncWork/SceneSyncClient`: success, 0 errors, 17 warnings from existing SceneSyncClient sample/editor code.
- Unity dynamic smoke: `ok:top-level-physics-world`.
- Unity dynamic smoke: `ok:nested-physics-not-scene`.
- Unity dynamic smoke: `ok:missing-physics-preserves-replacement-metadata`.
- `uloop get-logs --log-type Error` in `SceneSyncClient`: 0 errors.
- `npm run test:physics`: 34 tests passed.

## Verification Project

- Used `/Users/afjk/github/SceneSyncWork/SceneSyncClient` as the local Unity verification project.
- Added local file package refs there for verification only; those project-local manifest/Library changes are not part of this PR.
