### PR TITLE
[codex] Add SceneSync Rapier PlayerUI parity sample

### DIFF
--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -161,6 +161,26 @@ export function normalizeObjectPhysics(input = null) {
     physics.angularVelocity = [0, 0, 0];
   }
 
+  if (Number.isFinite(Number(input.density))) {
+    physics.density = bodyType === 'static'
+      ? finiteNonNegativeNumber(input.density, 0)
+      : positiveNumber(input.density, 1);
+  }
+  if (Number.isFinite(Number(input.linearDamping))) {
+    physics.linearDamping = finiteNonNegativeNumber(input.linearDamping, 0);
+  }
+  if (Number.isFinite(Number(input.angularDamping))) {
+    physics.angularDamping = finiteNonNegativeNumber(input.angularDamping, 0);
+  }
+  if (typeof input.canSleep === 'boolean') {
+    physics.canSleep = input.canSleep;
+  }
+  if (typeof input.ccd === 'boolean') {
+    physics.ccd = input.ccd;
+  } else if (typeof input.ccdEnabled === 'boolean') {
+    physics.ccd = input.ccdEnabled;
+  }
+
   if (shape === 'sphere' && Number.isFinite(Number(input.radius))) {
     physics.radius = positiveNumber(input.radius, 0.5);
   }
