### PR TITLE
[codex] Add Scene Sync physics hash diagnostics wire

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -204,6 +204,36 @@ state.
   worlds. Do not use for network divergence detection; prefer
   `networkStateHash()` instead.
 
+### Scene Physics Hash Messages
+
+During Shared Playback, only the current Web Scene Clock controller broadcasts
+low-frequency `scene-physics-hash` messages. The browser sends them after fixed
+physics updates at tick `0` and every 30 ticks thereafter:
+
+```json
+{
+  "kind": "scene-physics-hash",
+  "source": "physics",
+  "phase": "postPhysics",
+  "profile": "SceneSyncRapierParity-0.30",
+  "hashVersion": "SceneSyncCanonicalPhysicsHashV1",
+  "rapierCoreVersion": "0.30.0",
+  "tick": 120,
+  "hash": "0123456789abcdef",
+  "timestep": 0.016666666666666666,
+  "activeTime": 2,
+  "worldAge": 2,
+  "worldEpochTime": 0,
+  "sceneClockRevision": 8,
+  "controller": { "id": "peer-id", "nickname": "Host" },
+  "sentAt": 1782010000000
+}
+```
+
+Followers should compare the hash only when the fixed tick and hash version
+match their local world. A mismatch is a divergence signal for diagnostics and
+future snapshot resync; it is not a request to stream or apply body transforms.
+
 ## Shared Playback
 
 Shared Playback uses:
@@ -304,6 +334,11 @@ keeps `LastStateHash` updated after rebuilds, resets, and physics steps without
 requiring log output. Use it as the Unity-side value to compare with the Web
 runtime's `world.canonicalStateHash()` when both hosts are on the same
 `SceneSyncRapierParity-0.30` profile.
+
+The bridge also consumes Web `scene-physics-hash` messages. The latest report is
+available through `LastRemoteHashReport`, `LastRemoteHashMatched`, and the
+`HashReportReceived` event. Reports compare tick, hash version, and canonical
+hash, but they intentionally do not perform resync yet.
 
 ## Supported Shapes
 

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -1,14 +1,17 @@
 import {
+  CANONICAL_PHYSICS_HASH_VERSION,
   createWorld,
   DEFAULT_TIMESTEP_SECONDS,
   getRapierPhysicsInitError,
   initRapierPhysics,
   isRapierPhysicsReady,
   normalizeRapierWorldOptions,
+  RAPIER_CORE_VERSION,
 } from './physics/index.js';
 import { createCollisionPairKey } from './runtime/runtime-events.js';
 
 export const DEFAULT_SCENE_PHYSICS_DURATION = 10;
