### PR TITLE
[codex] Fix Unity presence room URLs

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
+++ b/unity/com.afjk.scene-sync/Editor/PresenceClient.cs
@@ -61,9 +61,7 @@ namespace Afjk.SceneSync.Editor
             _cts = new CancellationTokenSource();
             _ws = new ClientWebSocket();
 
-            var url = string.IsNullOrEmpty(room)
-                ? presenceUrl
-                : presenceUrl + "/?room=" + room;
+            var url = Afjk.SceneSync.SceneSyncPresenceUrl.BuildRoomUrl(presenceUrl, room);
 
             try
             {

--- a/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
+++ b/unity/com.afjk.scene-sync/Runtime/PresenceClientRuntime.cs
@@ -63,9 +63,7 @@ namespace Afjk.SceneSync
             _cts = new CancellationTokenSource();
             _ws = new ClientWebSocket();
 
-            var url = string.IsNullOrEmpty(room)
-                ? presenceUrl
-                : presenceUrl + "/?room=" + room;
+            var url = SceneSyncPresenceUrl.BuildRoomUrl(presenceUrl, room);
 
             try
             {

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncPresenceUrl.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncPresenceUrl.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Afjk.SceneSync
+{
+    public static class SceneSyncPresenceUrl
+    {
+        public static string BuildRoomUrl(string presenceUrl, string room)
+        {
+            if (string.IsNullOrEmpty(presenceUrl)) return presenceUrl ?? string.Empty;
+            if (string.IsNullOrEmpty(room)) return presenceUrl;
+
+            var encodedRoom = Uri.EscapeDataString(room);
+            if (presenceUrl.IndexOf('?') >= 0)
+            {
+                var separator = presenceUrl.EndsWith("?", StringComparison.Ordinal)
+                    || presenceUrl.EndsWith("&", StringComparison.Ordinal)
+                        ? string.Empty
+                        : "&";
+                return presenceUrl + separator + "room=" + encodedRoom;
+            }
+
+            if (presenceUrl.EndsWith("/ws/", StringComparison.Ordinal))
+            {
+                return presenceUrl.Substring(0, presenceUrl.Length - 1) + "?room=" + encodedRoom;
+            }
+
+            if (presenceUrl.EndsWith("/", StringComparison.Ordinal)
+                || presenceUrl.EndsWith("/ws", StringComparison.Ordinal))
+            {
+                return presenceUrl + "?room=" + encodedRoom;
+            }
+
+            return presenceUrl + "/?room=" + encodedRoom;
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncPresenceUrl.cs.meta
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncPresenceUrl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92a5a4063eab41049b350deab290c46d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add a shared Unity `SceneSyncPresenceUrl.BuildRoomUrl` helper.
- Reuse it from both Runtime and Editor presence clients so `ws://host/ws` and `ws://host/ws/` become `ws://host/ws?room=...` instead of the invalid `/ws/?room=...` path.
- Preserve the existing `/presence/?room=...` behavior for non-`/ws` base paths and support query strings.

## Validation
- `git diff --check`
- `/Users/afjk/.local/bin/uloop compile` from `SceneSyncClient` -> 0 errors, existing warnings only
- `/Users/afjk/.local/bin/uloop execute-dynamic-code --code "...SceneSyncPresenceUrl.BuildRoomUrl cases..."` from `SceneSyncClient` -> success