### PR TITLE
[codex] Preserve Unity Rapier motion across rebuilds

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -287,6 +287,11 @@ The bridge also follows Shared Playback `scene-clock` messages. It derives the
 target Rapier tick from the shared clock time and restores the initial Rapier
 snapshot when a reset or seek-to-zero payload carries a `physicsBaseline`.
 
+When object or scene metadata changes force a rebuild, Unity preserves dynamic
+body pose, linear velocity, and angular velocity for unchanged Scene Sync object
+ids. Reset baselines opt out of this and restore the initial snapshot unless
+`physicsBaseline.preserveMotion` is explicitly true.
+
 Unity collision events are exposed through `SceneSyncRapierBridge.CollisionEvent`
 using the same v0 event shape as Web runtime events: `physics.collision.enter`
 and `physics.collision.exit`, sorted `objectIdA` / `objectIdB`, `pairKey`,

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -42,6 +42,11 @@ uses the shared clock time to step Rapier to the matching fixed tick. Reset and
 seek-to-zero payloads with `physicsBaseline` restore the initial Rapier snapshot
 before stepping again.
 
+When scene metadata changes cause a Rapier world rebuild, the bridge preserves
+dynamic body pose, linear velocity, and angular velocity for matching Scene Sync
+object ids. Reset baselines still restore the initial snapshot unless
+`physicsBaseline.preserveMotion` is explicitly true.
+
 `SceneSyncRapierBridge.CollisionEvent` raises Web-compatible
 `physics.collision.enter` and `physics.collision.exit` events after fixed physics
 steps. Events include sorted `objectIdA` / `objectIdB`, `pairKey`, physics

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -43,6 +43,7 @@ namespace Afjk.SceneSync.Rapier
         private bool hasInitialSnapshot;
         private bool hasPendingWorldEpochTime;
         private bool lastStepLimited;
+        private bool preserveMotionOnNextRebuild = true;
         private float accumulator;
         private float worldEpochTime;
         private float pendingWorldEpochTime;
@@ -176,6 +177,11 @@ namespace Afjk.SceneSync.Rapier
 
         public void RebuildWorld()
         {
+            var preservedBodyStates = preserveMotionOnNextRebuild
+                ? CapturePreservedBodyStates()
+                : new Dictionary<string, PreservedBodyState>(StringComparer.Ordinal);
+            preserveMotionOnNextRebuild = true;
+
             dirty = false;
             accumulator = 0f;
             tick = 0;
@@ -208,7 +214,8 @@ namespace Afjk.SceneSync.Rapier
 
                 foreach (var candidate in candidates.OrderBy(item => item.ObjectId, StringComparer.Ordinal))
                 {
-                    CreateBody(candidate);
+                    preservedBodyStates.TryGetValue(candidate.ObjectId, out var preservedState);
+                    CreateBody(candidate, preservedState);
                 }
 
                 worldEpochTime = hasPendingWorldEpochTime
@@ -381,6 +388,8 @@ namespace Afjk.SceneSync.Rapier
         private void ApplyPhysicsResetBaseline(string raw, double activeTime)
         {
             var baselineJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "physicsBaseline");
+            var preserveMotion = !string.IsNullOrWhiteSpace(baselineJson)
+                && ReadBool(baselineJson, "preserveMotion", false);
             var worldEpoch = !string.IsNullOrWhiteSpace(baselineJson)
                 ? ReadDouble(baselineJson, "worldEpochTime", activeTime)
                 : activeTime;
@@ -391,7 +400,7 @@ namespace Afjk.SceneSync.Rapier
             accumulator = 0f;
             lastStepLimited = false;
 
-            if (world != null && hasInitialSnapshot && world.TryReadSnapshot(initialSnapshot))
+            if (!preserveMotion && world != null && hasInitialSnapshot && world.TryReadSnapshot(initialSnapshot))
             {
                 worldEpochTime = pendingWorldEpochTime;
                 hasPendingWorldEpochTime = false;
@@ -405,6 +414,7 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
+            preserveMotionOnNextRebuild = preserveMotion;
             dirty = true;
         }
 
@@ -481,16 +491,43 @@ namespace Afjk.SceneSync.Rapier
             world.SetColliderStableId(collider, stableId);
         }
 
