### PR TITLE
[codex] Fix SceneSync physics interaction drift

### DIFF
--- a/html/assets/js/scenesync/physics/rapier-world.js
+++ b/html/assets/js/scenesync/physics/rapier-world.js
@@ -790,6 +790,13 @@ export function createWorld(options = {}) {
     };
   }
 
+  function setTick(nextTick) {
+    if (!Number.isInteger(nextTick) || nextTick < 0) return false;
+    tick = nextTick;
+    checkpoints.clear();
+    return true;
+  }
+
   function getCanonicalRecords() {
     const records = groundRecord ? [[groundRecord.id, groundRecord]] : [];
     for (const entry of bodyRecords.entries()) records.push(entry);
@@ -1076,6 +1083,7 @@ export function createWorld(options = {}) {
     setBodyState,
     step,
     stepTo,
+    setTick,
     snapshot,
     restore,
     canonicalStateHash,

--- a/html/assets/js/scenesync/physics/rapier-world.js
+++ b/html/assets/js/scenesync/physics/rapier-world.js
@@ -735,11 +735,20 @@ export function createWorld(options = {}) {
       state.angularVelocity || state.angvel,
       current?.angularVelocity || [0, 0, 0],
     );
+    const wakeUp = state.sleeping === true ? false : true;
 
-    body.setTranslation(vectorObject(position), true);
-    body.setRotation(quaternionObject(rotation), true);
-    body.setLinvel(vectorObject(velocity), true);
-    body.setAngvel(vectorObject(angularVelocity), true);
+    body.setTranslation(vectorObject(position), wakeUp);
+    body.setRotation(quaternionObject(rotation), wakeUp);
+    body.setLinvel(vectorObject(velocity), wakeUp);
+    body.setAngvel(vectorObject(angularVelocity), wakeUp);
+    if (typeof state.enabled === 'boolean' && typeof body.setEnabled === 'function') {
+      body.setEnabled(state.enabled);
+    }
+    if (typeof body.sleep === 'function' && state.sleeping === true) {
+      try { body.sleep(); } catch {}
+    } else if (typeof body.wakeUp === 'function' && state.sleeping === false) {
+      try { body.wakeUp(); } catch {}
+    }
     return true;
   }
 

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -848,6 +848,167 @@ export function createScenePhysicsRuntime({
     return true;
   }
 
+  function getLastEventRevisionAfterTimelineBranch(nextRevision, branchTick) {
+    const normalizedRevision = Math.max(0, Math.floor(Number(nextRevision) || 0));
+    const normalizedBranchTick = Math.max(0, Math.floor(Number(branchTick) || 0));
+    let revision = 0;
+    for (const input of bodyStateInputHistory) {
+      if (input.timelineRevision === normalizedRevision || input.applyTick <= normalizedBranchTick) {
+        revision = Math.max(revision, input.eventRevision || 0);
+      }
+    }
+    for (const input of pendingBodyStateInputs) {
+      if (input.timelineRevision === normalizedRevision || input.applyTick <= normalizedBranchTick) {
+        revision = Math.max(revision, input.eventRevision || 0);
+      }
+    }
+    return revision;
+  }
+
+  function applySnapshotReport(payload = {}, clockState = null, options = {}) {
+    const localTickBeforeApply = world?.tick ?? -1;
+    const remoteHash = typeof payload.hash === 'string' ? payload.hash.trim() : '';
+    const bodyCount = Array.isArray(payload.bodies) ? payload.bodies.length : 0;
+    let dynamicBodyCount = 0;
+    let appliedBodyCount = 0;
+    let missingBodyCount = 0;
+    let applied = false;
+
+    const payloadTimelineId = normalizeTimelineId(payload.timelineId);
+    const payloadTimelineRevision = nonNegativeInteger(payload.timelineRevision, 0);
+    const payloadTimelineForkTick = nonNegativeInteger(payload.timelineForkTick, 0);
+    const payloadTimelineClearRevision = nonNegativeInteger(payload.timelineClearRevision, 0);
+    const payloadLastEventRevision = nonNegativeInteger(payload.lastEventRevision, 0);
+    const payloadSceneClockRevision = Number.isFinite(Number(payload.sceneClockRevision))
+      ? Math.floor(Number(payload.sceneClockRevision))
+      : null;
+    const latestSceneClockRevision = Number.isFinite(Number(options.latestSceneClockRevision))
+      ? Math.floor(Number(options.latestSceneClockRevision))
+      : null;
+    const expectedLastEventRevision = payloadTimelineRevision > timelineRevision
+      ? getLastEventRevisionAfterTimelineBranch(payloadTimelineRevision, payloadTimelineForkTick)
+      : lastEventRevision;
+    const payloadTick = nonNegativeInteger(payload.tick, -1);
+
+    const canApply = payload?.kind === 'scene-physics-snapshot'
+      && world
+      && payload.snapshotVersion === SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION
+      && payload.hashVersion === CANONICAL_PHYSICS_HASH_VERSION
+      && payload.profile === SCENE_SYNC_RAPIER_PROFILE
+      && Array.isArray(payload.bodies)
+      && payloadTick >= 0
+      && payloadTimelineId === timelineId
+      && payloadTimelineRevision >= timelineRevision
+      && payloadTimelineClearRevision === timelineClearRevision
+      && (payloadSceneClockRevision == null ||
+        latestSceneClockRevision == null ||
+        payloadSceneClockRevision >= latestSceneClockRevision)
+      && payloadLastEventRevision >= expectedLastEventRevision
+      && payloadTick >= localTickBeforeApply;
+
+    if (canApply) {
+      const bodyStates = [];
+      for (const body of payload.bodies) {
+        if (!body || body.type === 'static') continue;
+        dynamicBodyCount += 1;
+        const id = typeof body.id === 'string' ? body.id.trim() : '';
+        if (!id || !hasDynamicBody(id)) {
+          missingBodyCount += 1;
+          continue;
+        }
+        bodyStates.push({
+          id,
+          position: readVec3(body.position, [0, 0, 0]),
+          rotation: readQuaternion(body.rotation, [0, 0, 0, 1]),
+          velocity: readVec3(body.velocity || body.linearVelocity || body.linvel, [0, 0, 0]),
+          angularVelocity: readVec3(body.angularVelocity || body.angvel, [0, 0, 0]),
+        });
+      }
+
+      if (missingBodyCount === 0) {
+        if (payloadTimelineRevision > timelineRevision) {
+          advanceTimelineRevision(payloadTimelineRevision, payloadTimelineForkTick);
+        }
+        for (const state of bodyStates) {
+          if (world.setBodyState?.(state.id, state) === true) {
+            appliedBodyCount += 1;
+          }
+        }
+        applied = appliedBodyCount === dynamicBodyCount;
+        if (applied) {
+          world.setTick?.(payloadTick);
+          worldEpochTime = Number.isFinite(Number(payload.worldEpochTime))
+            ? Math.max(0, Number(payload.worldEpochTime))
+            : Math.max(0, getClockTime(clockState) - payloadTick * Math.max(0.000001, timestepSeconds));
+          pendingWorldEpochTime = null;
+          previousCollisionPairs = new Set();
+          applyWorldToObjects(clockState);
+        }
+      }
+    }
+
+    const localHash = world?.canonicalStateHash?.() || '';
+    const hashMatched = applied && remoteHash && localHash && remoteHash === localHash;
+    return {
+      kind: 'scene-physics-snapshot',
+      snapshotVersion: payload?.snapshotVersion,
+      remoteHash,
+      localHash,
+      hashVersion: payload?.hashVersion,
+      profile: payload?.profile,
+      rapierCoreVersion: payload?.rapierCoreVersion,
+      tick: payloadTick,
+      localTick: localTickBeforeApply,
+      sceneClockRevision: payloadSceneClockRevision,
+      bodyCount,
+      dynamicBodyCount,
+      appliedBodyCount,
+      missingBodyCount,
+      applied,
+      matched: hashMatched,
+    };
+  }
+
+  function compareHashReport(payload = {}) {
+    const remoteTick = nonNegativeInteger(payload.tick, -1);
+    const remoteHash = typeof payload.hash === 'string' ? payload.hash.trim() : '';
+    const localTick = world?.tick ?? -1;
+    const localHash = world?.canonicalStateHash?.() || '';
+    const hashVersionMatched = payload.hashVersion === CANONICAL_PHYSICS_HASH_VERSION;
+    const profileMatched = payload.profile === SCENE_SYNC_RAPIER_PROFILE;
+    const timelineMatched = normalizeTimelineId(payload.timelineId) === timelineId
+      && nonNegativeInteger(payload.timelineRevision, timelineRevision) === timelineRevision
+      && nonNegativeInteger(payload.timelineClearRevision, timelineClearRevision) === timelineClearRevision;
+    const tickMatched = remoteTick >= 0 && remoteTick === localTick;
+    const matched = Boolean(
+      remoteHash &&
+      localHash &&
+      tickMatched &&
+      hashVersionMatched &&
+      profileMatched &&
+      timelineMatched &&
+      remoteHash === localHash,
+    );
+    return {
+      kind: 'scene-physics-hash',
+      remoteHash,
+      localHash,
+      hashVersion: payload.hashVersion,
+      profile: payload.profile,
+      rapierCoreVersion: payload.rapierCoreVersion,
+      tick: remoteTick,
+      localTick,
+      tickMatched,
+      hashVersionMatched,
+      profileMatched,
+      timelineMatched,
+      matched,
+      sceneClockRevision: Number.isFinite(Number(payload.sceneClockRevision))
+        ? Math.floor(Number(payload.sceneClockRevision))
+        : null,
+    };
+  }
+
   function clearInputHistory(payload = {}) {
     const payloadTimelineId = normalizeTimelineId(payload.timelineId);
     if (payloadTimelineId !== timelineId) return false;
@@ -1139,6 +1300,8 @@ export function createScenePhysicsRuntime({
     markDirty,
     queueInput,
     clearInputHistory,
+    applySnapshotReport,
+    compareHashReport,
     rebuild,
     update,
     createSnapshotReport,

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -449,6 +449,7 @@ export function createScenePhysicsRuntime({
   let dirty = true;
   let world = null;
   let initialSnapshot = null;
+  let authoritativeSnapshotBaseline = null;
   let entryMap = new Map();
   let active = false;
   let timestepSeconds = DEFAULT_TIMESTEP_SECONDS;
@@ -471,6 +472,7 @@ export function createScenePhysicsRuntime({
     world?.free?.();
     world = null;
     initialSnapshot = null;
+    authoritativeSnapshotBaseline = null;
     entryMap = new Map();
     active = false;
     timestepSeconds = DEFAULT_TIMESTEP_SECONDS;
@@ -585,6 +587,7 @@ export function createScenePhysicsRuntime({
     }
 
     initialSnapshot = world.snapshot();
+    authoritativeSnapshotBaseline = null;
     dirty = false;
     preserveMotionOnRebuild = true;
     resetMotionObjectIds = new Set();
@@ -616,6 +619,7 @@ export function createScenePhysicsRuntime({
   function resetToInitialPose(clockState = null) {
     if (!world || !initialSnapshot) return false;
     world.restore(initialSnapshot);
+    authoritativeSnapshotBaseline = null;
     previousCollisionPairs = new Set();
     worldEpochTime = getClockTime(clockState);
     applyWorldToObjects(clockState);
@@ -828,6 +832,7 @@ export function createScenePhysicsRuntime({
     ));
     timelineRevision = nextRevision;
     timelineForkTick = forkTick;
+    authoritativeSnapshotBaseline = null;
 
     const keepInput = (input) => (
       input.timelineRevision === timelineRevision ||
@@ -863,6 +868,71 @@ export function createScenePhysicsRuntime({
       }
     }
     return revision;
+  }
+
+  function inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision) {
+    if (!input) return false;
+    if (input.timelineClearRevision !== timelineClearRevision) return false;
+    if (input.applyTick > snapshotTick) return false;
+    if (nonNegativeInteger(input.eventRevision, 0) > snapshotLastEventRevision) return false;
+    return input.timelineRevision === timelineRevision || input.applyTick <= timelineForkTick;
+  }
+
+  function markInputsCoveredBySnapshot(snapshotTick, snapshotLastEventRevision) {
+    bodyStateInputHistory = bodyStateInputHistory.filter((input) => {
+      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
+        appliedBodyStateInputIds.add(input.inputId);
+        return false;
+      }
+      return true;
+    });
+    pendingBodyStateInputs = pendingBodyStateInputs.filter((input) => {
+      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
+        appliedBodyStateInputIds.add(input.inputId);
+        return false;
+      }
+      return true;
+    });
+    for (const [objectId, input] of activeBodyStateHolds.entries()) {
+      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
+        activeBodyStateHolds.delete(objectId);
+      }
+    }
+    lastEventRevision = Math.max(lastEventRevision, snapshotLastEventRevision);
+  }
+
+  function setAuthoritativeSnapshotBaseline(snapshotTick, snapshotLastEventRevision) {
+    if (!world?.snapshot) return;
+    authoritativeSnapshotBaseline = {
+      tick: snapshotTick,
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision: snapshotLastEventRevision,
+      worldEpochTime,
+      snapshot: world.snapshot(),
+    };
+  }
+
+  function restoreAuthoritativeSnapshotBaseline() {
+    const baseline = authoritativeSnapshotBaseline;
+    if (!baseline || !world || world.restore(baseline.snapshot) !== true) return false;
+    timelineId = baseline.timelineId;
+    timelineRevision = baseline.timelineRevision;
+    timelineForkTick = baseline.timelineForkTick;
+    timelineClearRevision = baseline.timelineClearRevision;
+    lastEventRevision = Math.max(lastEventRevision, baseline.lastEventRevision);
+    worldEpochTime = baseline.worldEpochTime;
+    pendingWorldEpochTime = null;
+    previousCollisionPairs = new Set();
+    appliedBodyStateInputIds.clear();
+    activeBodyStateHolds = new Map();
+    pendingBodyStateInputs = [];
+    for (const input of bodyStateInputHistory) {
+      addPendingBodyStateInput(input);
+    }
+    return true;
   }
 
   function applySnapshotReport(payload = {}, clockState = null, options = {}) {
@@ -909,7 +979,7 @@ export function createScenePhysicsRuntime({
     if (canApply) {
       const bodyStates = [];
       for (const body of payload.bodies) {
-        if (!body || body.type === 'static') continue;
+        if (!body || body.type === 'static' || body.type === 'fixed' || body.static === true) continue;
         dynamicBodyCount += 1;
         const id = typeof body.id === 'string' ? body.id.trim() : '';
         if (!id || !hasDynamicBody(id)) {
@@ -922,6 +992,8 @@ export function createScenePhysicsRuntime({
           rotation: readQuaternion(body.rotation, [0, 0, 0, 1]),
           velocity: readVec3(body.velocity || body.linearVelocity || body.linvel, [0, 0, 0]),
           angularVelocity: readVec3(body.angularVelocity || body.angvel, [0, 0, 0]),
+          sleeping: typeof body.sleeping === 'boolean' ? body.sleeping : undefined,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
         });
       }
 
@@ -949,6 +1021,10 @@ export function createScenePhysicsRuntime({
 
     const localHash = world?.canonicalStateHash?.() || '';
     const hashMatched = applied && remoteHash && localHash && remoteHash === localHash;
+    if (hashMatched) {
+      markInputsCoveredBySnapshot(payloadTick, payloadLastEventRevision);
+      setAuthoritativeSnapshotBaseline(payloadTick, payloadLastEventRevision);
+    }
     return {
       kind: 'scene-physics-snapshot',
       snapshotVersion: payload?.snapshotVersion,
@@ -1169,6 +1245,13 @@ export function createScenePhysicsRuntime({
     if (targetTick < world.tick && initialSnapshot) {
       rewindBodyStateInputsToInitialSnapshot();
     }
+    if (
+      authoritativeSnapshotBaseline &&
+      world.tick < authoritativeSnapshotBaseline.tick &&
+      targetTick >= authoritativeSnapshotBaseline.tick
+    ) {
+      restoreAuthoritativeSnapshotBaseline();
+    }
     const stepResult = world.stepTo(targetTick, { beforeStep: applyDueBodyStateInputs });
     if (stepResult?.limited === true) {
       active = false;
@@ -1268,6 +1351,8 @@ export function createScenePhysicsRuntime({
           rotation: body.rotation,
           velocity: body.linvel,
           angularVelocity: body.angvel,
+          sleeping: body.sleeping,
+          enabled: body.enabled,
         }))
       : [];
 

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -226,6 +226,184 @@ test('scene physics runtime applies a newer remote physics snapshot', () => {
   follower.dispose();
 });
 
+test('scene physics runtime applies remote snapshots with default fixed ground', () => {
+  const makeBall = () => makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [1, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = {
+    enabled: true,
+    worldOptions: {
+      gravity: [0, 0, 0],
+      ground: {
+        y: 0,
+        restitution: 0.2,
+        friction: 0.5,
+      },
+      timestep: 1 / 60,
+    },
+  };
+  const authorityObject = makeBall();
+  const followerObject = makeBall();
+  const authority = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(authorityObject)],
+  });
+  const follower = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(followerObject)],
+  });
+
+  authority.update({ t: 0, transportActive: true });
+  follower.update({ t: 0, transportActive: true });
+  authority.update({ t: 10 / 60 + 1e-8, transportActive: true });
+  follower.update({ t: 5 / 60 + 1e-8, transportActive: true });
+
+  const snapshot = authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true });
+  assert.ok(snapshot.bodies.some((body) => body.id === '__scenesync_ground__' && body.type === 'fixed'));
+  const report = follower.applySnapshotReport(snapshot, { t: 10 / 60 + 1e-8, transportActive: true });
+
+  assert.equal(report.applied, true);
+  assert.equal(report.matched, true);
+  assert.equal(report.missingBodyCount, 0);
+  assert.equal(follower.getTick(), 10);
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  authority.dispose();
+  follower.dispose();
+});
+
+test('scene physics runtime drops pending inputs covered by a matching snapshot', () => {
+  const makeBall = () => makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = {
+    enabled: true,
+    worldOptions: {
+      gravity: [0, 0, 0],
+      ground: null,
+      timestep: 1 / 60,
+    },
+  };
+  const authorityObject = makeBall();
+  const followerObject = makeBall();
+  const authority = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(authorityObject)],
+  });
+  const follower = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(followerObject)],
+  });
+  const input = {
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'covered-drag:000001',
+    timelineId: 'default',
+    timelineRevision: 0,
+    eventRevision: 1,
+    interactionId: 'covered-drag',
+    sequence: 1,
+    phase: 'grab-release',
+    objectId: 'ball',
+    applyTick: 8,
+    position: [8, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [0, 0, 0],
+    angularVelocity: [0, 0, 0],
+  };
+
+  authority.update({ t: 0, transportActive: true });
+  follower.update({ t: 0, transportActive: true });
+  assert.equal(authority.queueInput(input), true);
+  assert.equal(follower.queueInput({
+    ...input,
+    position: [30, 2, 0],
+  }), true);
+  authority.update({ t: 10 / 60 + 1e-8, transportActive: true });
+
+  const snapshot = authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true });
+  assert.equal(snapshot.lastEventRevision, 1);
+  const report = follower.applySnapshotReport(snapshot, { t: 10 / 60 + 1e-8, transportActive: true });
+  assert.equal(report.applied, true);
+  assert.equal(report.matched, true);
+  assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
+
+  follower.update({ t: 10 / 60 + 1e-8, transportActive: true });
+  assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  follower.update({ t: 5 / 60 + 1e-8, transportActive: true });
+  follower.update({ t: 10 / 60 + 1e-8, transportActive: true });
+  assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  authority.dispose();
+  follower.dispose();
+});
+
+test('scene physics runtime restores snapshot sleeping state for canonical convergence', () => {
+  const object = makeObject({
+    objectId: 'box',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'box',
+      halfExtents: [0.5, 0.5, 0.5],
+      velocity: [1, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  runtime.update({ t: 2 / 60 + 1e-8, transportActive: true });
+  const snapshot = runtime.createSnapshotReport({ t: 2 / 60 + 1e-8, transportActive: true });
+  const body = snapshot.bodies.find((item) => item.id === 'box');
+  body.sleeping = true;
+  body.velocity = [0, 0, 0];
+  body.angularVelocity = [0, 0, 0];
+  snapshot.hash = null;
+
+  const report = runtime.applySnapshotReport(snapshot, { t: 2 / 60 + 1e-8, transportActive: true });
+  snapshot.hash = report.localHash;
+  const matchedReport = runtime.applySnapshotReport(snapshot, { t: 2 / 60 + 1e-8, transportActive: true });
+
+  assert.equal(matchedReport.applied, true);
+  assert.equal(matchedReport.matched, true);
+  assert.equal(runtime.getDynamicBodyState('box').sleeping, true);
+
+  runtime.dispose();
+});
+
 test('scene physics runtime rejects stale remote physics snapshots', () => {
   const object = makeObject({
     objectId: 'ball',
@@ -1299,6 +1477,8 @@ test('scene physics runtime creates canonical snapshot reports on demand', () =>
     rotation: [0, 0, 0, 1],
     velocity: [0.25, 0, 0],
     angularVelocity: [0, 0, 0],
+    sleeping: false,
+    enabled: true,
   });
 });
 

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -171,6 +171,98 @@ test('queues scene physics input and applies it at the requested tick', () => {
   runtime.dispose();
 });
 
+test('scene physics runtime applies a newer remote physics snapshot', () => {
+  const makeBall = () => makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [1, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = {
+    enabled: true,
+    worldOptions: {
+      gravity: [0, 0, 0],
+      ground: null,
+      timestep: 1 / 60,
+    },
+  };
+  const authorityObject = makeBall();
+  const followerObject = makeBall();
+  const authority = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(authorityObject)],
+  });
+  const follower = makeRuntime({
+    scenePhysics,
+    entries: [makeEntry(followerObject)],
+  });
+
+  authority.update({ t: 0, transportActive: true });
+  follower.update({ t: 0, transportActive: true });
+  authority.update({ t: 10 / 60 + 1e-8, transportActive: true });
+  follower.update({ t: 5 / 60 + 1e-8, transportActive: true });
+  assert.equal(authority.getTick(), 10);
+  assert.equal(follower.getTick(), 5);
+
+  const snapshot = authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true });
+  const report = follower.applySnapshotReport(snapshot, { t: 10 / 60 + 1e-8, transportActive: true });
+
+  assert.equal(report.applied, true);
+  assert.equal(report.matched, true);
+  assert.equal(follower.getTick(), 10);
+  assertVectorClose(
+    follower.getDynamicBodyState('ball').position,
+    authority.getDynamicBodyState('ball').position,
+  );
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  authority.dispose();
+  follower.dispose();
+});
+
+test('scene physics runtime rejects stale remote physics snapshots', () => {
+  const object = makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [1, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const runtime = makeRuntime({
+    scenePhysics: {
+      enabled: true,
+      worldOptions: {
+        gravity: [0, 0, 0],
+        ground: null,
+        timestep: 1 / 60,
+      },
+    },
+    entries: [makeEntry(object)],
+  });
+
+  runtime.update({ t: 0, transportActive: true });
+  runtime.update({ t: 10 / 60 + 1e-8, transportActive: true });
+  const staleSnapshot = runtime.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true });
+  staleSnapshot.tick = 5;
+  const report = runtime.applySnapshotReport(staleSnapshot, { t: 10 / 60 + 1e-8, transportActive: true });
+
+  assert.equal(report.applied, false);
+  assert.equal(runtime.getTick(), 10);
+
+  runtime.dispose();
+});
+
 test('rewinds and replays when a scene physics input arrives late', () => {
   const object = makeObject({
     objectId: 'ball',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5671,10 +5671,10 @@ function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null) {
     appliedBodyCount: report.appliedBodyCount,
     missingBodyCount: report.missingBodyCount,
   });
-  if (report.applied) {
+  if (report.matched) {
     notifySceneSyncShellStateChanged('scene-physics-snapshot');
   }
-  return report.applied === true;
+  return report.matched === true;
 }
 
 function requestScenePhysicsSnapshotForHashMismatch(payload = {}, fromPeer = null, report = null) {

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1381,6 +1381,7 @@ const SAMPLE_CUBE_OBJECT_ID = 'sample-cube';
 const SAMPLE_CUBE_COLOR = '#4488ff';
 const SCENE_PHYSICS_HASH_BROADCAST_TICK_INTERVAL = 30;
 const SCENE_PHYSICS_SNAPSHOT_BROADCAST_TICK_INTERVAL = 120;
+const SCENE_PHYSICS_SNAPSHOT_REQUEST_COOLDOWN_MS = 1000;
 const PLAYER_PHYSICS_DRAG_INPUT_INTERVAL_MS = 50;
 const PLAYER_PHYSICS_DRAG_INPUT_LEAD_TICKS = 8;
 const PLAYER_PHYSICS_DRAG_THROW_VELOCITY_SCALE = 1.2;
@@ -1417,6 +1418,8 @@ let lastScenePhysicsSnapshotBroadcastTick = null;
 let lastScenePhysicsSnapshotBroadcastHash = null;
 let lastScenePhysicsSnapshotBroadcastRevision = null;
 let lastScenePhysicsSnapshotBroadcastClearRevision = null;
+let lastScenePhysicsSnapshotRequestTick = null;
+let lastScenePhysicsSnapshotRequestAt = 0;
 const scenePhysicsRuntime = createScenePhysicsRuntime({
   getScenePhysics: () => scenePhysicsState,
   getObjectEntries: () => Array.from(managedObjects.entries()).map(([objectId, object]) => ({
@@ -5648,6 +5651,100 @@ function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
   };
 }
 
+function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null) {
+  const report = scenePhysicsRuntime.applySnapshotReport?.(
+    payload,
+    getSceneClockStateForLoomlet(performance.now()),
+    {
+      latestSceneClockRevision: sceneClockState.sharedRevision,
+    },
+  );
+  if (!report) return false;
+  console.debug('[scene-physics] snapshot received', {
+    fromId: fromPeer?.id || null,
+    tick: report.tick,
+    localTick: report.localTick,
+    applied: report.applied,
+    matched: report.matched,
+    bodyCount: report.bodyCount,
+    dynamicBodyCount: report.dynamicBodyCount,
+    appliedBodyCount: report.appliedBodyCount,
+    missingBodyCount: report.missingBodyCount,
+  });
+  if (report.applied) {
+    notifySceneSyncShellStateChanged('scene-physics-snapshot');
+  }
+  return report.applied === true;
+}
+
+function requestScenePhysicsSnapshotForHashMismatch(payload = {}, fromPeer = null, report = null) {
+  if (isSceneClockControllerSelf()) return false;
+  if (!report?.tickMatched || !report?.hashVersionMatched || !report?.profileMatched || !report?.timelineMatched) {
+    return false;
+  }
+  if (!Number.isInteger(report.tick) || report.tick < 0) return false;
+
+  const now = performance.now();
+  if (
+    lastScenePhysicsSnapshotRequestTick === report.tick &&
+    now - lastScenePhysicsSnapshotRequestAt < SCENE_PHYSICS_SNAPSHOT_REQUEST_COOLDOWN_MS
+  ) {
+    return false;
+  }
+  lastScenePhysicsSnapshotRequestTick = report.tick;
+  lastScenePhysicsSnapshotRequestAt = now;
+
+  const request = {
+    kind: 'scene-physics-snapshot-request',
+    source: 'physics',
+    phase: 'postPhysics',
+    snapshotVersion: SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION,
+    profile: payload.profile || SCENE_SYNC_RAPIER_PROFILE,
+    hashVersion: payload.hashVersion,
+    timelineVersion: payload.timelineVersion,
+    timelineId: payload.timelineId || 'default',
+    timelineRevision: payload.timelineRevision,
+    timelineForkTick: payload.timelineForkTick,
+    timelineClearRevision: payload.timelineClearRevision,
+    lastEventRevision: payload.lastEventRevision,
+    requestId: typeof globalThis.crypto?.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID().replace(/-/g, '')
+      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`,
+    reason: 'hash-mismatch',
+    tick: report.tick,
+    localTick: report.localTick,
+    remoteHash: report.remoteHash,
+    localHash: report.localHash,
+    sceneClockRevision: payload.sceneClockRevision,
+    sentAt: Date.now(),
+  };
+
+  if (fromPeer?.id) {
+    sendHandoff({ targetId: fromPeer.id, payload: request });
+  } else {
+    broadcast(request);
+  }
+  return true;
+}
+
+function applyScenePhysicsHashPayload(payload = {}, fromPeer = null) {
+  const report = scenePhysicsRuntime.compareHashReport?.(payload);
+  if (!report) return false;
+  if (report.matched) return true;
+
+  console.debug('[scene-physics] hash mismatch', {
+    fromId: fromPeer?.id || null,
+    tick: report.tick,
+    localTick: report.localTick,
+    remoteHash: report.remoteHash,
+    localHash: report.localHash,
+    hashVersionMatched: report.hashVersionMatched,
+    profileMatched: report.profileMatched,
+    timelineMatched: report.timelineMatched,
+  });
+  return requestScenePhysicsSnapshotForHashMismatch(payload, fromPeer, report);
+}
+
 function applyScenePhysicsInputLogClear(payload = {}, now = performance.now()) {
   const cleared = scenePhysicsRuntime.clearInputHistory?.(payload) === true;
   if (!cleared) return false;
@@ -7184,6 +7281,18 @@ function handleHandoff(data) {
       if (applyScenePhysicsInputLogClear(payload)) {
         notifySceneStateChanged('scene-physics-input-log-clear');
       }
+      break;
+    }
+    case 'scene-physics-snapshot': {
+      if (isOwn) break;
+      if (applyScenePhysicsSnapshotPayload(payload, data.from)) {
+        notifySceneStateChanged('scene-physics-snapshot');
+      }
+      break;
+    }
+    case 'scene-physics-hash': {
+      if (isOwn) break;
+      applyScenePhysicsHashPayload(payload, data.from);
       break;
     }
     case 'scene-physics-snapshot-request': {

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -135,8 +135,7 @@ namespace Afjk.SceneSync.Rapier
         public int PreparePhysicsTimelineBranch(int branchTick)
         {
             var normalizedBranchTick = Mathf.Max(0, branchTick);
-            if (HasFutureBodyStateInputs(normalizedBranchTick))
-                AdvancePhysicsTimeline(timelineRevision + 1, normalizedBranchTick);
+            AdvancePhysicsTimeline(timelineRevision + 1, normalizedBranchTick);
             return timelineRevision;
         }
         public bool AutoRun


### PR DESCRIPTION
## Summary
- Add Web-side handling for incoming `scene-physics-snapshot` and `scene-physics-hash` messages so browser clients can detect and correct Rapier drift.
- Add body-state snapshot application to the Scene Sync physics runtime and expose a tick setter in the Rapier world wrapper for authoritative snapshot recovery.
- Align Unity Rapier drag interactions with Web by always branching the physics timeline when a local drag begins.
- Harden snapshot convergence by skipping fixed/static bodies, restoring sleeping/enabled state, dropping snapshot-covered inputs from replay history, and using matched snapshots as an authoritative replay baseline.

## Root Cause
Unity could consume physics snapshots and hash reports, but Web clients were only broadcasting them. PC Web and iPhone Safari therefore had no correction path when they drifted after interactive physics input. Unity also only branched the physics input timeline when future inputs existed, while Web started every local drag on a new timeline revision, so cross-client interaction replay could diverge. Follow-up review found additional Web-only convergence holes around default fixed ground bodies, sleeping state hashing, and stale pending/history inputs replaying after a matched snapshot.

## Validation
- `npm run test:physics` (64 passed)
- Unity batchmode compile for `/private/tmp/scenesync-unity-compile` with local Scene Sync packages
- `git diff --check`
- Review agent follow-up: blocking findingsなし