### PR TITLE
[codex] Request physics snapshots on Unity hash mismatch

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -276,6 +276,33 @@ Snapshot bodies use Scene Sync wire coordinates. Followers should only apply a
 snapshot when the snapshot version, hash version, physics profile, and dynamic
 body set match the local world.
 
+When Unity receives a `scene-physics-hash` for the same tick and hash version but
+the local hash differs, the bridge publishes a
+`scene-physics-snapshot-request` through the Unity Scene Sync outbound message
+bus:
+
+```json
+{
+  "kind": "scene-physics-snapshot-request",
+  "source": "physics",
+  "phase": "postPhysics",
+  "snapshotVersion": "SceneSyncPhysicsSnapshotV1",
+  "profile": "SceneSyncRapierParity-0.30",
+  "hashVersion": "SceneSyncCanonicalPhysicsHashV1",
+  "requestId": "request-id",
+  "reason": "hash-mismatch",
+  "tick": 120,
+  "localTick": 120,
+  "remoteHash": "0123456789abcdef",
+  "localHash": "fedcba9876543210",
+  "sceneClockRevision": 8
+}
+```
+
+`SceneSyncManager` routes outbound bus messages through the active presence
+client. The Web controller responds to snapshot requests with a targeted handoff
+containing the latest `scene-physics-snapshot`.
+
 ## Shared Playback
 
 Shared Playback uses:
@@ -387,6 +414,10 @@ applies dynamic body pose, linear velocity, angular velocity, tick, and world
 epoch when every dynamic body id in the snapshot exists locally. The latest
 snapshot result is exposed through `LastRemoteSnapshotReport`,
 `LastRemoteSnapshotApplied`, and `SnapshotReceived`.
+
+When `requestSnapshotOnHashMismatch` is enabled, the bridge requests a snapshot
+after same-tick hash mismatches. Requests are cooldown-limited by
+`snapshotRequestCooldownSeconds`.
 
 ## Supported Shapes
 

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5252,18 +5252,30 @@ function maybeBroadcastScenePhysicsSnapshot(physicsTick, clockState = null) {
     return;
   }
 
-  const snapshot = scenePhysicsRuntime.createSnapshotReport(clockState);
-  if (!snapshot || snapshot.snapshotVersion !== SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION) return;
+  const snapshot = createScenePhysicsSnapshotPayload(clockState);
+  if (!snapshot) return;
 
   lastScenePhysicsSnapshotBroadcastTick = tick;
   lastScenePhysicsSnapshotBroadcastHash = hash;
   lastScenePhysicsSnapshotBroadcastRevision = revision;
-  broadcast({
+  broadcast(snapshot);
+}
+
+function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
+  const snapshot = scenePhysicsRuntime.createSnapshotReport(clockState);
+  if (!snapshot || snapshot.snapshotVersion !== SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION) {
+    return null;
+  }
+  const revision = Number.isFinite(sceneClockState.sharedRevision)
+    ? sceneClockState.sharedRevision
+    : null;
+  return {
     ...snapshot,
     sceneClockRevision: revision,
     controller: getSceneClockController(),
     sentAt: Date.now(),
-  });
+    ...extra,
+  };
 }
 
 function broadcastSceneClockEvent(action, extra = {}) {
@@ -6710,6 +6722,25 @@ function handleHandoff(data) {
       });
       notifySceneStateChanged('scene-physics-handoff');
       publishSharedObjectClockBaselines('scene-physics-baseline');
