### PR TITLE
[codex] Add Scene Sync physics snapshot wire

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -234,6 +234,48 @@ Followers should compare the hash only when the fixed tick and hash version
 match their local world. A mismatch is a divergence signal for diagnostics and
 future snapshot resync; it is not a request to stream or apply body transforms.
 
+### Scene Physics Snapshot Messages
+
+The Shared Playback controller also publishes low-frequency
+`scene-physics-snapshot` baselines at tick `0` and every 120 fixed ticks. These
+messages are coarse resync checkpoints, not the normal playback transport:
+
+```json
+{
+  "kind": "scene-physics-snapshot",
+  "source": "physics",
+  "phase": "postPhysics",
+  "snapshotVersion": "SceneSyncPhysicsSnapshotV1",
+  "profile": "SceneSyncRapierParity-0.30",
+  "hashVersion": "SceneSyncCanonicalPhysicsHashV1",
+  "rapierCoreVersion": "0.30.0",
+  "tick": 120,
+  "hash": "0123456789abcdef",
+  "timestep": 0.016666666666666666,
+  "activeTime": 2,
+  "worldAge": 2,
+  "worldEpochTime": 0,
+  "bodyCount": 1,
+  "bodies": [
+    {
+      "id": "box-1",
+      "type": "dynamic",
+      "position": [0, 1, 0],
+      "rotation": [0, 0, 0, 1],
+      "velocity": [0, 0, 0],
+      "angularVelocity": [0, 0, 0]
+    }
+  ],
+  "sceneClockRevision": 8,
+  "controller": { "id": "peer-id", "nickname": "Host" },
+  "sentAt": 1782010000000
+}
+```
+
+Snapshot bodies use Scene Sync wire coordinates. Followers should only apply a
+snapshot when the snapshot version, hash version, physics profile, and dynamic
+body set match the local world.
+
 ## Shared Playback
 
 Shared Playback uses:
@@ -339,6 +381,12 @@ The bridge also consumes Web `scene-physics-hash` messages. The latest report is
 available through `LastRemoteHashReport`, `LastRemoteHashMatched`, and the
 `HashReportReceived` event. Reports compare tick, hash version, and canonical
 hash, but they intentionally do not perform resync yet.
+
+Unity bridge snapshot support consumes `SceneSyncPhysicsSnapshotV1` messages and
+applies dynamic body pose, linear velocity, angular velocity, tick, and world
+epoch when every dynamic body id in the snapshot exists locally. The latest
+snapshot result is exposed through `LastRemoteSnapshotReport`,
+`LastRemoteSnapshotApplied`, and `SnapshotReceived`.
 
 ## Supported Shapes
 

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -12,6 +12,7 @@ import { createCollisionPairKey } from './runtime/runtime-events.js';
 
 export const DEFAULT_SCENE_PHYSICS_DURATION = 10;
 export const SCENE_SYNC_RAPIER_PROFILE = 'SceneSyncRapierParity-0.30';
