### PR TITLE
[codex] Prevent Rapier interaction sample snapshot rollback

### DIFF
--- a/unity/com.afjk.scene-sync-rapier/README.md
+++ b/unity/com.afjk.scene-sync-rapier/README.md
@@ -100,6 +100,11 @@ physics tick before stepping. For picking, the sample uses Unity raycasts; when 
 dynamic Scene Sync object has no Collider, it can add a lightweight BoxCollider
 from renderer bounds for Play Mode interaction.
 
+By default the sample disables automatic remote physics snapshot correction while
+it is active. Shared Playback Player UI still drives the shared clock, but its
+periodic `scene-physics-snapshot` messages should not overwrite the local
+drag/release authority immediately after an interaction input.
+
 ## PlayerUI Parity Sample
 
 `SceneSyncRapierParitySampleBootstrap` builds a small floor + falling box scene

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -127,6 +127,16 @@ namespace Afjk.SceneSync.Rapier
             get => preserveMotionOnRebuild;
             set => preserveMotionOnRebuild = value;
         }
+        public bool AutoApplyRemoteSnapshots
+        {
+            get => autoApplyRemoteSnapshots;
+            set => autoApplyRemoteSnapshots = value;
+        }
+        public bool RequestSnapshotOnHashMismatch
+        {
+            get => requestSnapshotOnHashMismatch;
+            set => requestSnapshotOnHashMismatch = value;
+        }
 
         private void OnEnable()
         {

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierInteractionSample.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Afjk.SceneSync;
 using UnityEngine;
 
@@ -19,6 +20,7 @@ namespace Afjk.SceneSync.Rapier
         [SerializeField] private float maxThrowSpeed = 18f;
         [SerializeField] private bool autoAddPickColliders = true;
         [SerializeField] private float pickColliderRefreshInterval = 1f;
+        [SerializeField] private bool disableRemoteSnapshotCorrection = true;
 
         private string draggingObjectId;
         private Quaternion draggingRotation = Quaternion.identity;
@@ -33,6 +35,9 @@ namespace Afjk.SceneSync.Rapier
         private Vector3 previousLookMousePosition;
         private float yaw;
         private float pitch;
+        private SceneSyncRapierBridge snapshotOverrideBridge;
+        private static readonly Dictionary<SceneSyncRapierBridge, SnapshotCorrectionOverrideState> SnapshotOverrides =
+            new Dictionary<SceneSyncRapierBridge, SnapshotCorrectionOverrideState>();
 
         private bool IsDragging => !string.IsNullOrWhiteSpace(draggingObjectId);
 
@@ -50,6 +55,7 @@ namespace Afjk.SceneSync.Rapier
 
         private void OnDisable()
         {
+            RestoreSnapshotCorrectionOverride();
             StopLooking();
             ClearDrag();
         }
@@ -70,6 +76,8 @@ namespace Afjk.SceneSync.Rapier
 
             if (targetCamera == null)
                 targetCamera = Camera.main != null ? Camera.main : FindFirstObjectByType<Camera>();
+
+            UpdateSnapshotCorrectionOverride();
         }
 
         private void InitializeLookAngles()
@@ -220,6 +228,58 @@ namespace Afjk.SceneSync.Rapier
             hasDragTarget = false;
         }
 
+        private void UpdateSnapshotCorrectionOverride()
+        {
+            if (!isActiveAndEnabled || !disableRemoteSnapshotCorrection || bridge == null)
+            {
+                RestoreSnapshotCorrectionOverride();
+                return;
+            }
+
+            if (snapshotOverrideBridge == bridge)
+                return;
+
+            RestoreSnapshotCorrectionOverride();
+            snapshotOverrideBridge = bridge;
+            if (SnapshotOverrides.TryGetValue(bridge, out var state))
+            {
+                state.ReferenceCount++;
+                SnapshotOverrides[bridge] = state;
+                return;
+            }
+
+            SnapshotOverrides[bridge] = new SnapshotCorrectionOverrideState(
+                bridge.AutoApplyRemoteSnapshots,
+                bridge.RequestSnapshotOnHashMismatch);
+            bridge.AutoApplyRemoteSnapshots = false;
+            bridge.RequestSnapshotOnHashMismatch = false;
+        }
+
+        private void RestoreSnapshotCorrectionOverride()
+        {
+            if (snapshotOverrideBridge == null)
+                return;
+
+            if (SnapshotOverrides.TryGetValue(snapshotOverrideBridge, out var state))
+            {
+                state.ReferenceCount--;
+                if (state.ReferenceCount <= 0)
+                {
+                    if (!snapshotOverrideBridge.AutoApplyRemoteSnapshots)
+                        snapshotOverrideBridge.AutoApplyRemoteSnapshots = state.AutoApplyRemoteSnapshots;
+                    if (!snapshotOverrideBridge.RequestSnapshotOnHashMismatch)
+                        snapshotOverrideBridge.RequestSnapshotOnHashMismatch = state.RequestSnapshotOnHashMismatch;
+                    SnapshotOverrides.Remove(snapshotOverrideBridge);
+                }
+                else
+                {
+                    SnapshotOverrides[snapshotOverrideBridge] = state;
+                }
+            }
+
+            snapshotOverrideBridge = null;
+        }
+
         private bool TryPickDynamicObject(out SceneSyncIdentity identity, out Vector3 hitPoint)
         {
             identity = null;
@@ -363,6 +423,20 @@ namespace Afjk.SceneSync.Rapier
             while (angle > 180f) angle -= 360f;
             while (angle < -180f) angle += 360f;
             return angle;
+        }
+
+        private struct SnapshotCorrectionOverrideState
+        {
+            public SnapshotCorrectionOverrideState(bool autoApplyRemoteSnapshots, bool requestSnapshotOnHashMismatch)
+            {
+                AutoApplyRemoteSnapshots = autoApplyRemoteSnapshots;
+                RequestSnapshotOnHashMismatch = requestSnapshotOnHashMismatch;
+                ReferenceCount = 1;
+            }
+
+            public bool AutoApplyRemoteSnapshots { get; }
+            public bool RequestSnapshotOnHashMismatch { get; }
+            public int ReferenceCount { get; set; }
         }
     }
 }


### PR DESCRIPTION
## Summary

Prevents the Unity interaction sample from being immediately overwritten by Web Player UI physics snapshots after releasing a dragged body.

In Shared Playback, Player UI remains the clock controller and periodically broadcasts `scene-physics-snapshot`. That is useful for diagnostics/correction, but it can override the Unity-side drag/release input authority right after an interaction. The sample now disables automatic remote snapshot correction while it is active, then restores the previous bridge settings on disable.

## Changes

- Expose `SceneSyncRapierBridge.AutoApplyRemoteSnapshots` and `RequestSnapshotOnHashMismatch` as public properties.
- Add `disableRemoteSnapshotCorrection` to `SceneSyncRapierInteractionSample`, defaulting to enabled.
- Restore the bridge's previous correction settings when the sample is disabled.
- Document the behavior in the Rapier package README.

## Validation

- `git diff --check`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient compile --force-recompile`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient get-logs --log-type Error --max-count 50 --include-stack-trace` returned 0 errors
- Unity dynamic code smoke test found the new bridge properties and loaded `SceneSyncRapierInteractionSample`