### PR TITLE
[codex] Add SceneSync physics event history clear

### DIFF
--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -14,6 +14,7 @@ const KNOWN_KINDS = new Set([
   'scene-unlock',
   'scene-physics-hash',
   'scene-physics-input',
+  'scene-physics-input-log-clear',
   'scene-physics-input-log-request',
   'scene-physics-snapshot',
   'scene-physics-snapshot-request',
@@ -166,7 +167,7 @@ function validateScenePhysicsInputPayload(payload, maxStringLength) {
     const result = validateOptionalReasonableString(payload, key, maxStringLength);
     if (!result.ok) return result;
   }
-  for (const key of ['timelineRevision', 'eventRevision', 'sequence', 'branchTick']) {
+  for (const key of ['timelineRevision', 'timelineClearRevision', 'eventRevision', 'sequence', 'branchTick']) {
     const result = validateOptionalNonNegativeInteger(payload, key);
     if (!result.ok) return result;
   }
@@ -211,6 +212,7 @@ function validateScenePhysicsSyncPayload(payload, maxStringLength) {
     'bodyCount',
     'timelineRevision',
     'timelineForkTick',
+    'timelineClearRevision',
     'lastEventRevision',
   ]) {
     const result = validateOptionalNonNegativeInteger(payload, key);
@@ -440,6 +442,20 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-physics-input') {
     return validateScenePhysicsInputPayload(payload, maxStringLength);
+  }
+
+  if (payload.kind === 'scene-physics-input-log-clear') {
+    for (const key of ['timelineVersion', 'timelineId', 'reason']) {
+      const result = validateOptionalReasonableString(payload, key, maxStringLength);
+      if (!result.ok) return result;
+    }
+    for (const key of ['timelineRevision', 'timelineForkTick', 'timelineClearRevision', 'lastEventRevision']) {
+      const result = validateOptionalNonNegativeInteger(payload, key);
+      if (!result.ok) return result;
+    }
+    const sentAtResult = validateOptionalFiniteNumber(payload, 'sentAt');
+    if (!sentAtResult.ok) return sentAtResult;
+    return { ok: true };
   }
 
   if (

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -525,6 +525,19 @@ function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
 
+function stableJsonStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJsonStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function normalizePhysicsTimelineId(value) {
   return typeof value === 'string' && value.trim()
     ? value.trim()
@@ -541,6 +554,7 @@ function cloneRoomPhysicsTimelines(roomId) {
       timelineRevision: timeline.timelineRevision,
       timelineForkTick: timeline.timelineForkTick,
       lastEventRevision: timeline.lastEventRevision,
+      clearRevision: timeline.clearRevision || 0,
       events: cloneJson(timeline.events) || [],
     });
   }
@@ -565,6 +579,7 @@ function getPhysicsTimeline(timelines, timelineId) {
     timelineRevision: 0,
     timelineForkTick: 0,
     lastEventRevision: 0,
+    clearRevision: 0,
     events: [],
   };
   timelines.set(normalizedTimelineId, timeline);
@@ -591,9 +606,58 @@ function findPhysicsTimelineEventByInputId(timeline, inputId) {
   return timeline.events.find(event => event.inputId === inputId.trim()) || null;
 }
 
+function areSceneBatchOperationsMirrored(ops, actions) {
+  if (!Array.isArray(ops) || !Array.isArray(actions)) return false;
+  if (ops.length !== actions.length) return false;
+  for (let index = 0; index < ops.length; index += 1) {
+    if (stableJsonStringify(ops[index]) !== stableJsonStringify(actions[index])) return false;
+  }
+  return true;
+}
+
+function collectSceneBatchOperations(payload) {
+  const ops = Array.isArray(payload?.ops) ? payload.ops : null;
+  const actions = Array.isArray(payload?.actions) ? payload.actions : null;
+  if (ops && actions) {
+    return areSceneBatchOperationsMirrored(ops, actions)
+      ? ops
+      : [...ops, ...actions];
+  }
+  return ops || actions || [];
+}
+
+function clearPhysicsTimeline(timelines, timelineId, requestedRevision = 0) {
+  const timeline = getPhysicsTimeline(timelines, timelineId);
+  timeline.timelineRevision = Math.max(
+    timeline.timelineRevision + 2,
+    Math.max(0, Math.floor(Number(requestedRevision) || 0)) + 1,
+  );
+  timeline.timelineForkTick = 0;
+  timeline.lastEventRevision = 0;
+  timeline.clearRevision = timeline.timelineRevision;
+  timeline.events = [];
+  return timeline;
+}
+
 function canonicalizeScenePhysicsPayloadInTimelines(timelines, payload) {
   if (payload?.kind === 'scene-batch') {
     const nextPayload = { ...payload };
+    if (
+      Array.isArray(payload.ops) &&
+      Array.isArray(payload.actions) &&
+      areSceneBatchOperationsMirrored(payload.ops, payload.actions)
+    ) {
+      const operations = [];
+      for (const operation of payload.ops) {
+        const result = canonicalizeScenePhysicsPayloadInTimelines(timelines, operation);
+        if (!result.ok) return result;
+        operations.push(result.payload);
+      }
+      nextPayload.ops = operations;
+      nextPayload.actions = cloneJson(operations);
+      return { ok: true, payload: nextPayload };
+    }
+
     for (const key of ['ops', 'actions']) {
       if (!Array.isArray(payload[key])) continue;
       const operations = [];
@@ -605,6 +669,23 @@ function canonicalizeScenePhysicsPayloadInTimelines(timelines, payload) {
       nextPayload[key] = operations;
     }
     return { ok: true, payload: nextPayload };
+  }
+
+  if (payload?.kind === 'scene-physics-input-log-clear') {
+    const timelineId = normalizePhysicsTimelineId(payload.timelineId);
+    const timeline = clearPhysicsTimeline(timelines, timelineId, payload.timelineRevision);
+    return {
+      ok: true,
+      payload: {
+        ...payload,
+        timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+        timelineId,
+        timelineRevision: timeline.timelineRevision,
+        timelineForkTick: timeline.timelineForkTick,
+        timelineClearRevision: timeline.clearRevision,
+        lastEventRevision: timeline.lastEventRevision,
+      },
+    };
   }
 
   if (payload?.kind !== 'scene-physics-input') {
@@ -623,13 +704,17 @@ function canonicalizeScenePhysicsPayloadInTimelines(timelines, payload) {
   const requestedBranchTick = Math.max(0, Math.floor(Number(payload.branchTick ?? applyTick) || 0));
   const branchTick = Math.min(requestedBranchTick, applyTick);
   const payloadTimelineRevision = Math.max(0, Math.floor(Number(payload.timelineRevision) || 0));
+  const payloadTimelineClearRevision = Math.max(0, Math.floor(Number(payload.timelineClearRevision) || 0));
   const latestTick = getLatestPhysicsEventTick(timeline);
   const existingEvent = findPhysicsTimelineEventByInputId(timeline, payload.inputId);
   if (existingEvent) {
     return { ok: true, payload: cloneJson(existingEvent), duplicate: true };
   }
 
-  if (payloadTimelineRevision < timeline.timelineRevision) {
+  if (
+    payloadTimelineRevision < timeline.timelineRevision ||
+    payloadTimelineClearRevision !== (timeline.clearRevision || 0)
+  ) {
     return {
       ok: false,
       status: 409,
@@ -656,6 +741,7 @@ function canonicalizeScenePhysicsPayloadInTimelines(timelines, payload) {
     timelineId,
     timelineRevision: timeline.timelineRevision,
     timelineForkTick: timeline.timelineForkTick,
+    timelineClearRevision: timeline.clearRevision || 0,
     branchTick,
     eventRevision,
   };
@@ -680,11 +766,16 @@ function canonicalizeScenePhysicsPayload(roomId, payload) {
 function payloadIncludesScenePhysicsInput(payload) {
   if (payload?.kind === 'scene-physics-input') return true;
   if (payload?.kind !== 'scene-batch') return false;
-  const operations = [
-    ...(Array.isArray(payload.ops) ? payload.ops : []),
-    ...(Array.isArray(payload.actions) ? payload.actions : []),
-  ];
+  const operations = collectSceneBatchOperations(payload);
   return operations.some(payloadIncludesScenePhysicsInput);
+}
+
+function payloadRequiresScenePhysicsSenderEcho(payload) {
+  if (payload?.kind === 'scene-physics-input-log-clear') return true;
+  if (payloadIncludesScenePhysicsInput(payload)) return true;
+  if (payload?.kind !== 'scene-batch') return false;
+  const operations = collectSceneBatchOperations(payload);
+  return operations.some(payloadRequiresScenePhysicsSenderEcho);
 }
 
 function sendRoomPhysicsTimeline(client, timelineId = null) {
@@ -699,6 +790,22 @@ function sendRoomPhysicsTimeline(client, timelineId = null) {
   const normalizedTimelineId = timelineId ? normalizePhysicsTimelineId(timelineId) : null;
   for (const timeline of roomTimelines.values()) {
     if (normalizedTimelineId && timeline.timelineId !== normalizedTimelineId) continue;
+    if (timeline.clearRevision > 0) {
+      safeSend(client.conn, {
+        type: 'handoff',
+        from: sender,
+        payload: {
+          kind: 'scene-physics-input-log-clear',
+          timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+          timelineId: timeline.timelineId,
+          timelineRevision: timeline.clearRevision,
+          timelineForkTick: 0,
+          timelineClearRevision: timeline.clearRevision,
+          lastEventRevision: 0,
+          reason: 'timeline-replay',
+        },
+      });
+    }
     for (const event of timeline.events) {
       safeSend(client.conn, {
         type: 'handoff',
@@ -859,10 +966,7 @@ function simulateObjectLimitUpdate(objectIds, payload, roomId, actorId) {
   }
 
   if (payload.kind === 'scene-batch') {
-    const operations = [
-      ...(Array.isArray(payload.ops) ? payload.ops : []),
-      ...(Array.isArray(payload.actions) ? payload.actions : []),
-    ];
+    const operations = collectSceneBatchOperations(payload);
     for (const op of operations) {
       const result = simulateObjectLimitUpdate(nextObjectIds, op, roomId, actorId);
       if (!result.ok) return result;
@@ -1124,8 +1228,8 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
     };
   }
 
-  if (peers.length > 0) {
-  const physicsTimelinePayload = canonicalizeScenePhysicsPayload(roomId, nextPayload);
+  if (peers.length > 0 || nextPayload?.kind === 'scene-physics-input-log-clear') {
+    const physicsTimelinePayload = canonicalizeScenePhysicsPayload(roomId, nextPayload);
     if (!physicsTimelinePayload.ok) {
       return {
         status: physicsTimelinePayload.status || 409,
@@ -1962,7 +2066,7 @@ function createPresenceServer() {
             }
 
             broadcastHandoff(client, data, {
-              includeSender: payloadIncludesScenePhysicsInput(data.payload),
+              includeSender: payloadRequiresScenePhysicsSenderEcho(data.payload),
             });
           }
           break;

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -361,6 +361,7 @@ describe('presence REST broadcast API', () => {
       assert.equal(first.payload.eventRevision, 1);
       assert.equal(first.payload.timelineRevision, 0);
       assert.equal(first.payload.timelineForkTick, 0);
+      assert.equal(first.payload.timelineClearRevision, 0);
       assert.equal(first.payload.timelineVersion, 'SceneSyncPhysicsTimelineV1');
       assert.equal(firstSender.payload.eventRevision, 1);
       assert.equal(firstSender.payload.inputId, 'drag-a:000001');
@@ -393,6 +394,7 @@ describe('presence REST broadcast API', () => {
       assert.equal(branch.payload.eventRevision, 2);
       assert.equal(branch.payload.timelineRevision, 1);
       assert.equal(branch.payload.timelineForkTick, 10);
+      assert.equal(branch.payload.timelineClearRevision, 0);
       assert.equal(branch.payload.branchTick, 10);
 
       const staleError = waitForMessage(sender, message => message.type === 'error');
@@ -466,12 +468,165 @@ describe('presence REST broadcast API', () => {
       assert.equal(replay.payload.inputId, 'replay-drag:000001');
       assert.equal(replay.payload.eventRevision, 1);
       assert.equal(replay.payload.timelineRevision, 0);
+      assert.equal(replay.payload.timelineClearRevision, 0);
     } finally {
       await Promise.all([
         closeClient(sender),
         closeClient(receiver),
         lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
       ]);
+    }
+  });
+
+  it('clears scene physics input history and advances the timeline revision', async () => {
+    const roomId = 'physics-clear-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    let lateJoiner = null;
+    try {
+      const firstInput = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'clear-drag:000001',
+          timelineId: 'default',
+          timelineRevision: 0,
+          objectId: 'box',
+          applyTick: 4,
+          position: [1, 2, 3],
+          rotation: [0, 0, 0, 1],
+        },
+      }));
+      const first = await firstInput;
+      assert.equal(first.payload.eventRevision, 1);
+
+      const clearEcho = waitForMessage(sender, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input-log-clear');
+      const clearReceiver = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input-log-clear');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input-log-clear',
+          timelineId: 'default',
+          reason: 'test-clear',
+        },
+      }));
+
+      const [echo, received] = await Promise.all([clearEcho, clearReceiver]);
+      assert.equal(echo.payload.timelineVersion, 'SceneSyncPhysicsTimelineV1');
+      assert.equal(echo.payload.timelineId, 'default');
+      assert.equal(echo.payload.timelineRevision, 2);
+      assert.equal(echo.payload.timelineForkTick, 0);
+      assert.equal(echo.payload.timelineClearRevision, 2);
+      assert.equal(echo.payload.lastEventRevision, 0);
+      assert.equal(received.payload.timelineRevision, 2);
+      assert.equal(received.payload.timelineClearRevision, 2);
+
+      lateJoiner = await connectClient(roomId, 'Physics Late');
+      const markerPromise = waitForMessage(lateJoiner, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-physics-input-log-clear');
+      lateJoiner.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input-log-request',
+          timelineId: 'default',
+        },
+      }));
+      const marker = await markerPromise;
+      assert.equal(marker.from.id, 'server');
+      assert.equal(marker.payload.timelineRevision, echo.payload.timelineRevision);
+      assert.equal(marker.payload.timelineClearRevision, echo.payload.timelineClearRevision);
+
+      const staleError = waitForMessage(sender, message => message.type === 'error');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'clear-stale:000001',
+          timelineId: 'default',
+          timelineRevision: echo.payload.timelineRevision,
+          timelineClearRevision: 0,
+          objectId: 'box',
+          applyTick: 5,
+          position: [2, 2, 3],
+          rotation: [0, 0, 0, 1],
+        },
+      }));
+      const error = await staleError;
+      assert.equal(error.error, 'stale_physics_timeline');
+
+      const freshInput = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.inputId === 'clear-fresh:000001');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-physics-input',
+          inputType: 'set-body-state',
+          inputId: 'clear-fresh:000001',
+          timelineId: 'default',
+          timelineRevision: echo.payload.timelineRevision,
+          timelineClearRevision: echo.payload.timelineClearRevision,
+          objectId: 'box',
+          applyTick: 1,
+          position: [0, 2, 3],
+          rotation: [0, 0, 0, 1],
+        },
+      }));
+      const fresh = await freshInput;
+      assert.equal(fresh.payload.timelineRevision, 2);
+      assert.equal(fresh.payload.timelineClearRevision, 2);
+      assert.equal(fresh.payload.eventRevision, 1);
+    } finally {
+      await Promise.all([
+        closeClient(sender),
+        closeClient(receiver),
+        lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
+      ]);
+    }
+  });
+
+  it('deduplicates mirrored scene-batch clear operations with reordered keys', async () => {
+    const roomId = 'physics-clear-batch-room';
+    const sender = await connectClient(roomId, 'Physics Sender');
+    const receiver = await connectClient(roomId, 'Physics Receiver');
+    try {
+      const senderEcho = waitForMessage(sender, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      const receiverMessage = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-batch');
+      sender.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-batch',
+          ops: [{
+            kind: 'scene-physics-input-log-clear',
+            timelineId: 'default',
+            reason: 'mirror-clear',
+          }],
+          actions: [{
+            reason: 'mirror-clear',
+            timelineId: 'default',
+            kind: 'scene-physics-input-log-clear',
+          }],
+        },
+      }));
+
+      const [echo, received] = await Promise.all([senderEcho, receiverMessage]);
+      assert.equal(echo.payload.ops[0].timelineRevision, 2);
+      assert.equal(echo.payload.actions[0].timelineRevision, 2);
+      assert.equal(received.payload.ops[0].timelineRevision, 2);
+      assert.equal(received.payload.actions[0].timelineRevision, 2);
+      assert.equal(echo.payload.ops[0].timelineClearRevision, 2);
+      assert.equal(echo.payload.actions[0].timelineClearRevision, 2);
+      assert.equal(received.payload.ops[0].timelineClearRevision, 2);
+      assert.equal(received.payload.actions[0].timelineClearRevision, 2);
+    } finally {
+      await Promise.all([closeClient(sender), closeClient(receiver)]);
     }
   });
 
