### PR TITLE
fix(scene-sync): replay physics input history after Back-to-Start

### DIFF
--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -589,6 +589,15 @@ export function createScenePhysicsRuntime({
     preserveMotionOnRebuild = true;
     resetMotionObjectIds = new Set();
     previousCollisionPairs = new Set();
+
+    // Hard reset rebuild (Back to Start / zero baseline) starts a fresh world at
+    // tick 0, so the tick-based rewind in update() (targetTick < world.tick) never
+    // re-arms recorded inputs. Re-queue the input history here so it replays
+    // deterministically from the reset, matching plain backward-seek behaviour.
+    if (useInitialTransform && bodyStateInputHistory.length > 0) {
+      rewindBodyStateInputsToInitialSnapshot();
+    }
+
     return entryMap.size > 0
       ? { ok: true }
       : { ok: false, reason: 'no-bodies' };

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -217,6 +217,71 @@ test('rewinds and replays when a scene physics input arrives late', () => {
   runtime.dispose();
 });
 
+test('replays recorded input history after a Back-to-Start zero baseline reset', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  // Play and record a drag input, then confirm it applies during the first run.
+  runtime.update({ t: 0, active: true });
+  runtime.update({ t: 0.2, active: true });
+  assert.equal(runtime.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'replay-drag-1',
+    objectId: 'ball',
+    applyTick: 1,
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  runtime.update({ t: 0.25, active: true });
+  assert.ok(object.position.toArray()[0] > 3.15, 'input applied during first playback');
+
+  // Back to Start: the player stop button issues a zero baseline reset, which
+  // markDirty(preserveMotion:false) -> rebuilds the world at tick 0.
+  const baseline = createPhysicsResetBaseline({
+    time: 0,
+    worldEpochTime: 0,
+    preserveMotion: false,
+    reason: 'player-reset',
+  });
+  applyPhysicsResetBaseline(runtime, { t: 0, mode: 'local-preview', active: false }, baseline);
+  runtime.update({ t: 0, active: false });
+
+  // Press Play again: the recorded input history must replay from the reset.
+  runtime.update({ t: 0, active: true });
+  runtime.update({ t: 0.2, active: true });
+  runtime.update({ t: 0.25, active: true });
+  assert.ok(
+    object.position.toArray()[0] > 3.15,
+    'recorded input history should replay after Back-to-Start reset',
+  );
+
+  runtime.dispose();
+});
+
 test('keeps scene physics input pending until the body exists', () => {
   const entries = [];
   const object = makeObject({


### PR DESCRIPTION
The player shell stop button's "Back to Start" issues a zero baseline
reset (markDirty preserveMotion:false), which rebuilds the physics world
at tick 0. Because the fresh world starts at tick 0, the tick-based
rewind in update() (targetTick < world.tick) never fired, and rebuild()
did not re-queue the recorded body-state input history. As a result,
pressing play after Back-to-Start did not replay recorded interactions,
unlike a plain backward seek.

Re-arm the recorded input history during hard-reset rebuilds so the
timeline replays deterministically from the reset, matching
backward-seek behaviour. Add a regression test covering the
Back-to-Start replay path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SQBVFCM6QoN2JJtzWwwwLs