@@ -267,6 +287,11 @@ export function buildPhysicsBodyDef({ objectId, object, physics, useInitialTrans
     static: normalized.bodyType === 'static',
     restitution: normalized.restitution,
     friction: normalized.friction,
+    density: Number.isFinite(Number(normalized.density)) ? normalized.density : undefined,
+    linearDamping: Number.isFinite(Number(normalized.linearDamping)) ? normalized.linearDamping : undefined,
+    angularDamping: Number.isFinite(Number(normalized.angularDamping)) ? normalized.angularDamping : undefined,
+    canSleep: typeof normalized.canSleep === 'boolean' ? normalized.canSleep : undefined,
+    ccd: typeof normalized.ccd === 'boolean' ? normalized.ccd : undefined,
   };
 
   if (shape === 'sphere') {

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -161,10 +161,10 @@ export function normalizeObjectPhysics(input = null) {
     physics.angularVelocity = [0, 0, 0];
   }
 
-  if (Number.isFinite(Number(input.density))) {
-    physics.density = bodyType === 'static'
-      ? finiteNonNegativeNumber(input.density, 0)
-      : positiveNumber(input.density, 1);
+  if (bodyType === 'static') {
+    physics.density = finiteNonNegativeNumber(input.density, 0);
+  } else if (Number.isFinite(Number(input.density))) {
+    physics.density = positiveNumber(input.density, 1);
   }
   if (Number.isFinite(Number(input.linearDamping))) {
     physics.linearDamping = finiteNonNegativeNumber(input.linearDamping, 0);

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -2,6 +2,7 @@ import test, { before } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   applyPhysicsResetBaseline,
+  buildPhysicsBodyDef,
   createPhysicsResetBaseline,
   createScenePhysicsRuntime,
   isScenePhysicsZeroTime,
@@ -146,7 +147,21 @@ test('normalizes parity object physics fields used by Rapier hashing', () => {
   assert.equal(normalizeObjectPhysics({
     enabled: true,
     bodyType: 'static',
-    density: 0,
+  }).density, 0);
+
+  const staticObject = makeObject({
+    objectId: 'static-box',
+    scale: [2, 2, 2],
+    physics: {
+      enabled: true,
+      bodyType: 'static',
+      shape: 'box',
+    },
+  });
+  assert.equal(buildPhysicsBodyDef({
+    objectId: 'static-box',
+    object: staticObject,
+    physics: staticObject.userData.physics,
   }).density, 0);
 });
 

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -117,6 +117,39 @@ test('normalizes object physics with practical defaults', () => {
   });
 });
 
+test('normalizes parity object physics fields used by Rapier hashing', () => {
+  assert.deepEqual(normalizeObjectPhysics({
+    enabled: true,
+    bodyType: 'dynamic',
+    density: 1,
+    linearDamping: 0.02,
+    angularDamping: 0.03,
+    canSleep: false,
+    ccd: true,
+  }), {
+    version: 1,
+    enabled: true,
+    bodyType: 'dynamic',
+    shape: 'box',
+    mass: 1,
+    restitution: 0.2,
+    friction: 0.5,
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+    density: 1,
+    linearDamping: 0.02,
+    angularDamping: 0.03,
+    canSleep: false,
+    ccd: true,
+  });
+
+  assert.equal(normalizeObjectPhysics({
+    enabled: true,
+    bodyType: 'static',
+    density: 0,
+  }).density, 0);
+});
+
 test('scene physics runtime is a function of supplied clock time', () => {
   const object = makeObject();
   const scenePhysics = normalizeScenePhysics({
@@ -209,6 +242,73 @@ test('scene physics runtime reports canonical hash metadata for wire diagnostics
   assert.equal(result.rapierCoreVersion, RAPIER_CORE_VERSION);
   assert.match(result.hash, /^[0-9a-f]{16}$/);
   assert.equal(result.stateHash, result.hash);
+});
+
+test('scene physics runtime produces a stable SceneSync Rapier sample hash', () => {
+  const floor = makeObject({
+    objectId: 'floor',
+    position: [0, -0.5, 0],
+    scale: [12, 1, 12],
+    physics: {
+      enabled: true,
+      bodyType: 'static',
+      shape: 'box',
+      halfExtents: [6, 0.5, 6],
+      density: 0,
+      friction: 0.5,
+      restitution: 0.2,
+      initialTransform: {
+        position: [0, -0.5, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [12, 1, 12],
+      },
+    },
+  });
+  const box = makeObject({
+    objectId: 'box-1',
+    position: [-0.75, 5, 0],
+    scale: [1, 1, 1],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'box',
+      halfExtents: [0.5, 0.5, 0.5],
+      density: 1,
+      friction: 0.5,
+      restitution: 0.2,
+      velocity: [0.75, 0, 0.15],
+      angularVelocity: [0.35, 1.25, 0.55],
+      linearDamping: 0.02,
+      angularDamping: 0.02,
+      canSleep: false,
+      ccd: false,
+      initialTransform: {
+        position: [-0.75, 5, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+      },
+    },
+  });
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: {
+      gravity: [0, -9.81, 0],
+      ground: null,
+      timestep: 1 / 60,
+    },
+  });
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => [makeEntry(floor), makeEntry(box)],
+    isClockActive: () => true,
+  });
+
+  const initial = runtime.update({ t: 0, mode: 'shared-playback', active: true, transportActive: true });
+  assert.equal(initial.hash, '43af70bb0d584167');
+
+  const atTick60 = runtime.update({ t: 1 + 1e-6, mode: 'shared-playback', active: true, transportActive: true });
+  assert.equal(atTick60.tick, 60);
+  assert.equal(atTick60.hash, 'e0c4380396163cee');
 });
 
 test('scene physics runtime creates canonical snapshot reports on demand', () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "test:e2e:install-browsers": "PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium",
     "test:e2e:scene-sync-export-import": "node scripts/scenesync-export-import-browser-e2e.mjs",
     "test:e2e:scene-sync-physics-live-room": "node scripts/scenesync-physics-live-room-smoke.mjs",
-    "test:e2e:scene-sync-unity-physics-presence": "node scripts/scenesync-unity-physics-presence-smoke.mjs"
+    "test:e2e:scene-sync-unity-physics-presence": "node scripts/scenesync-unity-physics-presence-smoke.mjs",
+    "test:e2e:scene-sync-rapier-playerui-sample": "node scripts/scenesync-rapier-playerui-sample.mjs --verify",
+    "sample:scene-sync-rapier": "node scripts/scenesync-rapier-playerui-sample.mjs --unity"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.3.0",

--- a/scripts/scenesync-rapier-playerui-sample.mjs
+++ b/scripts/scenesync-rapier-playerui-sample.mjs
@@ -1,0 +1,805 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { createPresenceServer } from '../apps/presence-server/src/server.mjs';
+import { initRapierPhysics } from '../html/assets/js/scenesync/physics/rapier-world.js';
+import {
+  createScenePhysicsRuntime,
+  normalizeScenePhysics,
+} from '../html/assets/js/scenesync/scene-physics.js';
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const htmlRoot = path.join(repoRoot, 'html');
+const require = createRequire(import.meta.url);
+const WebSocket = require(path.join(repoRoot, 'apps/presence-server/node_modules/ws'));
+
+process.env.GPT_SESSION_SECRET ||= 'scene-sync-rapier-playerui-sample-secret';
+
+const DEFAULT_FIXTURE = path.join(repoRoot, 'fixtures/rapier/parity-basic-001.json');
+const DEFAULT_TICKS = [0, 30, 60];
+const DEFAULT_ROOT_NAME = '__SceneSyncRapierPlayerUiSample';
+const TEST_TIMEOUT_MS = 90000;
+
+const mimeTypes = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.webp', 'image/webp'],
+  ['.hdr', 'application/octet-stream'],
+  ['.glb', 'model/gltf-binary'],
+  ['.wasm', 'application/wasm'],
+]);
+
+function parseArgs(argv) {
+  const options = {
+    fixturePath: DEFAULT_FIXTURE,
+    roomId: `rapier-sample-${Date.now().toString(36)}`,
+    withUnity: false,
+    verify: false,
+    hold: true,
+    uloopBin: process.env.ULOOP_BIN || 'uloop',
+    unityProject: process.env.SCENESYNC_UNITY_PROJECT || path.resolve(repoRoot, '..', 'SceneSyncClient'),
+    rootName: DEFAULT_ROOT_NAME,
+    rebroadcastMs: 0,
+    ticks: DEFAULT_TICKS,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--unity') {
+      options.withUnity = true;
+    } else if (arg === '--no-unity') {
+      options.withUnity = false;
+    } else if (arg === '--verify') {
+      options.verify = true;
+      options.withUnity = true;
+      options.hold = false;
+    } else if (arg === '--no-hold') {
+      options.hold = false;
+    } else if (arg === '--hold') {
+      options.hold = true;
+    } else if (arg === '--room') {
+      options.roomId = argv[++i] || options.roomId;
+    } else if (arg.startsWith('--room=')) {
+      options.roomId = arg.slice('--room='.length) || options.roomId;
+    } else if (arg === '--fixture') {
+      options.fixturePath = path.resolve(argv[++i] || options.fixturePath);
+    } else if (arg.startsWith('--fixture=')) {
+      options.fixturePath = path.resolve(arg.slice('--fixture='.length) || options.fixturePath);
+    } else if (arg === '--unity-project') {
+      options.unityProject = path.resolve(argv[++i] || options.unityProject);
+    } else if (arg.startsWith('--unity-project=')) {
+      options.unityProject = path.resolve(arg.slice('--unity-project='.length) || options.unityProject);
+    } else if (arg === '--uloop-bin') {
+      options.uloopBin = argv[++i] || options.uloopBin;
+    } else if (arg.startsWith('--uloop-bin=')) {
+      options.uloopBin = arg.slice('--uloop-bin='.length) || options.uloopBin;
+    } else if (arg === '--ticks') {
+      options.ticks = parseTicks(argv[++i], options.ticks);
+    } else if (arg.startsWith('--ticks=')) {
+      options.ticks = parseTicks(arg.slice('--ticks='.length), options.ticks);
+    } else if (arg === '--rebroadcast-ms') {
+      options.rebroadcastMs = Math.max(0, Number(argv[++i]) || options.rebroadcastMs);
+    } else if (arg.startsWith('--rebroadcast-ms=')) {
+      options.rebroadcastMs = Math.max(0, Number(arg.slice('--rebroadcast-ms='.length)) || options.rebroadcastMs);
+    }
+  }
+
+  return options;
+}
+
+function parseTicks(value, fallback) {
+  const ticks = String(value || '')
+    .split(',')
+    .map((tick) => Number(tick.trim()))
+    .filter((tick) => Number.isInteger(tick) && tick >= 0);
+  return ticks.length ? Array.from(new Set(ticks)).sort((left, right) => left - right) : fallback;
+}
+
+function sendBuffer(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,OPTIONS,HEAD',
+    'access-control-allow-headers': 'content-type',
+    'content-length': body.byteLength,
+    ...headers,
+  });
+  res.end(body);
+}
+
+function resolveStaticPath(urlPath) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(urlPath, 'http://localhost').pathname);
+  } catch {
+    return null;
+  }
+
+  if (pathname.endsWith('/')) pathname = `${pathname}index.html`;
+
+  const candidate = path.resolve(htmlRoot, `.${pathname}`);
+  if (!candidate.startsWith(`${htmlRoot}${path.sep}`) && candidate !== htmlRoot) return null;
+  return candidate;
+}
+
+function createStaticServer() {
+  const server = createServer(async (req, res) => {
+    if (req.method === 'OPTIONS') {
+      sendBuffer(res, 204, Buffer.alloc(0));
+      return;
+    }
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      sendBuffer(res, 405, Buffer.from('Method not allowed'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+      return;
+    }
+
+    const filePath = resolveStaticPath(req.url || '/');
+    if (!filePath) {
+      sendBuffer(res, 400, Buffer.from('Bad request'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+      return;
+    }
+
+    try {
+      const body = await readFile(filePath);
+      const contentType = mimeTypes.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
+      sendBuffer(res, 200, req.method === 'HEAD' ? Buffer.alloc(0) : body, {
+        'content-type': contentType,
+        ...(req.method === 'HEAD' ? { 'content-length': body.byteLength } : {}),
+      });
+    } catch {
+      sendBuffer(res, 404, Buffer.from('Not found'), {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+    }
+  });
+
+  return listenServer(server);
+}
+
+function listenServer(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve(server);
+    });
+  });
+}
+
+function serverUrl(server, scheme = 'http') {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Server did not expose a TCP address');
+  }
+  return `${scheme}://127.0.0.1:${address.port}`;
+}
+
+function waitForEvent(target, event, timeoutMs = TEST_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${event}`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      target.off(event, onEvent);
+      target.off('error', onError);
+    };
+    const onEvent = (...args) => {
+      cleanup();
+      resolve(args);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    target.once(event, onEvent);
+    if (event !== 'error') target.once('error', onError);
+  });
+}
+
+function waitForMessage(ws, predicate, { timeoutMs = TEST_TIMEOUT_MS, label = 'websocket message' } = {}) {
+  const seen = [];
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${label}; recent messages: ${JSON.stringify(seen.slice(-8))}`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`websocket closed while waiting for ${label}`));
+    };
+    const onMessage = (raw) => {
+      let message;
+      try {
+        message = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      seen.push({
+        type: message.type || null,
+        kind: message.payload?.kind || null,
+        tick: message.payload?.tick ?? null,
+        hash: message.payload?.hash || null,
+        from: message.from?.nickname || message.from?.id || null,
+      });
+      if (!predicate(message)) return;
+      cleanup();
+      resolve(message);
+    };
+    ws.on('message', onMessage);
+    ws.once('error', onError);
+    ws.once('close', onClose);
+  });
+}
+
+async function connectPresenceClient(wsBaseUrl, roomId, nickname) {
+  const ws = new WebSocket(`${wsBaseUrl}?room=${encodeURIComponent(roomId)}`);
+  const welcomePromise = waitForMessage(ws, message => message.type === 'welcome', {
+    label: `${nickname} welcome`,
+  });
+  await waitForEvent(ws, 'open');
+  ws.send(JSON.stringify({
+    type: 'hello',
+    nickname,
+    device: 'SceneSync Rapier Sample',
+    userId: `${nickname.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now().toString(36)}`,
+  }));
+  const welcome = await welcomePromise;
+  ws.presenceId = welcome.id;
+  return ws;
+}
+
+function closeWebSocket(ws) {
+  if (!ws || ws.readyState === WebSocket.CLOSED) return Promise.resolve();
+  const closed = waitForEvent(ws, 'close', 5000).catch(() => {});
+  ws.terminate();
+  return closed;
+}
+
+function closeHttpServer(server) {
+  if (!server) return Promise.resolve();
+  server.closeIdleConnections?.();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      server.closeAllConnections?.();
+      resolve();
+    }, 3000);
+    server.close(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function stopPresenceServer(server) {
+  if (!server) return;
+  await Promise.race([
+    server.stop(),
+    new Promise(resolve => setTimeout(resolve, 3000)),
+  ]);
+}
+
+function vector3(value, fallback = [0, 0, 0]) {
+  return Array.isArray(value) && value.length >= 3
+    ? [Number(value[0]) || 0, Number(value[1]) || 0, Number(value[2]) || 0]
+    : [...fallback];
+}
+
+function quat(value, fallback = [0, 0, 0, 1]) {
+  return Array.isArray(value) && value.length >= 4
+    ? [Number(value[0]) || 0, Number(value[1]) || 0, Number(value[2]) || 0, Number(value[3]) || 0]
+    : [...fallback];
+}
+
+function finite(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function fixtureBodyToSceneObject(body) {
+  const halfExtents = vector3(body.halfExtents, [0.5, 0.5, 0.5]);
+  const position = vector3(body.position, [0, 0, 0]);
+  const rotation = quat(body.rotation, [0, 0, 0, 1]);
+  const scale = halfExtents.map(component => component * 2);
+  const isStatic = body.type === 'fixed' || body.type === 'static' || body.static === true || Number(body.density) === 0;
+  const physics = {
+    version: 1,
+    enabled: true,
+    bodyType: isStatic ? 'static' : 'dynamic',
+    shape: body.shape === 'sphere' ? 'sphere' : 'box',
+    halfExtents,
+    density: isStatic ? 0 : finite(body.density, finite(body.mass, 1)),
+    friction: finite(body.friction, 0.5),
+    restitution: finite(body.restitution, 0.2),
+    initialTransform: { position, rotation, scale },
+  };
+
+  if (!isStatic) {
+    physics.velocity = vector3(body.linearVelocity || body.velocity, [0, 0, 0]);
+    physics.angularVelocity = vector3(body.angularVelocity, [0, 0, 0]);
+    physics.linearDamping = finite(body.linearDamping, 0);
+    physics.angularDamping = finite(body.angularDamping, 0);
+    physics.canSleep = body.canSleep !== false;
+    physics.ccd = body.ccd === true;
+  }
+
+  return {
+    name: body.id === 'floor' ? 'Rapier Sample Floor' : 'Rapier Sample Box',
+    asset: {
+      type: 'primitive',
+      primitive: physics.shape,
+      color: body.id === 'floor' ? '#6b7479' : '#296bdc',
+    },
+    position,
+    rotation,
+    scale,
+    physics,
+  };
+}
+
+function createSceneStateFromFixture(fixture) {
+  const objects = {};
+  for (const body of fixture.bodies || []) {
+    if (!body?.id) continue;
+    objects[body.id] = fixtureBodyToSceneObject(body);
+  }
+
+  return {
+    kind: 'scene-state',
+    envId: 'studio',
+    physics: {
+      version: 1,
+      enabled: true,
+      duration: 10,
+      worldOptions: {
+        gravity: vector3(fixture.gravity, [0, -9.81, 0]),
+        ground: null,
+        timestep: finite(fixture.timestep, 1 / 60),
+      },
+    },
+    objects,
+  };
+}
+
+function createSceneClockPayload({ controllerId, revision, startRoomNow, includeReset = false }) {
+  const nowMs = Date.now();
+  const roomNow = nowMs / 1000;
+  const payload = {
+    kind: 'scene-clock',
+    action: includeReset ? 'mode' : 'sync',
+    mode: 'shared-playback',
+    source: 'room',
+    offset: -startRoomNow,
+    paused: false,
+    rate: 1,
+    controller: {
+      id: controllerId,
+      nickname: 'Rapier Sample Loader',
+    },
+    revision,
+    roomNow,
+    sentAt: nowMs,
+  };
+
+  if (includeReset) {
+    payload.physicsBaseline = {
+      kind: 'reset',
+      time: 0,
+      worldEpochTime: 0,
+      preserveMotion: false,
+      reason: 'rapier-playerui-sample',
+    };
+  }
+
+  return payload;
+}
+
+async function loadFixture(fixturePath) {
+  return JSON.parse(await readFile(fixturePath, 'utf8'));
+}
+
+function vectorValue(values) {
+  return {
+    values: [...values],
+    toArray() {
+      return [...this.values];
+    },
+    fromArray(next) {
+      this.values = [...next];
+    },
+  };
+}
+
+function createRuntimeObject(objectId, entry) {
+  return {
+    userData: {
+      objectId,
+      physics: entry.physics,
+      asset: entry.asset,
+    },
+    position: vectorValue(vector3(entry.position, [0, 0, 0])),
+    scale: vectorValue(vector3(entry.scale, [1, 1, 1])),
+    quaternion: {
+      values: quat(entry.rotation, [0, 0, 0, 1]),
+      toArray() {
+        return [...this.values];
+      },
+      fromArray(next) {
+        this.values = [...next];
+      },
+    },
+    updateMatrixWorld() {},
+  };
+}
+
+async function createExpectedHashes(sceneState, ticks) {
+  await initRapierPhysics();
+  const scenePhysics = normalizeScenePhysics(sceneState.physics);
+  const entries = Object.entries(sceneState.objects || {})
+    .map(([objectId, entry]) => ({
+      objectId,
+      object: createRuntimeObject(objectId, entry),
+      physics: entry.physics,
+    }));
+  const runtime = createScenePhysicsRuntime({
+    getScenePhysics: () => scenePhysics,
+    getObjectEntries: () => entries,
+    isClockActive: () => true,
+  });
+  const hashes = {};
+  for (const tick of ticks) {
+    const timestep = scenePhysics.worldOptions.timestep || 1 / 60;
+    const time = tick === 0 ? 0 : tick * timestep + 1e-6;
+    const result = runtime.update({
+      t: time,
+      mode: 'shared-playback',
+      active: true,
+      transportActive: true,
+    });
+    if (result.tick !== tick) {
+      throw new Error(`SceneSync runtime reached tick ${result.tick}, expected ${tick}.`);
+    }
+    hashes[String(tick)] = result.hash;
+  }
+  return hashes;
+}
+
+function csharpString(value) {
+  return `System.Text.Encoding.UTF8.GetString(System.Convert.FromBase64String("${Buffer.from(value).toString('base64')}"))`;
+}
+
+async function execFileWithTimeout(file, args, options = {}, timeoutMs = 45000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await execFileAsync(file, args, {
+      ...options,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError' || error?.code === 'ABORT_ERR') {
+      throw new Error(`timed out after ${timeoutMs}ms: ${file} ${args.join(' ')}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function executeUnityCode(options, code) {
+  const { stdout, stderr } = await execFileWithTimeout(
+    options.uloopBin,
+    ['--project-path', options.unityProject, 'execute-dynamic-code', '--code', code],
+    { maxBuffer: 1024 * 1024 * 8 },
+    45000,
+  );
+  const output = `${stdout || ''}${stderr || ''}`.trim();
+  if (output) {
+    let parsed = null;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      // Keep raw output for error reporting below.
+    }
+    if (parsed && parsed.success === false) throw new Error(output);
+  }
+  return output;
+}
+
+async function controlPlayMode(options, action) {
+  await execFileWithTimeout(
+    options.uloopBin,
+    ['--project-path', options.unityProject, 'control-play-mode', '--action', action, '--timeout-seconds', '60'],
+    { maxBuffer: 1024 * 1024 * 4 },
+    75000,
+  );
+}
+
+function createUnitySetupCode({ rootName, presenceUrl, roomId }) {
+  return `
+using UnityEngine;
+using Afjk.SceneSync.Rapier;
+
+void DestroyIfFound(string name)
+{
+    var target = GameObject.Find(name);
+    if (target != null) UnityEngine.Object.DestroyImmediate(target);
+}
+
+var rootName = ${csharpString(rootName)};
+DestroyIfFound(rootName);
+DestroyIfFound("__SceneSyncImportDebug");
+DestroyIfFound("__SceneSyncBootstrapDebug");
+
+var root = new GameObject(rootName);
+var sample = root.AddComponent<SceneSyncRapierParitySampleBootstrap>();
+sample.PresenceUrl = ${csharpString(presenceUrl)};
+sample.Room = ${csharpString(roomId)};
+sample.Nickname = "Unity Rapier Sample";
+sample.AutoConnect = true;
+sample.RequireSceneClock = true;
+sample.BuildOnStart = true;
+Debug.Log("ok:scenesync-rapier-playerui-sample-configured:" + rootName);
+`;
+}
+
+async function setupUnitySample(options, presenceUrl, roomId) {
+  await controlPlayMode(options, 'Stop').catch(() => {});
+  await executeUnityCode(options, createUnitySetupCode({
+    rootName: options.rootName,
+    presenceUrl,
+    roomId,
+  }));
+  await controlPlayMode(options, 'Play');
+}
+
+async function cleanupUnitySample(options) {
+  await controlPlayMode(options, 'Stop').catch((error) => {
+    console.warn(`[unity-cleanup] ${error.message}`);
+  });
+  await executeUnityCode(options, `
+using UnityEngine;
+void DestroyIfFound(string name)
+{
+    var target = GameObject.Find(name);
+    if (target != null) UnityEngine.Object.DestroyImmediate(target);
+}
+DestroyIfFound(${csharpString(options.rootName)});
+DestroyIfFound("__SceneSyncImportDebug");
+DestroyIfFound("__SceneSyncBootstrapDebug");
+Debug.Log("ok:scenesync-rapier-playerui-sample-cleanup");
+`).catch((error) => {
+    console.warn(`[unity-cleanup] ${error.message}`);
+  });
+}
+
+function sendBroadcast(ws, payload) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: 'broadcast', payload }));
+}
+
+function sendHandoff(ws, targetId, payload) {
+  if (!ws || ws.readyState !== WebSocket.OPEN || !targetId) return;
+  ws.send(JSON.stringify({ type: 'handoff', targetId, payload }));
+}
+
+function installLoaderHandlers(ws, sceneState, expectedHashes) {
+  let revision = 0;
+  let sentResetClock = false;
+  let startRoomNow = Date.now() / 1000;
+  const hashTable = new Map();
+  const observedPhysicsHashes = [];
+  const physicsHashWaiters = new Set();
+  const publishScene = () => sendBroadcast(ws, sceneState);
+  const publishClock = (targetId = null, { reset = false } = {}) => {
+    revision += 1;
+    const includeReset = reset || !sentResetClock;
+    if (includeReset) {
+      startRoomNow = Date.now() / 1000;
+      sentResetClock = true;
+    }
+    const payload = createSceneClockPayload({
+      controllerId: ws.presenceId,
+      revision,
+      startRoomNow,
+      includeReset,
+    });
+    if (targetId) sendHandoff(ws, targetId, payload);
+    else sendBroadcast(ws, payload);
+  };
+
+  ws.on('message', (raw) => {
+    let message;
+    try {
+      message = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+
+    if (message.type !== 'handoff' || !message.payload) return;
+    const payload = message.payload;
+    if (payload.kind === 'scene-request') {
+      if (message.from?.nickname !== 'Unity Rapier Sample') {
+        sendHandoff(ws, message.from?.id, sceneState);
+      }
+      publishClock(message.from?.id, { reset: !sentResetClock });
+      return;
+    }
+
+    if (payload.kind !== 'scene-physics-hash') return;
+    const peer = message.from?.nickname || message.from?.id || 'unknown';
+    const tick = payload.tick;
+    const hash = payload.hash;
+    if (!Number.isInteger(tick) || typeof hash !== 'string') return;
+
+    const expected = expectedHashes[String(tick)];
+    const record = { message, peer, tick, hash };
+    observedPhysicsHashes.push(record);
+    while (observedPhysicsHashes.length > 32) observedPhysicsHashes.shift();
+
+    for (const waiter of Array.from(physicsHashWaiters)) {
+      if (!waiter.predicate(record)) continue;
+      physicsHashWaiters.delete(waiter);
+      waiter.resolve(record);
+    }
+
+    const key = `${tick}:${hash}`;
+    if (!hashTable.has(key)) hashTable.set(key, new Set());
+    hashTable.get(key).add(peer);
+    const peers = Array.from(hashTable.get(key)).sort();
+    const status = expected ? (expected === hash ? 'MATCH' : `MISMATCH expected=${expected}`) : 'OBSERVED';
+    console.log(`[physics-hash] tick=${tick} hash=${hash} peers=${peers.join(',')} ${status}`);
+  });
+
+  const waitForPhysicsHash = ({ peer, tick, timeoutMs = TEST_TIMEOUT_MS }) => {
+    const predicate = record => (
+      record.tick === tick
+      && (!peer || record.peer === peer)
+    );
+    const existing = observedPhysicsHashes.find(predicate);
+    if (existing) return Promise.resolve(existing);
+
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        predicate,
+        resolve: (record) => {
+          clearTimeout(timer);
+          resolve(record);
+        },
+      };
+      const timer = setTimeout(() => {
+        physicsHashWaiters.delete(waiter);
+        reject(new Error(`timed out waiting for physics hash tick ${tick}; recent hashes: ${JSON.stringify(observedPhysicsHashes.slice(-8).map(record => ({
+          tick: record.tick,
+          hash: record.hash,
+          peer: record.peer,
+        })))}`));
+      }, timeoutMs);
+      physicsHashWaiters.add(waiter);
+    });
+  };
+
+  return { publishScene, publishClock, waitForPhysicsHash };
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2));
+  const fixture = await loadFixture(options.fixturePath);
+  const sceneState = createSceneStateFromFixture(fixture);
+  const expectedHashes = await createExpectedHashes(sceneState, options.ticks);
+
+  const presenceServer = createPresenceServer();
+  await listenServer(presenceServer);
+  const staticServer = await createStaticServer();
+  const wsBaseUrl = `${serverUrl(presenceServer, 'ws')}/ws`;
+  const playerUrl = `${serverUrl(staticServer)}/scenesync/?room=${encodeURIComponent(options.roomId)}&presence=${encodeURIComponent(wsBaseUrl)}&dev=1`;
+  const loaderWs = await connectPresenceClient(wsBaseUrl, options.roomId, 'Rapier Sample Loader');
+  const loader = installLoaderHandlers(loaderWs, sceneState, expectedHashes);
+  const targetTick = Math.max(...options.ticks);
+  const unityHashPromise = options.verify
+    ? loader.waitForPhysicsHash({ peer: 'Unity Rapier Sample', tick: targetTick })
+    : null;
+  let rebroadcastTimer = null;
+  let unityStarted = false;
+
+  const cleanup = async () => {
+    if (rebroadcastTimer) clearInterval(rebroadcastTimer);
+    if (unityStarted) await cleanupUnitySample(options);
+    await closeWebSocket(loaderWs);
+    await closeHttpServer(staticServer);
+    await stopPresenceServer(presenceServer);
+  };
+
+  try {
+    console.log(JSON.stringify({
+      roomId: options.roomId,
+      playerUrl,
+      presenceUrl: wsBaseUrl,
+      fixture: path.relative(repoRoot, options.fixturePath),
+      expectedHashes,
+      unity: options.withUnity ? options.unityProject : null,
+    }, null, 2));
+
+    if (options.withUnity) {
+      await setupUnitySample(options, wsBaseUrl, options.roomId);
+      unityStarted = true;
+      await waitForMessage(loaderWs, message => (
+        (message.type === 'peers'
+          && Array.isArray(message.peers)
+          && message.peers.some(peer => peer.nickname === 'Unity Rapier Sample'))
+        || message.from?.nickname === 'Unity Rapier Sample'
+      ), { label: 'Unity Rapier Sample peer or message' });
+    }
+
+    if (!options.withUnity) {
+      loader.publishScene();
+    }
+    loader.publishClock();
+    if (options.rebroadcastMs > 0 && options.hold) {
+      rebroadcastTimer = setInterval(() => {
+        loader.publishScene();
+        loader.publishClock();
+      }, options.rebroadcastMs);
+    }
+
+    if (options.verify) {
+      const record = await unityHashPromise;
+      assert.equal(record.hash, expectedHashes[String(targetTick)]);
+      console.log(JSON.stringify({
+        ok: true,
+        verified: 'unity-web-rapier-parity',
+        roomId: options.roomId,
+        tick: targetTick,
+        hash: record.hash,
+      }, null, 2));
+      return;
+    }
+
+    if (options.hold) {
+      console.log('Open PlayerUI URL above. Press Ctrl+C to stop the sample.');
+      await new Promise((resolve) => {
+        process.once('SIGINT', resolve);
+        process.once('SIGTERM', resolve);
+      });
+    }
+  } finally {
+    await cleanup();
+  }
+}
+
+run().then(() => {
+  process.exit(0);
+}).catch((error) => {
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -59,13 +59,14 @@ requiring `logStateHash`; enable `logStateHash` only when console output is
 useful. Compare this value with the browser runtime's `world.canonicalStateHash()`
 only when both hosts use the same Scene Sync Rapier parity profile.
 
-During Shared Playback, the Web clock controller periodically broadcasts
-`scene-physics-hash` messages with `SceneSyncCanonicalPhysicsHashV1`, Rapier core
-version, physics profile, fixed `tick`, and canonical hash. The bridge stores
-the latest report in `LastRemoteHashReport`, exposes `LastRemoteHashMatched`,
-and raises `HashReportReceived` after comparing the remote hash with the local
-world at the same tick. This is diagnostic only; it does not resync or stream
-body transforms.
+During Shared Playback, the Web clock controller and the Unity bridge
+periodically broadcast `scene-physics-hash` messages with
+`SceneSyncCanonicalPhysicsHashV1`, Rapier core version, physics profile, fixed
+`tick`, and canonical hash. The bridge stores the latest remote report in
+`LastRemoteHashReport`, exposes `LastRemoteHashMatched`, and raises
+`HashReportReceived` after comparing the remote hash with the local world at the
+same tick. Hash messages are diagnostic and drive snapshot requests; they do not
+stream body transforms.
 
 The bridge also accepts `scene-physics-snapshot` messages using
 `SceneSyncPhysicsSnapshotV1`. When `autoApplyRemoteSnapshots` is enabled and all
@@ -79,3 +80,27 @@ publish a `scene-physics-snapshot-request` through `SceneSyncMessageBus`. A
 `SceneSyncManager` in the scene routes that request through the active presence
 connection, allowing the Web Shared Playback controller to hand back a targeted
 snapshot.
+
+## PlayerUI Parity Sample
+
+`SceneSyncRapierParitySampleBootstrap` builds a small floor + falling box scene
+matching `fixtures/rapier/parity-basic-001.json`, connects a `SceneSyncManager`
+to a room, and shows tick/hash diagnostics in the Unity Game View.
+
+From the repo root:
+
+```bash
+npm run sample:scene-sync-rapier
+```
+
+The command starts a local presence server, configures the sibling
+`SceneSyncClient` project through uloop, enters Unity Play Mode, and prints a
+PlayerUI URL. Open that URL to see the Web side in the same room. The loader peer
+keeps the sample `scene-state` available and logs `scene-physics-hash` messages
+from Unity and PlayerUI.
+
+For an automated Unity-vs-Web Rapier hash check without launching a browser:
+
+```bash
+npm run test:e2e:scene-sync-rapier-playerui-sample
+```

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -19,17 +19,23 @@ namespace Afjk.SceneSync.Rapier
         private const string CanonicalStateHashVersion = "SceneSyncCanonicalPhysicsHashV1";
         private const string PhysicsProfile = "SceneSyncRapierParity-0.30";
         private const string SnapshotVersion = "SceneSyncPhysicsSnapshotV1";
+        private const string RapierCoreVersion = "0.30.0";
 
         [SerializeField] private bool autoRun = true;
         [SerializeField] private bool useSceneClock = true;
+        [SerializeField] private bool requireSceneClock;
         [SerializeField] private bool applyDynamicTransforms = true;
+        [SerializeField] private bool preserveMotionOnRebuild = true;
         [SerializeField] private bool includeGround = true;
+        [SerializeField] private Transform bodyRoot;
         [SerializeField] private float metadataScanInterval = 0.5f;
         [SerializeField] private float maxFrameStepSeconds = 0.25f;
         [SerializeField] private int maxClockStepsPerUpdate = 600;
         [SerializeField] private int maxCollisionEventsPerDrain = 256;
         [SerializeField] private bool autoApplyRemoteSnapshots = true;
         [SerializeField] private bool requestSnapshotOnHashMismatch = true;
+        [SerializeField] private bool broadcastStateHash = true;
+        [SerializeField] private int stateHashBroadcastTickInterval = 30;
         [SerializeField] private float snapshotRequestCooldownSeconds = 1f;
         [SerializeField] private bool logStateHash;
 
@@ -62,6 +68,9 @@ namespace Afjk.SceneSync.Rapier
         private SceneSyncRapierSnapshotReport lastRemoteSnapshotReport;
         private int lastSnapshotRequestTick = int.MinValue;
         private float lastSnapshotRequestTime = float.NegativeInfinity;
+        private int lastStateHashBroadcastTick = int.MinValue;
+        private int lastStateHashBroadcastRevision = int.MinValue;
+        private string lastStateHashBroadcastHash;
 
         public event Action<SceneSyncRapierCollisionEvent> CollisionEvent;
         public event Action<SceneSyncRapierHashReport> HashReportReceived;
@@ -79,6 +88,40 @@ namespace Afjk.SceneSync.Rapier
         public bool HasRemoteSnapshotReport => hasRemoteSnapshotReport;
         public SceneSyncRapierSnapshotReport LastRemoteSnapshotReport => lastRemoteSnapshotReport;
         public bool LastRemoteSnapshotApplied => hasRemoteSnapshotReport && lastRemoteSnapshotReport.Applied;
+        public int LastStateHashBroadcastTick => lastStateHashBroadcastTick;
+        public string LastStateHashBroadcastHash => lastStateHashBroadcastHash;
+        public bool AutoRun
+        {
+            get => autoRun;
+            set => autoRun = value;
+        }
+        public bool UseSceneClock
+        {
+            get => useSceneClock;
+            set => useSceneClock = value;
+        }
+        public bool RequireSceneClock
+        {
+            get => requireSceneClock;
+            set => requireSceneClock = value;
+        }
+        public Transform BodyRoot
+        {
+            get => bodyRoot;
+            set
+            {
+                if (bodyRoot == value) return;
+                bodyRoot = value;
+                objectPhysicsJson.Clear();
+                preserveMotionOnNextRebuild = false;
+                dirty = true;
+            }
+        }
+        public bool PreserveMotionOnRebuild
+        {
+            get => preserveMotionOnRebuild;
+            set => preserveMotionOnRebuild = value;
+        }
 
         private void OnEnable()
         {
@@ -112,6 +155,9 @@ namespace Afjk.SceneSync.Rapier
                 UpdateFromSceneClock();
                 return;
             }
+
+            if (useSceneClock && requireSceneClock)
+                return;
 
             StepLocalFrame();
         }
@@ -186,6 +232,7 @@ namespace Afjk.SceneSync.Rapier
                 return false;
             tick++;
             DrainCollisionEventsIntoCurrentPairs();
+            UpdateStateHashAtBroadcastTick();
             return true;
         }
 
@@ -196,7 +243,8 @@ namespace Afjk.SceneSync.Rapier
 
         public void RebuildWorld()
         {
-            var preservedBodyStates = preserveMotionOnNextRebuild
+            RefreshMetadataFromScene();
+            var preservedBodyStates = preserveMotionOnRebuild && preserveMotionOnNextRebuild
                 ? CapturePreservedBodyStates()
                 : new Dictionary<string, PreservedBodyState>(StringComparer.Ordinal);
             preserveMotionOnNextRebuild = true;
@@ -205,6 +253,7 @@ namespace Afjk.SceneSync.Rapier
             accumulator = 0f;
             tick = 0;
             lastStateHash = null;
+            ResetStateHashBroadcastCache();
             lastStepLimited = false;
             hasInitialSnapshot = false;
             initialSnapshot = default;
@@ -275,7 +324,7 @@ namespace Afjk.SceneSync.Rapier
             }
             else
             {
-                foreach (var metadata in FindObjectsByType<SceneSyncPhysicsMetadata>(FindObjectsSortMode.None))
+                foreach (var metadata in FindScenePhysicsMetadata())
                 {
                     if (metadata == null || string.IsNullOrWhiteSpace(metadata.ScenePhysicsJson)) continue;
                     var next = ScenePhysicsDefinition.Parse(metadata.ScenePhysicsJson);
@@ -288,7 +337,7 @@ namespace Afjk.SceneSync.Rapier
                 }
             }
 
-            foreach (var identity in FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None))
+            foreach (var identity in FindSceneSyncIdentities())
             {
                 if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
                 var metadata = identity.GetComponent<SceneSyncPhysicsMetadata>();
@@ -310,9 +359,8 @@ namespace Afjk.SceneSync.Rapier
 
         private List<BodyCandidate> CollectBodyCandidates()
         {
-            var identities = FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None);
             var byId = new Dictionary<string, SceneSyncIdentity>(StringComparer.Ordinal);
-            foreach (var identity in identities)
+            foreach (var identity in FindSceneSyncIdentities())
             {
                 if (identity == null || string.IsNullOrWhiteSpace(identity.ObjectId)) continue;
                 if (!byId.ContainsKey(identity.ObjectId))
@@ -329,6 +377,20 @@ namespace Afjk.SceneSync.Rapier
             }
 
             return result;
+        }
+
+        private SceneSyncIdentity[] FindSceneSyncIdentities()
+        {
+            return bodyRoot != null
+                ? bodyRoot.GetComponentsInChildren<SceneSyncIdentity>(true)
+                : FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None);
+        }
+
+        private SceneSyncPhysicsMetadata[] FindScenePhysicsMetadata()
+        {
+            return bodyRoot != null
+                ? bodyRoot.GetComponentsInChildren<SceneSyncPhysicsMetadata>(true)
+                : FindObjectsByType<SceneSyncPhysicsMetadata>(FindObjectsSortMode.None);
         }
 
         private void HandleSceneMessage(SceneSyncRawMessage message)
@@ -892,6 +954,7 @@ namespace Afjk.SceneSync.Rapier
         private void UpdateLastStateHash(string detail)
         {
             lastStateHash = ComputeStateHashHex();
+            MaybeBroadcastStateHash();
             if (!logStateHash || string.IsNullOrWhiteSpace(lastStateHash))
                 return;
 
@@ -899,6 +962,94 @@ namespace Afjk.SceneSync.Rapier
             if (!string.IsNullOrWhiteSpace(detail))
                 message += " " + detail;
             Debug.Log(message + " canonicalStateHash=" + lastStateHash);
+        }
+
+        private void UpdateStateHashAtBroadcastTick()
+        {
+            if (!broadcastStateHash || tick == 0)
+                return;
+
+            var interval = Mathf.Max(1, stateHashBroadcastTickInterval);
+            if (tick % interval != 0)
+                return;
+
+            lastStateHash = ComputeStateHashHex();
+            MaybeBroadcastStateHash();
+        }
+
+        private void ResetStateHashBroadcastCache()
+        {
+            lastStateHashBroadcastTick = int.MinValue;
+            lastStateHashBroadcastRevision = int.MinValue;
+            lastStateHashBroadcastHash = null;
+        }
+
+        private void MaybeBroadcastStateHash()
+        {
+            if (!broadcastStateHash || string.IsNullOrWhiteSpace(lastStateHash))
+                return;
+
+            var interval = Mathf.Max(1, stateHashBroadcastTickInterval);
+            if (tick != 0 && tick % interval != 0)
+                return;
+
+            if (!CanBroadcastStateHash())
+                return;
+
+            var revision = latestSceneClockRevision;
+            if (lastStateHashBroadcastTick == tick &&
+                lastStateHashBroadcastRevision == revision &&
+                string.Equals(lastStateHashBroadcastHash, lastStateHash, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var timestep = Mathf.Max(0.000001f, scenePhysics.Timestep);
+            var activeTime = GetCurrentPhysicsTime();
+            var worldAge = Mathf.Max(0f, tick * timestep);
+            var payload =
+                "{\"kind\":\"scene-physics-hash\"" +
+                ",\"source\":\"physics\"" +
+                ",\"phase\":\"postPhysics\"" +
+                ",\"profile\":\"" + PhysicsProfile + "\"" +
+                ",\"hashVersion\":\"" + CanonicalStateHashVersion + "\"" +
+                ",\"rapierCoreVersion\":\"" + RapierCoreVersion + "\"" +
+                ",\"tick\":" + tick.ToString(CultureInfo.InvariantCulture) +
+                ",\"hash\":\"" + SceneSyncWireJson.JsonEscape(lastStateHash) + "\"" +
+                ",\"timestep\":" + timestep.ToString(CultureInfo.InvariantCulture) +
+                ",\"activeTime\":" + activeTime.ToString(CultureInfo.InvariantCulture) +
+                ",\"worldAge\":" + worldAge.ToString(CultureInfo.InvariantCulture) +
+                ",\"worldEpochTime\":" + worldEpochTime.ToString(CultureInfo.InvariantCulture);
+
+            if (revision != int.MinValue)
+                payload += ",\"sceneClockRevision\":" + revision.ToString(CultureInfo.InvariantCulture);
+
+            payload += ",\"sentAt\":" + CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) + "}";
+
+            lastStateHashBroadcastTick = tick;
+            lastStateHashBroadcastRevision = revision;
+            lastStateHashBroadcastHash = lastStateHash;
+            SceneSyncMessageBus.PublishOutgoing(payload, null, this);
+        }
+
+        private static bool CanBroadcastStateHash()
+        {
+            var managers = FindObjectsByType<SceneSyncManager>(FindObjectsSortMode.None);
+            if (managers == null || managers.Length == 0)
+                return true;
+
+            foreach (var manager in managers)
+            {
+                if (manager != null && manager.IsConnected)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static long CurrentUnixTimeMilliseconds()
+        {
+            return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds;
         }
 
         private void DisposeWorld()

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierParitySampleBootstrap.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierParitySampleBootstrap.cs
@@ -1,0 +1,238 @@
+using System.Threading.Tasks;
+using Afjk.SceneSync;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Rapier
+{
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncRapierParitySampleBootstrap : MonoBehaviour
+    {
+        private const string ScenePhysicsJson =
+            "{\"version\":1,\"enabled\":true,\"duration\":10,\"worldOptions\":{\"gravity\":[0,-9.81,0],\"ground\":null,\"timestep\":0.016666666666666666}}";
+
+        private const string FloorPhysicsJson =
+            "{\"version\":1,\"enabled\":true,\"bodyType\":\"static\",\"shape\":\"box\",\"halfExtents\":[6,0.5,6],\"density\":0,\"friction\":0.5,\"restitution\":0.2,\"initialTransform\":{\"position\":[0,-0.5,0],\"rotation\":[0,0,0,1],\"scale\":[12,1,12]}}";
+
+        private const string BoxPhysicsJson =
+            "{\"version\":1,\"enabled\":true,\"bodyType\":\"dynamic\",\"shape\":\"box\",\"halfExtents\":[0.5,0.5,0.5],\"density\":1,\"friction\":0.5,\"restitution\":0.2,\"velocity\":[0.75,0,0.15],\"angularVelocity\":[0.35,1.25,0.55],\"linearDamping\":0.02,\"angularDamping\":0.02,\"canSleep\":false,\"ccd\":false,\"initialTransform\":{\"position\":[-0.75,5,0],\"rotation\":[0,0,0,1],\"scale\":[1,1,1]}}";
+
+        [SerializeField] private string presenceUrl = "wss://afjk.jp/presence";
+        [SerializeField] private string room = "rapier-parity";
+        [SerializeField] private string nickname = "Unity Rapier Sample";
+        [SerializeField] private bool autoConnect = true;
+        [SerializeField] private bool buildOnStart = true;
+        [SerializeField] private bool requireSceneClock = true;
+        [SerializeField] private bool showHud = true;
+
+        private SceneSyncManager manager;
+        private SceneSyncRapierBridge bridge;
+        private GameObject floorObject;
+        private GameObject boxObject;
+
+        public string PresenceUrl
+        {
+            get => presenceUrl;
+            set => presenceUrl = value ?? "";
+        }
+
+        public string Room
+        {
+            get => room;
+            set => room = value ?? "";
+        }
+
+        public string Nickname
+        {
+            get => nickname;
+            set => nickname = string.IsNullOrWhiteSpace(value) ? "Unity Rapier Sample" : value.Trim();
+        }
+
+        public bool AutoConnect
+        {
+            get => autoConnect;
+            set => autoConnect = value;
+        }
+
+        public bool BuildOnStart
+        {
+            get => buildOnStart;
+            set => buildOnStart = value;
+        }
+
+        public bool RequireSceneClock
+        {
+            get => requireSceneClock;
+            set => requireSceneClock = value;
+        }
+
+        public SceneSyncManager Manager => manager;
+        public SceneSyncRapierBridge Bridge => bridge;
+
+        private async void Start()
+        {
+            if (buildOnStart)
+                BuildSampleScene();
+
+            if (autoConnect)
+                await Connect();
+        }
+
+        public void BuildSampleScene()
+        {
+            manager = EnsureComponent<SceneSyncManager>();
+            manager.PresenceUrl = presenceUrl;
+            manager.ConfiguredRoom = room;
+            manager.Nickname = nickname;
+            manager.AutoConnect = false;
+            manager.SyncHierarchy = false;
+            manager.IncludeManagerChildren = true;
+
+            var sceneMetadata = EnsureComponent<SceneSyncPhysicsMetadata>();
+            sceneMetadata.ConfigureScenePhysics(ScenePhysicsJson);
+
+            bridge = EnsureComponent<SceneSyncRapierBridge>();
+            bridge.BodyRoot = transform;
+            bridge.AutoRun = true;
+            bridge.UseSceneClock = true;
+            bridge.RequireSceneClock = requireSceneClock;
+            bridge.PreserveMotionOnRebuild = false;
+
+            floorObject = CreateOrUpdateBody(
+                "floor",
+                "Rapier Sample Floor",
+                PrimitiveType.Cube,
+                new Vector3(0f, -0.5f, 0f),
+                Quaternion.identity,
+                new Vector3(12f, 1f, 12f),
+                FloorPhysicsJson,
+                new Color(0.42f, 0.46f, 0.48f));
+
+            boxObject = CreateOrUpdateBody(
+                "box-1",
+                "Rapier Sample Box",
+                PrimitiveType.Cube,
+                new Vector3(-0.75f, 5f, 0f),
+                Quaternion.identity,
+                Vector3.one,
+                BoxPhysicsJson,
+                new Color(0.16f, 0.42f, 0.88f));
+
+            AddManagedObject(floorObject);
+            AddManagedObject(boxObject);
+            bridge.RebuildWorld();
+        }
+
+        public async Task Connect()
+        {
+            if (manager == null)
+                BuildSampleScene();
+
+            await manager.Connect();
+        }
+
+        public void Disconnect()
+        {
+            manager?.Disconnect();
+        }
+
+        private T EnsureComponent<T>() where T : Component
+        {
+            var component = GetComponent<T>();
+            return component != null ? component : gameObject.AddComponent<T>();
+        }
+
+        private GameObject CreateOrUpdateBody(
+            string objectId,
+            string objectName,
+            PrimitiveType primitiveType,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 scale,
+            string physicsJson,
+            Color color)
+        {
+            var body = FindChildByObjectId(objectId);
+            if (body == null)
+            {
+                body = GameObject.CreatePrimitive(primitiveType);
+                body.transform.SetParent(transform, false);
+            }
+
+            body.name = objectName;
+            body.transform.SetPositionAndRotation(position, rotation);
+            body.transform.localScale = scale;
+
+            var unityCollider = body.GetComponent<Collider>();
+            if (unityCollider != null)
+                DestroyComponent(unityCollider);
+
+            var renderer = body.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                var material = renderer.sharedMaterial;
+                if (material == null || material.name.StartsWith("Default-", System.StringComparison.Ordinal))
+                {
+                    var shader = Shader.Find("Universal Render Pipeline/Lit") ?? Shader.Find("Standard");
+                    material = shader != null ? new Material(shader) : new Material(Shader.Find("Sprites/Default"));
+                    renderer.sharedMaterial = material;
+                }
+
+                material.color = color;
+            }
+
+            var identity = body.GetComponent<SceneSyncIdentity>();
+            if (identity == null)
+                identity = body.AddComponent<SceneSyncIdentity>();
+            identity.ConfigureUnityManaged(objectId);
+
+            var metadata = body.GetComponent<SceneSyncPhysicsMetadata>();
+            if (metadata == null)
+                metadata = body.AddComponent<SceneSyncPhysicsMetadata>();
+            metadata.ConfigureObjectPhysics(physicsJson);
+
+            return body;
+        }
+
+        private GameObject FindChildByObjectId(string objectId)
+        {
+            foreach (var identity in GetComponentsInChildren<SceneSyncIdentity>(true))
+            {
+                if (identity != null && identity.ObjectId == objectId)
+                    return identity.gameObject;
+            }
+
+            return null;
+        }
+
+        private void AddManagedObject(GameObject body)
+        {
+            if (body == null || manager == null || manager.ManagedObjects.Contains(body))
+                return;
+
+            manager.ManagedObjects.Add(body);
+        }
+
+        private static void DestroyComponent(Component component)
+        {
+            if (Application.isPlaying)
+                Destroy(component);
+            else
+                DestroyImmediate(component);
+        }
+
+        private void OnGUI()
+        {
+            if (!showHud || bridge == null)
+                return;
+
+            GUILayout.BeginArea(new Rect(12f, 12f, 520f, 140f), GUI.skin.box);
+            GUILayout.Label("SceneSync Rapier Parity Sample");
+            GUILayout.Label("Room: " + room);
+            GUILayout.Label("Connected: " + (manager != null && manager.IsConnected));
+            GUILayout.Label("Tick: " + bridge.Tick);
+            GUILayout.Label("Hash: " + (bridge.LastStateHash ?? "(none)"));
+            GUILayout.Label("Remote hash matched: " + bridge.LastRemoteHashMatched);
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierParitySampleBootstrap.cs.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierParitySampleBootstrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a47d1567d9a04803a6f71f3f8f6de5c8

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -14,6 +14,7 @@ namespace Afjk.SceneSync
         [SerializeField] private string _room = "";
         [SerializeField] private string _nickname = "Unity";
         [SerializeField] private bool _autoConnect = true;
+        [SerializeField] private bool _syncHierarchy = true;
         [SerializeField] private Transform _syncRoot;
         [SerializeField] private bool includeManagerChildren = true;
         [SerializeField] private List<GameObject> managedObjects = new List<GameObject>();
@@ -70,11 +71,31 @@ namespace Afjk.SceneSync
         }
 
         public bool IsConnected => _connected;
+        public string PresenceUrl
+        {
+            get => _presenceUrl;
+            set => _presenceUrl = value ?? "";
+        }
         public string Room => _client != null && !string.IsNullOrEmpty(_client.Room) ? _client.Room : _room;
         public string ConfiguredRoom
         {
             get => _room;
             set => _room = value ?? "";
+        }
+        public string Nickname
+        {
+            get => _nickname;
+            set => _nickname = string.IsNullOrWhiteSpace(value) ? "Unity" : value.Trim();
+        }
+        public bool AutoConnect
+        {
+            get => _autoConnect;
+            set => _autoConnect = value;
+        }
+        public bool SyncHierarchy
+        {
+            get => _syncHierarchy;
+            set => _syncHierarchy = value;
         }
         public List<PeerInfo> Peers => _peers;
         public GameObject SelectedObject => _selectedObject;
@@ -675,6 +696,7 @@ namespace Afjk.SceneSync
         private void Update()
         {
             if (_isShuttingDown || !_connected || !gameObject.activeInHierarchy) return;
+            if (!_syncHierarchy) return;
 
             var currentTime = Time.realtimeSinceStartup;
             var deltaTime = currentTime - _lastTime;


### PR DESCRIPTION
## Summary
- Add a Unity bootstrap component that builds the Rapier parity floor/box sample, connects SceneSync, and drives Rapier from Scene Clock.
- Add a local PlayerUI sample runner and automated Unity-vs-Web Rapier hash check.
- Extend the Rapier bridge to broadcast canonical physics hash messages and scope metadata scans to a sample root.
- Preserve density, damping, sleep, and CCD fields in the Web SceneSync physics normalization path.

## Why
The next milestone needs a concrete sample where Unity Play Mode and Web PlayerUI load the same SceneSync Rapier scene and can prove they are simulating the same physics state.

## Impact
Developers can run `npm run sample:scene-sync-rapier` to open the local PlayerUI room, or `npm run test:e2e:scene-sync-rapier-playerui-sample` to verify Unity reaches the same canonical Rapier hash as the Web runtime at tick 60.

## Root Cause / Notes
The Unity bridge previously received remote hash diagnostics but did not publish its own periodic `scene-physics-hash` messages. Scene Clock stepping can also advance across multiple fixed ticks in one frame, so the bridge now emits hashes when the internal tick reaches the configured interval, not only at the final frame tick.

## Validation
- `node --check scripts/scenesync-rapier-playerui-sample.mjs`
- `npm run test:physics`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient compile`
- `npm run test:e2e:scene-sync-rapier-playerui-sample`
- `npm run test:e2e:scene-sync-unity-physics-presence`
- `git diff --check`