### PR TITLE
[codex] Add SceneSync physics event log replay

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -14,6 +14,7 @@ const KNOWN_KINDS = new Set([
   'scene-unlock',
   'scene-physics-hash',
   'scene-physics-input',
+  'scene-physics-input-log-request',
   'scene-physics-snapshot',
   'scene-physics-snapshot-request',
   'scene-asset-request',

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -680,9 +680,10 @@ function canonicalizeScenePhysicsPayload(roomId, payload) {
 function payloadIncludesScenePhysicsInput(payload) {
   if (payload?.kind === 'scene-physics-input') return true;
   if (payload?.kind !== 'scene-batch') return false;
-  const operations = Array.isArray(payload.ops)
-    ? payload.ops
-    : (Array.isArray(payload.actions) ? payload.actions : []);
+  const operations = [
+    ...(Array.isArray(payload.ops) ? payload.ops : []),
+    ...(Array.isArray(payload.actions) ? payload.actions : []),
+  ];
   return operations.some(payloadIncludesScenePhysicsInput);
 }
 
@@ -858,9 +859,10 @@ function simulateObjectLimitUpdate(objectIds, payload, roomId, actorId) {
   }
 
   if (payload.kind === 'scene-batch') {
-    const operations = Array.isArray(payload.ops)
-      ? payload.ops
-      : (Array.isArray(payload.actions) ? payload.actions : []);
+    const operations = [
+      ...(Array.isArray(payload.ops) ? payload.ops : []),
+      ...(Array.isArray(payload.actions) ? payload.actions : []),
+    ];
     for (const op of operations) {
       const result = simulateObjectLimitUpdate(nextObjectIds, op, roomId, actorId);
       if (!result.ok) return result;

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -564,6 +564,11 @@ function branchPhysicsTimeline(timeline, branchTick) {
   timeline.events = timeline.events.filter(event => Number(event.applyTick) <= normalizedBranchTick);
 }
 
+function findPhysicsTimelineEventByInputId(timeline, inputId) {
+  if (typeof inputId !== 'string' || !inputId.trim()) return null;
+  return timeline.events.find(event => event.inputId === inputId.trim()) || null;
+}
+
 function canonicalizeScenePhysicsInput(roomId, payload) {
   if (payload?.kind !== 'scene-physics-input') {
     if (payload?.kind === 'scene-state') {
@@ -578,9 +583,15 @@ function canonicalizeScenePhysicsInput(roomId, payload) {
   const timelineId = normalizePhysicsTimelineId(payload.timelineId);
   const timeline = getRoomPhysicsTimeline(roomId, timelineId);
   const applyTick = Math.max(0, Math.floor(Number(payload.applyTick) || 0));
-  const branchTick = Math.max(0, Math.floor(Number(payload.branchTick ?? applyTick) || 0));
+  const requestedBranchTick = Math.max(0, Math.floor(Number(payload.branchTick ?? applyTick) || 0));
+  const branchTick = Math.min(requestedBranchTick, applyTick);
   const payloadTimelineRevision = Math.max(0, Math.floor(Number(payload.timelineRevision) || 0));
   const latestTick = getLatestPhysicsEventTick(timeline);
+  const existingEvent = findPhysicsTimelineEventByInputId(timeline, payload.inputId);
+  if (existingEvent) {
+    return { ok: true, payload: cloneJson(existingEvent), duplicate: true };
+  }
+
   if (payloadTimelineRevision < timeline.timelineRevision) {
     return {
       ok: false,
@@ -620,7 +631,7 @@ function canonicalizeScenePhysicsInput(roomId, payload) {
   return { ok: true, payload: event };
 }
 
-function replayRoomPhysicsTimeline(client) {
+function sendRoomPhysicsTimeline(client, timelineId = null) {
   const roomTimelines = roomPhysicsTimelines.get(client.roomId);
   if (!roomTimelines) return;
   const sender = {
@@ -629,7 +640,9 @@ function replayRoomPhysicsTimeline(client) {
     device: 'server',
   };
 
+  const normalizedTimelineId = timelineId ? normalizePhysicsTimelineId(timelineId) : null;
   for (const timeline of roomTimelines.values()) {
+    if (normalizedTimelineId && timeline.timelineId !== normalizedTimelineId) continue;
     for (const event of timeline.events) {
       safeSend(client.conn, {
         type: 'handoff',
@@ -640,37 +653,32 @@ function replayRoomPhysicsTimeline(client) {
   }
 }
 
+function createHandoffMessage(sender, payload) {
+  return {
+    type: 'handoff',
+    from: {
+      id: sender.id,
+      nickname: sender.nickname,
+      device: sender.device
+    },
+    payload: payload || {}
+  };
+}
+
 function deliverHandoff(sender, msg) {
   const room = rooms.get(sender.roomId);
   if (!room) return;
   const target = room.get(msg.targetId);
   if (!target) return;
-  const payload = {
-    type: 'handoff',
-    from: {
-      id: sender.id,
-      nickname: sender.nickname,
-      device: sender.device
-    },
-    payload: msg.payload || {}
-  };
-  safeSend(target.conn, payload);
+  safeSend(target.conn, createHandoffMessage(sender, msg.payload));
 }
 
-function broadcastHandoff(sender, msg) {
+function broadcastHandoff(sender, msg, { includeSender = false } = {}) {
   const room = rooms.get(sender.roomId);
   if (!room) return;
-  const payload = {
-    type: 'handoff',
-    from: {
-      id: sender.id,
-      nickname: sender.nickname,
-      device: sender.device
-    },
-    payload: msg.payload || {}
-  };
+  const payload = createHandoffMessage(sender, msg.payload);
   room.forEach(client => {
-    if (client.id !== sender.id) {
+    if (includeSender || client.id !== sender.id) {
       safeSend(client.conn, payload);
     }
   });
@@ -992,6 +1000,13 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
     });
   }
 
+  if (nextPayload?.kind === 'scene-physics-input-log-request') {
+    return {
+      status: 400,
+      body: { error: 'scene-physics-input-log-request requires a websocket client' },
+    };
+  }
+
   if (nextPayload?.type && SCENE_GRAPH_MESSAGE_TYPES.has(nextPayload.type)) {
     const validation = validateSceneGraphMessage(nextPayload);
     if (!validation.ok) {
@@ -1052,17 +1067,19 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
     };
   }
 
-  const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, nextPayload);
-  if (!physicsTimelinePayload.ok) {
-    return {
-      status: physicsTimelinePayload.status || 409,
-      body: {
-        error: physicsTimelinePayload.error || 'physics timeline rejected',
-        message: physicsTimelinePayload.message,
-      },
-    };
+  if (peers.length > 0) {
+    const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, nextPayload);
+    if (!physicsTimelinePayload.ok) {
+      return {
+        status: physicsTimelinePayload.status || 409,
+        body: {
+          error: physicsTimelinePayload.error || 'physics timeline rejected',
+          message: physicsTimelinePayload.message,
+        },
+      };
+    }
+    nextPayload = physicsTimelinePayload.payload;
   }
-  nextPayload = physicsTimelinePayload.payload;
 
   const message = {
     type: 'handoff',
@@ -1810,7 +1827,6 @@ function createPresenceServer() {
             client.userId = String(data.userId);
           }
           broadcastPeers(roomId);
-          replayRoomPhysicsTimeline(client);
           break;
         case 'handoff':
           if (data.targetId && data.payload) {
@@ -1861,6 +1877,11 @@ function createPresenceServer() {
                 return;
               }
 
+              if (data.payload.kind === 'scene-physics-input-log-request') {
+                sendRoomPhysicsTimeline(client, data.payload.timelineId);
+                return;
+              }
+
               const objectLimit = applySceneObjectLimits(roomId, data.payload, actorId);
               if (!objectLimit.ok) {
                 safeSend(conn, {
@@ -1883,7 +1904,9 @@ function createPresenceServer() {
               data.payload = physicsTimelinePayload.payload;
             }
 
-            broadcastHandoff(client, data);
+            broadcastHandoff(client, data, {
+              includeSender: data.payload?.kind === 'scene-physics-input',
+            });
           }
           break;
         case 'ping':
@@ -1970,6 +1993,7 @@ function createPresenceServer() {
     if (connectionSummaryInterval) clearInterval(connectionSummaryInterval);
     rooms.clear();
     roomObjectIds.clear();
+    roomPhysicsTimelines.clear();
     clientsByIpHash.clear();
     pendingSceneRequests.forEach(({ timer, resolve }) => {
       clearTimeout(timer);

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -34,9 +34,17 @@ const SCENE_GRAPH_MAX_SIZE = 64 * 1024; // 64 KB for graph payloads
 
 const rooms = new Map(); // roomId -> Map<clientId, Client>
 const roomObjectIds = new Map(); // roomId -> Set<objectId>
+const roomPhysicsTimelines = new Map(); // roomId -> Map<timelineId, PhysicsTimeline>
 const pendingSceneRequests = new Map(); // apiRequestId -> { resolve, timer }
 const pendingAiCommandResults = new Map(); // apiRequestId -> { resolve, timer }
 const clientsByIpHash = new Map(); // ipHash -> Set<clientId>
+
+const SCENE_SYNC_PHYSICS_TIMELINE_VERSION = 'SceneSyncPhysicsTimelineV1';
+const DEFAULT_SCENE_PHYSICS_TIMELINE_ID = 'default';
+const MAX_SCENE_PHYSICS_TIMELINE_EVENTS = Math.max(
+  1,
+  Math.floor(Number(process.env.SCENE_SYNC_PHYSICS_TIMELINE_EVENT_LIMIT) || 1024),
+);
 
 // ── Blob Store ────────────────────────────────────────────────────────────────
 const BLOB_MAX_SIZE = sceneSyncConfig.maxUploadBytes;
@@ -462,6 +470,7 @@ function removeClient(client) {
   if (!room.size) {
     rooms.delete(client.roomId);
     roomObjectIds.delete(client.roomId);
+    roomPhysicsTimelines.delete(client.roomId);
   }
 
   if (client.ipHash) {
@@ -509,6 +518,125 @@ function safeSend(conn, message) {
   } catch (err) {
     log('send fail', err.message);
     sceneSyncLogger.log('error', { reason: err.message });
+  }
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function normalizePhysicsTimelineId(value) {
+  return typeof value === 'string' && value.trim()
+    ? value.trim()
+    : DEFAULT_SCENE_PHYSICS_TIMELINE_ID;
+}
+
+function getRoomPhysicsTimeline(roomId, timelineId) {
+  const normalizedTimelineId = normalizePhysicsTimelineId(timelineId);
+  const roomTimelines = roomPhysicsTimelines.get(roomId) ?? new Map();
+  roomPhysicsTimelines.set(roomId, roomTimelines);
+  const existing = roomTimelines.get(normalizedTimelineId);
+  if (existing) return existing;
+
+  const timeline = {
+    timelineId: normalizedTimelineId,
+    timelineRevision: 0,
+    timelineForkTick: 0,
+    lastEventRevision: 0,
+    events: [],
+  };
+  roomTimelines.set(normalizedTimelineId, timeline);
+  return timeline;
+}
+
+function resetRoomPhysicsTimelines(roomId) {
+  roomPhysicsTimelines.delete(roomId);
+}
+
+function getLatestPhysicsEventTick(timeline) {
+  return timeline.events.reduce((max, event) => Math.max(max, Number(event.applyTick) || 0), 0);
+}
+
+function branchPhysicsTimeline(timeline, branchTick) {
+  const normalizedBranchTick = Math.max(0, Math.floor(Number(branchTick) || 0));
+  timeline.timelineRevision += 1;
+  timeline.timelineForkTick = normalizedBranchTick;
+  timeline.events = timeline.events.filter(event => Number(event.applyTick) <= normalizedBranchTick);
+}
+
+function canonicalizeScenePhysicsInput(roomId, payload) {
+  if (payload?.kind !== 'scene-physics-input') {
+    if (payload?.kind === 'scene-state') {
+      resetRoomPhysicsTimelines(roomId);
+    }
+    if (payload?.kind === 'scene-physics' && payload?.physics?.enabled !== true) {
+      resetRoomPhysicsTimelines(roomId);
+    }
+    return { ok: true, payload };
+  }
+
+  const timelineId = normalizePhysicsTimelineId(payload.timelineId);
+  const timeline = getRoomPhysicsTimeline(roomId, timelineId);
+  const applyTick = Math.max(0, Math.floor(Number(payload.applyTick) || 0));
+  const branchTick = Math.max(0, Math.floor(Number(payload.branchTick ?? applyTick) || 0));
+  const payloadTimelineRevision = Math.max(0, Math.floor(Number(payload.timelineRevision) || 0));
+  const latestTick = getLatestPhysicsEventTick(timeline);
+  if (payloadTimelineRevision < timeline.timelineRevision) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'stale_physics_timeline',
+      message: '古い物理タイムラインの入力は破棄されました。',
+    };
+  }
+
+  const shouldBranch = payloadTimelineRevision > timeline.timelineRevision || applyTick < latestTick;
+
+  if (shouldBranch) {
+    branchPhysicsTimeline(timeline, branchTick);
+  }
+
+  timeline.lastEventRevision += 1;
+  const eventRevision = timeline.lastEventRevision;
+  const inputId = typeof payload.inputId === 'string' && payload.inputId.trim()
+    ? payload.inputId.trim()
+    : `${timelineId}:${timeline.timelineRevision}:${eventRevision}`;
+  const event = {
+    ...payload,
+    inputId,
+    timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+    timelineId,
+    timelineRevision: timeline.timelineRevision,
+    timelineForkTick: timeline.timelineForkTick,
+    branchTick,
+    eventRevision,
+  };
+
+  timeline.events.push(cloneJson(event));
+  while (timeline.events.length > MAX_SCENE_PHYSICS_TIMELINE_EVENTS) {
+    timeline.events.shift();
+  }
+
+  return { ok: true, payload: event };
+}
+
+function replayRoomPhysicsTimeline(client) {
+  const roomTimelines = roomPhysicsTimelines.get(client.roomId);
+  if (!roomTimelines) return;
+  const sender = {
+    id: 'server',
+    nickname: 'SceneSync',
+    device: 'server',
+  };
+
+  for (const timeline of roomTimelines.values()) {
+    for (const event of timeline.events) {
+      safeSend(client.conn, {
+        type: 'handoff',
+        from: sender,
+        payload: cloneJson(event),
+      });
+    }
   }
 }
 
@@ -923,6 +1051,18 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
       body: { error: objectLimit.error, message: objectLimit.message },
     };
   }
+
+  const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, nextPayload);
+  if (!physicsTimelinePayload.ok) {
+    return {
+      status: physicsTimelinePayload.status || 409,
+      body: {
+        error: physicsTimelinePayload.error || 'physics timeline rejected',
+        message: physicsTimelinePayload.message,
+      },
+    };
+  }
+  nextPayload = physicsTimelinePayload.payload;
 
   const message = {
     type: 'handoff',
@@ -1670,6 +1810,7 @@ function createPresenceServer() {
             client.userId = String(data.userId);
           }
           broadcastPeers(roomId);
+          replayRoomPhysicsTimeline(client);
           break;
         case 'handoff':
           if (data.targetId && data.payload) {
@@ -1729,6 +1870,17 @@ function createPresenceServer() {
                 });
                 return;
               }
+
+              const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, data.payload);
+              if (!physicsTimelinePayload.ok) {
+                safeSend(conn, {
+                  type: 'error',
+                  error: physicsTimelinePayload.error || 'physics_timeline_rejected',
+                  message: physicsTimelinePayload.message,
+                });
+                return;
+              }
+              data.payload = physicsTimelinePayload.payload;
             }
 
             broadcastHandoff(client, data);

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -569,7 +569,28 @@ function findPhysicsTimelineEventByInputId(timeline, inputId) {
   return timeline.events.find(event => event.inputId === inputId.trim()) || null;
 }
 
-function canonicalizeScenePhysicsInput(roomId, payload) {
+function canonicalizeScenePhysicsPayload(roomId, payload) {
+  if (payload?.kind === 'scene-batch') {
+    const key = Array.isArray(payload.ops)
+      ? 'ops'
+      : (Array.isArray(payload.actions) ? 'actions' : null);
+    if (!key) return { ok: true, payload };
+
+    const operations = [];
+    for (const operation of payload[key]) {
+      const result = canonicalizeScenePhysicsPayload(roomId, operation);
+      if (!result.ok) return result;
+      operations.push(result.payload);
+    }
+    return {
+      ok: true,
+      payload: {
+        ...payload,
+        [key]: operations,
+      },
+    };
+  }
+
   if (payload?.kind !== 'scene-physics-input') {
     if (payload?.kind === 'scene-state') {
       resetRoomPhysicsTimelines(roomId);
@@ -629,6 +650,15 @@ function canonicalizeScenePhysicsInput(roomId, payload) {
   }
 
   return { ok: true, payload: event };
+}
+
+function payloadIncludesScenePhysicsInput(payload) {
+  if (payload?.kind === 'scene-physics-input') return true;
+  if (payload?.kind !== 'scene-batch') return false;
+  const operations = Array.isArray(payload.ops)
+    ? payload.ops
+    : (Array.isArray(payload.actions) ? payload.actions : []);
+  return operations.some(payloadIncludesScenePhysicsInput);
 }
 
 function sendRoomPhysicsTimeline(client, timelineId = null) {
@@ -1068,7 +1098,7 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
   }
 
   if (peers.length > 0) {
-    const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, nextPayload);
+  const physicsTimelinePayload = canonicalizeScenePhysicsPayload(roomId, nextPayload);
     if (!physicsTimelinePayload.ok) {
       return {
         status: physicsTimelinePayload.status || 409,
@@ -1892,7 +1922,7 @@ function createPresenceServer() {
                 return;
               }
 
-              const physicsTimelinePayload = canonicalizeScenePhysicsInput(roomId, data.payload);
+              const physicsTimelinePayload = canonicalizeScenePhysicsPayload(roomId, data.payload);
               if (!physicsTimelinePayload.ok) {
                 safeSend(conn, {
                   type: 'error',
@@ -1905,7 +1935,7 @@ function createPresenceServer() {
             }
 
             broadcastHandoff(client, data, {
-              includeSender: data.payload?.kind === 'scene-physics-input',
+              includeSender: payloadIncludesScenePhysicsInput(data.payload),
             });
           }
           break;

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -531,11 +531,33 @@ function normalizePhysicsTimelineId(value) {
     : DEFAULT_SCENE_PHYSICS_TIMELINE_ID;
 }
 
-function getRoomPhysicsTimeline(roomId, timelineId) {
+function cloneRoomPhysicsTimelines(roomId) {
+  const source = roomPhysicsTimelines.get(roomId);
+  const draft = new Map();
+  if (!source) return draft;
+  for (const [timelineId, timeline] of source.entries()) {
+    draft.set(timelineId, {
+      timelineId: timeline.timelineId,
+      timelineRevision: timeline.timelineRevision,
+      timelineForkTick: timeline.timelineForkTick,
+      lastEventRevision: timeline.lastEventRevision,
+      events: cloneJson(timeline.events) || [],
+    });
+  }
+  return draft;
+}
+
+function commitRoomPhysicsTimelines(roomId, timelines) {
+  if (!timelines || timelines.size === 0) {
+    roomPhysicsTimelines.delete(roomId);
+    return;
+  }
+  roomPhysicsTimelines.set(roomId, timelines);
+}
+
+function getPhysicsTimeline(timelines, timelineId) {
   const normalizedTimelineId = normalizePhysicsTimelineId(timelineId);
-  const roomTimelines = roomPhysicsTimelines.get(roomId) ?? new Map();
-  roomPhysicsTimelines.set(roomId, roomTimelines);
-  const existing = roomTimelines.get(normalizedTimelineId);
+  const existing = timelines.get(normalizedTimelineId);
   if (existing) return existing;
 
   const timeline = {
@@ -545,12 +567,12 @@ function getRoomPhysicsTimeline(roomId, timelineId) {
     lastEventRevision: 0,
     events: [],
   };
-  roomTimelines.set(normalizedTimelineId, timeline);
+  timelines.set(normalizedTimelineId, timeline);
   return timeline;
 }
 
-function resetRoomPhysicsTimelines(roomId) {
-  roomPhysicsTimelines.delete(roomId);
+function resetRoomPhysicsTimelines(timelines) {
+  timelines.clear();
 }
 
 function getLatestPhysicsEventTick(timeline) {
@@ -569,40 +591,34 @@ function findPhysicsTimelineEventByInputId(timeline, inputId) {
   return timeline.events.find(event => event.inputId === inputId.trim()) || null;
 }
 
-function canonicalizeScenePhysicsPayload(roomId, payload) {
+function canonicalizeScenePhysicsPayloadInTimelines(timelines, payload) {
   if (payload?.kind === 'scene-batch') {
-    const key = Array.isArray(payload.ops)
-      ? 'ops'
-      : (Array.isArray(payload.actions) ? 'actions' : null);
-    if (!key) return { ok: true, payload };
-
-    const operations = [];
-    for (const operation of payload[key]) {
-      const result = canonicalizeScenePhysicsPayload(roomId, operation);
-      if (!result.ok) return result;
-      operations.push(result.payload);
+    const nextPayload = { ...payload };
+    for (const key of ['ops', 'actions']) {
+      if (!Array.isArray(payload[key])) continue;
+      const operations = [];
+      for (const operation of payload[key]) {
+        const result = canonicalizeScenePhysicsPayloadInTimelines(timelines, operation);
+        if (!result.ok) return result;
+        operations.push(result.payload);
+      }
+      nextPayload[key] = operations;
     }
-    return {
-      ok: true,
-      payload: {
-        ...payload,
-        [key]: operations,
-      },
-    };
+    return { ok: true, payload: nextPayload };
   }
 
   if (payload?.kind !== 'scene-physics-input') {
     if (payload?.kind === 'scene-state') {
-      resetRoomPhysicsTimelines(roomId);
+      resetRoomPhysicsTimelines(timelines);
     }
     if (payload?.kind === 'scene-physics' && payload?.physics?.enabled !== true) {
-      resetRoomPhysicsTimelines(roomId);
+      resetRoomPhysicsTimelines(timelines);
     }
     return { ok: true, payload };
   }
 
   const timelineId = normalizePhysicsTimelineId(payload.timelineId);
-  const timeline = getRoomPhysicsTimeline(roomId, timelineId);
+  const timeline = getPhysicsTimeline(timelines, timelineId);
   const applyTick = Math.max(0, Math.floor(Number(payload.applyTick) || 0));
   const requestedBranchTick = Math.max(0, Math.floor(Number(payload.branchTick ?? applyTick) || 0));
   const branchTick = Math.min(requestedBranchTick, applyTick);
@@ -650,6 +666,15 @@ function canonicalizeScenePhysicsPayload(roomId, payload) {
   }
 
   return { ok: true, payload: event };
+}
+
+function canonicalizeScenePhysicsPayload(roomId, payload) {
+  const draft = cloneRoomPhysicsTimelines(roomId);
+  const result = canonicalizeScenePhysicsPayloadInTimelines(draft, payload);
+  if (result.ok) {
+    commitRoomPhysicsTimelines(roomId, draft);
+  }
+  return result;
 }
 
 function payloadIncludesScenePhysicsInput(payload) {

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -332,6 +332,8 @@ describe('presence REST broadcast API', () => {
     const sender = await connectClient(roomId, 'Physics Sender');
     const receiver = await connectClient(roomId, 'Physics Receiver');
     try {
+      const firstEcho = waitForMessage(sender, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
       const firstInput = waitForMessage(receiver, message =>
         message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
       sender.send(JSON.stringify({
@@ -355,11 +357,13 @@ describe('presence REST broadcast API', () => {
         },
       }));
 
-      const first = await firstInput;
+      const [first, firstSender] = await Promise.all([firstInput, firstEcho]);
       assert.equal(first.payload.eventRevision, 1);
       assert.equal(first.payload.timelineRevision, 0);
       assert.equal(first.payload.timelineForkTick, 0);
       assert.equal(first.payload.timelineVersion, 'SceneSyncPhysicsTimelineV1');
+      assert.equal(firstSender.payload.eventRevision, 1);
+      assert.equal(firstSender.payload.inputId, 'drag-a:000001');
 
       const branchInput = waitForMessage(receiver, message =>
         message.type === 'handoff' && message.payload?.inputId === 'drag-b:000001');
@@ -375,7 +379,7 @@ describe('presence REST broadcast API', () => {
           interactionId: 'drag-b',
           sequence: 1,
           phase: 'grab-release',
-          branchTick: 10,
+          branchTick: 999,
           objectId: 'box',
           applyTick: 10,
           position: [2, 2, 3],
@@ -439,8 +443,6 @@ describe('presence REST broadcast API', () => {
 
       lateJoiner = new WebSocket(`${wsBaseUrl}?room=${roomId}`);
       const welcomePromise = waitForMessage(lateJoiner, message => message.type === 'welcome');
-      const replayPromise = waitForMessage(lateJoiner, message =>
-        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
       await waitForEvent(lateJoiner, 'open');
       lateJoiner.send(JSON.stringify({
         type: 'hello',
@@ -448,6 +450,16 @@ describe('presence REST broadcast API', () => {
         device: 'Node Test',
       }));
       await welcomePromise;
+
+      const replayPromise = waitForMessage(lateJoiner, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      lateJoiner.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input-log-request',
+          timelineId: 'default',
+        },
+      }));
 
       const replay = await replayPromise;
       assert.equal(replay.from.id, 'server');

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -475,6 +475,42 @@ describe('presence REST broadcast API', () => {
     }
   });
 
+  it('canonicalizes scene physics inputs inside scene-batch payloads', async () => {
+    const roomId = 'physics-batch-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    try {
+      const senderEcho = waitForMessage(sender, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      const receiverMessage = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-batch',
+          ops: [{
+            kind: 'scene-physics-input',
+            inputType: 'set-body-state',
+            inputId: 'batch-drag:000001',
+            timelineRevision: 0,
+            eventRevision: 999,
+            objectId: 'batch-box',
+            applyTick: 3,
+            position: [1, 1, 1],
+            rotation: [0, 0, 0, 1],
+          }],
+        },
+      }));
+
+      const [echo, received] = await Promise.all([senderEcho, receiverMessage]);
+      assert.equal(echo.payload.ops[0].eventRevision, 1);
+      assert.equal(received.payload.ops[0].eventRevision, 1);
+      assert.equal(received.payload.ops[0].timelineVersion, 'SceneSyncPhysicsTimelineV1');
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
+    }
+  });
+
   it('broadcasts scene-env to change environment', async () => {
     const ws = await connectClient('env-test-room');
     try {

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -327,6 +327,142 @@ describe('presence REST broadcast API', () => {
     }
   });
 
+  it('assigns canonical scene physics input revisions per room', async () => {
+    const roomId = 'physics-timeline-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    try {
+      const firstInput = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'drag-a:000001',
+          timelineId: 'default',
+          timelineRevision: 0,
+          eventRevision: 999,
+          interactionId: 'drag-a',
+          sequence: 1,
+          phase: 'grab-move',
+          objectId: 'box',
+          applyTick: 20,
+          position: [1, 2, 3],
+          rotation: [0, 0, 0, 1],
+          velocity: [0, 0, 0],
+          angularVelocity: [0, 0, 0],
+        },
+      }));
+
+      const first = await firstInput;
+      assert.equal(first.payload.eventRevision, 1);
+      assert.equal(first.payload.timelineRevision, 0);
+      assert.equal(first.payload.timelineForkTick, 0);
+      assert.equal(first.payload.timelineVersion, 'SceneSyncPhysicsTimelineV1');
+
+      const branchInput = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.inputId === 'drag-b:000001');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'drag-b:000001',
+          timelineId: 'default',
+          timelineRevision: 1,
+          eventRevision: 1000,
+          interactionId: 'drag-b',
+          sequence: 1,
+          phase: 'grab-release',
+          branchTick: 10,
+          objectId: 'box',
+          applyTick: 10,
+          position: [2, 2, 3],
+          rotation: [0, 0, 0, 1],
+          velocity: [1, 0, 0],
+          angularVelocity: [0, 0, 0],
+        },
+      }));
+
+      const branch = await branchInput;
+      assert.equal(branch.payload.eventRevision, 2);
+      assert.equal(branch.payload.timelineRevision, 1);
+      assert.equal(branch.payload.timelineForkTick, 10);
+      assert.equal(branch.payload.branchTick, 10);
+
+      const staleError = waitForMessage(sender, message => message.type === 'error');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'stale:000001',
+          timelineId: 'default',
+          timelineRevision: 0,
+          objectId: 'box',
+          applyTick: 21,
+          position: [3, 2, 3],
+          rotation: [0, 0, 0, 1],
+        },
+      }));
+
+      const error = await staleError;
+      assert.equal(error.error, 'stale_physics_timeline');
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
+    }
+  });
+
+  it('replays scene physics input history to late joiners', async () => {
+    const roomId = 'physics-replay-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    let lateJoiner;
+    try {
+      const liveInput = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'replay-drag:000001',
+          objectId: 'ball',
+          applyTick: 4,
+          position: [1, 2, 3],
+          rotation: [0, 0, 0, 1],
+        },
+      }));
+      const live = await liveInput;
+      assert.equal(live.payload.eventRevision, 1);
+
+      lateJoiner = new WebSocket(`${wsBaseUrl}?room=${roomId}`);
+      const welcomePromise = waitForMessage(lateJoiner, message => message.type === 'welcome');
+      const replayPromise = waitForMessage(lateJoiner, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      await waitForEvent(lateJoiner, 'open');
+      lateJoiner.send(JSON.stringify({
+        type: 'hello',
+        nickname: 'Late Physics Client',
+        device: 'Node Test',
+      }));
+      await welcomePromise;
+
+      const replay = await replayPromise;
+      assert.equal(replay.from.id, 'server');
+      assert.equal(replay.payload.inputId, 'replay-drag:000001');
+      assert.equal(replay.payload.eventRevision, 1);
+      assert.equal(replay.payload.timelineRevision, 0);
+    } finally {
+      await Promise.all([
+        closeClient(sender),
+        closeClient(receiver),
+        lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
+      ]);
+    }
+  });
+
   it('broadcasts scene-env to change environment', async () => {
     const ws = await connectClient('env-test-room');
     try {

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -524,6 +524,68 @@ describe('presence REST broadcast API', () => {
     }
   });
 
+  it('detects scene physics inputs in scene-batch actions when ops is also present', async () => {
+    const roomId = 'physics-batch-actions-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    let lateJoiner = null;
+    try {
+      const senderEcho = waitForMessage(sender, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      const receiverMessage = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-batch',
+          ops: [{
+            kind: 'scene-env',
+            envId: 'outdoor_day',
+          }],
+          actions: [{
+            kind: 'scene-physics-input',
+            inputType: 'set-body-state',
+            inputId: 'batch-actions-drag:000001',
+            timelineRevision: 0,
+            eventRevision: 999,
+            objectId: 'batch-actions-box',
+            applyTick: 6,
+            position: [2, 1, 0],
+            rotation: [0, 0, 0, 1],
+          }],
+        },
+      }));
+
+      const [echo, received] = await Promise.all([senderEcho, receiverMessage]);
+      assert.equal(echo.payload.ops[0].kind, 'scene-env');
+      assert.equal(echo.payload.actions[0].eventRevision, 1);
+      assert.equal(received.payload.ops[0].kind, 'scene-env');
+      assert.equal(received.payload.actions[0].eventRevision, 1);
+      assert.equal(received.payload.actions[0].timelineVersion, 'SceneSyncPhysicsTimelineV1');
+
+      lateJoiner = await connectClient(roomId, 'Physics Late');
+      const replayPromise = waitForMessage(lateJoiner, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      lateJoiner.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input-log-request',
+          timelineId: 'default',
+        },
+      }));
+
+      const replay = await replayPromise;
+      assert.equal(replay.payload.inputId, 'batch-actions-drag:000001');
+      assert.equal(replay.payload.eventRevision, 1);
+    } finally {
+      await Promise.all([
+        closeClient(sender),
+        closeClient(receiver),
+        lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
+      ]);
+    }
+  });
+
   it('broadcasts scene-env to change environment', async () => {
     const ws = await connectClient('env-test-room');
     try {

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -499,12 +499,25 @@ describe('presence REST broadcast API', () => {
             position: [1, 1, 1],
             rotation: [0, 0, 0, 1],
           }],
+          actions: [{
+            kind: 'scene-physics-input',
+            inputType: 'set-body-state',
+            inputId: 'batch-drag:000001',
+            timelineRevision: 0,
+            eventRevision: 999,
+            objectId: 'batch-box',
+            applyTick: 3,
+            position: [1, 1, 1],
+            rotation: [0, 0, 0, 1],
+          }],
         },
       }));
 
       const [echo, received] = await Promise.all([senderEcho, receiverMessage]);
       assert.equal(echo.payload.ops[0].eventRevision, 1);
+      assert.equal(echo.payload.actions[0].eventRevision, 1);
       assert.equal(received.payload.ops[0].eventRevision, 1);
+      assert.equal(received.payload.actions[0].eventRevision, 1);
       assert.equal(received.payload.ops[0].timelineVersion, 'SceneSyncPhysicsTimelineV1');
     } finally {
       await Promise.all([closeClient(sender), closeClient(receiver)]);

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -642,14 +642,6 @@ export function createScenePhysicsRuntime({
       ? payload.inputId.trim()
       : (interactionId ? `${interactionId}:${sequence}` : `${objectId}:${applyTick}`);
 
-    if (
-      appliedBodyStateInputIds.has(inputId) ||
-      pendingBodyStateInputs.some((input) => input.inputId === inputId) ||
-      bodyStateInputHistory.some((input) => input.inputId === inputId)
-    ) {
-      return false;
-    }
-
     if (!Array.isArray(payload.position) || !Array.isArray(payload.rotation)) {
       return false;
     }
@@ -671,6 +663,10 @@ export function createScenePhysicsRuntime({
       angularVelocity: readVec3(payload.angularVelocity || payload.angvel, [0, 0, 0]),
     };
 
+    if (updateExistingBodyStateInput(input)) {
+      return true;
+    }
+
     lastEventRevision = Math.max(lastEventRevision, input.eventRevision);
     addBodyStateInputHistory(input);
     if (world && input.applyTick <= world.tick) {
@@ -683,6 +679,45 @@ export function createScenePhysicsRuntime({
     }
 
     addPendingBodyStateInput(input);
+    return true;
+  }
+
+  function bodyStateInputEquals(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  function replaceBodyStateInput(list, input) {
+    const index = list.findIndex((item) => item.inputId === input.inputId);
+    if (index < 0) return false;
+    if (bodyStateInputEquals(list[index], input)) return true;
+    list[index] = input;
+    list.sort(compareBodyStateInputs);
+    return true;
+  }
+
+  function updateExistingBodyStateInput(input) {
+    const hasApplied = appliedBodyStateInputIds.has(input.inputId);
+    const hasHistory = bodyStateInputHistory.some((item) => item.inputId === input.inputId);
+    const hasPending = pendingBodyStateInputs.some((item) => item.inputId === input.inputId);
+    if (!hasApplied && !hasHistory && !hasPending) return false;
+
+    const previous = bodyStateInputHistory.find((item) => item.inputId === input.inputId)
+      || pendingBodyStateInputs.find((item) => item.inputId === input.inputId)
+      || null;
+    const changed = !previous || !bodyStateInputEquals(previous, input);
+    if (hasHistory) {
+      replaceBodyStateInput(bodyStateInputHistory, input);
+    } else {
+      addBodyStateInputHistory(input);
+    }
+    if (hasPending) {
+      replaceBodyStateInput(pendingBodyStateInputs, input);
+    }
+    lastEventRevision = Math.max(lastEventRevision, input.eventRevision);
+
+    if (changed && world && (hasApplied || input.applyTick <= world.tick)) {
+      rewindBodyStateInputsToInitialSnapshot();
+    }
     return true;
   }
 

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -323,6 +323,63 @@ test('orders same-tick interaction inputs by event revision and sequence', () =>
   runtime.dispose();
 });
 
+test('updates existing scene physics input metadata from canonical server echo', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  const localInput = {
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'drag-echo:000001',
+    timelineId: 'default',
+    timelineRevision: 0,
+    eventRevision: 1,
+    interactionId: 'drag-echo',
+    sequence: 1,
+    phase: 'grab-release',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  };
+  assert.equal(runtime.queueInput(localInput), true);
+  assert.equal(runtime.queueInput({
+    ...localInput,
+    eventRevision: 7,
+    timelineForkTick: 0,
+  }), true);
+
+  const result = runtime.update({ t: 3 / 60, transportActive: true });
+  assert.equal(result.lastEventRevision, 7);
+  assert.ok(object.position.toArray()[0] > 3);
+
+  runtime.dispose();
+});
+
 test('branches the physics event timeline and drops old future inputs', () => {
   const object = makeObject({
     objectId: 'ball',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6485,6 +6485,10 @@ function handleHandoff(data) {
       }
       notifySceneStateChanged('scene-state-handoff');
       publishSharedObjectClockBaselines('scene-state-baseline');
+      broadcast({
+        kind: 'scene-physics-input-log-request',
+        timelineId: 'default',
+      });
       break;
     }
     case 'scene-request': {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6372,6 +6372,26 @@ async function respondToSceneRequest(from) {
 
 // ── Handoff 受信（Scene Sync 用） ────────────────────────
 
+function areSceneBatchOperationsMirrored(ops, actions) {
+  if (!Array.isArray(ops) || !Array.isArray(actions)) return false;
+  if (ops.length !== actions.length) return false;
+  for (let index = 0; index < ops.length; index += 1) {
+    if (JSON.stringify(ops[index]) !== JSON.stringify(actions[index])) return false;
+  }
+  return true;
+}
+
+function collectSceneBatchOperations(payload) {
+  const ops = Array.isArray(payload?.ops) ? payload.ops : null;
+  const actions = Array.isArray(payload?.actions) ? payload.actions : null;
+  if (ops && actions) {
+    return areSceneBatchOperationsMirrored(ops, actions)
+      ? ops
+      : [...ops, ...actions];
+  }
+  return ops || actions || null;
+}
+
 function handleHandoff(data) {
   const payload = data.payload;
   if (!payload) return;
@@ -6871,7 +6891,7 @@ function handleHandoff(data) {
       break;
     }
     case 'scene-batch': {
-      const batchOps = payload.ops ?? payload.actions;
+      const batchOps = collectSceneBatchOperations(payload);
       if (!Array.isArray(batchOps)) {
         console.warn('[scene-batch] invalid ops', payload);
         notifySceneStateChanged('scene-batch-handoff');

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6751,7 +6751,6 @@ function handleHandoff(data) {
       break;
     }
     case 'scene-physics-input': {
-      if (isOwn) break;
       scenePhysicsRuntime.queueInput(payload);
       notifySceneStateChanged('scene-physics-input');
       break;

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -377,6 +377,9 @@ namespace Afjk.SceneSync.Rapier
             if (input.TimelineRevision > timelineRevision)
                 AdvancePhysicsTimeline(input.TimelineRevision, input.BranchTick);
 
+            if (UpdateExistingBodyStateInput(input))
+                return true;
+
             if (HasBodyStateInput(input.InputId))
                 return false;
 
@@ -394,6 +397,44 @@ namespace Afjk.SceneSync.Rapier
             }
 
             AddPendingBodyStateInput(input);
+            return true;
+        }
+
+        private bool UpdateExistingBodyStateInput(BodyStateInput input)
+        {
+            var wasApplied = appliedBodyStateInputIds.Contains(input.InputId);
+            var historyIndex = bodyStateInputHistory.FindIndex(item => string.Equals(item.InputId, input.InputId, StringComparison.Ordinal));
+            var pendingIndex = pendingBodyStateInputs.FindIndex(item => string.Equals(item.InputId, input.InputId, StringComparison.Ordinal));
+            if (!wasApplied && historyIndex < 0 && pendingIndex < 0)
+                return false;
+
+            var previous = historyIndex >= 0
+                ? bodyStateInputHistory[historyIndex]
+                : (pendingIndex >= 0 ? pendingBodyStateInputs[pendingIndex] : default);
+            var changed = historyIndex < 0 && pendingIndex < 0 || !previous.Equals(input);
+
+            if (historyIndex >= 0)
+            {
+                bodyStateInputHistory[historyIndex] = input;
+                bodyStateInputHistory.Sort(CompareBodyStateInputs);
+            }
+            else
+            {
+                AddBodyStateInputHistory(input);
+            }
+
+            if (pendingIndex >= 0)
+            {
+                pendingBodyStateInputs[pendingIndex] = input;
+                pendingBodyStateInputs.Sort(CompareBodyStateInputs);
+            }
+
+            if (input.EventRevision > lastPhysicsEventRevision)
+                lastPhysicsEventRevision = input.EventRevision;
+
+            if (changed && world != null && (wasApplied || input.ApplyTick <= tick))
+                RewindBodyStateInputsToInitialSnapshot();
+
             return true;
         }
 
@@ -823,6 +864,7 @@ namespace Afjk.SceneSync.Rapier
                 }
 
                 dirty = true;
+                RequestPhysicsInputLog();
                 return;
             }
 
@@ -1225,6 +1267,16 @@ namespace Afjk.SceneSync.Rapier
                 ",\"localHash\":\"" + SceneSyncWireJson.JsonEscape(report.LocalHash) + "\"" +
                 ",\"sceneClockRevision\":" + report.SceneClockRevision.ToString(CultureInfo.InvariantCulture) +
                 "}";
+            SceneSyncMessageBus.PublishOutgoing(payload, null, this);
+        }
+
+        private void RequestPhysicsInputLog()
+        {
+            var payload =
+                "{\"kind\":\"scene-physics-input-log-request\"" +
+                ",\"timelineVersion\":\"" + TimelineVersion + "\"" +
+                ",\"timelineId\":\"" + SceneSyncWireJson.JsonEscape(timelineId) + "\"" +
+                ",\"sentAt\":" + CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) + "}";
             SceneSyncMessageBus.PublishOutgoing(payload, null, this);
         }
 


### PR DESCRIPTION
## Summary

- Add room-scoped SceneSync physics timeline state in the presence server.
- Canonicalize `scene-physics-input` broadcasts with server-assigned `eventRevision`, `timelineRevision`, `timelineForkTick`, and `timelineVersion`.
- Keep a bounded physics input event log per room and replay it to clients when they send `hello`, so late joiners can queue the same physics inputs before/after scene load.
- Reject stale physics inputs from older timeline revisions.

## Why

The previous PR added client-side timeline metadata, but the room still treated physics input order as peer-provided data. This adds the server-side basis for an event-history-first physics sync model: the room now has a canonical input sequence and can replay it to late joiners.

## Validation

- `node --check apps/presence-server/src/server.mjs`
- `git diff --check`
- `node --test --test-name-pattern "scene physics input" apps/presence-server/tests/api.test.mjs`
  - The two new matching subtests passed (`assigns canonical scene physics input revisions per room`, `replays scene physics input history to late joiners`). As with the existing presence-server test behavior in this environment, the Node process remained open after printing the matching `ok` results and was stopped manually.