### PR TITLE
[codex] Add SceneSync Rapier interaction sample

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -13,6 +13,7 @@ const KNOWN_KINDS = new Set([
   'scene-lock',
   'scene-unlock',
   'scene-physics-hash',
+  'scene-physics-input',
   'scene-physics-snapshot',
   'scene-physics-snapshot-request',
   'scene-asset-request',
@@ -150,6 +151,34 @@ function validatePhysicsSnapshotBody(body, maxStringLength) {
   if (body.angularVelocity !== undefined && !hasFiniteNumberArray(body.angularVelocity, 3)) {
     return { ok: false, reason: 'snapshot body.angularVelocity must be finite [x,y,z]' };
   }
+  return { ok: true };
+}
+
+function validateScenePhysicsInputPayload(payload, maxStringLength) {
+  if (payload.inputType !== 'set-body-state') {
+    return { ok: false, reason: 'scene-physics-input.inputType is invalid' };
+  }
+  if (!isReasonableString(payload.objectId, maxStringLength)) {
+    return { ok: false, reason: 'scene-physics-input.objectId must be a reasonable string' };
+  }
+  const inputIdResult = validateOptionalReasonableString(payload, 'inputId', maxStringLength);
+  if (!inputIdResult.ok) return inputIdResult;
+  if (!Number.isInteger(payload.applyTick) || payload.applyTick < 0) {
+    return { ok: false, reason: 'scene-physics-input.applyTick must be a non-negative integer' };
+  }
+  if (!hasFiniteNumberArray(payload.position, 3)) {
+    return { ok: false, reason: 'scene-physics-input.position must be finite [x,y,z]' };
+  }
+  if (!hasFiniteNumberArray(payload.rotation, 4)) {
+    return { ok: false, reason: 'scene-physics-input.rotation must be finite quaternion [x,y,z,w]' };
+  }
+  for (const key of ['velocity', 'linearVelocity', 'angularVelocity', 'angvel']) {
+    if (payload[key] !== undefined && !hasFiniteNumberArray(payload[key], 3)) {
+      return { ok: false, reason: `scene-physics-input.${key} must be finite [x,y,z]` };
+    }
+  }
+  const sentAtResult = validateOptionalFiniteNumber(payload, 'sentAt');
+  if (!sentAtResult.ok) return sentAtResult;
   return { ok: true };
 }
 
@@ -383,6 +412,10 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-physics') {
     return validateScenePhysicsPayload(payload.physics);
+  }
+
+  if (payload.kind === 'scene-physics-input') {
+    return validateScenePhysicsInputPayload(payload, maxStringLength);
   }
 
   if (

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -260,6 +260,19 @@ describe('Scene Sync guard helpers', () => {
     }).ok, true);
 
     assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-input',
+      inputType: 'set-body-state',
+      inputId: 'grab-1',
+      objectId: 'live-box',
+      applyTick: 90,
+      position: [1, 2, 3],
+      rotation: [0, 0, 0, 1],
+      velocity: [4, 0, 0],
+      angularVelocity: [0, 1, 0],
+      sentAt: Date.now(),
+    }).ok, true);
+
+    assert.equal(validateSceneSyncPayload({
       kind: 'scene-physics-snapshot-request',
       source: 'physics',
       phase: 'postPhysics',
@@ -309,6 +322,18 @@ describe('Scene Sync guard helpers', () => {
         id: 'live-box',
         position: [0, Infinity, 0],
       }],
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects invalid scene-physics input', () => {
+    const result = validateSceneSyncPayload({
+      kind: 'scene-physics-input',
+      inputType: 'set-body-state',
+      objectId: 'live-box',
+      applyTick: 90,
+      position: [1, Infinity, 3],
+      rotation: [0, 0, 0, 1],
     });
     assert.equal(result.ok, false);
   });

--- a/html/assets/js/scenesync/physics/rapier-world.js
+++ b/html/assets/js/scenesync/physics/rapier-world.js
@@ -720,6 +720,29 @@ export function createWorld(options = {}) {
     return exportRigidBody(id, record, getRigidBodyByHandle(record.handle));
   }
 
+  function setBodyState(id, state = {}) {
+    const record = bodyRecords.get(id);
+    if (!record || record.static) return false;
+
+    const body = getRigidBodyByHandle(record.handle);
+    if (!body) return false;
+
+    const current = exportRigidBody(id, record, body);
+    const position = readVec3(state.position, current?.position || [0, 0, 0]);
+    const rotation = readQuat(state.rotation, current?.rotation || [0, 0, 0, 1]);
+    const velocity = readVec3(state.velocity || state.linearVelocity, current?.velocity || [0, 0, 0]);
+    const angularVelocity = readVec3(
+      state.angularVelocity || state.angvel,
+      current?.angularVelocity || [0, 0, 0],
+    );
+
+    body.setTranslation(vectorObject(position), true);
+    body.setRotation(quaternionObject(rotation), true);
+    body.setLinvel(vectorObject(velocity), true);
+    body.setAngvel(vectorObject(angularVelocity), true);
+    return true;
+  }
+
   function getBodies() {
     return Array.from(bodyRecords.keys())
       .sort((left, right) => left.localeCompare(right))
@@ -738,7 +761,7 @@ export function createWorld(options = {}) {
     return tick;
   }
 
-  function stepTo(targetTick) {
+  function stepTo(targetTick, options = {}) {
     if (!Number.isInteger(targetTick) || targetTick < 0) {
       return { tick, reached: false, reason: 'invalid-target' };
     }
@@ -747,20 +770,15 @@ export function createWorld(options = {}) {
       return { tick, reached: false, reason: 'restore-required' };
     }
 
-    if (targetTick - tick > worldOptions.maxStepsPerUpdate) {
-      return {
-        tick,
-        reached: false,
-        steps: 0,
-        limited: true,
-        reason: 'step-limit',
-      };
-    }
-
+    const beforeStep = typeof options.beforeStep === 'function' ? options.beforeStep : null;
+    beforeStep?.(tick);
+    const stepLimit = Math.max(1, worldOptions.maxStepsPerUpdate);
+    const stepTarget = Math.min(targetTick, tick + stepLimit);
     let steps = 0;
-    while (tick < targetTick) {
+    while (tick < stepTarget) {
       step();
       steps += 1;
+      if (tick < stepTarget) beforeStep?.(tick);
     }
 
     return {
@@ -768,6 +786,7 @@ export function createWorld(options = {}) {
       reached: tick === targetTick,
       steps,
       limited: tick !== targetTick,
+      reason: tick === targetTick ? undefined : 'step-limit',
     };
   }
 
@@ -1054,6 +1073,7 @@ export function createWorld(options = {}) {
     removeBody,
     getBody,
     getBodies,
+    setBodyState,
     step,
     stepTo,
     snapshot,

--- a/html/assets/js/scenesync/physics/rapier-world.test.js
+++ b/html/assets/js/scenesync/physics/rapier-world.test.js
@@ -102,6 +102,41 @@ test('Rapier snapshot restore reproduces the same future', () => {
   b.free();
 });
 
+test('setBodyState applies dynamic body state through stepTo beforeStep hook', () => {
+  const world = createWorld({
+    gravity: [0, 0, 0],
+    ground: null,
+    timestep: 1 / 60,
+  });
+  world.addBody({
+    id: 'box',
+    shape: 'box',
+    halfExtents: [0.5, 0.5, 0.5],
+    position: [0, 0, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+    mass: 1,
+  });
+
+  const result = world.stepTo(2, {
+    beforeStep(tick) {
+      if (tick !== 1) return;
+      assert.equal(world.setBodyState('box', {
+        position: [3, 0, 0],
+        rotation: [0, 0, 0, 1],
+        velocity: [1, 0, 0],
+        angularVelocity: [0, 0, 0],
+      }), true);
+    },
+  });
+
+  assert.equal(result.reached, true);
+  assert.equal(world.tick, 2);
+  assert.ok(world.getBody('box').position[0] > 3);
+  world.free();
+});
+
 test('snapshot restore replaces stale body metadata with snapshot stable ids', () => {
   const a = createWorld({ gravity: -9.81, ground: null, timestep: 1 / 60 });
   const b = createWorld({ gravity: -9.81, ground: null, timestep: 1 / 60 });
@@ -299,7 +334,7 @@ test('stepTo caps very long fast-forward work', () => {
 
   const result = world.stepTo(100);
   assert.equal(result.limited, true);
-  assert.equal(world.tick, 0);
+  assert.equal(world.tick, 10);
 
   world.free();
 });

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -31,6 +31,8 @@ export const DEFAULT_SCENE_PHYSICS = Object.freeze({
 const BODY_TYPES = new Set(['dynamic', 'static']);
 const SHAPES = new Set(['box', 'sphere']);
 const ZERO_TIME_EPSILON = 1e-6;
+const MAX_PENDING_BODY_STATE_INPUTS = 256;
+const MAX_BODY_STATE_INPUT_HISTORY = 512;
 
 function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
@@ -423,8 +425,11 @@ export function createScenePhysicsRuntime({
   let preserveMotionOnRebuild = true;
   let resetMotionObjectIds = new Set();
   let previousCollisionPairs = new Set();
+  let pendingBodyStateInputs = [];
+  let bodyStateInputHistory = [];
+  const appliedBodyStateInputIds = new Set();
 
-  function clear() {
+  function clear({ preserveInputs = false } = {}) {
     world?.free?.();
     world = null;
     initialSnapshot = null;
@@ -436,6 +441,11 @@ export function createScenePhysicsRuntime({
     preserveMotionOnRebuild = true;
     resetMotionObjectIds = new Set();
     previousCollisionPairs = new Set();
+    if (!preserveInputs) {
+      pendingBodyStateInputs = [];
+      bodyStateInputHistory = [];
+      appliedBodyStateInputIds.clear();
+    }
   }
 
   function markDirty({
@@ -489,7 +499,7 @@ export function createScenePhysicsRuntime({
     const scenePhysics = normalizeScenePhysics(getScenePhysics?.());
     const entries = collectRuntimeEntries(getObjectEntries?.());
     if (!scenePhysics.enabled || entries.length === 0) {
-      clear();
+      clear({ preserveInputs: scenePhysics.enabled });
       dirty = false;
       return { ok: false, reason: 'no-bodies' };
     }
@@ -570,6 +580,130 @@ export function createScenePhysicsRuntime({
     return Math.max(0, getClockTime(clockState) - worldEpochTime);
   }
 
+  function queueInput(payload = {}) {
+    if (payload.kind !== 'scene-physics-input' || payload.inputType !== 'set-body-state') {
+      return false;
+    }
+
+    const objectId = typeof payload.objectId === 'string' ? payload.objectId.trim() : '';
+    if (!objectId) return false;
+
+    const applyTickNumber = Number(payload.applyTick);
+    const applyTick = Number.isFinite(applyTickNumber)
+      ? Math.max(0, Math.floor(applyTickNumber))
+      : (world?.tick || 0);
+    const inputId = typeof payload.inputId === 'string' && payload.inputId.trim()
+      ? payload.inputId.trim()
+      : `${objectId}:${applyTick}`;
+
+    if (
+      appliedBodyStateInputIds.has(inputId) ||
+      pendingBodyStateInputs.some((input) => input.inputId === inputId) ||
+      bodyStateInputHistory.some((input) => input.inputId === inputId)
+    ) {
+      return false;
+    }
+
+    if (!Array.isArray(payload.position) || !Array.isArray(payload.rotation)) {
+      return false;
+    }
+
+    const input = {
+      inputId,
+      objectId,
+      applyTick,
+      position: readVec3(payload.position, [0, 0, 0]),
+      rotation: readQuaternion(payload.rotation, [0, 0, 0, 1]),
+      velocity: readVec3(payload.velocity || payload.linearVelocity, [0, 0, 0]),
+      angularVelocity: readVec3(payload.angularVelocity || payload.angvel, [0, 0, 0]),
+    };
+
+    addBodyStateInputHistory(input);
+    if (world && input.applyTick <= world.tick) {
+      if (input.applyTick < world.tick && hasDynamicBody(input.objectId) && rewindBodyStateInputsToInitialSnapshot()) {
+        return true;
+      }
+      if (input.applyTick === world.tick && applyBodyStateInput(input)) {
+        return true;
+      }
+    }
+
+    addPendingBodyStateInput(input);
+    return true;
+  }
+
+  function compareBodyStateInputs(left, right) {
+    return (
+      left.applyTick === right.applyTick
+        ? (left.inputId < right.inputId ? -1 : (left.inputId > right.inputId ? 1 : 0))
+        : left.applyTick - right.applyTick
+    );
+  }
+
+  function addBodyStateInputHistory(input) {
+    bodyStateInputHistory.push(input);
+    bodyStateInputHistory.sort(compareBodyStateInputs);
+    while (bodyStateInputHistory.length > MAX_BODY_STATE_INPUT_HISTORY) {
+      bodyStateInputHistory.shift();
+    }
+  }
+
+  function addPendingBodyStateInput(input) {
+    if (pendingBodyStateInputs.some((item) => item.inputId === input.inputId)) return;
+    pendingBodyStateInputs.push(input);
+    pendingBodyStateInputs.sort(compareBodyStateInputs);
+    while (pendingBodyStateInputs.length > MAX_PENDING_BODY_STATE_INPUTS) {
+      pendingBodyStateInputs.shift();
+    }
+  }
+
+  function applyDueBodyStateInputs(currentTick = world?.tick || 0) {
+    if (!world || pendingBodyStateInputs.length === 0) return false;
+
+    let applied = false;
+    for (let index = 0; index < pendingBodyStateInputs.length;) {
+      const input = pendingBodyStateInputs[index];
+      if (input.applyTick > currentTick) break;
+      if (input.applyTick < currentTick && hasDynamicBody(input.objectId) && rewindBodyStateInputsToInitialSnapshot()) {
+        return applied;
+      }
+      if (applyBodyStateInput(input)) {
+        pendingBodyStateInputs.splice(index, 1);
+        applied = true;
+        continue;
+      }
+      index += 1;
+    }
+    return applied;
+  }
+
+  function hasDynamicBody(objectId) {
+    const body = world?.getBody?.(objectId);
+    return Boolean(body && body.static !== true);
+  }
+
+  function rewindBodyStateInputsToInitialSnapshot() {
+    if (!world || !initialSnapshot || world.restore(initialSnapshot) !== true) {
+      return false;
+    }
+    previousCollisionPairs = new Set();
+    appliedBodyStateInputIds.clear();
+    pendingBodyStateInputs = [];
+    for (const input of bodyStateInputHistory) {
+      addPendingBodyStateInput(input);
+    }
+    return true;
+  }
+
+  function applyBodyStateInput(input) {
+    if (!input?.inputId || appliedBodyStateInputIds.has(input.inputId) || !world) {
+      return false;
+    }
+    const applied = world.setBodyState?.(input.objectId, input) === true;
+    if (applied) appliedBodyStateInputIds.add(input.inputId);
+    return applied;
+  }
+
   function update(clockState = null) {
     const scenePhysics = normalizeScenePhysics(getScenePhysics?.());
     if (!scenePhysics.enabled) {
@@ -593,10 +727,9 @@ export function createScenePhysicsRuntime({
     const worldAge = getWorldAge(clockState);
     const targetTick = Math.max(0, Math.floor(worldAge / timestepSeconds));
     if (targetTick < world.tick && initialSnapshot) {
-      world.restore(initialSnapshot);
-      previousCollisionPairs = new Set();
+      rewindBodyStateInputsToInitialSnapshot();
     }
-    const stepResult = world.stepTo(targetTick);
+    const stepResult = world.stepTo(targetTick, { beforeStep: applyDueBodyStateInputs });
     if (stepResult?.limited === true) {
       active = false;
       previousCollisionPairs = new Set();
@@ -712,6 +845,7 @@ export function createScenePhysicsRuntime({
 
   return {
     markDirty,
+    queueInput,
     rebuild,
     update,
     createSnapshotReport,

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -118,6 +118,146 @@ test('normalizes object physics with practical defaults', () => {
   });
 });
 
+test('queues scene physics input and applies it at the requested tick', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'drag-1',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+
+  const result = runtime.update({ t: 3 / 60, transportActive: true });
+  assert.equal(result.active, true);
+  assert.ok(result.tick >= 2);
+  assert.ok(object.position.toArray()[0] > 3);
+
+  runtime.dispose();
+});
+
+test('rewinds and replays when a scene physics input arrives late', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  runtime.update({ t: 0.2, transportActive: true });
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'late-drag-1',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+
+  const result = runtime.update({ t: 0.25, transportActive: true });
+  assert.equal(result.active, true);
+  assert.ok(object.position.toArray()[0] > 3.15);
+
+  runtime.dispose();
+});
+
+test('keeps scene physics input pending until the body exists', () => {
+  const entries = [];
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries,
+  });
+
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'pending-drag-1',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+
+  runtime.update({ t: 0, transportActive: true });
+  entries.push(makeEntry(object));
+  runtime.update({ t: 0, transportActive: true });
+  const result = runtime.update({ t: 3 / 60, transportActive: true });
+  assert.equal(result.active, true);
+  assert.ok(object.position.toArray()[0] > 3);
+
+  runtime.dispose();
+});
+
 test('normalizes parity object physics fields used by Rapier hashing', () => {
   assert.deepEqual(normalizeObjectPhysics({
     enabled: true,

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6416,7 +6416,8 @@ function handleHandoff(data) {
     payload.kind === 'scene-delta' ||
     payload.kind === 'scene-add' ||
     payload.kind === 'scene-remove' ||
-    payload.kind === 'scene-physics'
+    payload.kind === 'scene-physics' ||
+    payload.kind === 'scene-physics-input'
   ) {
     console.debug('[handoff] scene mutation received', {
       kind: payload.kind,
@@ -6738,6 +6739,12 @@ function handleHandoff(data) {
       });
       notifySceneStateChanged('scene-physics-handoff');
       publishSharedObjectClockBaselines('scene-physics-baseline');
+      break;
+    }
+    case 'scene-physics-input': {
+      if (isOwn) break;
+      scenePhysicsRuntime.queueInput(payload);
+      notifySceneStateChanged('scene-physics-input');
       break;
     }
     case 'scene-physics-snapshot-request': {

--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -81,6 +81,25 @@ publish a `scene-physics-snapshot-request` through `SceneSyncMessageBus`. A
 connection, allowing the Web Shared Playback controller to hand back a targeted
 snapshot.
 
+## Interaction Sample
+
+`SceneSyncRapierInteractionSample` is a Play Mode helper for rooms that already
+use `SceneSyncRapierBridge`. Add it to the same setup scene, assign the bridge
+and camera if auto-discovery is not enough, then enter Play Mode.
+
+- `WASD` moves the camera horizontally relative to view direction.
+- `E` / `Q` moves up and down.
+- Right mouse drag rotates the camera.
+- Left mouse drag grabs a dynamic Rapier body under the cursor and publishes
+  `scene-physics-input` events.
+- Left mouse release publishes the final body state with throw velocity.
+
+The sample does not publish Scene Sync transform deltas while dragging. It sends
+scheduled Rapier body-state inputs, and Unity/Web apply those inputs at the same
+physics tick before stepping. For picking, the sample uses Unity raycasts; when a
+dynamic Scene Sync object has no Collider, it can add a lightweight BoxCollider
+from renderer bounds for Play Mode interaction.
+
 ## PlayerUI Parity Sample
 
 `SceneSyncRapierParitySampleBootstrap` builds a small floor + falling box scene

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -20,6 +20,8 @@ namespace Afjk.SceneSync.Rapier
         private const string PhysicsProfile = "SceneSyncRapierParity-0.30";
         private const string SnapshotVersion = "SceneSyncPhysicsSnapshotV1";
         private const string RapierCoreVersion = "0.30.0";
+        private const int MaxPendingBodyStateInputs = 256;
+        private const int MaxBodyStateInputHistory = 512;
 
         [SerializeField] private bool autoRun = true;
         [SerializeField] private bool useSceneClock = true;
@@ -44,7 +46,10 @@ namespace Afjk.SceneSync.Rapier
         private readonly Dictionary<RapierColliderHandle, string> colliderObjectIds = new Dictionary<RapierColliderHandle, string>();
         private readonly HashSet<string> currentCollisionPairs = new HashSet<string>(StringComparer.Ordinal);
         private readonly HashSet<string> previousCollisionPairs = new HashSet<string>(StringComparer.Ordinal);
+        private readonly HashSet<string> appliedBodyStateInputIds = new HashSet<string>(StringComparer.Ordinal);
         private readonly List<SceneSyncRapierCollisionEvent> lastCollisionEvents = new List<SceneSyncRapierCollisionEvent>();
+        private readonly List<BodyStateInput> pendingBodyStateInputs = new List<BodyStateInput>();
+        private readonly List<BodyStateInput> bodyStateInputHistory = new List<BodyStateInput>();
 
         private RapierWorld world;
         private RapierSnapshot initialSnapshot;
@@ -193,19 +198,10 @@ namespace Afjk.SceneSync.Rapier
             var targetTick = Mathf.Max(0, Mathf.FloorToInt(Mathf.Max(0f, clockTime - worldEpochTime) / timestep));
             lastStepLimited = false;
             lastCollisionEvents.Clear();
+            if (targetTick < tick)
+                RewindBodyStateInputsToInitialSnapshot();
 
-            if (targetTick < tick && hasInitialSnapshot)
-            {
-                if (world.TryReadSnapshot(initialSnapshot))
-                {
-                    tick = 0;
-                    accumulator = 0f;
-                    currentCollisionPairs.Clear();
-                    previousCollisionPairs.Clear();
-                    lastCollisionEvents.Clear();
-                }
-            }
-
+            var appliedInputs = ApplyDueBodyStateInputs();
             var maxSteps = Mathf.Max(1, maxClockStepsPerUpdate);
             var steps = 0;
             while (tick < targetTick && steps < maxSteps)
@@ -217,17 +213,18 @@ namespace Afjk.SceneSync.Rapier
             if (tick < targetTick)
                 lastStepLimited = true;
 
-            if (steps > 0 || targetTick == 0)
+            if (steps > 0 || targetTick == 0 || appliedInputs)
             {
                 ApplyWorldTransforms();
                 FlushCollisionEvents(clockTime);
-                if (steps > 0 || string.IsNullOrWhiteSpace(lastStateHash))
+                if (steps > 0 || appliedInputs || string.IsNullOrWhiteSpace(lastStateHash))
                     UpdateLastStateHash("targetTick=" + targetTick.ToString(CultureInfo.InvariantCulture));
             }
         }
 
         private bool StepWorldOnce()
         {
+            ApplyDueBodyStateInputs();
             if (world == null || !world.Step())
                 return false;
             tick++;
@@ -239,6 +236,210 @@ namespace Afjk.SceneSync.Rapier
         public void MarkDirty()
         {
             dirty = true;
+        }
+
+        public bool HasDynamicBody(string objectId)
+        {
+            return !string.IsNullOrWhiteSpace(objectId) &&
+                bindings.TryGetValue(objectId, out var binding) &&
+                !binding.IsStatic;
+        }
+
+        public bool TryGetDynamicBodyState(
+            string objectId,
+            out Vector3 position,
+            out Quaternion rotation,
+            out Vector3 linearVelocity,
+            out Vector3 angularVelocity)
+        {
+            position = Vector3.zero;
+            rotation = Quaternion.identity;
+            linearVelocity = Vector3.zero;
+            angularVelocity = Vector3.zero;
+
+            if (string.IsNullOrWhiteSpace(objectId) ||
+                world == null ||
+                !bindings.TryGetValue(objectId, out var binding) ||
+                binding.IsStatic ||
+                !world.TryGetRigidBodyState(binding.Body, out var state))
+            {
+                return false;
+            }
+
+            position = WireToUnityPosition(state.Transform.Position);
+            rotation = WireToUnityRotation(state.Transform.Rotation);
+            linearVelocity = WireToUnityVector(state.LinearVelocity);
+            angularVelocity = WireToUnityVector(state.AngularVelocity);
+            return true;
+        }
+
+        public bool TrySetDynamicBodyState(
+            string objectId,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 linearVelocity,
+            Vector3 angularVelocity,
+            bool wakeUp = true)
+        {
+            if (string.IsNullOrWhiteSpace(objectId) ||
+                world == null ||
+                !bindings.TryGetValue(objectId, out var binding) ||
+                binding.IsStatic)
+            {
+                return false;
+            }
+
+            var ok = world.SetTransform(
+                binding.Body,
+                new RapierTransform(UnityToWirePosition(position), UnityToWireRotation(rotation)));
+            ok = world.SetLinearVelocity(binding.Body, UnityToWireVector(linearVelocity), wakeUp) && ok;
+            ok = world.SetAngularVelocity(binding.Body, UnityToWireVector(angularVelocity), wakeUp) && ok;
+            if (!ok) return false;
+
+            if (binding.GameObject != null)
+                binding.GameObject.transform.SetPositionAndRotation(position, rotation);
+            UpdateLastStateHash("input");
+            return true;
+        }
+
+        public bool QueueBodyStateInput(
+            string inputId,
+            string objectId,
+            int applyTick,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 linearVelocity,
+            Vector3 angularVelocity)
+        {
+            if (string.IsNullOrWhiteSpace(objectId))
+                return false;
+
+            var normalizedInputId = string.IsNullOrWhiteSpace(inputId)
+                ? Guid.NewGuid().ToString("N")
+                : inputId.Trim();
+            if (HasBodyStateInput(normalizedInputId))
+            {
+                return false;
+            }
+
+            var input = new BodyStateInput(
+                normalizedInputId,
+                objectId,
+                Mathf.Max(0, applyTick),
+                position,
+                rotation,
+                linearVelocity,
+                angularVelocity);
+
+            AddBodyStateInputHistory(input);
+
+            if (world != null && input.ApplyTick <= tick)
+            {
+                if (input.ApplyTick < tick && HasDynamicBody(input.ObjectId) && RewindBodyStateInputsToInitialSnapshot())
+                    return true;
+
+                if (input.ApplyTick == tick && ApplyBodyStateInput(input))
+                    return true;
+            }
+
+            AddPendingBodyStateInput(input);
+            return true;
+        }
+
+        public bool PublishBodyStateInput(
+            string objectId,
+            int applyTick,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 linearVelocity,
+            Vector3 angularVelocity,
+            string inputId = null,
+            object source = null)
+        {
+            var normalizedInputId = string.IsNullOrWhiteSpace(inputId)
+                ? Guid.NewGuid().ToString("N")
+                : inputId.Trim();
+            if (!QueueBodyStateInput(
+                normalizedInputId,
+                objectId,
+                applyTick,
+                position,
+                rotation,
+                linearVelocity,
+                angularVelocity))
+            {
+                return false;
+            }
+
+            SceneSyncMessageBus.PublishOutgoing(BuildBodyStateInputJson(
+                normalizedInputId,
+                objectId,
+                applyTick,
+                position,
+                rotation,
+                linearVelocity,
+                angularVelocity), null, source ?? this);
+            return true;
+        }
+
+        public static string BuildBodyStateInputJson(
+            string inputId,
+            string objectId,
+            int applyTick,
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 linearVelocity,
+            Vector3 angularVelocity)
+        {
+            var wirePosition = UnityToWirePosition(position);
+            var wireRotation = UnityToWireRotation(rotation);
+            var wireLinearVelocity = UnityToWireVector(linearVelocity);
+            var wireAngularVelocity = UnityToWireVector(angularVelocity);
+            return "{\"kind\":\"scene-physics-input\"" +
+                ",\"inputType\":\"set-body-state\"" +
+                ",\"inputId\":\"" + SceneSyncWireJson.JsonEscape(inputId) + "\"" +
+                ",\"objectId\":\"" + SceneSyncWireJson.JsonEscape(objectId) + "\"" +
+                ",\"applyTick\":" + Mathf.Max(0, applyTick).ToString(CultureInfo.InvariantCulture) +
+                ",\"position\":" + FormatVector3Json(wirePosition) +
+                ",\"rotation\":" + FormatQuaternionJson(wireRotation) +
+                ",\"velocity\":" + FormatVector3Json(wireLinearVelocity) +
+                ",\"angularVelocity\":" + FormatVector3Json(wireAngularVelocity) +
+                ",\"sentAt\":" + CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) + "}";
+        }
+
+        private bool HasBodyStateInput(string inputId)
+        {
+            return !string.IsNullOrWhiteSpace(inputId) && (
+                appliedBodyStateInputIds.Contains(inputId) ||
+                pendingBodyStateInputs.Any(item => string.Equals(item.InputId, inputId, StringComparison.Ordinal)) ||
+                bodyStateInputHistory.Any(item => string.Equals(item.InputId, inputId, StringComparison.Ordinal)));
+        }
+
+        private void AddBodyStateInputHistory(BodyStateInput input)
+        {
+            bodyStateInputHistory.Add(input);
+            bodyStateInputHistory.Sort(CompareBodyStateInputs);
+            while (bodyStateInputHistory.Count > MaxBodyStateInputHistory)
+                bodyStateInputHistory.RemoveAt(0);
+        }
+
+        private void AddPendingBodyStateInput(BodyStateInput input)
+        {
+            if (pendingBodyStateInputs.Any(item => string.Equals(item.InputId, input.InputId, StringComparison.Ordinal)))
+                return;
+
+            pendingBodyStateInputs.Add(input);
+            pendingBodyStateInputs.Sort(CompareBodyStateInputs);
+            while (pendingBodyStateInputs.Count > MaxPendingBodyStateInputs)
+                pendingBodyStateInputs.RemoveAt(0);
+        }
+
+        private static int CompareBodyStateInputs(BodyStateInput left, BodyStateInput right)
+        {
+            var tickCompare = left.ApplyTick.CompareTo(right.ApplyTick);
+            return tickCompare != 0
+                ? tickCompare
+                : string.CompareOrdinal(left.InputId, right.InputId);
         }
 
         public void RebuildWorld()
@@ -428,6 +629,12 @@ namespace Afjk.SceneSync.Rapier
             if (raw.Contains("\"kind\":\"scene-physics-hash\""))
             {
                 ApplyScenePhysicsHash(raw, message.FromPeerId);
+                return;
+            }
+
+            if (raw.Contains("\"kind\":\"scene-physics-input\""))
+            {
+                ApplyScenePhysicsInput(raw);
                 return;
             }
 
@@ -624,6 +831,111 @@ namespace Afjk.SceneSync.Rapier
                     + " hashVersion="
                     + (hashVersion ?? "null"));
             }
+        }
+
+        private void ApplyScenePhysicsInput(string raw)
+        {
+            if (!string.Equals(
+                SceneSyncWireJson.ExtractString(raw, "inputType"),
+                "set-body-state",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var objectId = SceneSyncWireJson.ExtractString(raw, "objectId");
+            if (string.IsNullOrWhiteSpace(objectId)) return;
+
+            var inputId = SceneSyncWireJson.ExtractString(raw, "inputId");
+            if (string.IsNullOrWhiteSpace(inputId))
+                inputId = objectId + ":" + ReadInt(raw, "applyTick", tick).ToString(CultureInfo.InvariantCulture);
+
+            if (!TryReadVector3(SceneSyncWireJson.ExtractArray(raw, "position"), out var wirePosition) ||
+                !TryReadQuaternion(SceneSyncWireJson.ExtractArray(raw, "rotation"), out var wireRotation))
+            {
+                return;
+            }
+
+            var wireLinearVelocity = Vector3.zero;
+            var wireAngularVelocity = Vector3.zero;
+            TryReadVector3(SceneSyncWireJson.ExtractArray(raw, "velocity"), out wireLinearVelocity);
+            if (!TryReadVector3(SceneSyncWireJson.ExtractArray(raw, "angularVelocity"), out wireAngularVelocity))
+                TryReadVector3(SceneSyncWireJson.ExtractArray(raw, "angvel"), out wireAngularVelocity);
+
+            QueueBodyStateInput(
+                inputId,
+                objectId,
+                ReadInt(raw, "applyTick", tick),
+                WireToUnityPosition(wirePosition),
+                WireToUnityRotation(wireRotation),
+                WireToUnityVector(wireLinearVelocity),
+                WireToUnityVector(wireAngularVelocity));
+        }
+
+        private bool ApplyDueBodyStateInputs()
+        {
+            if (world == null || pendingBodyStateInputs.Count == 0)
+                return false;
+
+            var applied = false;
+            for (var i = 0; i < pendingBodyStateInputs.Count;)
+            {
+                var input = pendingBodyStateInputs[i];
+                if (input.ApplyTick > tick) break;
+                if (input.ApplyTick < tick && HasDynamicBody(input.ObjectId) && RewindBodyStateInputsToInitialSnapshot())
+                    return applied;
+
+                if (ApplyBodyStateInput(input))
+                {
+                    pendingBodyStateInputs.RemoveAt(i);
+                    applied = true;
+                    continue;
+                }
+
+                i++;
+            }
+
+            return applied;
+        }
+
+        private bool RewindBodyStateInputsToInitialSnapshot()
+        {
+            if (world == null || !hasInitialSnapshot || !world.TryReadSnapshot(initialSnapshot))
+                return false;
+
+            tick = 0;
+            accumulator = 0f;
+            lastStepLimited = false;
+            currentCollisionPairs.Clear();
+            previousCollisionPairs.Clear();
+            lastCollisionEvents.Clear();
+            appliedBodyStateInputIds.Clear();
+            pendingBodyStateInputs.Clear();
+            foreach (var input in bodyStateInputHistory)
+                AddPendingBodyStateInput(input);
+            lastStateHash = null;
+            ResetStateHashBroadcastCache();
+            return true;
+        }
+
+        private bool ApplyBodyStateInput(BodyStateInput input)
+        {
+            if (string.IsNullOrWhiteSpace(input.InputId) ||
+                appliedBodyStateInputIds.Contains(input.InputId))
+            {
+                return false;
+            }
+
+            var applied = TrySetDynamicBodyState(
+                input.ObjectId,
+                input.Position,
+                input.Rotation,
+                input.LinearVelocity,
+                input.AngularVelocity);
+            if (applied)
+                appliedBodyStateInputIds.Add(input.InputId);
+
+            return applied;
         }
 
         private void MaybeRequestSnapshotForHashMismatch(SceneSyncRapierHashReport report)
@@ -1081,6 +1393,33 @@ namespace Afjk.SceneSync.Rapier
             return new Quaternion(value.x, value.y, -value.z, -value.w);
         }
 
+        private static Vector3 UnityToWireVector(Vector3 value)
+        {
+            return new Vector3(value.x, value.y, -value.z);
+        }
+
+        private static Vector3 WireToUnityVector(Vector3 value)
+        {
+            return new Vector3(value.x, value.y, -value.z);
+        }
+
+        private static string FormatVector3Json(Vector3 value)
+        {
+            return "[" +
+                SceneSyncWireJson.FormatFloat(value.x) + "," +
+                SceneSyncWireJson.FormatFloat(value.y) + "," +
+                SceneSyncWireJson.FormatFloat(value.z) + "]";
+        }
+
+        private static string FormatQuaternionJson(Quaternion value)
+        {
+            return "[" +
+                SceneSyncWireJson.FormatFloat(value.x) + "," +
+                SceneSyncWireJson.FormatFloat(value.y) + "," +
+                SceneSyncWireJson.FormatFloat(value.z) + "," +
+                SceneSyncWireJson.FormatFloat(value.w) + "]";
+        }
+
         private static string CreateCollisionPairKey(string left, string right, out string objectIdA, out string objectIdB)
         {
             objectIdA = null;
@@ -1277,6 +1616,35 @@ namespace Afjk.SceneSync.Rapier
             }
 
             public RapierRigidBodyHandle Body { get; }
+            public Vector3 Position { get; }
+            public Quaternion Rotation { get; }
+            public Vector3 LinearVelocity { get; }
+            public Vector3 AngularVelocity { get; }
+        }
+
+        private readonly struct BodyStateInput
+        {
+            public BodyStateInput(
+                string inputId,
+                string objectId,
+                int applyTick,
+                Vector3 position,
+                Quaternion rotation,
+                Vector3 linearVelocity,
+                Vector3 angularVelocity)
+            {
+                InputId = inputId;
+                ObjectId = objectId;
+                ApplyTick = applyTick;
+                Position = position;
+                Rotation = rotation;
+                LinearVelocity = linearVelocity;
+                AngularVelocity = angularVelocity;
+            }
+
+            public string InputId { get; }
+            public string ObjectId { get; }
+            public int ApplyTick { get; }
             public Vector3 Position { get; }
             public Quaternion Rotation { get; }
             public Vector3 LinearVelocity { get; }

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs
@@ -1,0 +1,368 @@
+using Afjk.SceneSync;
+using UnityEngine;
+
+namespace Afjk.SceneSync.Rapier
+{
+    [DisallowMultipleComponent]
+    public sealed class SceneSyncRapierInteractionSample : MonoBehaviour
+    {
+        [SerializeField] private SceneSyncRapierBridge bridge;
+        [SerializeField] private Camera targetCamera;
+        [SerializeField] private LayerMask pickLayers = ~0;
+        [SerializeField] private float pickMaxDistance = 200f;
+        [SerializeField] private float moveSpeed = 6f;
+        [SerializeField] private float fastMoveMultiplier = 3f;
+        [SerializeField] private float lookSensitivity = 0.15f;
+        [SerializeField] private float inputIntervalSeconds = 0.05f;
+        [SerializeField] private int inputLeadTicks = 8;
+        [SerializeField] private float throwVelocityScale = 1.2f;
+        [SerializeField] private float maxThrowSpeed = 18f;
+        [SerializeField] private bool autoAddPickColliders = true;
+        [SerializeField] private float pickColliderRefreshInterval = 1f;
+
+        private string draggingObjectId;
+        private Quaternion draggingRotation = Quaternion.identity;
+        private Vector3 dragGrabOffset;
+        private Vector3 previousDragTarget;
+        private Vector3 dragVelocity;
+        private float previousDragTargetTime;
+        private float nextInputPublishAt;
+        private float nextColliderRefreshAt;
+        private bool hasDragTarget;
+        private bool looking;
+        private Vector3 previousLookMousePosition;
+        private float yaw;
+        private float pitch;
+
+        private bool IsDragging => !string.IsNullOrWhiteSpace(draggingObjectId);
+
+        private void Awake()
+        {
+            ResolveReferences();
+            InitializeLookAngles();
+        }
+
+        private void OnEnable()
+        {
+            ResolveReferences();
+            InitializeLookAngles();
+        }
+
+        private void OnDisable()
+        {
+            StopLooking();
+            ClearDrag();
+        }
+
+        private void Update()
+        {
+            ResolveReferences();
+            RefreshPickCollidersIfNeeded();
+            UpdateCameraMovement();
+            UpdateCameraLook();
+            UpdateDragInput();
+        }
+
+        private void ResolveReferences()
+        {
+            if (bridge == null)
+                bridge = FindFirstObjectByType<SceneSyncRapierBridge>();
+
+            if (targetCamera == null)
+                targetCamera = Camera.main != null ? Camera.main : FindFirstObjectByType<Camera>();
+        }
+
+        private void InitializeLookAngles()
+        {
+            if (targetCamera == null) return;
+            var euler = targetCamera.transform.eulerAngles;
+            yaw = euler.y;
+            pitch = NormalizeAngle(euler.x);
+        }
+
+        private void UpdateCameraMovement()
+        {
+            if (targetCamera == null) return;
+
+            var input = Vector3.zero;
+            if (Input.GetKey(KeyCode.W)) input += Vector3.forward;
+            if (Input.GetKey(KeyCode.S)) input += Vector3.back;
+            if (Input.GetKey(KeyCode.D)) input += Vector3.right;
+            if (Input.GetKey(KeyCode.A)) input += Vector3.left;
+            if (Input.GetKey(KeyCode.E)) input += Vector3.up;
+            if (Input.GetKey(KeyCode.Q)) input += Vector3.down;
+            if (input.sqrMagnitude <= 0f) return;
+
+            input = Vector3.ClampMagnitude(input, 1f);
+            var cameraTransform = targetCamera.transform;
+            var worldMove =
+                cameraTransform.forward * input.z +
+                cameraTransform.right * input.x +
+                Vector3.up * input.y;
+            var speed = moveSpeed * (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)
+                ? fastMoveMultiplier
+                : 1f);
+            cameraTransform.position += worldMove * (speed * Time.unscaledDeltaTime);
+        }
+
+        private void UpdateCameraLook()
+        {
+            if (targetCamera == null) return;
+
+            if (Input.GetMouseButtonDown(1))
+            {
+                looking = true;
+                previousLookMousePosition = Input.mousePosition;
+                Cursor.visible = false;
+                Cursor.lockState = CursorLockMode.Confined;
+            }
+
+            if (!looking) return;
+
+            if (!Input.GetMouseButton(1))
+            {
+                StopLooking();
+                return;
+            }
+
+            var current = Input.mousePosition;
+            var delta = current - previousLookMousePosition;
+            previousLookMousePosition = current;
+            yaw += delta.x * lookSensitivity;
+            pitch = Mathf.Clamp(pitch - delta.y * lookSensitivity, -88f, 88f);
+            targetCamera.transform.rotation = Quaternion.Euler(pitch, yaw, 0f);
+        }
+
+        private void StopLooking()
+        {
+            looking = false;
+            Cursor.visible = true;
+            Cursor.lockState = CursorLockMode.None;
+        }
+
+        private void UpdateDragInput()
+        {
+            if (bridge == null || targetCamera == null || !bridge.HasWorld)
+            {
+                ClearDrag();
+                return;
+            }
+
+            if (Input.GetMouseButtonDown(0) && !Input.GetMouseButton(1))
+                BeginDrag();
+
+            if (!IsDragging) return;
+
+            if (!Input.GetMouseButton(0))
+            {
+                ReleaseDrag();
+                return;
+            }
+
+            if (TryGetDragTarget(out var targetPosition))
+            {
+                UpdateDragVelocity(targetPosition);
+                if (Time.unscaledTime >= nextInputPublishAt)
+                    PublishDragState(targetPosition, dragVelocity);
+            }
+        }
+
+        private void BeginDrag()
+        {
+            if (!TryPickDynamicObject(out var identity, out var hitPoint))
+                return;
+
+            if (!bridge.TryGetDynamicBodyState(
+                    identity.ObjectId,
+                    out var position,
+                    out var rotation,
+                    out var linearVelocity,
+                    out _))
+            {
+                return;
+            }
+
+            draggingObjectId = identity.ObjectId;
+            draggingRotation = rotation;
+            dragGrabOffset = position - hitPoint;
+            previousDragTarget = position;
+            dragVelocity = linearVelocity;
+            previousDragTargetTime = Time.unscaledTime;
+            nextInputPublishAt = 0f;
+            hasDragTarget = true;
+        }
+
+        private void ReleaseDrag()
+        {
+            if (!IsDragging)
+            {
+                ClearDrag();
+                return;
+            }
+
+            if (TryGetDragTarget(out var targetPosition))
+                UpdateDragVelocity(targetPosition);
+
+            var throwVelocity = Vector3.ClampMagnitude(dragVelocity * Mathf.Max(0f, throwVelocityScale), maxThrowSpeed);
+            PublishDragState(previousDragTarget, throwVelocity);
+            ClearDrag();
+        }
+
+        private void ClearDrag()
+        {
+            draggingObjectId = null;
+            draggingRotation = Quaternion.identity;
+            dragGrabOffset = Vector3.zero;
+            previousDragTarget = Vector3.zero;
+            dragVelocity = Vector3.zero;
+            previousDragTargetTime = 0f;
+            nextInputPublishAt = 0f;
+            hasDragTarget = false;
+        }
+
+        private bool TryPickDynamicObject(out SceneSyncIdentity identity, out Vector3 hitPoint)
+        {
+            identity = null;
+            hitPoint = Vector3.zero;
+
+            var ray = targetCamera.ScreenPointToRay(Input.mousePosition);
+            if (!Physics.Raycast(ray, out var hit, Mathf.Max(0.01f, pickMaxDistance), pickLayers, QueryTriggerInteraction.Ignore))
+                return false;
+
+            identity = hit.collider.GetComponentInParent<SceneSyncIdentity>();
+            if (identity == null ||
+                string.IsNullOrWhiteSpace(identity.ObjectId) ||
+                !bridge.HasDynamicBody(identity.ObjectId))
+            {
+                identity = null;
+                return false;
+            }
+
+            hitPoint = hit.point;
+            return true;
+        }
+
+        private bool TryGetDragTarget(out Vector3 targetPosition)
+        {
+            targetPosition = previousDragTarget;
+            if (!IsDragging || targetCamera == null)
+                return false;
+
+            var ray = targetCamera.ScreenPointToRay(Input.mousePosition);
+            var planeNormal = -targetCamera.transform.forward;
+            var plane = new Plane(planeNormal, previousDragTarget - dragGrabOffset);
+            if (!plane.Raycast(ray, out var distance))
+                return false;
+
+            targetPosition = ray.GetPoint(distance) + dragGrabOffset;
+            return true;
+        }
+
+        private void UpdateDragVelocity(Vector3 targetPosition)
+        {
+            var now = Time.unscaledTime;
+            if (hasDragTarget)
+            {
+                var deltaTime = Mathf.Max(0.0001f, now - previousDragTargetTime);
+                dragVelocity = (targetPosition - previousDragTarget) / deltaTime;
+            }
+
+            previousDragTarget = targetPosition;
+            previousDragTargetTime = now;
+            hasDragTarget = true;
+        }
+
+        private void PublishDragState(Vector3 position, Vector3 linearVelocity)
+        {
+            if (!IsDragging || bridge == null) return;
+            var applyTick = bridge.Tick + Mathf.Max(0, inputLeadTicks);
+            bridge.PublishBodyStateInput(
+                draggingObjectId,
+                applyTick,
+                position,
+                draggingRotation,
+                linearVelocity,
+                Vector3.zero,
+                null,
+                this);
+            nextInputPublishAt = Time.unscaledTime + Mathf.Max(0.005f, inputIntervalSeconds);
+        }
+
+        private void RefreshPickCollidersIfNeeded()
+        {
+            if (!autoAddPickColliders || Time.unscaledTime < nextColliderRefreshAt)
+                return;
+
+            nextColliderRefreshAt = Time.unscaledTime + Mathf.Max(0.1f, pickColliderRefreshInterval);
+            var identities = FindObjectsByType<SceneSyncIdentity>(FindObjectsSortMode.None);
+            foreach (var identity in identities)
+            {
+                if (identity == null ||
+                    string.IsNullOrWhiteSpace(identity.ObjectId) ||
+                    identity.GetComponentInChildren<Collider>() != null ||
+                    bridge == null ||
+                    !bridge.HasDynamicBody(identity.ObjectId))
+                {
+                    continue;
+                }
+
+                if (TryCalculateLocalRendererBounds(identity.transform, out var bounds))
+                {
+                    var collider = identity.gameObject.AddComponent<BoxCollider>();
+                    collider.center = bounds.center;
+                    collider.size = Vector3.Max(bounds.size, Vector3.one * 0.05f);
+                }
+            }
+        }
+
+        private static bool TryCalculateLocalRendererBounds(Transform root, out Bounds localBounds)
+        {
+            localBounds = new Bounds(Vector3.zero, Vector3.zero);
+            if (root == null) return false;
+
+            var renderers = root.GetComponentsInChildren<Renderer>(true);
+            var hasBounds = false;
+            foreach (var renderer in renderers)
+            {
+                if (renderer == null) continue;
+                var bounds = renderer.bounds;
+                var min = bounds.min;
+                var max = bounds.max;
+                var corners = new[]
+                {
+                    new Vector3(min.x, min.y, min.z),
+                    new Vector3(min.x, min.y, max.z),
+                    new Vector3(min.x, max.y, min.z),
+                    new Vector3(min.x, max.y, max.z),
+                    new Vector3(max.x, min.y, min.z),
+                    new Vector3(max.x, min.y, max.z),
+                    new Vector3(max.x, max.y, min.z),
+                    new Vector3(max.x, max.y, max.z),
+                };
+
+                foreach (var corner in corners)
+                {
+                    var localPoint = root.InverseTransformPoint(corner);
+                    if (hasBounds)
+                    {
+                        localBounds.Encapsulate(localPoint);
+                    }
+                    else
+                    {
+                        localBounds = new Bounds(localPoint, Vector3.zero);
+                        hasBounds = true;
+                    }
+                }
+            }
+
+            return hasBounds;
+        }
+
+        private static float NormalizeAngle(float angle)
+        {
+            while (angle > 180f) angle -= 360f;
+            while (angle < -180f) angle += 360f;
+            return angle;
+        }
+    }
+}

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs.meta
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c77b52e399a042ebb08d27590fc2a05c


### PR DESCRIPTION
## Summary

Adds a Play Mode interaction sample for SceneSync Rapier rooms. The sample lets Unity users move the camera with WASD/EQ, rotate with right-drag, and grab/throw dynamic Rapier bodies with left-drag.

The interaction path sends scheduled `scene-physics-input` body-state events instead of Scene Sync transform deltas. Unity and Web queue those inputs by `applyTick` and apply them before stepping Rapier, so the follow-on physics result can stay deterministic across clients in the same room.

## Changes

- Add `SceneSyncRapierInteractionSample` runtime component and README usage notes.
- Add Unity bridge APIs for dynamic body state lookup, input queuing, input history replay, and `scene-physics-input` publishing.
- Add Web Rapier world/runtime support for queued body-state inputs, late-input rewind/replay, no-body pending retention, and bounded catch-up stepping.
- Route `scene-physics-input` handoffs through Player UI and validate them in the presence server schema.
- Add JS tests for body-state input application, late replay, pending body creation, step-limit catch-up, and schema validation.

## Validation

- `git diff --check`
- `node --test html/assets/js/scenesync/physics/rapier-world.test.js`
- `node --test html/assets/js/scenesync/scene-physics.test.js`
- Inline presence schema validation for valid/invalid `scene-physics-input`
- GitHub Actions: `CI - Scene Sync Physics / Test Scene Sync Physics` passed on `8949f58`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient compile --force-recompile`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient get-logs --log-type Error --max-count 50 --include-stack-trace` returned 0 errors
- Unity dynamic code smoke test loaded `SceneSyncRapierInteractionSample` and generated a `scene-physics-input` payload

Review agent re-check found no blocking issues after the late-input and pending-body fixes.