+      break;
+    }
+    case 'scene-physics-snapshot-request': {
+      if (isOwn) break;
+      if (!isSceneClockControllerSelf()) break;
+      const snapshot = createScenePhysicsSnapshotPayload(
+        getSceneClockStateForLoomlet(performance.now()),
+        {
+          requestId: payload.requestId,
+          requestTick: payload.tick,
+          requestReason: payload.reason || 'snapshot-request',
+        },
+      );
+      if (!snapshot) break;
+      if (data.from?.id) {
+        sendHandoff({ targetId: data.from.id, payload: snapshot });
+      } else {
+        broadcast(snapshot);
+      }
       break;
     }
     case 'scene-mesh': {

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -73,3 +73,9 @@ dynamic body ids exist locally, the bridge applies the remote body pose, linear
 velocity, angular velocity, fixed tick, and world epoch. Snapshot results are
 available through `LastRemoteSnapshotReport`, `LastRemoteSnapshotApplied`, and
 `SnapshotReceived`.
+
+When `requestSnapshotOnHashMismatch` is enabled, same-tick hash mismatches
+publish a `scene-physics-snapshot-request` through `SceneSyncMessageBus`. A
+`SceneSyncManager` in the scene routes that request through the active presence
+connection, allowing the Web Shared Playback controller to hand back a targeted
+snapshot.

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -29,6 +29,8 @@ namespace Afjk.SceneSync.Rapier
         [SerializeField] private int maxClockStepsPerUpdate = 600;
         [SerializeField] private int maxCollisionEventsPerDrain = 256;
         [SerializeField] private bool autoApplyRemoteSnapshots = true;
+        [SerializeField] private bool requestSnapshotOnHashMismatch = true;
+        [SerializeField] private float snapshotRequestCooldownSeconds = 1f;
         [SerializeField] private bool logStateHash;
 
         private readonly Dictionary<string, string> objectPhysicsJson = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -58,6 +60,8 @@ namespace Afjk.SceneSync.Rapier
         private SceneSyncRapierHashReport lastRemoteHashReport;
         private bool hasRemoteSnapshotReport;
         private SceneSyncRapierSnapshotReport lastRemoteSnapshotReport;
+        private int lastSnapshotRequestTick = int.MinValue;
+        private float lastSnapshotRequestTime = float.NegativeInfinity;
 
         public event Action<SceneSyncRapierCollisionEvent> CollisionEvent;
         public event Action<SceneSyncRapierHashReport> HashReportReceived;
@@ -542,6 +546,7 @@ namespace Afjk.SceneSync.Rapier
                 matched);
             hasRemoteHashReport = true;
             HashReportReceived?.Invoke(lastRemoteHashReport);
+            MaybeRequestSnapshotForHashMismatch(lastRemoteHashReport);
 
             if (logStateHash && !matched)
             {
@@ -557,6 +562,38 @@ namespace Afjk.SceneSync.Rapier
                     + " hashVersion="
                     + (hashVersion ?? "null"));
             }
+        }
+
+        private void MaybeRequestSnapshotForHashMismatch(SceneSyncRapierHashReport report)
+        {
+            if (!requestSnapshotOnHashMismatch || report.Matched) return;
+            if (!report.TickMatched || !report.HashVersionMatched) return;
+            if (report.Tick < 0) return;
+
+            var now = Time.unscaledTime;
+            var cooldown = Mathf.Max(0f, snapshotRequestCooldownSeconds);
+            if (lastSnapshotRequestTick == report.Tick && now - lastSnapshotRequestTime < cooldown)
+                return;
+
+            lastSnapshotRequestTick = report.Tick;
+            lastSnapshotRequestTime = now;
+            var requestId = Guid.NewGuid().ToString("N");
+            var payload =
+                "{\"kind\":\"scene-physics-snapshot-request\"" +
+                ",\"source\":\"physics\"" +
+                ",\"phase\":\"postPhysics\"" +
+                ",\"snapshotVersion\":\"" + SnapshotVersion + "\"" +
+                ",\"profile\":\"" + PhysicsProfile + "\"" +
+                ",\"hashVersion\":\"" + CanonicalStateHashVersion + "\"" +
+                ",\"requestId\":\"" + SceneSyncWireJson.JsonEscape(requestId) + "\"" +
+                ",\"reason\":\"hash-mismatch\"" +
+                ",\"tick\":" + report.Tick.ToString(CultureInfo.InvariantCulture) +
+                ",\"localTick\":" + report.LocalTick.ToString(CultureInfo.InvariantCulture) +
+                ",\"remoteHash\":\"" + SceneSyncWireJson.JsonEscape(report.Hash) + "\"" +
+                ",\"localHash\":\"" + SceneSyncWireJson.JsonEscape(report.LocalHash) + "\"" +
+                ",\"sceneClockRevision\":" + report.SceneClockRevision.ToString(CultureInfo.InvariantCulture) +
+                "}";
+            SceneSyncMessageBus.PublishOutgoing(payload, null, this);
         }
 
         private void ApplySceneClock(string raw)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -145,6 +145,8 @@ namespace Afjk.SceneSync
         {
             if (_isApplicationQuitting) return;
 
+            SceneSyncMessageBus.MessageRequested += HandleSceneSyncOutgoingMessage;
+
             if (_isShuttingDown)
             {
                 _isShuttingDown = false;
@@ -159,6 +161,7 @@ namespace Afjk.SceneSync
 
         private void OnDisable()
         {
+            SceneSyncMessageBus.MessageRequested -= HandleSceneSyncOutgoingMessage;
             BeginLifecycleDisconnect("OnDisable");
         }
 
@@ -1047,6 +1050,17 @@ namespace Afjk.SceneSync
             {
                 _ = HandleFileHandoff(fromId, raw);
             }
+        }
+
+        private void HandleSceneSyncOutgoingMessage(SceneSyncOutgoingMessage message)
+        {
+            if (_isShuttingDown || !_connected || _client == null || string.IsNullOrWhiteSpace(message.PayloadJson))
+                return;
+
+            if (message.IsHandoff)
+                _ = _client.SendHandoff(message.TargetPeerId, message.PayloadJson);
+            else
+                _ = _client.Broadcast(message.PayloadJson);
         }
 
         private void HandleSceneBatch(string raw, string fromId = null)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncMessageBus.cs
@@ -16,14 +16,36 @@ namespace Afjk.SceneSync
         public object Source { get; }
     }
 