+export const SCENE_SYNC_RAPIER_PROFILE = 'SceneSyncRapierParity-0.30';
 export const DEFAULT_SCENE_PHYSICS = Object.freeze({
   version: 1,
   enabled: false,
@@ -560,6 +563,7 @@ export function createScenePhysicsRuntime({
       }
     }
 
+    const clockTime = getClockTime(clockState);
     const worldAge = getWorldAge(clockState);
     const targetTick = Math.max(0, Math.floor(worldAge / timestepSeconds));
     if (targetTick < world.tick && initialSnapshot) {
@@ -624,9 +628,19 @@ export function createScenePhysicsRuntime({
       previousCollisionPairs = currentPairs;
     }
 
+    const stateHash = world.canonicalStateHash();
     return {
       active: true,
       tick: world.tick,
+      timestep: world.timestep || timestepSeconds,
+      activeTime: clockTime,
+      worldAge,
+      worldEpochTime,
+      profile: SCENE_SYNC_RAPIER_PROFILE,
+      hashVersion: CANONICAL_PHYSICS_HASH_VERSION,
+      rapierCoreVersion: RAPIER_CORE_VERSION,
+      stateHash,
+      hash: stateHash,
       limited: stepResult?.limited === true,
       reached: stepResult?.reached !== false,
       events: collisionEvents,

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -7,9 +7,14 @@ import {
   isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
+  SCENE_SYNC_RAPIER_PROFILE,
   shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
-import { initRapierPhysics } from './physics/index.js';
+import {
+  CANONICAL_PHYSICS_HASH_VERSION,
+  initRapierPhysics,
+  RAPIER_CORE_VERSION,
+} from './physics/index.js';
 
 before(async () => {
   await initRapierPhysics();
@@ -168,6 +173,41 @@ test('scene physics runtime treats rebuild time as the physics world epoch', () 
 
   runtime.update({ t: roomTime + 0.5, mode: 'room-time', active: true });
   assert.ok(object.position.toArray()[1] < 2);
+});
+
+test('scene physics runtime reports canonical hash metadata for wire diagnostics', () => {
+  const object = makeObject({
+    objectId: 'hash-box',
+    position: [0, 0.5, 0],
+    physics: {
+      enabled: true,
+      shape: 'box',
+      halfExtents: [0.5, 0.5, 0.5],
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+      timestep: 1 / 60,
+    },
+  });
+  const runtime = makeRuntime({ scenePhysics, entries: [makeEntry(object)] });
+
+  const result = runtime.update({ t: 0, mode: 'shared-playback', active: true });
+
+  assert.equal(result.active, true);
+  assert.equal(result.tick, 0);
+  assert.ok(Math.abs(result.timestep - 1 / 60) < 1e-8);
+  assert.equal(result.worldEpochTime, 0);
+  assert.equal(result.profile, SCENE_SYNC_RAPIER_PROFILE);
+  assert.equal(result.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
+  assert.equal(result.rapierCoreVersion, RAPIER_CORE_VERSION);
+  assert.match(result.hash, /^[0-9a-f]{16}$/);
+  assert.equal(result.stateHash, result.hash);
 });
 
 test('scene physics runtime keeps existing body motion when a new body rebases the world', () => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -83,6 +83,7 @@ import {
   isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
+  SCENE_SYNC_RAPIER_PROFILE,
   serializeObjectPhysics,
   serializeScenePhysics,
   shouldResetPhysicsForSceneClockPayload,
@@ -1376,6 +1377,7 @@ function endMultiTransformHistory() {
 
 const SAMPLE_CUBE_OBJECT_ID = 'sample-cube';
 const SAMPLE_CUBE_COLOR = '#4488ff';
+const SCENE_PHYSICS_HASH_BROADCAST_TICK_INTERVAL = 30;
 
 function createSampleCube() {
   const sampleGeo = new THREE.BoxGeometry(1, 1, 1);
@@ -1400,6 +1402,9 @@ const managedObjects = new Map();
 const selectedObjectIds = new Set();
 const selectionHelpers = new Map();
 let scenePhysicsState = normalizeScenePhysics();
+let lastScenePhysicsHashBroadcastTick = null;
+let lastScenePhysicsHashBroadcastHash = null;
+let lastScenePhysicsHashBroadcastRevision = null;
 const scenePhysicsRuntime = createScenePhysicsRuntime({
   getScenePhysics: () => scenePhysicsState,
   getObjectEntries: () => Array.from(managedObjects.entries()).map(([objectId, object]) => ({
@@ -4562,6 +4567,7 @@ renderer.setAnimationLoop((time, frame) => {
   const now = performance.now();
   const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
   const physicsTick = scenePhysicsRuntime.update(sceneClockStateForTick);
+  maybeBroadcastScenePhysicsHash(physicsTick, sceneClockStateForTick);
   if ((physicsTick.active || physicsTick.reset) && selectedObjectIds.size > 0) {
     updateSelectionHelpers();
   }
@@ -5161,6 +5167,55 @@ function publishSharedObjectClockBaselines(reason = 'baseline') {
   updateClockLegacyFields(now);
   broadcastSceneClockEvent(reason, {
     objectClocks: getSharedObjectClockPayload(now),
+  });
+}
+
+function maybeBroadcastScenePhysicsHash(physicsTick, clockState = null) {
+  if (!physicsTick?.active) return;
+  if (clockState?.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (!isSceneClockControllerSelf()) return;
+
+  const tick = Number(physicsTick.tick);
+  const hash = typeof physicsTick.hash === 'string'
+    ? physicsTick.hash
+    : physicsTick.stateHash;
+  if (!Number.isInteger(tick) || tick < 0 || typeof hash !== 'string' || hash.length === 0) {
+    return;
+  }
+  if (tick !== 0 && tick % SCENE_PHYSICS_HASH_BROADCAST_TICK_INTERVAL !== 0) {
+    return;
+  }
+
+  const revision = Number.isFinite(sceneClockState.sharedRevision)
+    ? sceneClockState.sharedRevision
+    : null;
+  if (
+    lastScenePhysicsHashBroadcastTick === tick &&
+    lastScenePhysicsHashBroadcastHash === hash &&
+    lastScenePhysicsHashBroadcastRevision === revision
+  ) {
+    return;
+  }
+
+  lastScenePhysicsHashBroadcastTick = tick;
+  lastScenePhysicsHashBroadcastHash = hash;
+  lastScenePhysicsHashBroadcastRevision = revision;
+  broadcast({
+    kind: 'scene-physics-hash',
+    source: 'physics',
+    phase: 'postPhysics',
+    profile: physicsTick.profile || SCENE_SYNC_RAPIER_PROFILE,
+    hashVersion: physicsTick.hashVersion,
+    rapierCoreVersion: physicsTick.rapierCoreVersion,
+    tick,
+    hash,
+    timestep: physicsTick.timestep,
+    activeTime: physicsTick.activeTime ?? clockState?.activeTime ?? clockState?.t,
+    worldAge: physicsTick.worldAge,
+    worldEpochTime: physicsTick.worldEpochTime,
+    sceneClockRevision: revision,
+    controller: getSceneClockController(),
+    sentAt: Date.now(),
   });
 }
 

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -58,3 +58,11 @@ steps. Events include sorted `objectIdA` / `objectIdB`, `pairKey`, physics
 requiring `logStateHash`; enable `logStateHash` only when console output is
 useful. Compare this value with the browser runtime's `world.canonicalStateHash()`
 only when both hosts use the same Scene Sync Rapier parity profile.
+
+During Shared Playback, the Web clock controller periodically broadcasts
+`scene-physics-hash` messages with `SceneSyncCanonicalPhysicsHashV1`, Rapier core
+version, physics profile, fixed `tick`, and canonical hash. The bridge stores
+the latest report in `LastRemoteHashReport`, exposes `LastRemoteHashMatched`,
+and raises `HashReportReceived` after comparing the remote hash with the local
+world at the same tick. This is diagnostic only; it does not resync or stream
+body transforms.

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -51,8 +51,11 @@ namespace Afjk.SceneSync.Rapier
         private int latestSceneClockRevision = int.MinValue;
         private float nextMetadataScanAt;
         private string lastStateHash;
+        private bool hasRemoteHashReport;
+        private SceneSyncRapierHashReport lastRemoteHashReport;
 
         public event Action<SceneSyncRapierCollisionEvent> CollisionEvent;
+        public event Action<SceneSyncRapierHashReport> HashReportReceived;
 
         public string StateHashVersion => CanonicalStateHashVersion;
         public int Tick => tick;
@@ -60,6 +63,9 @@ namespace Afjk.SceneSync.Rapier
         public bool HasWorld => world != null && world.IsCreated;
         public bool LastStepLimited => lastStepLimited;
         public IReadOnlyList<SceneSyncRapierCollisionEvent> LastCollisionEvents => lastCollisionEvents;
+        public bool HasRemoteHashReport => hasRemoteHashReport;
+        public SceneSyncRapierHashReport LastRemoteHashReport => lastRemoteHashReport;
+        public bool LastRemoteHashMatched => hasRemoteHashReport && lastRemoteHashReport.Matched;
 
         private void OnEnable()
         {
@@ -338,6 +344,12 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
+            if (raw.Contains("\"kind\":\"scene-physics-hash\""))
+            {
+                ApplyScenePhysicsHash(raw, message.FromPeerId);
+                return;
+            }
+
             if (raw.Contains("\"kind\":\"scene-physics\""))
             {
                 scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
@@ -360,6 +372,64 @@ namespace Afjk.SceneSync.Rapier
             if (string.IsNullOrWhiteSpace(id)) return;
             if (ApplyObjectPhysicsJson(id, raw))
                 dirty = true;
+        }
+
+        private void ApplyScenePhysicsHash(string raw, string fromPeerId)
+        {
+            var remoteHash = NormalizeHash(SceneSyncWireJson.ExtractString(raw, "hash"));
+            var hashVersion = SceneSyncWireJson.ExtractString(raw, "hashVersion");
+            var profile = SceneSyncWireJson.ExtractString(raw, "profile");
+            var rapierCoreVersion = SceneSyncWireJson.ExtractString(raw, "rapierCoreVersion");
+            var remoteTick = ReadInt(raw, "tick", -1);
+            var timestep = ReadFloat(raw, "timestep", scenePhysics.Timestep);
+            var activeTime = ReadFloat(raw, "activeTime", float.NaN);
+            var worldAge = ReadFloat(raw, "worldAge", float.NaN);
+            var reportedWorldEpochTime = ReadFloat(raw, "worldEpochTime", float.NaN);
+            var sceneClockRevision = ReadInt(raw, "sceneClockRevision", int.MinValue);
+
+            var localHash = NormalizeHash(ComputeStateHashHex());
+            var tickMatched = remoteTick == tick;
+            var hashVersionMatched = string.Equals(hashVersion, CanonicalStateHashVersion, StringComparison.Ordinal);
+            var matched = tickMatched
+                && hashVersionMatched
+                && !string.IsNullOrWhiteSpace(remoteHash)
+                && !string.IsNullOrWhiteSpace(localHash)
+                && string.Equals(remoteHash, localHash, StringComparison.Ordinal);
+
+            lastRemoteHashReport = new SceneSyncRapierHashReport(
+                remoteHash,
+                localHash,
+                hashVersion,
+                profile,
+                rapierCoreVersion,
+                remoteTick,
+                tick,
+                timestep,
+                activeTime,
+                worldAge,
+                reportedWorldEpochTime,
+                sceneClockRevision,
+                fromPeerId,
+                tickMatched,
+                hashVersionMatched,
+                matched);
+            hasRemoteHashReport = true;
+            HashReportReceived?.Invoke(lastRemoteHashReport);
+
+            if (logStateHash && !matched)
+            {
+                Debug.LogWarning(
+                    "[SceneSyncRapier] scene-physics-hash mismatch remoteTick="
+                    + remoteTick.ToString(CultureInfo.InvariantCulture)
+                    + " localTick="
+                    + tick.ToString(CultureInfo.InvariantCulture)
+                    + " remoteHash="
+                    + (remoteHash ?? "null")
+                    + " localHash="
+                    + (localHash ?? "null")
+                    + " hashVersion="
+                    + (hashVersion ?? "null"));
+            }
         }
 
         private void ApplySceneClock(string raw)
@@ -744,6 +814,12 @@ namespace Afjk.SceneSync.Rapier
             return value.HasValue && IsFinite(value.Value) ? value.Value : fallback;
         }
 
+        private static int ReadInt(string json, string field, int fallback)
+        {
+            var value = ReadDouble(json, field, double.NaN);
+            return IsFinite(value) ? Mathf.FloorToInt((float)value) : fallback;
+        }
+
         private static double ReadDouble(string json, string field, double fallback)
         {
             var raw = SceneSyncWireJson.ExtractTopLevelRawValue(json, field);
@@ -765,6 +841,13 @@ namespace Afjk.SceneSync.Rapier
         {
             var value = SceneSyncWireJson.ExtractBoolean(json, field);
             return value ?? fallback;
+        }
+
+        private static string NormalizeHash(string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? null
+                : value.Trim().ToLowerInvariant();
         }
 
         private static bool IsFinite(float value)

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierHashReport.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierHashReport.cs
@@ -1,0 +1,61 @@
+namespace Afjk.SceneSync.Rapier
+{
+    public readonly struct SceneSyncRapierHashReport
+    {
+        public SceneSyncRapierHashReport(
+            string hash,
+            string localHash,
+            string hashVersion,
+            string profile,
+            string rapierCoreVersion,
+            int tick,
+            int localTick,
+            float timestep,
+            float activeTime,
+            float worldAge,
+            float worldEpochTime,
+            int sceneClockRevision,
+            string fromPeerId,
+            bool tickMatched,
+            bool hashVersionMatched,
+            bool matched)
+        {
+            Hash = hash;
+            LocalHash = localHash;
+            HashVersion = hashVersion;
+            Profile = profile;
+            RapierCoreVersion = rapierCoreVersion;
+            Tick = tick;
+            LocalTick = localTick;
+            Timestep = timestep;
+            ActiveTime = activeTime;
+            WorldAge = worldAge;
+            WorldEpochTime = worldEpochTime;
+            SceneClockRevision = sceneClockRevision;
+            FromPeerId = fromPeerId;
+            TickMatched = tickMatched;
+            HashVersionMatched = hashVersionMatched;
+            Matched = matched;
+        }
+
+        public string Kind => "scene-physics-hash";
+        public string Source => "physics";
+        public string Phase => "postPhysics";
+        public string Hash { get; }
+        public string LocalHash { get; }
+        public string HashVersion { get; }
+        public string Profile { get; }
+        public string RapierCoreVersion { get; }
+        public int Tick { get; }
+        public int LocalTick { get; }
+        public float Timestep { get; }
+        public float ActiveTime { get; }
+        public float WorldAge { get; }
+        public float WorldEpochTime { get; }
+        public int SceneClockRevision { get; }
+        public string FromPeerId { get; }
+        public bool TickMatched { get; }
+        public bool HashVersionMatched { get; }
+        public bool Matched { get; }
+    }
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierHashReport.cs.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierHashReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91a97e472e2141b5b32f7a016de41cbc


### PR DESCRIPTION
## Summary

Adds a low-frequency Scene Sync physics hash diagnostic path between the Web Rapier runtime and the Unity Rapier bridge.

- Web physics runtime now returns canonical hash metadata (`SceneSyncCanonicalPhysicsHashV1`, Rapier core version, parity profile, tick, timestep, world epoch data).
- The Shared Playback controller broadcasts `scene-physics-hash` at tick 0 and every 30 ticks.
- Unity bridge consumes hash reports, compares them to the local canonical hash at the same tick, stores `LastRemoteHashReport`, exposes `LastRemoteHashMatched`, and raises `HashReportReceived`.
- Docs describe the diagnostic wire message and clarify that it does not resync or stream body transforms.

## Validation

- `npm run test:physics`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `/Users/afjk/.local/bin/uloop compile` in `SceneSyncClient` (0 errors; existing Unity-chan obsolete warnings remain)
- Unity dynamic smoke via `uloop execute-dynamic-code`: `ok:hash-report:3ddaec40d39daded`
- `/Users/afjk/.local/bin/uloop get-logs --log-type Error` (0 errors)

## Notes

This is intentionally diagnostic-only. Divergence recovery should be added as a separate snapshot/resync contract.