+export const SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION = 'SceneSyncPhysicsSnapshotV1';
 export const DEFAULT_SCENE_PHYSICS = Object.freeze({
   version: 1,
   enabled: false,
@@ -647,10 +648,48 @@ export function createScenePhysicsRuntime({
     };
   }
 
+  function createSnapshotReport(clockState = null) {
+    if (!world) return null;
+
+    const dump = world.canonicalStateDump();
+    const clockTime = getClockTime(clockState);
+    const worldAge = getWorldAge(clockState);
+    const stateHash = world.canonicalStateHash();
+    const bodies = Array.isArray(dump.bodies)
+      ? dump.bodies.map((body) => ({
+          id: body.id,
+          type: body.type,
+          position: body.position,
+          rotation: body.rotation,
+          velocity: body.linvel,
+          angularVelocity: body.angvel,
+        }))
+      : [];
+
+    return {
+      kind: 'scene-physics-snapshot',
+      source: 'physics',
+      phase: 'postPhysics',
+      snapshotVersion: SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION,
+      profile: SCENE_SYNC_RAPIER_PROFILE,
+      hashVersion: CANONICAL_PHYSICS_HASH_VERSION,
+      rapierCoreVersion: RAPIER_CORE_VERSION,
+      tick: world.tick,
+      hash: stateHash,
+      timestep: world.timestep || timestepSeconds,
+      activeTime: clockTime,
+      worldAge,
+      worldEpochTime,
+      bodyCount: bodies.length,
+      bodies,
+    };
+  }
+
   return {
     markDirty,
     rebuild,
     update,
+    createSnapshotReport,
     resetToInitialPose,
     resetActiveToInitialPose,
     hasBodies() {

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -7,6 +7,7 @@ import {
   isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
+  SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION,
   SCENE_SYNC_RAPIER_PROFILE,
   shouldResetPhysicsForSceneClockPayload,
 } from './scene-physics.js';
@@ -208,6 +209,49 @@ test('scene physics runtime reports canonical hash metadata for wire diagnostics
   assert.equal(result.rapierCoreVersion, RAPIER_CORE_VERSION);
   assert.match(result.hash, /^[0-9a-f]{16}$/);
   assert.equal(result.stateHash, result.hash);
+});
+
+test('scene physics runtime creates canonical snapshot reports on demand', () => {
+  const object = makeObject({
+    objectId: 'snapshot-box',
+    position: [0, 0.5, 0],
+    physics: {
+      enabled: true,
+      shape: 'box',
+      halfExtents: [0.5, 0.5, 0.5],
+      velocity: [0.25, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: -9.81,
+      ground: null,
+      timestep: 1 / 60,
+    },
+  });
+  const runtime = makeRuntime({ scenePhysics, entries: [makeEntry(object)] });
+
+  const result = runtime.update({ t: 0, mode: 'shared-playback', active: true });
+  const snapshot = runtime.createSnapshotReport({ t: 0, mode: 'shared-playback', active: true });
+
+  assert.equal(snapshot.kind, 'scene-physics-snapshot');
+  assert.equal(snapshot.snapshotVersion, SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION);
+  assert.equal(snapshot.profile, SCENE_SYNC_RAPIER_PROFILE);
+  assert.equal(snapshot.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);
+  assert.equal(snapshot.rapierCoreVersion, RAPIER_CORE_VERSION);
+  assert.equal(snapshot.tick, result.tick);
+  assert.equal(snapshot.hash, result.hash);
+  assert.equal(snapshot.bodyCount, 1);
+  assert.deepEqual(snapshot.bodies[0], {
+    id: 'snapshot-box',
+    type: 'dynamic',
+    position: [0, 0.5, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0.25, 0, 0],
+    angularVelocity: [0, 0, 0],
+  });
 });
 
 test('scene physics runtime keeps existing body motion when a new body rebases the world', () => {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -83,6 +83,7 @@ import {
   isScenePhysicsZeroTime,
   normalizeObjectPhysics,
   normalizeScenePhysics,
+  SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION,
   SCENE_SYNC_RAPIER_PROFILE,
   serializeObjectPhysics,
   serializeScenePhysics,
@@ -1378,6 +1379,7 @@ function endMultiTransformHistory() {
 const SAMPLE_CUBE_OBJECT_ID = 'sample-cube';
 const SAMPLE_CUBE_COLOR = '#4488ff';
 const SCENE_PHYSICS_HASH_BROADCAST_TICK_INTERVAL = 30;
+const SCENE_PHYSICS_SNAPSHOT_BROADCAST_TICK_INTERVAL = 120;
 
 function createSampleCube() {
   const sampleGeo = new THREE.BoxGeometry(1, 1, 1);
@@ -1405,6 +1407,9 @@ let scenePhysicsState = normalizeScenePhysics();
 let lastScenePhysicsHashBroadcastTick = null;
 let lastScenePhysicsHashBroadcastHash = null;
 let lastScenePhysicsHashBroadcastRevision = null;
+let lastScenePhysicsSnapshotBroadcastTick = null;
+let lastScenePhysicsSnapshotBroadcastHash = null;
+let lastScenePhysicsSnapshotBroadcastRevision = null;
 const scenePhysicsRuntime = createScenePhysicsRuntime({
   getScenePhysics: () => scenePhysicsState,
   getObjectEntries: () => Array.from(managedObjects.entries()).map(([objectId, object]) => ({
@@ -4568,6 +4573,7 @@ renderer.setAnimationLoop((time, frame) => {
   const sceneClockStateForTick = getSceneClockStateForLoomlet(now);
   const physicsTick = scenePhysicsRuntime.update(sceneClockStateForTick);
   maybeBroadcastScenePhysicsHash(physicsTick, sceneClockStateForTick);
+  maybeBroadcastScenePhysicsSnapshot(physicsTick, sceneClockStateForTick);
   if ((physicsTick.active || physicsTick.reset) && selectedObjectIds.size > 0) {
     updateSelectionHelpers();
   }
@@ -5213,6 +5219,47 @@ function maybeBroadcastScenePhysicsHash(physicsTick, clockState = null) {
     activeTime: physicsTick.activeTime ?? clockState?.activeTime ?? clockState?.t,
     worldAge: physicsTick.worldAge,
     worldEpochTime: physicsTick.worldEpochTime,
+    sceneClockRevision: revision,
+    controller: getSceneClockController(),
+    sentAt: Date.now(),
+  });
+}
+
+function maybeBroadcastScenePhysicsSnapshot(physicsTick, clockState = null) {
+  if (!physicsTick?.active) return;
+  if (clockState?.mode !== CLOCK_MODES.SHARED_PLAYBACK) return;
+  if (!isSceneClockControllerSelf()) return;
+
+  const tick = Number(physicsTick.tick);
+  const hash = typeof physicsTick.hash === 'string'
+    ? physicsTick.hash
+    : physicsTick.stateHash;
+  if (!Number.isInteger(tick) || tick < 0 || typeof hash !== 'string' || hash.length === 0) {
+    return;
+  }
+  if (tick !== 0 && tick % SCENE_PHYSICS_SNAPSHOT_BROADCAST_TICK_INTERVAL !== 0) {
+    return;
+  }
+
+  const revision = Number.isFinite(sceneClockState.sharedRevision)
+    ? sceneClockState.sharedRevision
+    : null;
+  if (
+    lastScenePhysicsSnapshotBroadcastTick === tick &&
+    lastScenePhysicsSnapshotBroadcastHash === hash &&
+    lastScenePhysicsSnapshotBroadcastRevision === revision
+  ) {
+    return;
+  }
+
+  const snapshot = scenePhysicsRuntime.createSnapshotReport(clockState);
+  if (!snapshot || snapshot.snapshotVersion !== SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION) return;
+
+  lastScenePhysicsSnapshotBroadcastTick = tick;
+  lastScenePhysicsSnapshotBroadcastHash = hash;
+  lastScenePhysicsSnapshotBroadcastRevision = revision;
+  broadcast({
+    ...snapshot,
     sceneClockRevision: revision,
     controller: getSceneClockController(),
     sentAt: Date.now(),

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -66,3 +66,10 @@ the latest report in `LastRemoteHashReport`, exposes `LastRemoteHashMatched`,
 and raises `HashReportReceived` after comparing the remote hash with the local
 world at the same tick. This is diagnostic only; it does not resync or stream
 body transforms.
+
+The bridge also accepts `scene-physics-snapshot` messages using
+`SceneSyncPhysicsSnapshotV1`. When `autoApplyRemoteSnapshots` is enabled and all
+dynamic body ids exist locally, the bridge applies the remote body pose, linear
+velocity, angular velocity, fixed tick, and world epoch. Snapshot results are
+available through `LastRemoteSnapshotReport`, `LastRemoteSnapshotApplied`, and
+`SnapshotReceived`.

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -17,6 +17,8 @@ namespace Afjk.SceneSync.Rapier
         private const double ZeroTimeEpsilon = 0.000001d;
         private const string GroundStableId = "__scenesync_ground__";
         private const string CanonicalStateHashVersion = "SceneSyncCanonicalPhysicsHashV1";
+        private const string PhysicsProfile = "SceneSyncRapierParity-0.30";
+        private const string SnapshotVersion = "SceneSyncPhysicsSnapshotV1";
 
         [SerializeField] private bool autoRun = true;
         [SerializeField] private bool useSceneClock = true;
@@ -26,6 +28,7 @@ namespace Afjk.SceneSync.Rapier
         [SerializeField] private float maxFrameStepSeconds = 0.25f;
         [SerializeField] private int maxClockStepsPerUpdate = 600;
         [SerializeField] private int maxCollisionEventsPerDrain = 256;
+        [SerializeField] private bool autoApplyRemoteSnapshots = true;
         [SerializeField] private bool logStateHash;
 
         private readonly Dictionary<string, string> objectPhysicsJson = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -53,9 +56,12 @@ namespace Afjk.SceneSync.Rapier
         private string lastStateHash;
         private bool hasRemoteHashReport;
         private SceneSyncRapierHashReport lastRemoteHashReport;
+        private bool hasRemoteSnapshotReport;
+        private SceneSyncRapierSnapshotReport lastRemoteSnapshotReport;
 
         public event Action<SceneSyncRapierCollisionEvent> CollisionEvent;
         public event Action<SceneSyncRapierHashReport> HashReportReceived;
+        public event Action<SceneSyncRapierSnapshotReport> SnapshotReceived;
 
         public string StateHashVersion => CanonicalStateHashVersion;
         public int Tick => tick;
@@ -66,6 +72,9 @@ namespace Afjk.SceneSync.Rapier
         public bool HasRemoteHashReport => hasRemoteHashReport;
         public SceneSyncRapierHashReport LastRemoteHashReport => lastRemoteHashReport;
         public bool LastRemoteHashMatched => hasRemoteHashReport && lastRemoteHashReport.Matched;
+        public bool HasRemoteSnapshotReport => hasRemoteSnapshotReport;
+        public SceneSyncRapierSnapshotReport LastRemoteSnapshotReport => lastRemoteSnapshotReport;
+        public bool LastRemoteSnapshotApplied => hasRemoteSnapshotReport && lastRemoteSnapshotReport.Applied;
 
         private void OnEnable()
         {
@@ -344,6 +353,12 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
+            if (raw.Contains("\"kind\":\"scene-physics-snapshot\""))
+            {
+                ApplyScenePhysicsSnapshot(raw, message.FromPeerId);
+                return;
+            }
+
             if (raw.Contains("\"kind\":\"scene-physics-hash\""))
             {
                 ApplyScenePhysicsHash(raw, message.FromPeerId);
@@ -372,6 +387,118 @@ namespace Afjk.SceneSync.Rapier
             if (string.IsNullOrWhiteSpace(id)) return;
             if (ApplyObjectPhysicsJson(id, raw))
                 dirty = true;
+        }
+
+        private void ApplyScenePhysicsSnapshot(string raw, string fromPeerId)
+        {
+            var payloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "payload") ?? raw;
+            ScenePhysicsSnapshotPayload payload = null;
+            try
+            {
+                payload = JsonUtility.FromJson<ScenePhysicsSnapshotPayload>(payloadJson);
+            }
+            catch (Exception error)
+            {
+                Debug.LogWarning("[SceneSyncRapier] Failed to parse scene-physics-snapshot: " + error.Message);
+            }
+
+            var remoteHash = NormalizeHash(payload?.hash);
+            var localTickBeforeApply = tick;
+            var bodyCount = payload?.bodies != null ? payload.bodies.Length : 0;
+            var dynamicBodyCount = 0;
+            var appliedBodyCount = 0;
+            var missingBodyCount = 0;
+            var applied = false;
+
+            var canApply = autoApplyRemoteSnapshots
+                && payload != null
+                && world != null
+                && world.IsCreated
+                && string.Equals(payload.snapshotVersion, SnapshotVersion, StringComparison.Ordinal)
+                && string.Equals(payload.hashVersion, CanonicalStateHashVersion, StringComparison.Ordinal)
+                && string.Equals(payload.profile, PhysicsProfile, StringComparison.Ordinal)
+                && payload.tick >= 0
+                && payload.bodies != null;
+
+            var bodyStates = new List<SnapshotBodyState>();
+            if (canApply)
+            {
+                foreach (var body in payload.bodies)
+                {
+                    if (body == null || !IsDynamicSnapshotBody(body))
+                        continue;
+
+                    dynamicBodyCount++;
+                    if (string.IsNullOrWhiteSpace(body.id) ||
+                        !bindings.TryGetValue(body.id, out var binding) ||
+                        binding.IsStatic ||
+                        !TryCreateSnapshotBodyState(body, binding.Body, out var state))
+                    {
+                        missingBodyCount++;
+                        continue;
+                    }
+
+                    bodyStates.Add(state);
+                }
+
+                if (missingBodyCount == 0)
+                {
+                    foreach (var state in bodyStates)
+                    {
+                        var ok = world.SetTransform(state.Body, new RapierTransform(state.Position, state.Rotation));
+                        ok = world.SetLinearVelocity(state.Body, state.LinearVelocity, true) && ok;
+                        ok = world.SetAngularVelocity(state.Body, state.AngularVelocity, true) && ok;
+                        if (ok) appliedBodyCount++;
+                    }
+
+                    applied = appliedBodyCount == dynamicBodyCount;
+                    if (applied)
+                    {
+                        tick = payload.tick;
+                        worldEpochTime = IsFinite(payload.worldEpochTime)
+                            ? Mathf.Max(0f, payload.worldEpochTime)
+                            : Mathf.Max(0f, sceneClock.GetTime() - tick * Mathf.Max(0.000001f, scenePhysics.Timestep));
+                        hasPendingWorldEpochTime = false;
+                        pendingWorldEpochTime = 0f;
+                        accumulator = 0f;
+                        lastStepLimited = false;
+                        currentCollisionPairs.Clear();
+                        previousCollisionPairs.Clear();
+                        lastCollisionEvents.Clear();
+                        ApplyWorldTransforms();
+                        UpdateLastStateHash("snapshot");
+                    }
+                }
+            }
+
+            var localHash = NormalizeHash(ComputeStateHashHex());
+            var hashMatched = applied
+                && !string.IsNullOrWhiteSpace(remoteHash)
+                && !string.IsNullOrWhiteSpace(localHash)
+                && string.Equals(remoteHash, localHash, StringComparison.Ordinal);
+            lastRemoteSnapshotReport = new SceneSyncRapierSnapshotReport(
+                payload?.snapshotVersion,
+                remoteHash,
+                localHash,
+                payload?.hashVersion,
+                payload?.profile,
+                payload?.rapierCoreVersion,
+                payload?.tick ?? -1,
+                localTickBeforeApply,
+                payload?.timestep ?? 0f,
+                payload?.activeTime ?? float.NaN,
+                payload?.worldAge ?? float.NaN,
+                payload?.worldEpochTime ?? float.NaN,
+                payload?.sceneClockRevision ?? int.MinValue,
+                fromPeerId,
+                bodyCount,
+                dynamicBodyCount,
+                appliedBodyCount,
+                missingBodyCount,
+                applied,
+                hashMatched);
+            hasRemoteSnapshotReport = true;
+            SnapshotReceived?.Invoke(lastRemoteSnapshotReport);
         }
 
         private void ApplyScenePhysicsHash(string raw, string fromPeerId)
@@ -850,6 +977,61 @@ namespace Afjk.SceneSync.Rapier
                 : value.Trim().ToLowerInvariant();
         }
 
+        private static bool IsDynamicSnapshotBody(ScenePhysicsSnapshotBody body)
+        {
+            return body != null &&
+                !string.Equals(body.type, "fixed", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(body.type, "static", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryCreateSnapshotBodyState(
+            ScenePhysicsSnapshotBody body,
+            RapierRigidBodyHandle handle,
+            out SnapshotBodyState state)
+        {
+            state = default;
+            if (!TryReadVector3(body.position, out var position) ||
+                !TryReadQuaternion(body.rotation, out var rotation))
+            {
+                return false;
+            }
+
+            var linearVelocity = Vector3.zero;
+            var angularVelocity = Vector3.zero;
+            TryReadVector3(body.velocity, out linearVelocity);
+            if (body.angularVelocity != null)
+                TryReadVector3(body.angularVelocity, out angularVelocity);
+            else
+                TryReadVector3(body.angvel, out angularVelocity);
+            if (body.velocity == null && body.linvel != null)
+                TryReadVector3(body.linvel, out linearVelocity);
+
+            state = new SnapshotBodyState(handle, position, rotation, linearVelocity, angularVelocity);
+            return true;
+        }
+
+        private static bool TryReadVector3(float[] values, out Vector3 vector)
+        {
+            vector = Vector3.zero;
+            if (values == null || values.Length < 3) return false;
+            if (!IsFinite(values[0]) || !IsFinite(values[1]) || !IsFinite(values[2])) return false;
+            vector = new Vector3(values[0], values[1], values[2]);
+            return true;
+        }
+
+        private static bool TryReadQuaternion(float[] values, out Quaternion rotation)
+        {
+            rotation = Quaternion.identity;
+            if (values == null || values.Length < 4) return false;
+            if (!IsFinite(values[0]) || !IsFinite(values[1]) || !IsFinite(values[2]) || !IsFinite(values[3]))
+            {
+                return false;
+            }
+
+            rotation = Normalize(new Quaternion(values[0], values[1], values[2], values[3]));
+            return true;
+        }
+
         private static bool IsFinite(float value)
         {
             return !float.IsNaN(value) && !float.IsInfinity(value);
@@ -858,6 +1040,59 @@ namespace Afjk.SceneSync.Rapier
         private static bool IsFinite(double value)
         {
             return !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        [Serializable]
+        private sealed class ScenePhysicsSnapshotPayload
+        {
+            public string snapshotVersion;
+            public string profile;
+            public string hashVersion;
+            public string rapierCoreVersion;
+            public int tick;
+            public string hash;
+            public float timestep;
+            public float activeTime;
+            public float worldAge;
+            public float worldEpochTime;
+            public int sceneClockRevision;
+            public ScenePhysicsSnapshotBody[] bodies;
+        }
+
+        [Serializable]
+        private sealed class ScenePhysicsSnapshotBody
+        {
+            public string id;
+            public string type;
+            public float[] position;
+            public float[] rotation;
+            public float[] velocity;
+            public float[] angularVelocity;
+            public float[] linvel;
+            public float[] angvel;
+        }
+
+        private readonly struct SnapshotBodyState
+        {
+            public SnapshotBodyState(
+                RapierRigidBodyHandle body,
+                Vector3 position,
+                Quaternion rotation,
+                Vector3 linearVelocity,
+                Vector3 angularVelocity)
+            {
+                Body = body;
+                Position = position;
+                Rotation = rotation;
+                LinearVelocity = linearVelocity;
+                AngularVelocity = angularVelocity;
+            }
+
+            public RapierRigidBodyHandle Body { get; }
+            public Vector3 Position { get; }
+            public Quaternion Rotation { get; }
+            public Vector3 LinearVelocity { get; }
+            public Vector3 AngularVelocity { get; }
         }
 
         private readonly struct SceneClockState

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierSnapshotReport.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierSnapshotReport.cs
@@ -1,0 +1,73 @@
+namespace Afjk.SceneSync.Rapier
+{
+    public readonly struct SceneSyncRapierSnapshotReport
+    {
+        public SceneSyncRapierSnapshotReport(
+            string snapshotVersion,
+            string hash,
+            string localHash,
+            string hashVersion,
+            string profile,
+            string rapierCoreVersion,
+            int tick,
+            int localTickBeforeApply,
+            float timestep,
+            float activeTime,
+            float worldAge,
+            float worldEpochTime,
+            int sceneClockRevision,
+            string fromPeerId,
+            int bodyCount,
+            int dynamicBodyCount,
+            int appliedBodyCount,
+            int missingBodyCount,
+            bool applied,
+            bool hashMatched)
+        {
+            SnapshotVersion = snapshotVersion;
+            Hash = hash;
+            LocalHash = localHash;
+            HashVersion = hashVersion;
+            Profile = profile;
+            RapierCoreVersion = rapierCoreVersion;
+            Tick = tick;
+            LocalTickBeforeApply = localTickBeforeApply;
+            Timestep = timestep;
+            ActiveTime = activeTime;
+            WorldAge = worldAge;
+            WorldEpochTime = worldEpochTime;
+            SceneClockRevision = sceneClockRevision;
+            FromPeerId = fromPeerId;
+            BodyCount = bodyCount;
+            DynamicBodyCount = dynamicBodyCount;
+            AppliedBodyCount = appliedBodyCount;
+            MissingBodyCount = missingBodyCount;
+            Applied = applied;
+            HashMatched = hashMatched;
+        }
+
+        public string Kind => "scene-physics-snapshot";
+        public string Source => "physics";
+        public string Phase => "postPhysics";
+        public string SnapshotVersion { get; }
+        public string Hash { get; }
+        public string LocalHash { get; }
+        public string HashVersion { get; }
+        public string Profile { get; }
+        public string RapierCoreVersion { get; }
+        public int Tick { get; }
+        public int LocalTickBeforeApply { get; }
+        public float Timestep { get; }
+        public float ActiveTime { get; }
+        public float WorldAge { get; }
+        public float WorldEpochTime { get; }
+        public int SceneClockRevision { get; }
+        public string FromPeerId { get; }
+        public int BodyCount { get; }
+        public int DynamicBodyCount { get; }
+        public int AppliedBodyCount { get; }
+        public int MissingBodyCount { get; }
+        public bool Applied { get; }
+        public bool HashMatched { get; }
+    }
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierSnapshotReport.cs.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierSnapshotReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f674bb5bab854089be1ec4b45cf68f43


### PR DESCRIPTION
## Summary

Adds a coarse Scene Sync physics snapshot wire path for Shared Playback resync baselines.

- Web Rapier runtime can generate `SceneSyncPhysicsSnapshotV1` reports on demand from the canonical state dump.
- The Web Shared Playback controller broadcasts `scene-physics-snapshot` at tick 0 and every 120 fixed ticks.
- Unity Rapier bridge consumes snapshots, validates snapshot version/hash version/profile/body ids, and applies dynamic body pose, linear velocity, angular velocity, tick, and world epoch when the local dynamic body set matches.
- Snapshot results are exposed as `LastRemoteSnapshotReport`, `LastRemoteSnapshotApplied`, and `SnapshotReceived`.
- Docs describe the snapshot payload and clarify that snapshots are coarse resync checkpoints, not per-frame transform streaming.

## Validation

- `npm run test:physics`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `git diff --check`
- `/Users/afjk/.local/bin/uloop compile` in `SceneSyncClient` (0 errors; existing Unity-chan obsolete warnings remain)
- Unity dynamic smoke via `uloop execute-dynamic-code`: `ok:snapshot-applied:tick=12:hash=49a6a9d49f4e58ca:pos=(2.000, 3.000, 0.000)`
- `/Users/afjk/.local/bin/uloop get-logs --log-type Error` (0 errors)

## Notes

This PR adds periodic/baseline snapshot transport and Unity application. Request-on-mismatch and targeted snapshot responses should be a separate follow-up.