### PR TITLE
[codex] Add Scene Sync Rapier hash diagnostics

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -292,6 +292,13 @@ using the same v0 event shape as Web runtime events: `physics.collision.enter`
 and `physics.collision.exit`, sorted `objectIdA` / `objectIdB`, `pairKey`,
 physics `tick`, `source: "physics"`, and `phase: "postPhysics"`.
 
+`SceneSyncRapierBridge.ComputeStateHashHex()` exposes Unity Rapier's current
+`SceneSyncCanonicalPhysicsHashV1` as 16-character lowercase hex. The bridge also
+keeps `LastStateHash` updated after rebuilds, resets, and physics steps without
+requiring log output. Use it as the Unity-side value to compare with the Web
+runtime's `world.canonicalStateHash()` when both hosts are on the same
+`SceneSyncRapierParity-0.30` profile.
+
 ## Supported Shapes
 
 The current Scene Sync UI maps to Rapier sphere and cuboid colliders:

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -46,3 +46,10 @@ before stepping again.
 `physics.collision.enter` and `physics.collision.exit` events after fixed physics
 steps. Events include sorted `objectIdA` / `objectIdB`, `pairKey`, physics
 `tick`, `time`, `source: "physics"`, and `phase: "postPhysics"`.
+
+`SceneSyncRapierBridge.ComputeStateHashHex()` returns the current
+`SceneSyncCanonicalPhysicsHashV1` value as 16-character lowercase hex.
+`LastStateHash` is updated after rebuilds, resets, and physics steps without
+requiring `logStateHash`; enable `logStateHash` only when console output is
+useful. Compare this value with the browser runtime's `world.canonicalStateHash()`
+only when both hosts use the same Scene Sync Rapier parity profile.

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -16,6 +16,7 @@ namespace Afjk.SceneSync.Rapier
         private const float GroundThickness = 0.1f;
         private const double ZeroTimeEpsilon = 0.000001d;
         private const string GroundStableId = "__scenesync_ground__";
+        private const string CanonicalStateHashVersion = "SceneSyncCanonicalPhysicsHashV1";
 
         [SerializeField] private bool autoRun = true;
         [SerializeField] private bool useSceneClock = true;
@@ -52,6 +53,7 @@ namespace Afjk.SceneSync.Rapier
 
         public event Action<SceneSyncRapierCollisionEvent> CollisionEvent;
 
+        public string StateHashVersion => CanonicalStateHashVersion;
         public int Tick => tick;
         public string LastStateHash => lastStateHash;
         public bool HasWorld => world != null && world.IsCreated;
@@ -114,11 +116,7 @@ namespace Afjk.SceneSync.Rapier
             {
                 ApplyWorldTransforms();
                 FlushCollisionEvents(GetCurrentPhysicsTime());
-                if (logStateHash)
-                {
-                    lastStateHash = world.StateHash().ToString("x16", CultureInfo.InvariantCulture);
-                    Debug.Log("[SceneSyncRapier] tick=" + tick + " stateHash=" + lastStateHash);
-                }
+                UpdateLastStateHash(null);
             }
         }
 
@@ -157,11 +155,8 @@ namespace Afjk.SceneSync.Rapier
             {
                 ApplyWorldTransforms();
                 FlushCollisionEvents(clockTime);
-                if (logStateHash)
-                {
-                    lastStateHash = world.StateHash().ToString("x16", CultureInfo.InvariantCulture);
-                    Debug.Log("[SceneSyncRapier] tick=" + tick + " targetTick=" + targetTick + " stateHash=" + lastStateHash);
-                }
+                if (steps > 0 || string.IsNullOrWhiteSpace(lastStateHash))
+                    UpdateLastStateHash("targetTick=" + targetTick.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -223,6 +218,7 @@ namespace Afjk.SceneSync.Rapier
                 pendingWorldEpochTime = 0f;
                 hasInitialSnapshot = world.TryCreateSnapshot(out initialSnapshot);
                 ApplyWorldTransforms();
+                UpdateLastStateHash("rebuilt");
             }
             catch (Exception error)
             {
@@ -405,6 +401,7 @@ namespace Afjk.SceneSync.Rapier
                 previousCollisionPairs.Clear();
                 lastCollisionEvents.Clear();
                 ApplyWorldTransforms();
+                UpdateLastStateHash("reset");
                 return;
             }
 
@@ -611,6 +608,26 @@ namespace Afjk.SceneSync.Rapier
         private float GetCurrentPhysicsTime()
         {
             return worldEpochTime + tick * Mathf.Max(0.000001f, scenePhysics.Timestep);
+        }
+
+        public string ComputeStateHashHex()
+        {
+            if (world == null || !world.IsCreated)
+                return null;
+
+            return world.StateHash().ToString("x16", CultureInfo.InvariantCulture);
+        }
+
+        private void UpdateLastStateHash(string detail)
+        {
+            lastStateHash = ComputeStateHashHex();
+            if (!logStateHash || string.IsNullOrWhiteSpace(lastStateHash))
+                return;
+
+            var message = "[SceneSyncRapier] tick=" + tick.ToString(CultureInfo.InvariantCulture);
+            if (!string.IsNullOrWhiteSpace(detail))
+                message += " " + detail;
+            Debug.Log(message + " canonicalStateHash=" + lastStateHash);
         }
 
         private void DisposeWorld()


### PR DESCRIPTION
## Summary
- expose `SceneSyncRapierBridge.ComputeStateHashHex()` for Unity-side `SceneSyncCanonicalPhysicsHashV1` diagnostics
- keep `LastStateHash` updated after rebuilds, resets, and physics steps without requiring log output
- document comparing the Unity hash with browser `world.canonicalStateHash()` under the same parity profile

## Validation
- `/Users/afjk/.local/bin/uloop compile` in `SceneSyncClient`
- Unity CLI Loop dynamic smoke: `ok:state-hash-diagnostics:417f10e857ac4668`
- `/Users/afjk/.local/bin/uloop get-logs --log-type Error` in `SceneSyncClient`
- `npm run test:physics`