### PR TITLE
[codex] Add Scene Sync physics live room smoke

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -12,6 +12,9 @@ const KNOWN_KINDS = new Set([
   'scene-avatar',
   'scene-lock',
   'scene-unlock',
+  'scene-physics-hash',
+  'scene-physics-snapshot',
+  'scene-physics-snapshot-request',
   'scene-asset-request',
   'scene-inspector',
   'scene-batch',
@@ -85,6 +88,130 @@ function validateScenePhysicsPayload(physics) {
         }
       }
     }
+  }
+
+  return { ok: true };
+}
+
+function validateOptionalReasonableString(payload, key, maxLength = 128) {
+  if (payload[key] === undefined || payload[key] === null) return { ok: true };
+  if (!isReasonableString(payload[key], maxLength)) {
+    return { ok: false, reason: `${key} must be a reasonable string` };
+  }
+  return { ok: true };
+}
+
+function validateOptionalFiniteNumber(payload, key) {
+  if (payload[key] === undefined || payload[key] === null) return { ok: true };
+  if (!isFiniteNumber(payload[key])) {
+    return { ok: false, reason: `${key} must be finite` };
+  }
+  return { ok: true };
+}
+
+function validateOptionalNonNegativeInteger(payload, key) {
+  if (payload[key] === undefined || payload[key] === null) return { ok: true };
+  if (!Number.isInteger(payload[key]) || payload[key] < 0) {
+    return { ok: false, reason: `${key} must be a non-negative integer` };
+  }
+  return { ok: true };
+}
+
+function validatePhysicsController(controller, maxStringLength) {
+  if (controller === undefined || controller === null) return { ok: true };
+  if (typeof controller !== 'object' || Array.isArray(controller)) {
+    return { ok: false, reason: 'controller must be an object or null' };
+  }
+  for (const key of ['id', 'nickname']) {
+    const result = validateOptionalReasonableString(controller, key, maxStringLength);
+    if (!result.ok) return { ok: false, reason: `controller.${result.reason}` };
+  }
+  return { ok: true };
+}
+
+function validatePhysicsSnapshotBody(body, maxStringLength) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, reason: 'snapshot body must be an object' };
+  }
+  if (!isReasonableString(body.id, maxStringLength)) {
+    return { ok: false, reason: 'snapshot body.id must be a reasonable string' };
+  }
+  const typeResult = validateOptionalReasonableString(body, 'type', maxStringLength);
+  if (!typeResult.ok) return { ok: false, reason: `snapshot body.${typeResult.reason}` };
+  if (body.position !== undefined && !hasFiniteNumberArray(body.position, 3)) {
+    return { ok: false, reason: 'snapshot body.position must be finite [x,y,z]' };
+  }
+  if (body.rotation !== undefined && !hasFiniteNumberArray(body.rotation, 4)) {
+    return { ok: false, reason: 'snapshot body.rotation must be finite quaternion [x,y,z,w]' };
+  }
+  if (body.velocity !== undefined && !hasFiniteNumberArray(body.velocity, 3)) {
+    return { ok: false, reason: 'snapshot body.velocity must be finite [x,y,z]' };
+  }
+  if (body.angularVelocity !== undefined && !hasFiniteNumberArray(body.angularVelocity, 3)) {
+    return { ok: false, reason: 'snapshot body.angularVelocity must be finite [x,y,z]' };
+  }
+  return { ok: true };
+}
+
+function validateScenePhysicsSyncPayload(payload, maxStringLength) {
+  for (const key of ['source', 'phase', 'profile', 'hashVersion', 'rapierCoreVersion', 'hash']) {
+    const result = validateOptionalReasonableString(payload, key, maxStringLength);
+    if (!result.ok) return result;
+  }
+
+  for (const key of ['tick', 'localTick', 'requestTick', 'bodyCount']) {
+    const result = validateOptionalNonNegativeInteger(payload, key);
+    if (!result.ok) return result;
+  }
+
+  for (const key of [
+    'timestep',
+    'activeTime',
+    'worldAge',
+    'worldEpochTime',
+    'sceneClockRevision',
+    'sentAt',
+  ]) {
+    const result = validateOptionalFiniteNumber(payload, key);
+    if (!result.ok) return result;
+  }
+
+  const controllerValidation = validatePhysicsController(payload.controller, maxStringLength);
+  if (!controllerValidation.ok) return controllerValidation;
+
+  if (payload.kind === 'scene-physics-hash') {
+    if (payload.hash !== undefined && !isReasonableString(payload.hash, maxStringLength)) {
+      return { ok: false, reason: 'scene-physics-hash.hash must be a reasonable string' };
+    }
+    return { ok: true };
+  }
+
+  if (payload.kind === 'scene-physics-snapshot-request') {
+    for (const key of ['snapshotVersion', 'requestId', 'reason', 'remoteHash', 'localHash']) {
+      const result = validateOptionalReasonableString(payload, key, maxStringLength);
+      if (!result.ok) return result;
+    }
+    return { ok: true };
+  }
+
+  if (payload.kind === 'scene-physics-snapshot') {
+    for (const key of ['snapshotVersion', 'requestId', 'requestReason']) {
+      const result = validateOptionalReasonableString(payload, key, maxStringLength);
+      if (!result.ok) return result;
+    }
+    if (payload.bodies !== undefined) {
+      if (!Array.isArray(payload.bodies)) {
+        return { ok: false, reason: 'scene-physics-snapshot.bodies must be an array' };
+      }
+      if (payload.bodies.length > 1000) {
+        return { ok: false, reason: 'scene-physics-snapshot.bodies is too large' };
+      }
+      for (const body of payload.bodies) {
+        const result = validatePhysicsSnapshotBody(body, maxStringLength);
+        if (!result.ok) return result;
+      }
+    }
+    return { ok: true };
   }
 
   return { ok: true };
@@ -256,6 +383,14 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-physics') {
     return validateScenePhysicsPayload(payload.physics);
+  }
+
+  if (
+    payload.kind === 'scene-physics-hash' ||
+    payload.kind === 'scene-physics-snapshot' ||
+    payload.kind === 'scene-physics-snapshot-request'
+  ) {
+    return validateScenePhysicsSyncPayload(payload, maxStringLength);
   }
 
   if (payload.kind === 'scene-batch') {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -240,6 +240,79 @@ describe('Scene Sync guard helpers', () => {
     assert.equal(result.ok, true);
   });
 
+  it('accepts scene-physics sync messages', () => {
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-hash',
+      source: 'physics',
+      phase: 'postPhysics',
+      profile: 'SceneSyncRapierParity-0.30',
+      hashVersion: 'SceneSyncCanonicalPhysicsHashV1',
+      rapierCoreVersion: '0.19.3',
+      tick: 30,
+      hash: 'dcb86ee6b590ceb4',
+      timestep: 1 / 60,
+      activeTime: 0.5,
+      worldAge: 0.5,
+      worldEpochTime: 0,
+      sceneClockRevision: 1,
+      controller: { id: 'peer-web', nickname: 'Web' },
+      sentAt: Date.now(),
+    }).ok, true);
+
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-snapshot-request',
+      source: 'physics',
+      phase: 'postPhysics',
+      snapshotVersion: 'SceneSyncPhysicsSnapshotV1',
+      profile: 'SceneSyncRapierParity-0.30',
+      hashVersion: 'SceneSyncCanonicalPhysicsHashV1',
+      requestId: 'request-1',
+      reason: 'hash-mismatch',
+      tick: 30,
+      localTick: 30,
+      remoteHash: 'dcb86ee6b590ceb4',
+      localHash: '0000000000000000',
+      sceneClockRevision: 1,
+    }).ok, true);
+
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-snapshot',
+      source: 'physics',
+      phase: 'postPhysics',
+      snapshotVersion: 'SceneSyncPhysicsSnapshotV1',
+      profile: 'SceneSyncRapierParity-0.30',
+      hashVersion: 'SceneSyncCanonicalPhysicsHashV1',
+      tick: 30,
+      hash: 'dcb86ee6b590ceb4',
+      timestep: 1 / 60,
+      activeTime: 0.5,
+      worldAge: 0.5,
+      worldEpochTime: 0,
+      bodyCount: 1,
+      requestId: 'request-1',
+      bodies: [{
+        id: 'live-box',
+        type: 'dynamic',
+        position: [0, 0.5, 0],
+        rotation: [0, 0, 0, 1],
+        velocity: [0, 0, 0],
+        angularVelocity: [0, 0, 0],
+      }],
+    }).ok, true);
+  });
+
+  it('rejects invalid scene-physics sync snapshots', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-physics-snapshot',
+      tick: 1,
+      bodies: [{
+        id: 'live-box',
+        position: [0, Infinity, 0],
+      }],
+    });
+    assert.equal(result.ok, false);
+  });
+
   it('rejects scene-physics with invalid gravity', () => {
     const result = validateSceneSyncPayload({
       kind: 'scene-physics',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -4687,6 +4687,22 @@ function resolvePresenceUrl() {
   return isLocal ? 'ws://localhost:8787' : 'wss://afjk.jp/presence';
 }
 
+function buildPresenceRoomUrl(base, roomCode) {
+  if (!roomCode) return base;
+  const encodedRoom = encodeURIComponent(roomCode);
+  if (base.includes('?')) {
+    const separator = base.endsWith('?') || base.endsWith('&') ? '' : '&';
+    return `${base}${separator}room=${encodedRoom}`;
+  }
+  if (base.endsWith('/ws/')) {
+    return `${base.slice(0, -1)}?room=${encodedRoom}`;
+  }
+  if (base.endsWith('/') || base.endsWith('/ws')) {
+    return `${base}?room=${encodedRoom}`;
+  }
+  return `${base}/?room=${encodedRoom}`;
+}
+
 function sanitizeRoomCode(s) {
   if (!s) return null;
   const cleaned = String(s).trim().toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 24);
@@ -6067,9 +6083,7 @@ function renderRoomSection() {
 
 function connectPresence() {
   const base = resolvePresenceUrl();
-  const url = activeRoomCode
-    ? `${base}/?room=${encodeURIComponent(activeRoomCode)}`
-    : base;
+  const url = buildPresenceRoomUrl(base, activeRoomCode);
 
   const ws = new WebSocket(url);
   presenceState.ws = ws;
@@ -10694,13 +10708,54 @@ const dragDropManager = new DragDropManager({
   urlImporter: urlImporterCallback,
 });
 
-window.__sceneSyncDebug = {
+const sceneSyncDebugApi = {
   ...(window.__sceneSyncDebug || {}),
   dragDropManager,
   getSelection: getCurrentSelectionPayload,
   getActiveTransformTweenCount: () => activeTransformTweens.size,
   audioSource: audioSourceHostApi,
 };
+
+if (isDevUiEnabled()) {
+  Object.assign(sceneSyncDebugApi, {
+    presence: () => ({
+      connected: presenceState.ws?.readyState === WebSocket.OPEN,
+      readyState: presenceState.ws?.readyState ?? WebSocket.CLOSED,
+      id: presenceState.id,
+      userId: presenceState.userId,
+      room: presenceState.room,
+      peers: presenceState.peers.map(peer => ({
+        id: peer.id,
+        nickname: peer.nickname || null,
+        device: peer.device || null,
+        userId: peer.userId || null,
+      })),
+    }),
+    sceneClock: {
+      requestControl: () => {
+        requestSceneClockControl();
+        return getSceneClockStateForShell();
+      },
+      play: () => {
+        playSceneClock();
+        return getSceneClockStateForShell();
+      },
+      state: () => getSceneClockStateForShell(),
+    },
+    physics: {
+      snapshot: () => createScenePhysicsSnapshotPayload(
+        getSceneClockStateForLoomlet(performance.now())
+      ),
+      state: () => ({
+        hasBodies: scenePhysicsRuntime.hasBodies(),
+        scenePhysics: getScenePhysicsForSerialize({ enableWhenObjectsExist: false }),
+        objectIds: Array.from(managedObjects.keys()),
+      }),
+    },
+  });
+}
+
+window.__sceneSyncDebug = sceneSyncDebugApi;
 
 // Loomlet host 連携用の AudioSource 操作 API（play/pause/stop/seek/playOneShot/setVolume/setClip/syncToAnimation/unsync）。
 window.sceneSyncAudioSource = audioSourceHostApi;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:scene-sync-export-behaviors": "node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js",
     "test:scene-sync-export-import": "node --test html/assets/js/scenesync/importers/scene-sync-export/*.test.js html/assets/js/scenesync-export/export/*.test.js html/assets/js/scenesync-export/viewer/*.test.js",
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
-    "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs"
+    "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs",
+    "test:e2e:scene-sync-physics-live-room": "node scripts/scenesync-physics-live-room-smoke.mjs"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",

--- a/scripts/scenesync-physics-live-room-smoke.mjs
+++ b/scripts/scenesync-physics-live-room-smoke.mjs
@@ -1,0 +1,449 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createPresenceServer } from '../apps/presence-server/src/server.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const htmlRoot = path.join(repoRoot, 'html');
+const browserPath = path.join(repoRoot, '.playwright-browsers');
+const require = createRequire(import.meta.url);
+const WebSocket = require(path.join(repoRoot, 'apps/presence-server/node_modules/ws'));
+
+process.env.PLAYWRIGHT_BROWSERS_PATH ||= browserPath;
+process.env.GPT_SESSION_SECRET ||= 'scene-sync-physics-live-room-smoke-secret';
+
+const TEST_TIMEOUT_MS = 60000;
+
+const mimeTypes = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.webp', 'image/webp'],
+  ['.hdr', 'application/octet-stream'],
+  ['.glb', 'model/gltf-binary'],
+  ['.wasm', 'application/wasm'],
+]);
+
+function sendBuffer(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,OPTIONS,HEAD',
+    'access-control-allow-headers': 'content-type',
+    'content-length': body.byteLength,
+    ...headers,
+  });
+  res.end(body);
+}
+
+function resolveStaticPath(urlPath) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(urlPath, 'http://localhost').pathname);
+  } catch {
+    return null;
+  }
+
+  if (pathname.endsWith('/')) {
+    pathname = `${pathname}index.html`;
+  }
+
+  const candidate = path.resolve(htmlRoot, `.${pathname}`);
+  if (!candidate.startsWith(`${htmlRoot}${path.sep}`) && candidate !== htmlRoot) {
+    return null;
+  }
+  return candidate;
+}
+
+function createStaticServer() {
+  const server = createServer(async (req, res) => {
+    if (req.method === 'OPTIONS') {
+      sendBuffer(res, 204, Buffer.alloc(0));
+      return;
+    }
+
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      sendBuffer(res, 405, Buffer.from('Method not allowed'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+      return;
+    }
+
+    const filePath = resolveStaticPath(req.url || '/');
+    if (!filePath) {
+      sendBuffer(res, 400, Buffer.from('Bad request'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+      return;
+    }
+
+    try {
+      const body = await readFile(filePath);
+      const contentType = mimeTypes.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
+      sendBuffer(res, 200, req.method === 'HEAD' ? Buffer.alloc(0) : body, {
+        'content-type': contentType,
+        ...(req.method === 'HEAD' ? { 'content-length': body.byteLength } : {}),
+      });
+    } catch {
+      sendBuffer(res, 404, Buffer.from('Not found'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve(server);
+    });
+  });
+}
+
+function listenPresenceServer(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve(server);
+    });
+  });
+}
+
+function serverUrl(server, scheme = 'http') {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Server did not expose a TCP address');
+  }
+  return `${scheme}://127.0.0.1:${address.port}`;
+}
+
+function waitForEvent(target, event, timeoutMs = TEST_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${event}`));
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      target.off(event, onEvent);
+      target.off('error', onError);
+    };
+    const onEvent = (...args) => {
+      cleanup();
+      resolve(args);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    target.once(event, onEvent);
+    if (event !== 'error') {
+      target.once('error', onError);
+    }
+  });
+}
+
+function waitForMessage(ws, predicate, { timeoutMs = TEST_TIMEOUT_MS, label = 'websocket message' } = {}) {
+  const seen = [];
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${label}; recent messages: ${JSON.stringify(seen.slice(-8))}`));
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`websocket closed while waiting for ${label}`));
+    };
+    const onMessage = (raw) => {
+      let message;
+      try {
+        message = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      seen.push({
+        type: message.type || null,
+        kind: message.payload?.kind || null,
+        from: message.from?.id || null,
+      });
+      if (!predicate(message)) return;
+      cleanup();
+      resolve(message);
+    };
+
+    ws.on('message', onMessage);
+    ws.once('error', onError);
+    ws.once('close', onClose);
+  });
+}
+
+async function connectPresenceClient(wsBaseUrl, roomId, nickname) {
+  const ws = new WebSocket(`${wsBaseUrl}?room=${encodeURIComponent(roomId)}`);
+  const welcomePromise = waitForMessage(ws, message => message.type === 'welcome', {
+    label: `${nickname} welcome`,
+  });
+  await waitForEvent(ws, 'open');
+  ws.send(JSON.stringify({
+    type: 'hello',
+    nickname,
+    device: 'Unity Smoke',
+    userId: `${nickname.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now().toString(36)}`,
+  }));
+  const welcome = await welcomePromise;
+  ws.presenceId = welcome.id;
+  return ws;
+}
+
+async function closeWebSocket(ws) {
+  if (!ws || ws.readyState === WebSocket.CLOSED) return;
+  if (ws.readyState === WebSocket.CLOSING) {
+    await waitForEvent(ws, 'close', 5000).catch(() => {});
+    return;
+  }
+  ws.terminate();
+  await waitForEvent(ws, 'close', 5000).catch(() => {});
+}
+
+async function closeServer(server) {
+  if (!server) return;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function summarizeConsole(consoleMessages) {
+  return consoleMessages.filter((entry) => {
+    if (/GL Driver Message .*ReadPixels/.test(entry.text)) return false;
+    if (/Failed to load resource: the server responded with a status of 404/.test(entry.text)) return false;
+    if (/THREE\.GLTFExporter: Creating normalized normal attribute/.test(entry.text)) return false;
+    if (/BGM.*autoplay blocked/.test(entry.text)) return false;
+    return true;
+  });
+}
+
+function createLivePhysicsSceneState() {
+  return {
+    kind: 'scene-state',
+    envId: 'studio',
+    physics: {
+      version: 1,
+      enabled: true,
+      duration: 4,
+      worldOptions: {
+        gravity: -9.81,
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    objects: {
+      'live-box': {
+        name: 'Live Physics Box',
+        asset: {
+          type: 'primitive',
+          primitive: 'box',
+          color: '#4488ff',
+        },
+        position: [0, 1.25, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        physics: {
+          version: 1,
+          enabled: true,
+          bodyType: 'dynamic',
+          shape: 'box',
+          halfExtents: [0.5, 0.5, 0.5],
+          mass: 1,
+          restitution: 0.2,
+          friction: 0.5,
+          velocity: [0, 0, 0],
+          angularVelocity: [0, 0, 0],
+        },
+      },
+    },
+  };
+}
+
+function createSnapshotRequestPayload(hashPayload, requestId) {
+  return {
+    kind: 'scene-physics-snapshot-request',
+    source: 'physics',
+    phase: 'postPhysics',
+    snapshotVersion: 'SceneSyncPhysicsSnapshotV1',
+    profile: hashPayload.profile || 'SceneSyncRapierParity-0.30',
+    hashVersion: hashPayload.hashVersion || 'SceneSyncCanonicalPhysicsHashV1',
+    requestId,
+    reason: 'live-room-smoke',
+    tick: hashPayload.tick,
+    localTick: hashPayload.tick,
+    remoteHash: hashPayload.hash,
+    localHash: '0000000000000000',
+    sceneClockRevision: hashPayload.sceneClockRevision,
+  };
+}
+
+async function run() {
+  const { chromium } = await import('playwright');
+  const presenceServer = createPresenceServer();
+  await listenPresenceServer(presenceServer);
+  const staticServer = await createStaticServer();
+  const httpBaseUrl = serverUrl(staticServer);
+  const wsBaseUrl = `${serverUrl(presenceServer, 'ws')}/ws`;
+  const roomId = `physics-live-${Date.now().toString(36)}`;
+  const result = {
+    roomId,
+    url: `${httpBaseUrl}/scenesync/?room=${roomId}&presence=${encodeURIComponent(wsBaseUrl)}&dev=1`,
+    console: [],
+    pageErrors: [],
+    assertions: [],
+  };
+
+  let browser;
+  let unityWs;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 900 },
+    });
+
+    await context.addInitScript(() => {
+      localStorage.setItem('sceneSync.welcomeSeen', 'true');
+      localStorage.setItem('sceneSync.displayName', 'SceneSync Web Smoke');
+    });
+
+    const page = await context.newPage();
+    page.on('console', (msg) => {
+      const type = msg.type();
+      if (type === 'error' || type === 'warning') {
+        result.console.push({ type, text: msg.text() });
+      }
+    });
+    page.on('pageerror', (error) => {
+      result.pageErrors.push(error.message || String(error));
+    });
+
+    await page.goto(result.url, { waitUntil: 'domcontentloaded', timeout: TEST_TIMEOUT_MS });
+    await page.waitForFunction(() => window.__sceneSyncDebug?.presence?.().connected, null, {
+      timeout: TEST_TIMEOUT_MS,
+    });
+    await page.waitForFunction(
+      () => document.querySelector('canvas') && document.querySelector('canvas').width > 0,
+      null,
+      { timeout: TEST_TIMEOUT_MS },
+    );
+    const webPresence = await page.evaluate(() => window.__sceneSyncDebug.presence());
+    assert.ok(webPresence.id, 'web peer must have a presence id');
+    result.assertions.push(`web:${webPresence.id}`);
+
+    unityWs = await connectPresenceClient(wsBaseUrl, roomId, 'Unity Physics Smoke');
+    assert.ok(unityWs.presenceId, 'unity peer must have a presence id');
+    result.assertions.push(`unity:${unityWs.presenceId}`);
+
+    await page.waitForFunction(() => {
+      const presence = window.__sceneSyncDebug?.presence?.();
+      return presence?.peers?.some(peer => peer.nickname === 'Unity Physics Smoke');
+    }, null, { timeout: TEST_TIMEOUT_MS });
+
+    unityWs.send(JSON.stringify({
+      type: 'broadcast',
+      payload: createLivePhysicsSceneState(),
+    }));
+
+    await page.waitForFunction(() => {
+      const physics = window.__sceneSyncDebug?.physics?.state?.();
+      return physics?.scenePhysics?.enabled === true
+        && physics?.objectIds?.includes('live-box')
+        && physics?.hasBodies === true;
+    }, null, { timeout: TEST_TIMEOUT_MS });
+    result.assertions.push('scene-state-applied');
+
+    const hashPromise = waitForMessage(unityWs, message => (
+      message.type === 'handoff'
+      && message.payload?.kind === 'scene-physics-hash'
+      && message.from?.id === webPresence.id
+      && Number.isInteger(message.payload.tick)
+      && typeof message.payload.hash === 'string'
+    ), { label: 'web scene-physics-hash' });
+
+    await page.evaluate(() => {
+      const clock = window.__sceneSyncDebug.sceneClock.requestControl();
+      window.__sceneSyncDebug.sceneClock.play();
+      return clock;
+    });
+
+    const hashMessage = await hashPromise;
+    result.assertions.push(`hash:${hashMessage.payload.tick}:${hashMessage.payload.hash}`);
+
+    const requestId = `snapshot-request-${Date.now().toString(36)}`;
+    const snapshotPromise = waitForMessage(unityWs, message => (
+      message.type === 'handoff'
+      && message.payload?.kind === 'scene-physics-snapshot'
+      && message.payload?.requestId === requestId
+      && message.from?.id === webPresence.id
+    ), { label: 'targeted scene-physics-snapshot' });
+
+    unityWs.send(JSON.stringify({
+      type: 'broadcast',
+      payload: createSnapshotRequestPayload(hashMessage.payload, requestId),
+    }));
+
+    const snapshotMessage = await snapshotPromise;
+    const snapshot = snapshotMessage.payload;
+    assert.equal(snapshot.snapshotVersion, 'SceneSyncPhysicsSnapshotV1');
+    assert.equal(snapshot.requestId, requestId);
+    assert.ok(Number.isInteger(snapshot.tick), 'snapshot tick must be an integer');
+    assert.equal(typeof snapshot.hash, 'string');
+    assert.ok(Array.isArray(snapshot.bodies), 'snapshot must include bodies');
+    assert.ok(snapshot.bodies.some(body => body.id === 'live-box'), 'snapshot must include live-box body');
+    result.assertions.push(`snapshot:${snapshot.tick}:${snapshot.hash}:${snapshot.bodies.length}`);
+
+    const consoleMessages = summarizeConsole(result.console)
+      .filter(entry => entry.type === 'error');
+    assert.deepEqual(result.pageErrors, [], 'page errors should be empty');
+    assert.deepEqual(consoleMessages, [], `unexpected browser console errors: ${JSON.stringify(consoleMessages)}`);
+
+    console.log(JSON.stringify({
+      ok: true,
+      roomId,
+      assertions: result.assertions,
+    }, null, 2));
+  } finally {
+    await closeWebSocket(unityWs);
+    if (browser) await browser.close();
+    await closeServer(staticServer);
+    if (presenceServer) await presenceServer.stop();
+  }
+}
+
+run().catch((error) => {
+  const message = error?.stack || error?.message || String(error);
+  console.error(message);
+  if (/Executable doesn't exist|browserType\.launch/.test(message)) {
+    console.error('Run `npm run test:e2e:install-browsers` and retry this smoke test.');
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Allow Scene Sync physics hash, snapshot, and snapshot request messages through the presence-server schema with finite-number validation.
- Add a Playwright live-room smoke that starts a local presence server, loads the Web SceneSync client, simulates a Unity peer over WebSocket, and verifies hash -> snapshot request -> targeted snapshot handoff.
- Add `?dev=1` debug hooks for presence state, shared playback control, and physics snapshot readiness, plus robust room URL building for `/ws` presence overrides.

## Validation
- `node --check scripts/scenesync-physics-live-room-smoke.mjs`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check apps/presence-server/src/scenesync/message-schema.mjs`
- `git diff --check`
- `node -e "import('./apps/presence-server/src/scenesync/message-schema.mjs').then(({validateSceneSyncPayload}) => { const messages = [{kind:'scene-physics-hash', tick:0, hash:'abc'}, {kind:'scene-physics-snapshot-request', requestId:'r1', tick:0, localTick:0, remoteHash:'abc', localHash:'def'}, {kind:'scene-physics-snapshot', tick:0, hash:'abc', bodies:[{id:'box', position:[0,1,0], rotation:[0,0,0,1], velocity:[0,0,0], angularVelocity:[0,0,0]}]}]; if (!messages.every(message => validateSceneSyncPayload(message).ok)) process.exit(1); if (validateSceneSyncPayload({kind:'scene-physics-snapshot', bodies:[{id:'box', position:[0, Infinity, 0]}]}).ok) process.exit(1); console.log('ok:scene-physics-sync-schema'); })"`
- `npm run test:physics`

## Notes
- `npm run test:e2e:scene-sync-physics-live-room` could not be completed in the Codex macOS sandbox because Chromium exits during launch with `MachPortRendezvousServer ... Permission denied (1100)`. The script now exits cleanly on that launch failure; it should be run in a normal local/CI browser environment.