### PR TITLE
Fix player physics drag snapping back during playback

### DIFF
--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -620,6 +620,31 @@ export function createScenePhysicsRuntime({
     return reset;
   }
 
+  // Read each dynamic body's initial (authoring) pose WITHOUT disturbing the live
+  // simulation or the scene objects. Persistence paths must serialize the initial
+  // pose, but doing so must not visibly teleport the running bodies (that snap-back
+  // is what made interactive drags appear to "rewind").
+  function getInitialBodyPoses() {
+    if (!world || !initialSnapshot) return null;
+    const liveState = world.snapshot();
+    if (world.restore(initialSnapshot) !== true) {
+      return null;
+    }
+    const poses = new Map();
+    for (const objectId of entryMap.keys()) {
+      const body = world.getBody(objectId);
+      if (!body || body.static) continue;
+      poses.set(objectId, {
+        position: readVec3(body.position),
+        rotation: readQuaternion(body.rotation),
+      });
+    }
+    // Restore the live state. Note: we deliberately do NOT call applyWorldToObjects,
+    // so the scene meshes keep their current (simulated) transforms.
+    world.restore(liveState);
+    return poses;
+  }
+
   function getWorldAge(clockState) {
     return Math.max(0, getClockTime(clockState) - worldEpochTime);
   }
@@ -1110,6 +1135,7 @@ export function createScenePhysicsRuntime({
     createSnapshotReport,
     resetToInitialPose,
     resetActiveToInitialPose,
+    getInitialBodyPoses,
     getTimelineState() {
       return {
         timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -1565,3 +1565,33 @@ test('scene physics runtime clears collision pairs after rebuild (no stale exit)
   assert.deepEqual(exitEvents, [], 'rebuild should not produce false exit events');
   runtime.dispose();
 });
+
+test('getInitialBodyPoses returns the initial pose without disturbing the live simulation', () => {
+  const object = makeObject({ objectId: 'ball', position: [0, 5, 0] });
+  const scenePhysics = normalizeScenePhysics({
+    enabled: true,
+    worldOptions: { gravity: -9.81, ground: null, timestep: 1 / 60 },
+  });
+  const runtime = makeRuntime({ scenePhysics, entries: [makeEntry(object)] });
+
+  // Advance so the live pose diverges from the initial pose.
+  runtime.update({ t: 0, transportActive: true });
+  runtime.update({ t: 0.5, transportActive: true });
+  const liveTick = runtime.getTick();
+  const livePos = object.position.toArray();
+  assert.ok(livePos[1] < 5, 'precondition: ball should have fallen below its initial height');
+
+  const poses = runtime.getInitialBodyPoses();
+  // Returns the initial (authoring) pose, not the live simulated one.
+  assert.ok(poses instanceof Map);
+  assertVectorClose(poses.get('ball').position, [0, 5, 0]);
+
+  // The live world and the scene object are untouched by the read.
+  assert.equal(runtime.getTick(), liveTick, 'live tick must be unchanged');
+  assert.deepEqual(object.position.toArray(), livePos, 'live mesh transform must be unchanged');
+
+  // The simulation continues seamlessly from the live state (does not restart from t=0).
+  runtime.update({ t: 1.0, transportActive: true });
+  assert.ok(object.position.toArray()[1] < livePos[1], 'simulation should keep advancing from the live pose');
+  runtime.dispose();
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -6673,17 +6673,19 @@ async function respondToSceneRequest(from) {
   console.log('[SceneSync] Responding to scene-request from:',
     from?.nickname || from?.id);
 
-  resetScenePhysicsRuntimeBeforePersistence();
+  // Serialize the initial physics pose without disturbing the live simulation/visuals.
+  const initialPhysicsPoses = scenePhysicsRuntime.getInitialBodyPoses?.() || null;
 
   const objects = {};
 
   for (const [objectId, obj] of managedObjects) {
     if (isSampleCubeObjectId(objectId)) continue;
 
+    const initialPose = initialPhysicsPoses?.get(objectId) || null;
     const entry = {
       name: obj.userData.name || obj.name || objectId,
-      position: obj.position.toArray(),
-      rotation: obj.quaternion.toArray(),
+      position: initialPose ? initialPose.position : obj.position.toArray(),
+      rotation: initialPose ? initialPose.rotation : obj.quaternion.toArray(),
       scale: obj.scale.toArray(),
     };
     const clock = serializeObjectClockForSceneSync(obj);
@@ -13794,7 +13796,9 @@ function hasSnapshotRestorableObjects() {
 }
 
 function createCurrentSceneSnapshot() {
-  resetScenePhysicsRuntimeBeforePersistence();
+  // Persistence stores the initial physics pose, but reading it must NOT disturb the
+  // live simulation/visuals (otherwise an in-progress drag visibly snaps back).
+  const initialPhysicsPoses = scenePhysicsRuntime.getInitialBodyPoses?.() || null;
 
   const objects = [];
 
@@ -13807,11 +13811,12 @@ function createCurrentSceneSnapshot() {
     const audioSources = getObjectAudioSourcesForSerialize(object);
     const physics = getObjectPhysicsForSerialize(object);
 
+    const initialPose = initialPhysicsPoses?.get(objectId) || null;
     const entry = {
       objectId,
       name: object.userData?.name || object.name || objectId,
-      position: object.position.toArray(),
-      rotation: object.quaternion.toArray(),
+      position: initialPose ? initialPose.position : object.position.toArray(),
+      rotation: initialPose ? initialPose.rotation : object.quaternion.toArray(),
       scale: object.scale.toArray(),
       visible: object.visible !== false,
       asset,


### PR DESCRIPTION
Room-snapshot persistence reset the live physics world to its initial
pose as a side effect: createCurrentSceneSnapshot() and
respondToSceneRequest() called resetScenePhysicsRuntimeBeforePersistence()
-> resetActiveToInitialPose(), which restores the initial Rapier snapshot
AND calls applyWorldToObjects(), teleporting the live meshes.

Because an interactive physics drag fires notifySceneStateChanged(), it
schedules a room-snapshot autosave, so this reset ran during/just after
the drag and visibly reverted the dragged object (and, on a later drag,
every previously dragged object) to its initial pose. A drag performed
while paused survived only because its inputs branch from tick 0.

Add a non-destructive ScenePhysicsRuntime.getInitialBodyPoses() that
reads each dynamic body's initial pose by snapshotting the live world,
restoring the initial snapshot to read poses, then restoring the live
world again -- without ever calling applyWorldToObjects(). The autosave
and scene-request paths now serialize the initial pose from this map
instead of mutating the live simulation, so dragged bodies keep their
position. Manual export still uses the existing reset path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ACLy1NySLEiCrft75FbXwo