@@ -519,6 +674,7 @@ describe('presence REST broadcast API', () => {
       assert.equal(received.payload.ops[0].eventRevision, 1);
       assert.equal(received.payload.actions[0].eventRevision, 1);
       assert.equal(received.payload.ops[0].timelineVersion, 'SceneSyncPhysicsTimelineV1');
+      assert.equal(received.payload.ops[0].timelineClearRevision, 0);
     } finally {
       await Promise.all([closeClient(sender), closeClient(receiver)]);
     }

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -254,6 +254,12 @@ describe('Scene Sync guard helpers', () => {
       activeTime: 0.5,
       worldAge: 0.5,
       worldEpochTime: 0,
+      timelineVersion: 'SceneSyncPhysicsTimelineV1',
+      timelineId: 'default',
+      timelineRevision: 1,
+      timelineForkTick: 88,
+      timelineClearRevision: 0,
+      lastEventRevision: 3,
       sceneClockRevision: 1,
       controller: { id: 'peer-web', nickname: 'Web' },
       sentAt: Date.now(),
@@ -266,6 +272,7 @@ describe('Scene Sync guard helpers', () => {
       timelineVersion: 'SceneSyncPhysicsTimelineV1',
       timelineId: 'default',
       timelineRevision: 1,
+      timelineClearRevision: 0,
       eventRevision: 3,
       interactionId: 'drag-1',
       sequence: 2,
@@ -281,6 +288,18 @@ describe('Scene Sync guard helpers', () => {
     }).ok, true);
 
     assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-input-log-clear',
+      timelineVersion: 'SceneSyncPhysicsTimelineV1',
+      timelineId: 'default',
+      timelineRevision: 2,
+      timelineForkTick: 0,
+      timelineClearRevision: 2,
+      lastEventRevision: 0,
+      reason: 'player-stop-clear',
+      sentAt: Date.now(),
+    }).ok, true);
+
+    assert.equal(validateSceneSyncPayload({
       kind: 'scene-physics-snapshot-request',
       source: 'physics',
       phase: 'postPhysics',
@@ -289,6 +308,7 @@ describe('Scene Sync guard helpers', () => {
       timelineId: 'default',
       timelineRevision: 1,
       timelineForkTick: 88,
+      timelineClearRevision: 0,
       lastEventRevision: 3,
       profile: 'SceneSyncRapierParity-0.30',
       hashVersion: 'SceneSyncCanonicalPhysicsHashV1',
@@ -310,6 +330,7 @@ describe('Scene Sync guard helpers', () => {
       timelineId: 'default',
       timelineRevision: 1,
       timelineForkTick: 88,
+      timelineClearRevision: 0,
       lastEventRevision: 3,
       profile: 'SceneSyncRapierParity-0.30',
       hashVersion: 'SceneSyncCanonicalPhysicsHashV1',

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -453,6 +453,7 @@ export function createScenePhysicsRuntime({
   let timelineId = DEFAULT_SCENE_PHYSICS_TIMELINE_ID;
   let timelineRevision = 0;
   let timelineForkTick = 0;
+  let timelineClearRevision = 0;
   let lastEventRevision = 0;
 
   function clear({ preserveInputs = false } = {}) {
@@ -474,6 +475,7 @@ export function createScenePhysicsRuntime({
       timelineId = DEFAULT_SCENE_PHYSICS_TIMELINE_ID;
       timelineRevision = 0;
       timelineForkTick = 0;
+      timelineClearRevision = 0;
       lastEventRevision = 0;
     }
   }
@@ -627,7 +629,11 @@ export function createScenePhysicsRuntime({
 
     const payloadTimelineRevision = nonNegativeInteger(payload.timelineRevision, timelineRevision);
     const branchTick = nonNegativeInteger(payload.branchTick, applyTick);
-    if (payloadTimelineRevision < timelineRevision && applyTick > timelineForkTick) {
+    const payloadTimelineClearRevision = nonNegativeInteger(payload.timelineClearRevision, 0);
+    if (
+      payloadTimelineClearRevision !== timelineClearRevision ||
+      (payloadTimelineRevision < timelineRevision && applyTick > timelineForkTick)
+    ) {
       return false;
     }
     if (payloadTimelineRevision > timelineRevision) {
@@ -652,6 +658,7 @@ export function createScenePhysicsRuntime({
       applyTick,
       timelineId: payloadTimelineId,
       timelineRevision: payloadTimelineRevision,
+      timelineClearRevision: payloadTimelineClearRevision,
       eventRevision,
       interactionId,
       sequence,
@@ -752,6 +759,43 @@ export function createScenePhysicsRuntime({
     if (world && world.tick > timelineForkTick) {
       rewindBodyStateInputsToInitialSnapshot();
     }
+    return true;
+  }
+
+  function clearInputHistory(payload = {}) {
+    const payloadTimelineId = normalizeTimelineId(payload.timelineId);
+    if (payloadTimelineId !== timelineId) return false;
+
+    const hasCanonicalRevision = payload.timelineRevision !== undefined && payload.timelineRevision !== null;
+    const canonicalRevision = hasCanonicalRevision
+      ? nonNegativeInteger(payload.timelineRevision, timelineRevision)
+      : null;
+    const payloadTimelineClearRevision = nonNegativeInteger(
+      payload.timelineClearRevision,
+      canonicalRevision ?? timelineClearRevision + 1,
+    );
+    if (payloadTimelineClearRevision < timelineClearRevision) return false;
+    if (payloadTimelineClearRevision === timelineClearRevision) return false;
+    const nextRevision = hasCanonicalRevision
+      ? canonicalRevision
+      : timelineRevision + 1;
+    const forkTick = nonNegativeInteger(payload.timelineForkTick, 0);
+    timelineRevision = nextRevision;
+    timelineForkTick = forkTick;
+    timelineClearRevision = payloadTimelineClearRevision;
+    lastEventRevision = 0;
+    pendingBodyStateInputs = [];
+    bodyStateInputHistory = [];
+    appliedBodyStateInputIds.clear();
+    previousCollisionPairs = new Set();
+
+    if (world && initialSnapshot) {
+      resetToInitialPose({ t: 0 });
+    }
+    markDirty({
+      preserveMotion: false,
+      worldEpochTime: 0,
+    });
     return true;
   }
 
@@ -914,6 +958,7 @@ export function createScenePhysicsRuntime({
       timelineId,
       timelineRevision,
       timelineForkTick,
+      timelineClearRevision,
       lastEventRevision,
       profile: SCENE_SYNC_RAPIER_PROFILE,
       hashVersion: CANONICAL_PHYSICS_HASH_VERSION,
@@ -953,6 +998,7 @@ export function createScenePhysicsRuntime({
       timelineId,
       timelineRevision,
       timelineForkTick,
+      timelineClearRevision,
       lastEventRevision,
       profile: SCENE_SYNC_RAPIER_PROFILE,
       hashVersion: CANONICAL_PHYSICS_HASH_VERSION,
@@ -971,6 +1017,7 @@ export function createScenePhysicsRuntime({
   return {
     markDirty,
     queueInput,
+    clearInputHistory,
     rebuild,
     update,
     createSnapshotReport,
@@ -982,6 +1029,7 @@ export function createScenePhysicsRuntime({
         timelineId,
         timelineRevision,
         timelineForkTick,
+        timelineClearRevision,
         lastEventRevision,
       };
     },

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -456,6 +456,115 @@ test('branches the physics event timeline and drops old future inputs', () => {
   runtime.dispose();
 });
 
+test('clears scene physics input history and rejects stale inputs', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'clear-before',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [6, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  runtime.update({ t: 3 / 60, transportActive: true });
+  assertVectorClose(object.position.toArray(), [6, 2, 0]);
+
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'clear-local-branch',
+    timelineRevision: 3,
+    timelineClearRevision: 0,
+    branchTick: 1,
+    objectId: 'ball',
+    applyTick: 10,
+    position: [4, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  assert.equal(runtime.getTimelineState().timelineRevision, 3);
+
+  assert.equal(runtime.clearInputHistory({
+    kind: 'scene-physics-input-log-clear',
+    timelineId: 'default',
+    timelineRevision: 1,
+    timelineForkTick: 0,
+    timelineClearRevision: 1,
+  }), true);
+  assert.equal(runtime.getTimelineState().timelineRevision, 1);
+  assert.equal(runtime.getTimelineState().timelineClearRevision, 1);
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'clear-stale',
+    timelineRevision: 1,
+    timelineClearRevision: 0,
+    objectId: 'ball',
+    applyTick: 2,
+    position: [8, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), false);
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'clear-after',
+    timelineRevision: 1,
+    timelineClearRevision: 1,
+    eventRevision: 1,
+    objectId: 'ball',
+    applyTick: 1,
+    position: [2, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  assert.equal(runtime.clearInputHistory({
+    kind: 'scene-physics-input-log-clear',
+    timelineId: 'default',
+    timelineRevision: 1,
+    timelineForkTick: 0,
+    timelineClearRevision: 1,
+  }), false);
+
+  const result = runtime.update({ t: 3 / 60, transportActive: true });
+  assert.equal(result.timelineRevision, 1);
+  assert.equal(result.timelineClearRevision, 1);
+  assert.equal(result.lastEventRevision, 1);
+  assertVectorClose(object.position.toArray(), [2, 2, 0]);
+
+  runtime.dispose();
+});
+
 test('normalizes parity object physics fields used by Rapier hashing', () => {
   assert.deepEqual(normalizeObjectPhysics({
     enabled: true,
@@ -695,6 +804,7 @@ test('scene physics runtime creates canonical snapshot reports on demand', () =>
   assert.equal(snapshot.timelineId, 'default');
   assert.equal(snapshot.timelineRevision, 0);
   assert.equal(snapshot.timelineForkTick, 0);
+  assert.equal(snapshot.timelineClearRevision, 0);
   assert.equal(snapshot.lastEventRevision, 0);
   assert.equal(snapshot.profile, SCENE_SYNC_RAPIER_PROFILE);
   assert.equal(snapshot.hashVersion, CANONICAL_PHYSICS_HASH_VERSION);

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -84,6 +84,7 @@ import {
   normalizeObjectPhysics,
   normalizeScenePhysics,
   SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION,
+  SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
   SCENE_SYNC_RAPIER_PROFILE,
   serializeObjectPhysics,
   serializeScenePhysics,
@@ -1407,9 +1408,11 @@ let scenePhysicsState = normalizeScenePhysics();
 let lastScenePhysicsHashBroadcastTick = null;
 let lastScenePhysicsHashBroadcastHash = null;
 let lastScenePhysicsHashBroadcastRevision = null;
+let lastScenePhysicsHashBroadcastClearRevision = null;
 let lastScenePhysicsSnapshotBroadcastTick = null;
 let lastScenePhysicsSnapshotBroadcastHash = null;
 let lastScenePhysicsSnapshotBroadcastRevision = null;
+let lastScenePhysicsSnapshotBroadcastClearRevision = null;
 const scenePhysicsRuntime = createScenePhysicsRuntime({
   getScenePhysics: () => scenePhysicsState,
   getObjectEntries: () => Array.from(managedObjects.entries()).map(([objectId, object]) => ({
@@ -5212,10 +5215,14 @@ function maybeBroadcastScenePhysicsHash(physicsTick, clockState = null) {
   const revision = Number.isFinite(sceneClockState.sharedRevision)
     ? sceneClockState.sharedRevision
     : null;
+  const timelineClearRevision = Number.isFinite(physicsTick.timelineClearRevision)
+    ? physicsTick.timelineClearRevision
+    : null;
   if (
     lastScenePhysicsHashBroadcastTick === tick &&
     lastScenePhysicsHashBroadcastHash === hash &&
-    lastScenePhysicsHashBroadcastRevision === revision
+    lastScenePhysicsHashBroadcastRevision === revision &&
+    lastScenePhysicsHashBroadcastClearRevision === timelineClearRevision
   ) {
     return;
   }
@@ -5223,6 +5230,7 @@ function maybeBroadcastScenePhysicsHash(physicsTick, clockState = null) {
   lastScenePhysicsHashBroadcastTick = tick;
   lastScenePhysicsHashBroadcastHash = hash;
   lastScenePhysicsHashBroadcastRevision = revision;
+  lastScenePhysicsHashBroadcastClearRevision = timelineClearRevision;
   broadcast({
     kind: 'scene-physics-hash',
     source: 'physics',
@@ -5234,6 +5242,7 @@ function maybeBroadcastScenePhysicsHash(physicsTick, clockState = null) {
     timelineId: physicsTick.timelineId,
     timelineRevision: physicsTick.timelineRevision,
     timelineForkTick: physicsTick.timelineForkTick,
+    timelineClearRevision: physicsTick.timelineClearRevision,
     lastEventRevision: physicsTick.lastEventRevision,
     tick,
     hash,
@@ -5266,10 +5275,14 @@ function maybeBroadcastScenePhysicsSnapshot(physicsTick, clockState = null) {
   const revision = Number.isFinite(sceneClockState.sharedRevision)
     ? sceneClockState.sharedRevision
     : null;
+  const timelineClearRevision = Number.isFinite(physicsTick.timelineClearRevision)
+    ? physicsTick.timelineClearRevision
+    : null;
   if (
     lastScenePhysicsSnapshotBroadcastTick === tick &&
     lastScenePhysicsSnapshotBroadcastHash === hash &&
-    lastScenePhysicsSnapshotBroadcastRevision === revision
+    lastScenePhysicsSnapshotBroadcastRevision === revision &&
+    lastScenePhysicsSnapshotBroadcastClearRevision === timelineClearRevision
   ) {
     return;
   }
@@ -5280,6 +5293,7 @@ function maybeBroadcastScenePhysicsSnapshot(physicsTick, clockState = null) {
   lastScenePhysicsSnapshotBroadcastTick = tick;
   lastScenePhysicsSnapshotBroadcastHash = hash;
   lastScenePhysicsSnapshotBroadcastRevision = revision;
+  lastScenePhysicsSnapshotBroadcastClearRevision = timelineClearRevision;
   broadcast(snapshot);
 }
 
@@ -5298,6 +5312,36 @@ function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
     sentAt: Date.now(),
     ...extra,
   };
+}
+
+function applyScenePhysicsInputLogClear(payload = {}, now = performance.now()) {
+  const cleared = scenePhysicsRuntime.clearInputHistory?.(payload) === true;
+  if (!cleared) return false;
+  const physicsBaseline = createSharedPlaybackPhysicsResetBaseline(now, 'physics-input-log-clear');
+  resetAllObjectClocksForSceneClock(now, {
+    reason: 'physics-input-log-clear',
+    physicsBaseline,
+  });
+  notifySceneSyncShellStateChanged('scene-physics-input-log-clear');
+  return true;
+}
+
+function clearScenePhysicsInputLog(reason = 'player-stop-clear', now = performance.now()) {
+  const payload = {
+    kind: 'scene-physics-input-log-clear',
+    timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+    timelineId: 'default',
+    reason,
+    sentAt: Date.now(),
+  };
+
+  const ws = presenceState.ws;
+  if (sceneClockState.mode === CLOCK_MODES.SHARED_PLAYBACK && ws?.readyState === WebSocket.OPEN) {
+    broadcast(payload);
+    return;
+  }
+
+  applyScenePhysicsInputLogClear(payload, now);
 }
 
 function broadcastSceneClockEvent(action, extra = {}) {
@@ -5586,7 +5630,11 @@ function playSceneClock(now = performance.now()) {
 }
 
 function stopSceneClock(now = performance.now()) {
-  resetSceneClock(now);
+  if (isScenePhysicsZeroTime(getSceneClockTime(now))) {
+    clearScenePhysicsInputLog('player-stop-clear', now);
+  } else {
+    resetSceneClock(now);
+  }
   pauseSceneClock(now);
 }
 
@@ -6372,11 +6420,24 @@ async function respondToSceneRequest(from) {
 
 // ── Handoff 受信（Scene Sync 用） ────────────────────────
 
+function stableJsonStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJsonStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function areSceneBatchOperationsMirrored(ops, actions) {
   if (!Array.isArray(ops) || !Array.isArray(actions)) return false;
   if (ops.length !== actions.length) return false;
   for (let index = 0; index < ops.length; index += 1) {
-    if (JSON.stringify(ops[index]) !== JSON.stringify(actions[index])) return false;
+    if (stableJsonStringify(ops[index]) !== stableJsonStringify(actions[index])) return false;
   }
   return true;
 }
@@ -6442,6 +6503,7 @@ function handleHandoff(data) {
     payload.kind === 'scene-add' ||
     payload.kind === 'scene-remove' ||
     payload.kind === 'scene-physics' ||
+    payload.kind === 'scene-physics-input-log-clear' ||
     payload.kind === 'scene-physics-input'
   ) {
     console.debug('[handoff] scene mutation received', {
@@ -6773,6 +6835,12 @@ function handleHandoff(data) {
     case 'scene-physics-input': {
       scenePhysicsRuntime.queueInput(payload);
       notifySceneStateChanged('scene-physics-input');
+      break;
+    }
+    case 'scene-physics-input-log-clear': {
+      if (applyScenePhysicsInputLogClear(payload)) {
+        notifySceneStateChanged('scene-physics-input-log-clear');
+      }
       break;
     }
     case 'scene-physics-snapshot-request': {

--- a/html/assets/js/scenesync/shells/player/player-shell.css
+++ b/html/assets/js/scenesync/shells/player/player-shell.css
@@ -362,6 +362,12 @@
   color: #e2e8f0;
 }
 
+.player-stop-symbol {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .player-btn-play-pause {
   width: 36px;
   height: 36px;

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -97,9 +97,7 @@ function createPanelHtml({ title, closeable }) {
       </div>
       <div class="player-controls">
         <button class="player-btn player-btn-stop" data-player-stop type="button" title="Stop">
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <rect x="3" y="3" width="10" height="10" rx="2"/>
-          </svg>
+          <span class="player-stop-symbol" data-player-stop-symbol aria-hidden="true">|&lt;</span>
         </button>
         <button class="player-btn player-btn-play-pause" data-player-play-pause data-player-playing="0" type="button" title="Play">
           <svg class="icon-play" width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
@@ -200,7 +198,14 @@ export function createPlayerTransportPanel({
     }
 
     const stopBtn = panel.querySelector('[data-player-stop]');
-    if (stopBtn) stopBtn.disabled = controlsDisabled;
+    if (stopBtn) {
+      const atStart = Math.abs(time) <= 0.000001;
+      stopBtn.disabled = controlsDisabled;
+      stopBtn.title = atStart ? 'Clear Physics Event History' : 'Back to Start';
+      stopBtn.setAttribute('aria-label', stopBtn.title);
+      const symbolEl = stopBtn.querySelector('[data-player-stop-symbol]');
+      if (symbolEl) symbolEl.textContent = atStart ? '🔳' : '|<';
+    }
 
     const modeEl = panel.querySelector('[data-player-clock-mode]');
     if (modeEl) {

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -81,6 +81,7 @@ namespace Afjk.SceneSync.Rapier
         private string timelineId = DefaultTimelineId;
         private int timelineRevision;
         private int timelineForkTick;
+        private int timelineClearRevision;
         private long lastPhysicsEventRevision;
         private long localPhysicsEventRevisionCounter;
 
@@ -106,6 +107,7 @@ namespace Afjk.SceneSync.Rapier
         public string TimelineId => timelineId;
         public int TimelineRevision => timelineRevision;
         public int TimelineForkTick => timelineForkTick;
+        public int TimelineClearRevision => timelineClearRevision;
         public long LastPhysicsEventRevision => lastPhysicsEventRevision;
         public int LastBodyStateInputTick => bodyStateInputHistory.Count == 0
             ? -1
@@ -352,6 +354,7 @@ namespace Afjk.SceneSync.Rapier
                 Mathf.Max(0, applyTick),
                 timelineId,
                 timelineRevision,
+                timelineClearRevision,
                 0L,
                 null,
                 0,
@@ -369,6 +372,9 @@ namespace Afjk.SceneSync.Rapier
                 return false;
 
             if (!string.Equals(input.TimelineId, timelineId, StringComparison.Ordinal))
+                return false;
+
+            if (input.TimelineClearRevision != timelineClearRevision)
                 return false;
 
             if (input.TimelineRevision < timelineRevision && input.ApplyTick > timelineForkTick)
@@ -493,6 +499,7 @@ namespace Afjk.SceneSync.Rapier
                 applyTick,
                 timelineId,
                 normalizedTimelineRevision,
+                timelineClearRevision,
                 normalizedEventRevision,
                 interactionId,
                 sequence,
@@ -513,6 +520,7 @@ namespace Afjk.SceneSync.Rapier
                 applyTick,
                 timelineId,
                 normalizedTimelineRevision,
+                timelineClearRevision,
                 normalizedEventRevision,
                 interactionId,
                 sequence,
@@ -540,6 +548,7 @@ namespace Afjk.SceneSync.Rapier
                 applyTick,
                 DefaultTimelineId,
                 0,
+                0,
                 0L,
                 null,
                 0,
@@ -557,6 +566,7 @@ namespace Afjk.SceneSync.Rapier
             int applyTick,
             string timelineId,
             int timelineRevision,
+            int timelineClearRevision,
             long eventRevision,
             string interactionId,
             int sequence,
@@ -577,6 +587,7 @@ namespace Afjk.SceneSync.Rapier
                 ",\"timelineVersion\":\"" + TimelineVersion + "\"" +
                 ",\"timelineId\":\"" + SceneSyncWireJson.JsonEscape(NormalizeTimelineId(timelineId)) + "\"" +
                 ",\"timelineRevision\":" + Mathf.Max(0, timelineRevision).ToString(CultureInfo.InvariantCulture) +
+                ",\"timelineClearRevision\":" + Mathf.Max(0, timelineClearRevision).ToString(CultureInfo.InvariantCulture) +
                 ",\"eventRevision\":" + Math.Max(0L, eventRevision).ToString(CultureInfo.InvariantCulture) +
                 (!string.IsNullOrWhiteSpace(interactionId)
                     ? ",\"interactionId\":\"" + SceneSyncWireJson.JsonEscape(interactionId.Trim()) + "\""
@@ -628,6 +639,8 @@ namespace Afjk.SceneSync.Rapier
             if (tickCompare != 0) return tickCompare;
             var revisionCompare = left.TimelineRevision.CompareTo(right.TimelineRevision);
             if (revisionCompare != 0) return revisionCompare;
+            var clearRevisionCompare = left.TimelineClearRevision.CompareTo(right.TimelineClearRevision);
+            if (clearRevisionCompare != 0) return clearRevisionCompare;
             var eventCompare = left.EventRevision.CompareTo(right.EventRevision);
             if (eventCompare != 0) return eventCompare;
             var interactionCompare = string.CompareOrdinal(left.InteractionId ?? string.Empty, right.InteractionId ?? string.Empty);
@@ -892,6 +905,12 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
+            if (raw.Contains("\"kind\":\"scene-physics-input-log-clear\""))
+            {
+                ApplyScenePhysicsInputLogClear(raw);
+                return;
+            }
+
             if (raw.Contains("\"kind\":\"scene-physics\""))
             {
                 scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
@@ -938,6 +957,7 @@ namespace Afjk.SceneSync.Rapier
             var applied = false;
             var payloadTimelineId = NormalizeTimelineId(payload?.timelineId);
             var payloadTimelineRevision = payload != null ? Mathf.Max(0, payload.timelineRevision) : 0;
+            var payloadTimelineClearRevision = payload != null ? Mathf.Max(0, payload.timelineClearRevision) : 0;
             var payloadLastEventRevision = payload != null ? Math.Max(0L, payload.lastEventRevision) : 0L;
             var payloadSceneClockRevision = ReadInt(payloadJson, "sceneClockRevision", int.MinValue);
             var expectedLastEventRevision = payloadTimelineRevision > timelineRevision
@@ -955,6 +975,7 @@ namespace Afjk.SceneSync.Rapier
                 && payload.bodies != null
                 && string.Equals(payloadTimelineId, timelineId, StringComparison.Ordinal)
                 && payloadTimelineRevision >= timelineRevision
+                && payloadTimelineClearRevision == timelineClearRevision
                 && (payloadSceneClockRevision == int.MinValue ||
                     latestSceneClockRevision == int.MinValue ||
                     payloadSceneClockRevision >= latestSceneClockRevision)
@@ -1059,6 +1080,7 @@ namespace Afjk.SceneSync.Rapier
             var sceneClockRevision = ReadInt(raw, "sceneClockRevision", int.MinValue);
             var remoteTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
             var remoteTimelineRevision = ReadInt(raw, "timelineRevision", 0);
+            var remoteTimelineClearRevision = ReadInt(raw, "timelineClearRevision", 0);
             var remoteLastEventRevision = ReadLong(raw, "lastEventRevision", 0L);
 
             var localHash = NormalizeHash(ComputeStateHashHex());
@@ -1066,6 +1088,7 @@ namespace Afjk.SceneSync.Rapier
             var hashVersionMatched = string.Equals(hashVersion, CanonicalStateHashVersion, StringComparison.Ordinal);
             var timelineComparable = string.Equals(remoteTimelineId, timelineId, StringComparison.Ordinal)
                 && remoteTimelineRevision == timelineRevision
+                && remoteTimelineClearRevision == timelineClearRevision
                 && remoteLastEventRevision >= lastPhysicsEventRevision;
             var matched = timelineComparable
                 && tickMatched
@@ -1144,6 +1167,7 @@ namespace Afjk.SceneSync.Rapier
             var applyTick = ReadInt(raw, "applyTick", tick);
             var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
             var inputTimelineRevision = ReadInt(raw, "timelineRevision", timelineRevision);
+            var inputTimelineClearRevision = ReadInt(raw, "timelineClearRevision", 0);
             var inputEventRevision = ReadLong(raw, "eventRevision", 0L);
             var interactionId = SceneSyncWireJson.ExtractString(raw, "interactionId");
             var sequence = ReadInt(raw, "sequence", 0);
@@ -1156,6 +1180,7 @@ namespace Afjk.SceneSync.Rapier
                 applyTick,
                 inputTimelineId,
                 inputTimelineRevision,
+                inputTimelineClearRevision,
                 inputEventRevision,
                 interactionId,
                 sequence,
@@ -1165,6 +1190,21 @@ namespace Afjk.SceneSync.Rapier
                 WireToUnityRotation(wireRotation),
                 WireToUnityVector(wireLinearVelocity),
                 WireToUnityVector(wireAngularVelocity)));
+        }
+
+        private void ApplyScenePhysicsInputLogClear(string raw)
+        {
+            var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
+            if (!string.Equals(inputTimelineId, timelineId, StringComparison.Ordinal))
+                return;
+
+            var inputTimelineRevision = ReadInt(raw, "timelineRevision", timelineRevision + 1);
+            var inputTimelineClearRevision = ReadInt(raw, "timelineClearRevision", inputTimelineRevision);
+            if (inputTimelineClearRevision <= timelineClearRevision)
+                return;
+
+            var inputTimelineForkTick = ReadInt(raw, "timelineForkTick", 0);
+            ClearBodyStateInputHistory(inputTimelineRevision, inputTimelineForkTick, inputTimelineClearRevision);
         }
 
         private bool ApplyDueBodyStateInputs()
@@ -1213,6 +1253,43 @@ namespace Afjk.SceneSync.Rapier
             return true;
         }
 
+        private void ClearBodyStateInputHistory(int nextTimelineRevision, int nextTimelineForkTick, int nextTimelineClearRevision)
+        {
+            timelineRevision = nextTimelineRevision >= 0
+                ? Mathf.Max(0, nextTimelineRevision)
+                : timelineRevision + 1;
+            timelineForkTick = Mathf.Max(0, nextTimelineForkTick);
+            timelineClearRevision = Math.Max(timelineClearRevision, Mathf.Max(0, nextTimelineClearRevision));
+            lastPhysicsEventRevision = 0L;
+            localPhysicsEventRevisionCounter = lastPhysicsEventRevision;
+            bodyStateInputHistory.Clear();
+            pendingBodyStateInputs.Clear();
+            appliedBodyStateInputIds.Clear();
+            currentCollisionPairs.Clear();
+            previousCollisionPairs.Clear();
+            lastCollisionEvents.Clear();
+            accumulator = 0f;
+            tick = 0;
+            lastStepLimited = false;
+            pendingWorldEpochTime = 0f;
+            hasPendingWorldEpochTime = true;
+
+            if (world != null && hasInitialSnapshot && world.TryReadSnapshot(initialSnapshot))
+            {
+                worldEpochTime = 0f;
+                hasPendingWorldEpochTime = false;
+                ApplyWorldTransforms();
+                UpdateLastStateHash("input-clear");
+            }
+            else
+            {
+                preserveMotionOnNextRebuild = false;
+                dirty = true;
+            }
+
+            ResetStateHashBroadcastCache();
+        }
+
         private bool ApplyBodyStateInput(BodyStateInput input)
         {
             if (string.IsNullOrWhiteSpace(input.InputId) ||
@@ -1258,6 +1335,7 @@ namespace Afjk.SceneSync.Rapier
                 ",\"timelineId\":\"" + SceneSyncWireJson.JsonEscape(timelineId) + "\"" +
                 ",\"timelineRevision\":" + timelineRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"timelineForkTick\":" + timelineForkTick.ToString(CultureInfo.InvariantCulture) +
+                ",\"timelineClearRevision\":" + timelineClearRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"lastEventRevision\":" + lastPhysicsEventRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"requestId\":\"" + SceneSyncWireJson.JsonEscape(requestId) + "\"" +
                 ",\"reason\":\"hash-mismatch\"" +
@@ -1640,6 +1718,7 @@ namespace Afjk.SceneSync.Rapier
                 ",\"timelineId\":\"" + SceneSyncWireJson.JsonEscape(timelineId) + "\"" +
                 ",\"timelineRevision\":" + timelineRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"timelineForkTick\":" + timelineForkTick.ToString(CultureInfo.InvariantCulture) +
+                ",\"timelineClearRevision\":" + timelineClearRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"lastEventRevision\":" + lastPhysicsEventRevision.ToString(CultureInfo.InvariantCulture) +
                 ",\"tick\":" + tick.ToString(CultureInfo.InvariantCulture) +
                 ",\"hash\":\"" + SceneSyncWireJson.JsonEscape(lastStateHash) + "\"" +
@@ -1916,6 +1995,7 @@ namespace Afjk.SceneSync.Rapier
             public string timelineId;
             public int timelineRevision;
             public int timelineForkTick;
+            public int timelineClearRevision;
             public long lastEventRevision;
             public string profile;
             public string hashVersion;
@@ -1974,6 +2054,7 @@ namespace Afjk.SceneSync.Rapier
                 int applyTick,
                 string timelineId,
                 int timelineRevision,
+                int timelineClearRevision,
                 long eventRevision,
                 string interactionId,
                 int sequence,
@@ -1989,6 +2070,7 @@ namespace Afjk.SceneSync.Rapier
                 ApplyTick = applyTick;
                 TimelineId = NormalizeTimelineId(timelineId);
                 TimelineRevision = Mathf.Max(0, timelineRevision);
+                TimelineClearRevision = Mathf.Max(0, timelineClearRevision);
                 EventRevision = Math.Max(0L, eventRevision);
                 InteractionId = string.IsNullOrWhiteSpace(interactionId) ? null : interactionId.Trim();
                 Sequence = Mathf.Max(0, sequence);
@@ -2005,6 +2087,7 @@ namespace Afjk.SceneSync.Rapier
             public int ApplyTick { get; }
             public string TimelineId { get; }
             public int TimelineRevision { get; }
+            public int TimelineClearRevision { get; }
             public long EventRevision { get; }
             public string InteractionId { get; }
             public int Sequence { get; }


### PR DESCRIPTION
## Summary
- add `scene-physics-input-log-clear` to clear room-scoped Rapier input event history
- advance the physics timeline revision on clear so delayed old inputs are rejected as stale
- make the Player UI stop button jump to time 0 first, then clear history when pressed again at time 0
- update Web and Unity Rapier bridges to clear local pending/history/applied input state from the canonical clear event

## Behavior
- Stop button shows `|<` when playback time is non-zero and seeks/stops at time 0.
- Stop button shows `🔳` at time 0 and clears the physics event history for the room.
- Clear events are echoed to the sender, broadcast to peers, reset the local physics baseline, and start a fresh timeline revision.

## Validation
- `node --check apps/presence-server/src/server.mjs`
- `node --check apps/presence-server/src/scenesync/message-schema.mjs`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/shells/player/player-transport.js`
- `git diff --check`
- `node --test html/assets/js/scenesync/scene-physics.test.js`
- `node --test apps/presence-server/tests/scenesync-guards.test.mjs` (subtests ok; stopped after existing persistent process behavior)
- `node --test --test-name-pattern "scene physics input|scene-batch actions|physics input history|clears scene physics" apps/presence-server/tests/api.test.mjs` (matching subtests ok; stopped after existing persistent process behavior)
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient compile --force-recompile`
- `uloop --project-path /Users/afjk/github/SceneSyncWork/SceneSyncClient get-logs --log-type Error` → 0 errors
