### PR TITLE
[codex] Fix Scene Sync export viewer dependencies

### DIFF
--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -36,9 +36,32 @@ function mockFetch(responses) {
   globalThis.fetch = async (url) => {
     const entry = responses[url];
     if (!entry) return { ok: false, status: 404 };
-    return { ok: true, status: 200, arrayBuffer: async () => entry };
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      arrayBuffer: async () => entry,
+    };
   };
   return () => { globalThis.fetch = original; };
+}
+
+function readViewerSource(source) {
+  const sourcePath = path.join(repoRoot, 'html', source.src.replace(/^\//, ''));
+  const content = source.binary
+    ? fs.readFileSync(sourcePath)
+    : fs.readFileSync(sourcePath, 'utf8');
+  if (source.binary) return content;
+  return typeof source.transform === 'function' ? source.transform(content) : content;
+}
+
+function collectModuleImports(source) {
+  const imports = [];
+  const re = /(?:import|export)\s+(?:[^'";]+?\s+from\s+)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+  for (const match of source.matchAll(re)) {
+    imports.push(match[1] || match[2]);
+  }
+  return imports;
 }
 
 test('export package construction', async (t) => {
@@ -71,23 +94,23 @@ test('export package construction', async (t) => {
     assert.ok(generateExportIndexHtml().includes('index.html'));
   });
 
-  await t.test('viewer/ directory files are defined in VIEWER_SOURCES', () => {
-    // Verify the viewer file paths are consistent with what we expect in the ZIP
-    const expectedViewerFiles = [
+  await t.test('viewer runtime files are defined in VIEWER_SOURCES', () => {
+    const expectedPackageFiles = [
       'viewer/viewer.js',
       'viewer/create-viewer-core.js',
       'viewer/object-audio-controller.js',
       'viewer/static-asset-resolver.js',
       'viewer/scene-document.js',
+      'viewer/export-behavior-runtime.js',
+      'scenesync/plugins/scene-sync-physics-plugin.js',
+      'scenesync/plugins/scene-sync-loomlet-plugin.js',
+      'scenesync/runtime/schedule-context.js',
+      'scenesync/runtime/runtime-events.js',
       'viewer/viewer.css',
     ];
     const destPaths = VIEWER_SOURCES.map(s => s.dest);
-    for (const f of expectedViewerFiles) {
+    for (const f of expectedPackageFiles) {
       assert.ok(destPaths.includes(f), `VIEWER_SOURCES should contain ${f}`);
-    }
-    // All expected paths start with viewer/
-    for (const f of expectedViewerFiles) {
-      assert.ok(f.startsWith('viewer/'));
     }
   });
 
@@ -115,6 +138,33 @@ test('export package construction', async (t) => {
     const destPaths = VIEWER_SOURCES.map(s => s.dest);
     assert.equal(destPaths.some(path => path.startsWith('viewer/loom/')), false,
       `VIEWER_SOURCES should not contain old viewer/loom files (got: ${destPaths.join(', ')})`);
+  });
+
+  await t.test('VIEWER_SOURCES module imports resolve inside the ZIP', () => {
+    const sourceByDest = new Map(VIEWER_SOURCES.map(source => [source.dest, source]));
+    const includedPaths = new Set(sourceByDest.keys());
+    const externalImports = new Set([
+      'three',
+      '@dimforge/rapier3d-deterministic-compat',
+    ]);
+    const failures = [];
+
+    for (const source of VIEWER_SOURCES) {
+      if (source.binary || !/\.(?:m?js)$/.test(source.dest)) continue;
+      const transformedSource = readViewerSource(source);
+      for (const specifier of collectModuleImports(transformedSource)) {
+        if (!specifier || externalImports.has(specifier) || specifier.startsWith('three/')) continue;
+        if (!specifier.startsWith('.')) continue;
+
+        const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(source.dest), specifier));
+        const resolvedPath = path.posix.extname(resolved) ? resolved : `${resolved}.js`;
+        if (!includedPaths.has(resolvedPath)) {
+          failures.push(`${source.dest} imports ${specifier} -> ${resolvedPath}`);
+        }
+      }
+    }
+
+    assert.deepEqual(failures, []);
   });
 
   await t.test('scene.json includes behaviors when behaviorState provided', async () => {

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -12,7 +12,12 @@ import { normalizeExportMetadata } from './export-metadata.js';
 // These viewer source files are fetched from the current origin and bundled into the ZIP
 export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync-export/viewer/static-viewer-entry.js', dest: 'viewer/viewer.js' },
-  { src: '/assets/js/scenesync-export/viewer/create-viewer-core.js', dest: 'viewer/create-viewer-core.js' },
+  {
+    src: '/assets/js/scenesync-export/viewer/create-viewer-core.js',
+    dest: 'viewer/create-viewer-core.js',
+    transform: (source) => source.replaceAll('../../scenesync/', '../scenesync/'),
+  },
+  { src: '/assets/js/scenesync-export/viewer/export-behavior-runtime.js', dest: 'viewer/export-behavior-runtime.js' },
   { src: '/assets/js/scenesync-export/viewer/object-audio-controller.js', dest: 'viewer/object-audio-controller.js' },
   { src: '/assets/js/scenesync-export/viewer/static-asset-resolver.js', dest: 'viewer/static-asset-resolver.js' },
   { src: '/assets/js/scenesync-export/viewer/scene-document.js', dest: 'viewer/scene-document.js' },
@@ -20,13 +25,21 @@ export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync/shells/player/player-transport.js', dest: 'viewer/player-transport.js' },
   { src: '/assets/js/scenesync/shells/player/player-actions.js', dest: 'viewer/player-actions.js' },
   { src: '/assets/js/scenesync/shells/player/player-shell.css', dest: 'viewer/player-shell.css' },
-  { src: '/assets/js/scenesync/scene-physics.js', dest: 'viewer/scene-physics.js' },
+  {
+    src: '/assets/js/scenesync/scene-physics.js',
+    dest: 'viewer/scene-physics.js',
+    transform: (source) => source.replaceAll('./runtime/runtime-events.js', '../scenesync/runtime/runtime-events.js'),
+  },
   { src: '/assets/js/scenesync/physics/index.js', dest: 'viewer/physics/index.js' },
   { src: '/assets/js/scenesync/physics/rapier-world.js', dest: 'viewer/physics/rapier-world.js' },
+  { src: '/assets/js/scenesync/plugins/scene-sync-physics-plugin.js', dest: 'scenesync/plugins/scene-sync-physics-plugin.js' },
+  { src: '/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.js', dest: 'scenesync/plugins/scene-sync-loomlet-plugin.js' },
+  { src: '/assets/js/scenesync/runtime/schedule-context.js', dest: 'scenesync/runtime/schedule-context.js' },
+  { src: '/assets/js/scenesync/runtime/runtime-events.js', dest: 'scenesync/runtime/runtime-events.js' },
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },
   // deterministic-compat build — must match the build used by rapier-world.js
   { src: '/assets/vendor/rapier-deterministic/0.19.3/rapier.mjs', dest: 'viewer/rapier/rapier.js' },
-  { src: '/assets/vendor/rapier-deterministic/0.19.3/rapier_wasm3d_bg.wasm', dest: 'viewer/rapier/rapier_wasm3d_bg.wasm' },
+  { src: '/assets/vendor/rapier-deterministic/0.19.3/rapier_wasm3d_bg.wasm', dest: 'viewer/rapier/rapier_wasm3d_bg.wasm', binary: true },
   // Pinned Loomlet behavior graph runtime. Exported viewers must not depend on afjk.jp at runtime.
   {
     src: '/assets/vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js',
@@ -194,12 +207,12 @@ async function fetchViewerSources() {
   const failures = [];
 
   await Promise.all(
-    VIEWER_SOURCES.map(async ({ src, dest }) => {
+    VIEWER_SOURCES.map(async ({ src, dest, binary = false, transform = null }) => {
       try {
         const res = await fetch(src);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const text = await res.text();
-        results[dest] = text;
+        const content = binary ? await res.arrayBuffer() : await res.text();
+        results[dest] = typeof transform === 'function' ? transform(content) : content;
       } catch (err) {
         failures.push({ src, dest, error: err.message });
       }

--- a/html/assets/js/scenesync-export/export/build-export-package.test.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.test.js
@@ -82,6 +82,7 @@ async function withMockExportEnvironment(run) {
     globalThis.fetch = async () => ({
       ok: true,
       text: async () => 'export default {};',
+      arrayBuffer: async () => new ArrayBuffer(0),
     });
     globalThis.document = {
       createElement(tagName) {


### PR DESCRIPTION
## Summary

- Bundle the Scene Sync viewer runtime files that `create-viewer-core.js` now imports.
- Rewrite packaged viewer import paths so `scenesync/*` modules resolve inside the exported ZIP.
- Store the Rapier WASM viewer asset as binary instead of UTF-8 text.
- Add a regression test that walks `VIEWER_SOURCES` module imports and verifies every relative import resolves inside the ZIP file list.

## Root cause

The export package uses a fixed `VIEWER_SOURCES` list. Recent viewer changes added imports for `export-behavior-runtime.js`, runtime plugins, and schedule/runtime event helpers, but the fixed bundle list and tests were not updated. The package also copied source-tree relative imports that resolve outside the ZIP layout.

## Validation

- `node --test apps/presence-server/tests/build-export-package.test.mjs`
- `node --test html/assets/js/scenesync-export/export/build-export-package.test.js`
- `npm run test:scene-sync-export-import`
- `npm run test:plugins`
- `npm run test:runtime-schedule`
- `npm run test:export-behavior-runtime`

## E2E note

`npm run test:e2e:scene-sync-export-import` was attempted. After installing dependencies with a temporary npm cache and pointing Playwright at the existing browser cache, Chromium failed to launch in this local macOS sandbox with `MachPortRendezvousServer: Permission denied`, which matches the local browser sandbox limitation seen earlier.