-        private void CreateBody(BodyCandidate candidate)
+        private Dictionary<string, PreservedBodyState> CapturePreservedBodyStates()
+        {
+            var result = new Dictionary<string, PreservedBodyState>(StringComparer.Ordinal);
+            if (world == null || !world.IsCreated || bindings.Count == 0)
+                return result;
+
+            foreach (var pair in bindings)
+            {
+                var binding = pair.Value;
+                if (binding.IsStatic) continue;
+                if (!world.TryGetRigidBodyState(binding.Body, out var state)) continue;
+
+                result[pair.Key] = new PreservedBodyState(
+                    state.Transform.Position,
+                    state.Transform.Rotation,
+                    state.LinearVelocity,
+                    state.AngularVelocity);
+            }
+
+            return result;
+        }
+
+        private void CreateBody(BodyCandidate candidate, PreservedBodyState preservedState)
         {
             var definition = candidate.Definition;
+            var hasPreservedState = !definition.IsStatic && preservedState.HasValue;
             var body = world.CreateRigidBody(new RapierBodyDesc
             {
                 BodyType = definition.IsStatic ? RapierRigidBodyType.Fixed : RapierRigidBodyType.Dynamic,
-                Position = definition.Position,
-                Rotation = definition.Rotation,
-                LinearVelocity = definition.IsStatic ? Vector3.zero : definition.LinearVelocity,
-                AngularVelocity = definition.IsStatic ? Vector3.zero : definition.AngularVelocity,
+                Position = hasPreservedState ? preservedState.Position : definition.Position,
+                Rotation = hasPreservedState ? preservedState.Rotation : definition.Rotation,
+                LinearVelocity = definition.IsStatic
+                    ? Vector3.zero
+                    : (hasPreservedState ? preservedState.LinearVelocity : definition.LinearVelocity),
+                AngularVelocity = definition.IsStatic
+                    ? Vector3.zero
+                    : (hasPreservedState ? preservedState.AngularVelocity : definition.AngularVelocity),
                 LinearDamping = definition.LinearDamping,
                 AngularDamping = definition.AngularDamping,
                 CanSleep = definition.CanSleep,
@@ -837,6 +874,28 @@ namespace Afjk.SceneSync.Rapier
             public GameObject GameObject { get; }
             public RapierRigidBodyHandle Body { get; }
             public bool IsStatic { get; }
+        }
+
+        private readonly struct PreservedBodyState
+        {
+            public PreservedBodyState(
+                Vector3 position,
+                Quaternion rotation,
+                Vector3 linearVelocity,
+                Vector3 angularVelocity)
+            {
+                Position = position;
+                Rotation = rotation;
+                LinearVelocity = linearVelocity;
+                AngularVelocity = angularVelocity;
+                HasValue = true;
+            }
+
+            public bool HasValue { get; }
+            public Vector3 Position { get; }
+            public Quaternion Rotation { get; }
+            public Vector3 LinearVelocity { get; }
+            public Vector3 AngularVelocity { get; }
         }
 
         private enum PhysicsShape


### PR DESCRIPTION
## Summary
- preserve dynamic Rapier body pose, linear velocity, and angular velocity when Unity bridge rebuilds an existing Scene Sync physics world
- keep reset baselines restoring the initial snapshot unless `physicsBaseline.preserveMotion` is explicitly true
- document the rebuild motion behavior for the Unity bridge

## Validation
- `/Users/afjk/.local/bin/uloop compile` in `SceneSyncClient`
- Unity CLI Loop dynamic smoke: `ok:motion-preserved:x=0.08333335:vx=1`
- Unity CLI Loop dynamic smoke: `ok:reset-restores-initial:x=0`
- `/Users/afjk/.local/bin/uloop get-logs --log-type Error` in `SceneSyncClient`
- `npm run test:physics`