+    public readonly struct SceneSyncOutgoingMessage
+    {
+        public SceneSyncOutgoingMessage(string payloadJson, string targetPeerId, object source)
+        {
+            PayloadJson = payloadJson;
+            TargetPeerId = targetPeerId;
+            Source = source;
+        }
+
+        public string PayloadJson { get; }
+        public string TargetPeerId { get; }
+        public object Source { get; }
+        public bool IsHandoff => !string.IsNullOrWhiteSpace(TargetPeerId);
+    }
+
     public static class SceneSyncMessageBus
     {
         public static event Action<SceneSyncRawMessage> MessageReceived;
+        public static event Action<SceneSyncOutgoingMessage> MessageRequested;
 
         public static void PublishReceived(string rawJson, string fromPeerId = null, object source = null)
         {
             if (string.IsNullOrWhiteSpace(rawJson)) return;
             MessageReceived?.Invoke(new SceneSyncRawMessage(rawJson, fromPeerId, source));
+        }
+
+        public static void PublishOutgoing(string payloadJson, string targetPeerId = null, object source = null)
+        {
+            if (string.IsNullOrWhiteSpace(payloadJson)) return;
+            MessageRequested?.Invoke(new SceneSyncOutgoingMessage(payloadJson, targetPeerId, source));
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the loop from Unity hash mismatch detection to a Web snapshot response.

- Adds a Unity `SceneSyncMessageBus` outbound event and routes it through `SceneSyncManager` as broadcast or targeted handoff.
- Unity Rapier bridge now publishes `scene-physics-snapshot-request` when a same-tick `scene-physics-hash` mismatches locally.
- Web Shared Playback controller handles snapshot requests and replies to the requester with a targeted `scene-physics-snapshot` handoff.
- Docs describe the request payload and cooldown settings.

## Validation

- `npm run test:physics`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `git diff --check`
- `/Users/afjk/.local/bin/uloop compile` in `SceneSyncClient` after code changes (0 errors; existing warnings remain)
- Unity dynamic smoke via `uloop execute-dynamic-code`: `ok:snapshot-request:dcb86ee6b590ceb4`
- `/Users/afjk/.local/bin/uloop get-logs --log-type Error` (0 errors)

## Notes

A redundant final `uloop compile` retry after docs-only edits hit a local `/bin/ps` permission error, but the compile already passed after the code changes and no code changed afterward.