### PR TITLE
[codex] Seed default Rapier scene physics in setup

### DIFF
--- a/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
+++ b/unity/com.afjk.scene-sync/Editor/SceneSyncWindow.cs
@@ -16,6 +16,8 @@ namespace Afjk.SceneSync.Editor
         private const string MaxGlbUploadMiBPrefKey = "Afjk.SceneSync.MaxGlbUploadMiB";
         private const string ApplyTransparentNameHintsForExportPrefKey = "Afjk.SceneSync.ApplyTransparentNameHintsForExport";
         private const string RapierBridgeTypeName = "Afjk.SceneSync.Rapier.SceneSyncRapierBridge";
+        private const string DefaultRapierScenePhysicsJson =
+            "{\"version\":1,\"enabled\":true,\"duration\":10,\"worldOptions\":{\"gravity\":[0,-9.81,0],\"ground\":null,\"timestep\":0.016666666666666666}}";
         private const float DefaultMaxGlbUploadMiB = 50f;
         private const int MaxPersistentGlbSizeBytes = 50 * 1024 * 1024;
         private const long MaxPersistentGlbCacheBytes = 512L * 1024L * 1024L;
@@ -1172,6 +1174,12 @@ namespace Afjk.SceneSync.Editor
             if (metadata == null)
             {
                 metadata = Undo.AddComponent<SceneSyncPhysicsMetadata>(manager.gameObject);
+                changed = true;
+            }
+            if (metadata != null && string.IsNullOrWhiteSpace(metadata.ScenePhysicsJson))
+            {
+                Undo.RecordObject(metadata, "Configure Scene Sync Rapier Physics");
+                metadata.ConfigureScenePhysics(DefaultRapierScenePhysicsJson);
                 changed = true;
             }
 

--- a/unity/com.afjk.scene-sync/README.md
+++ b/unity/com.afjk.scene-sync/README.md
@@ -70,7 +70,8 @@ Git URL でインストールする場合も、`com.afjk.loomlet-runtime@0.3.0` 
    - `SceneSync Temporary`
    がシーンに作成されます
    - `com.afjk.scene-sync-rapier` が入っている場合は、`SceneSyncManager` に
-     `SceneSyncPhysicsMetadata` と `SceneSyncRapierBridge` も追加されます
+     `SceneSyncPhysicsMetadata` と `SceneSyncRapierBridge` も追加されます。
+     scene physics が未設定なら、デフォルトの重力 / timestep も設定されます
 3. `Room` にルームコードを入力する
 4. `Connect` を押す
 5. ブラウザで `https://afjk.jp/scenesync/?room=<同じルームコード>` を開く


### PR DESCRIPTION
## Summary

- Seed default enabled scene physics when `Create Scene Sync Setup` runs with `com.afjk.scene-sync-rapier` installed and the manager has no scene physics JSON yet.
- Keep existing scene physics metadata intact when a room or scene already provided it.
- Document the default gravity/timestep setup behavior.

## Why

New scenes created with the automated setup had `SceneSyncRapierBridge` and object-level physics metadata after loading a Web room, but no scene-level physics metadata. The bridge treated that as `scenePhysics.Enabled=false`, so it never created a Rapier world. Seeding the default scene physics restores Local Preview auto-run and gives Shared Playback a physics world to drive.

## Validation

- `git diff --check`
- Unity compile via `uloop execute-dynamic-code`
- Re-ran `CreateSceneSyncSetup` in the current new Unity scene and verified `SceneSyncPhysicsMetadata.ScenePhysicsJson` is populated.
- Entered Play Mode in room `hcc0y7`; verified connected, 21 object physics entries, 21 Rapier bindings, `HasWorld=true`, and ticking physics hash.