### PR TITLE
[codex] Stabilize SceneSync physics replay

### DIFF
--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -974,7 +974,7 @@ export function createScenePhysicsRuntime({
         latestSceneClockRevision == null ||
         payloadSceneClockRevision >= latestSceneClockRevision)
       && payloadLastEventRevision >= expectedLastEventRevision
-      && payloadTick >= localTickBeforeApply;
+      && (options.allowSnapshotRewind === true || payloadTick >= localTickBeforeApply);
 
     if (canApply) {
       const bodyStates = [];
@@ -1138,6 +1138,102 @@ export function createScenePhysicsRuntime({
     while (pendingBodyStateInputs.length > MAX_PENDING_BODY_STATE_INPUTS) {
       pendingBodyStateInputs.shift();
     }
+  }
+
+  function serializeBodyStateInput(input) {
+    return {
+      kind: 'scene-physics-input',
+      inputType: 'set-body-state',
+      inputId: input.inputId,
+      timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+      timelineId: input.timelineId,
+      timelineRevision: input.timelineRevision,
+      timelineClearRevision: input.timelineClearRevision,
+      eventRevision: input.eventRevision,
+      interactionId: input.interactionId,
+      sequence: input.sequence,
+      phase: input.phase,
+      controlMode: input.controlMode,
+      branchTick: input.branchTick,
+      objectId: input.objectId,
+      applyTick: input.applyTick,
+      position: input.position.slice(),
+      rotation: input.rotation.slice(),
+      velocity: input.velocity.slice(),
+      angularVelocity: input.angularVelocity.slice(),
+    };
+  }
+
+  function createInputLogReport(extra = {}) {
+    const inputs = bodyStateInputHistory.map(serializeBodyStateInput);
+    return {
+      kind: 'scene-physics-input-log',
+      source: 'physics',
+      phase: 'postPhysics',
+      timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision,
+      inputCount: inputs.length,
+      inputs,
+      ...extra,
+    };
+  }
+
+  function inputPayloadCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision) {
+    if (!input) return false;
+    const applyTick = nonNegativeInteger(input.applyTick, -1);
+    if (applyTick < 0 || applyTick > snapshotTick) return false;
+    if (nonNegativeInteger(input.eventRevision, 0) > snapshotLastEventRevision) return false;
+    if (normalizeTimelineId(input.timelineId) !== timelineId) return false;
+    if (nonNegativeInteger(input.timelineClearRevision, 0) !== timelineClearRevision) return false;
+    const inputTimelineRevision = nonNegativeInteger(input.timelineRevision, timelineRevision);
+    return inputTimelineRevision === timelineRevision || applyTick <= timelineForkTick;
+  }
+
+  function applyInputLogReport(payload = {}, options = {}) {
+    const payloadTimelineId = normalizeTimelineId(payload.timelineId);
+    const payloadTimelineClearRevision = nonNegativeInteger(payload.timelineClearRevision, timelineClearRevision);
+    const inputs = Array.isArray(payload.inputs) ? payload.inputs : [];
+    if (
+      payload?.kind !== 'scene-physics-input-log' ||
+      payloadTimelineId !== timelineId ||
+      payloadTimelineClearRevision !== timelineClearRevision
+    ) {
+      return {
+        kind: 'scene-physics-input-log',
+        accepted: false,
+        inputCount: inputs.length,
+        queuedCount: 0,
+      };
+    }
+
+    let queuedCount = 0;
+    let skippedCoveredCount = 0;
+    const snapshotTick = nonNegativeInteger(payload.snapshot?.tick, -1);
+    const snapshotLastEventRevision = nonNegativeInteger(payload.snapshot?.lastEventRevision, 0);
+    const skipCoveredInputs = options.skipInputsCoveredBySnapshot === true && snapshotTick >= 0;
+    for (const input of inputs) {
+      if (skipCoveredInputs && inputPayloadCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
+        skippedCoveredCount += 1;
+        continue;
+      }
+      if (queueInput(input)) queuedCount += 1;
+    }
+    return {
+      kind: 'scene-physics-input-log',
+      accepted: true,
+      inputCount: inputs.length,
+      queuedCount,
+      skippedCoveredCount,
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision,
+    };
   }
 
   function applyDueBodyStateInputs(currentTick = world?.tick || 0) {
@@ -1387,6 +1483,8 @@ export function createScenePhysicsRuntime({
     clearInputHistory,
     applySnapshotReport,
     compareHashReport,
+    createInputLogReport,
+    applyInputLogReport,
     rebuild,
     update,
     createSnapshotReport,

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -487,6 +487,159 @@ test('rewinds and replays when a scene physics input arrives late', () => {
   runtime.dispose();
 });
 
+test('exports and applies scene physics input logs for late join replay', () => {
+  const makeBall = () => makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [0, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = {
+    enabled: true,
+    worldOptions: {
+      gravity: [0, 0, 0],
+      ground: null,
+      timestep: 1 / 60,
+    },
+  };
+  const authorityObject = makeBall();
+  const followerObject = makeBall();
+  const authority = makeRuntime({ scenePhysics, entries: [makeEntry(authorityObject)] });
+  const follower = makeRuntime({ scenePhysics, entries: [makeEntry(followerObject)] });
+
+  authority.update({ t: 0, transportActive: true });
+  assert.equal(authority.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'late-join-drag-1',
+    objectId: 'ball',
+    applyTick: 1,
+    timelineId: 'default',
+    timelineRevision: 0,
+    timelineClearRevision: 0,
+    eventRevision: 1,
+    interactionId: 'late-join-drag',
+    sequence: 0,
+    phase: 'move',
+    position: [2, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  assert.equal(authority.queueInput({
+    kind: 'scene-physics-input',
+    inputType: 'set-body-state',
+    inputId: 'late-join-drag-2',
+    objectId: 'ball',
+    applyTick: 2,
+    timelineId: 'default',
+    timelineRevision: 0,
+    timelineClearRevision: 0,
+    eventRevision: 2,
+    interactionId: 'late-join-drag',
+    sequence: 1,
+    phase: 'move',
+    position: [3, 2, 0],
+    rotation: [0, 0, 0, 1],
+    velocity: [1, 0, 0],
+    angularVelocity: [0, 0, 0],
+  }), true);
+  authority.update({ t: 4 / 60, transportActive: true });
+
+  follower.update({ t: 0, transportActive: true });
+  const log = authority.createInputLogReport({ requestId: 'late-join-request' });
+  assert.equal(log.kind, 'scene-physics-input-log');
+  assert.equal(log.inputCount, 2);
+  assert.equal(log.lastEventRevision, 2);
+  assert.equal(log.inputs[0].inputId, 'late-join-drag-1');
+  assert.equal(log.inputs[1].inputId, 'late-join-drag-2');
+
+  const report = follower.applyInputLogReport(log);
+  assert.equal(report.accepted, true);
+  assert.equal(report.inputCount, 2);
+  assert.equal(report.queuedCount, 2);
+  follower.update({ t: 4 / 60, transportActive: true });
+
+  const authoritySnapshot = authority.createSnapshotReport({ t: 4 / 60, transportActive: true });
+  const followerSnapshot = follower.createSnapshotReport({ t: 4 / 60, transportActive: true });
+  assert.equal(followerSnapshot.hash, authoritySnapshot.hash);
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  const snapshotFollowerObject = makeBall();
+  const snapshotFollower = makeRuntime({ scenePhysics, entries: [makeEntry(snapshotFollowerObject)] });
+  snapshotFollower.update({ t: 0, transportActive: true });
+  snapshotFollower.update({ t: 6 / 60, transportActive: true });
+  const snapshotApplyReport = snapshotFollower.applySnapshotReport(
+    authoritySnapshot,
+    { t: 6 / 60, transportActive: true },
+    { allowSnapshotRewind: true },
+  );
+  assert.equal(snapshotApplyReport.matched, true);
+  const fullLogReport = snapshotFollower.applyInputLogReport(
+    { ...log, snapshot: authoritySnapshot },
+    { skipInputsCoveredBySnapshot: snapshotApplyReport.matched },
+  );
+  assert.equal(fullLogReport.accepted, true);
+  assert.equal(fullLogReport.queuedCount, 0);
+  assert.equal(fullLogReport.skippedCoveredCount, 2);
+
+  authority.dispose();
+  follower.dispose();
+  snapshotFollower.dispose();
+});
+
+test('applies input-log snapshot baseline even when local playback is ahead', () => {
+  const makeBall = () => makeObject({
+    objectId: 'ball',
+    position: [0, 2, 0],
+    physics: {
+      enabled: true,
+      bodyType: 'dynamic',
+      shape: 'sphere',
+      radius: 0.5,
+      velocity: [1, 0, 0],
+      angularVelocity: [0, 0, 0],
+    },
+  });
+  const scenePhysics = {
+    enabled: true,
+    worldOptions: {
+      gravity: [0, 0, 0],
+      ground: null,
+      timestep: 1 / 60,
+    },
+  };
+  const authorityObject = makeBall();
+  const followerObject = makeBall();
+  const authority = makeRuntime({ scenePhysics, entries: [makeEntry(authorityObject)] });
+  const follower = makeRuntime({ scenePhysics, entries: [makeEntry(followerObject)] });
+
+  authority.update({ t: 4 / 60, transportActive: true });
+  const snapshot = authority.createSnapshotReport({ t: 4 / 60, transportActive: true });
+  follower.update({ t: 0, transportActive: true });
+  follower.update({ t: 6 / 60, transportActive: true });
+
+  const rejected = follower.applySnapshotReport(snapshot, { t: 6 / 60, transportActive: true });
+  assert.equal(rejected.applied, false);
+  const accepted = follower.applySnapshotReport(
+    snapshot,
+    { t: 6 / 60, transportActive: true },
+    { allowSnapshotRewind: true },
+  );
+  assert.equal(accepted.matched, true);
+  assert.equal(follower.getTick(), snapshot.tick);
+  assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
+
+  authority.dispose();
+  follower.dispose();
+});
+
 test('replays recorded input history after a Back-to-Start zero baseline reset', () => {
   const object = makeObject({
     objectId: 'ball',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5651,12 +5651,13 @@ function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
   };
 }
 
-function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null) {
+function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null, options = {}) {
   const report = scenePhysicsRuntime.applySnapshotReport?.(
     payload,
     getSceneClockStateForLoomlet(performance.now()),
     {
       latestSceneClockRevision: sceneClockState.sharedRevision,
+      ...options,
     },
   );
   if (!report) return false;
@@ -5675,6 +5676,54 @@ function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null) {
     notifySceneSyncShellStateChanged('scene-physics-snapshot');
   }
   return report.matched === true;
+}
+
+function createScenePhysicsRequestId() {
+  return typeof globalThis.crypto?.randomUUID === 'function'
+    ? globalThis.crypto.randomUUID().replace(/-/g, '')
+    : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+}
+
+function createScenePhysicsInputLogPayload(clockState = null, extra = {}) {
+  const log = scenePhysicsRuntime.createInputLogReport?.();
+  if (!log || log.kind !== 'scene-physics-input-log') return null;
+  const revision = Number.isFinite(sceneClockState.sharedRevision)
+    ? sceneClockState.sharedRevision
+    : null;
+  const snapshot = createScenePhysicsSnapshotPayload(clockState, {
+    requestId: extra.requestId,
+    requestReason: extra.requestReason || extra.reason || 'input-log-request',
+  });
+  return {
+    ...log,
+    ...extra,
+    sceneClockRevision: revision,
+    controller: getSceneClockController(),
+    snapshot,
+    sentAt: Date.now(),
+  };
+}
+
+function applyScenePhysicsInputLogPayload(payload = {}, fromPeer = null) {
+  const snapshotMatched = payload.snapshot && typeof payload.snapshot === 'object'
+    ? applyScenePhysicsSnapshotPayload(payload.snapshot, fromPeer, { allowSnapshotRewind: true })
+    : false;
+  const report = scenePhysicsRuntime.applyInputLogReport?.(payload, {
+    skipInputsCoveredBySnapshot: snapshotMatched,
+  });
+  if (!report) return snapshotMatched;
+  console.debug('[scene-physics] input log received', {
+    fromId: fromPeer?.id || null,
+    accepted: report.accepted,
+    inputCount: report.inputCount,
+    queuedCount: report.queuedCount,
+    skippedCoveredCount: report.skippedCoveredCount,
+    timelineId: report.timelineId || payload.timelineId || null,
+    timelineRevision: report.timelineRevision ?? payload.timelineRevision ?? null,
+    timelineClearRevision: report.timelineClearRevision ?? payload.timelineClearRevision ?? null,
+    snapshotMatched,
+  });
+  return snapshotMatched || report.accepted === true;
 }
 
 function requestScenePhysicsSnapshotForHashMismatch(payload = {}, fromPeer = null, report = null) {
@@ -5707,9 +5756,7 @@ function requestScenePhysicsSnapshotForHashMismatch(payload = {}, fromPeer = nul
     timelineForkTick: payload.timelineForkTick,
     timelineClearRevision: payload.timelineClearRevision,
     lastEventRevision: payload.lastEventRevision,
-    requestId: typeof globalThis.crypto?.randomUUID === 'function'
-      ? globalThis.crypto.randomUUID().replace(/-/g, '')
-      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`,
+    requestId: createScenePhysicsRequestId(),
     reason: 'hash-mismatch',
     tick: report.tick,
     localTick: report.localTick,
@@ -6945,6 +6992,8 @@ function handleHandoff(data) {
     payload.kind === 'scene-remove' ||
     payload.kind === 'scene-physics' ||
     payload.kind === 'scene-physics-input-log-clear' ||
+    payload.kind === 'scene-physics-input-log-request' ||
+    payload.kind === 'scene-physics-input-log' ||
     payload.kind === 'scene-physics-input'
   ) {
     console.debug('[handoff] scene mutation received', {
@@ -7007,10 +7056,24 @@ function handleHandoff(data) {
       }
       notifySceneStateChanged('scene-state-handoff');
       publishSharedObjectClockBaselines('scene-state-baseline');
-      broadcast({
+      const timelineState = scenePhysicsRuntime.getTimelineState?.() || {};
+      const inputLogRequest = {
         kind: 'scene-physics-input-log-request',
-        timelineId: 'default',
-      });
+        timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+        timelineId: timelineState.timelineId || 'default',
+        timelineRevision: timelineState.timelineRevision,
+        timelineForkTick: timelineState.timelineForkTick,
+        timelineClearRevision: timelineState.timelineClearRevision,
+        lastEventRevision: timelineState.lastEventRevision,
+        requestId: createScenePhysicsRequestId(),
+        reason: 'scene-state-handoff',
+        sentAt: Date.now(),
+      };
+      if (data.from?.id) {
+        sendHandoff({ targetId: data.from.id, payload: inputLogRequest });
+      } else {
+        broadcast(inputLogRequest);
+      }
       break;
     }
     case 'scene-request': {
@@ -7275,6 +7338,36 @@ function handleHandoff(data) {
     case 'scene-physics-input': {
       scenePhysicsRuntime.queueInput(payload);
       notifySceneStateChanged('scene-physics-input');
+      break;
+    }
+    case 'scene-physics-input-log-request': {
+      if (isOwn) break;
+      const timelineState = scenePhysicsRuntime.getTimelineState?.() || {};
+      const requestedTimelineId = payload.timelineId || 'default';
+      if (timelineState.timelineId && requestedTimelineId !== timelineState.timelineId) break;
+      const inputLog = createScenePhysicsInputLogPayload(
+        getSceneClockStateForLoomlet(performance.now()),
+        {
+          requestId: payload.requestId,
+          requestTimelineId: requestedTimelineId,
+          requestTimelineRevision: payload.timelineRevision,
+          requestTimelineClearRevision: payload.timelineClearRevision,
+          requestReason: payload.reason || 'input-log-request',
+        },
+      );
+      if (!inputLog) break;
+      if (data.from?.id) {
+        sendHandoff({ targetId: data.from.id, payload: inputLog });
+      } else {
+        broadcast(inputLog);
+      }
+      break;
+    }
+    case 'scene-physics-input-log': {
+      if (isOwn) break;
+      if (applyScenePhysicsInputLogPayload(payload, data.from)) {
+        notifySceneStateChanged('scene-physics-input-log');
+      }
       break;
     }
     case 'scene-physics-input-log-clear': {

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -1158,7 +1158,7 @@ namespace Afjk.SceneSync.Rapier
                 }
 
                 dirty = true;
-                RequestPhysicsInputLog();
+                RequestPhysicsInputLog(message.FromPeerId);
                 return;
             }
 
@@ -1500,22 +1500,23 @@ namespace Afjk.SceneSync.Rapier
 
         private void ApplyScenePhysicsInputLog(string raw, string fromPeerId)
         {
-            var snapshotJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "snapshot");
+            var payloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "payload") ?? raw;
+            var snapshotJson = SceneSyncWireJson.ExtractTopLevelRawObject(payloadJson, "snapshot");
             var snapshotMatched = false;
             if (!string.IsNullOrWhiteSpace(snapshotJson))
                 snapshotMatched = ApplyScenePhysicsSnapshot(snapshotJson, fromPeerId, allowRewindSnapshot: true);
             var snapshotTick = ReadInt(snapshotJson, "tick", -1);
             var snapshotLastEventRevision = ReadLong(snapshotJson, "lastEventRevision", 0L);
 
-            var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
+            var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(payloadJson, "timelineId"));
             if (!string.Equals(inputTimelineId, timelineId, StringComparison.Ordinal))
                 return;
 
-            var inputTimelineClearRevision = ReadInt(raw, "timelineClearRevision", timelineClearRevision);
+            var inputTimelineClearRevision = ReadInt(payloadJson, "timelineClearRevision", timelineClearRevision);
             if (inputTimelineClearRevision != timelineClearRevision)
                 return;
 
-            foreach (var inputJson in ExtractObjectArrayEntries(raw, "inputs"))
+            foreach (var inputJson in ExtractObjectArrayEntries(payloadJson, "inputs"))
             {
                 if (snapshotMatched && InputJsonCoveredBySnapshot(inputJson, snapshotTick, snapshotLastEventRevision))
                     continue;
@@ -1724,7 +1725,7 @@ namespace Afjk.SceneSync.Rapier
             SceneSyncMessageBus.PublishOutgoing(payload, null, this);
         }
 
-        private void RequestPhysicsInputLog()
+        private void RequestPhysicsInputLog(string targetPeerId = null)
         {
             var requestId = Guid.NewGuid().ToString("N");
             var payload =
@@ -1738,17 +1739,18 @@ namespace Afjk.SceneSync.Rapier
                 ",\"requestId\":\"" + SceneSyncWireJson.JsonEscape(requestId) + "\"" +
                 ",\"reason\":\"scene-state-handoff\"" +
                 ",\"sentAt\":" + CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) + "}";
-            SceneSyncMessageBus.PublishOutgoing(payload, null, this);
+            SceneSyncMessageBus.PublishOutgoing(payload, targetPeerId, this);
         }
 
         private void PublishPhysicsInputLog(string requestRaw, string targetPeerId)
         {
-            var requestTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(requestRaw, "timelineId"));
+            var requestPayloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(requestRaw, "payload") ?? requestRaw;
+            var requestTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(requestPayloadJson, "timelineId"));
             if (!string.Equals(requestTimelineId, timelineId, StringComparison.Ordinal))
                 return;
 
-            var requestId = SceneSyncWireJson.ExtractString(requestRaw, "requestId");
-            SceneSyncMessageBus.PublishOutgoing(BuildPhysicsInputLogJson(requestId, requestRaw), targetPeerId, this);
+            var requestId = SceneSyncWireJson.ExtractString(requestPayloadJson, "requestId");
+            SceneSyncMessageBus.PublishOutgoing(BuildPhysicsInputLogJson(requestId, requestPayloadJson), targetPeerId, this);
         }
 
         private string BuildPhysicsInputLogJson(string requestId, string requestRaw)

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using AFJK.Rapier;
 using Afjk.SceneSync;
 using UnityEngine;
@@ -874,6 +875,26 @@ namespace Afjk.SceneSync.Rapier
             return input.TimelineRevision == timelineRevision || input.ApplyTick <= timelineForkTick;
         }
 
+        private bool InputJsonCoveredBySnapshot(string raw, int snapshotTick, long snapshotLastEventRevision)
+        {
+            if (string.IsNullOrWhiteSpace(raw) || snapshotTick < 0)
+                return false;
+            var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
+            if (!string.Equals(inputTimelineId, timelineId, StringComparison.Ordinal))
+                return false;
+            var inputTimelineClearRevision = ReadInt(raw, "timelineClearRevision", 0);
+            if (inputTimelineClearRevision != timelineClearRevision)
+                return false;
+            var applyTick = ReadInt(raw, "applyTick", -1);
+            if (applyTick < 0 || applyTick > snapshotTick)
+                return false;
+            var eventRevision = ReadLong(raw, "eventRevision", 0L);
+            if (eventRevision > snapshotLastEventRevision)
+                return false;
+            var inputTimelineRevision = ReadInt(raw, "timelineRevision", timelineRevision);
+            return inputTimelineRevision == timelineRevision || applyTick <= timelineForkTick;
+        }
+
         private void MarkInputsCoveredBySnapshot(int snapshotTick, long snapshotLastEventRevision)
         {
             for (var i = bodyStateInputHistory.Count - 1; i >= 0; i--)
@@ -1159,6 +1180,18 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
+            if (raw.Contains("\"kind\":\"scene-physics-input-log-request\""))
+            {
+                PublishPhysicsInputLog(raw, message.FromPeerId);
+                return;
+            }
+
+            if (raw.Contains("\"kind\":\"scene-physics-input-log\""))
+            {
+                ApplyScenePhysicsInputLog(raw, message.FromPeerId);
+                return;
+            }
+
             if (raw.Contains("\"kind\":\"scene-physics-input\""))
             {
                 ApplyScenePhysicsInput(raw);
@@ -1195,7 +1228,7 @@ namespace Afjk.SceneSync.Rapier
                 dirty = true;
         }
 
-        private void ApplyScenePhysicsSnapshot(string raw, string fromPeerId)
+        private bool ApplyScenePhysicsSnapshot(string raw, string fromPeerId, bool allowRewindSnapshot = false)
         {
             var payloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "payload") ?? raw;
             ScenePhysicsSnapshotPayload payload = null;
@@ -1240,7 +1273,7 @@ namespace Afjk.SceneSync.Rapier
                     latestSceneClockRevision == int.MinValue ||
                     payloadSceneClockRevision >= latestSceneClockRevision)
                 && payloadLastEventRevision >= expectedLastEventRevision
-                && payload.tick >= localTickBeforeApply;
+                && (allowRewindSnapshot || payload.tick >= localTickBeforeApply);
 
             var bodyStates = new List<SnapshotBodyState>();
             if (canApply)
@@ -1329,6 +1362,7 @@ namespace Afjk.SceneSync.Rapier
                 hashMatched);
             hasRemoteSnapshotReport = true;
             SnapshotReceived?.Invoke(lastRemoteSnapshotReport);
+            return hashMatched;
         }
 
         private void ApplyScenePhysicsHash(string raw, string fromPeerId)
@@ -1462,6 +1496,31 @@ namespace Afjk.SceneSync.Rapier
                 WireToUnityVector(wireLinearVelocity),
                 WireToUnityVector(wireAngularVelocity),
                 controlMode));
+        }
+
+        private void ApplyScenePhysicsInputLog(string raw, string fromPeerId)
+        {
+            var snapshotJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "snapshot");
+            var snapshotMatched = false;
+            if (!string.IsNullOrWhiteSpace(snapshotJson))
+                snapshotMatched = ApplyScenePhysicsSnapshot(snapshotJson, fromPeerId, allowRewindSnapshot: true);
+            var snapshotTick = ReadInt(snapshotJson, "tick", -1);
+            var snapshotLastEventRevision = ReadLong(snapshotJson, "lastEventRevision", 0L);
+
+            var inputTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(raw, "timelineId"));
+            if (!string.Equals(inputTimelineId, timelineId, StringComparison.Ordinal))
+                return;
+
+            var inputTimelineClearRevision = ReadInt(raw, "timelineClearRevision", timelineClearRevision);
+            if (inputTimelineClearRevision != timelineClearRevision)
+                return;
+
+            foreach (var inputJson in ExtractObjectArrayEntries(raw, "inputs"))
+            {
+                if (snapshotMatched && InputJsonCoveredBySnapshot(inputJson, snapshotTick, snapshotLastEventRevision))
+                    continue;
+                ApplyScenePhysicsInput(inputJson);
+            }
         }
 
         private void ApplyScenePhysicsInputLogClear(string raw)
@@ -1667,12 +1726,149 @@ namespace Afjk.SceneSync.Rapier
 
         private void RequestPhysicsInputLog()
         {
+            var requestId = Guid.NewGuid().ToString("N");
             var payload =
                 "{\"kind\":\"scene-physics-input-log-request\"" +
                 ",\"timelineVersion\":\"" + TimelineVersion + "\"" +
                 ",\"timelineId\":\"" + SceneSyncWireJson.JsonEscape(timelineId) + "\"" +
+                ",\"timelineRevision\":" + timelineRevision.ToString(CultureInfo.InvariantCulture) +
+                ",\"timelineForkTick\":" + timelineForkTick.ToString(CultureInfo.InvariantCulture) +
+                ",\"timelineClearRevision\":" + timelineClearRevision.ToString(CultureInfo.InvariantCulture) +
+                ",\"lastEventRevision\":" + lastPhysicsEventRevision.ToString(CultureInfo.InvariantCulture) +
+                ",\"requestId\":\"" + SceneSyncWireJson.JsonEscape(requestId) + "\"" +
+                ",\"reason\":\"scene-state-handoff\"" +
                 ",\"sentAt\":" + CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) + "}";
             SceneSyncMessageBus.PublishOutgoing(payload, null, this);
+        }
+
+        private void PublishPhysicsInputLog(string requestRaw, string targetPeerId)
+        {
+            var requestTimelineId = NormalizeTimelineId(SceneSyncWireJson.ExtractString(requestRaw, "timelineId"));
+            if (!string.Equals(requestTimelineId, timelineId, StringComparison.Ordinal))
+                return;
+
+            var requestId = SceneSyncWireJson.ExtractString(requestRaw, "requestId");
+            SceneSyncMessageBus.PublishOutgoing(BuildPhysicsInputLogJson(requestId, requestRaw), targetPeerId, this);
+        }
+
+        private string BuildPhysicsInputLogJson(string requestId, string requestRaw)
+        {
+            var builder = new StringBuilder();
+            builder.Append("{\"kind\":\"scene-physics-input-log\"");
+            builder.Append(",\"source\":\"physics\"");
+            builder.Append(",\"phase\":\"postPhysics\"");
+            builder.Append(",\"timelineVersion\":\"").Append(TimelineVersion).Append("\"");
+            builder.Append(",\"timelineId\":\"").Append(SceneSyncWireJson.JsonEscape(timelineId)).Append("\"");
+            builder.Append(",\"timelineRevision\":").Append(timelineRevision.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"timelineForkTick\":").Append(timelineForkTick.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"timelineClearRevision\":").Append(timelineClearRevision.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"lastEventRevision\":").Append(lastPhysicsEventRevision.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrWhiteSpace(requestId))
+                builder.Append(",\"requestId\":\"").Append(SceneSyncWireJson.JsonEscape(requestId)).Append("\"");
+            builder.Append(",\"requestTimelineId\":\"")
+                .Append(SceneSyncWireJson.JsonEscape(NormalizeTimelineId(SceneSyncWireJson.ExtractString(requestRaw, "timelineId"))))
+                .Append("\"");
+            if (SceneSyncWireJson.HasTopLevelField(requestRaw, "timelineRevision"))
+                builder.Append(",\"requestTimelineRevision\":")
+                    .Append(ReadInt(requestRaw, "timelineRevision", 0).ToString(CultureInfo.InvariantCulture));
+            if (SceneSyncWireJson.HasTopLevelField(requestRaw, "timelineClearRevision"))
+                builder.Append(",\"requestTimelineClearRevision\":")
+                    .Append(ReadInt(requestRaw, "timelineClearRevision", 0).ToString(CultureInfo.InvariantCulture));
+            var requestReason = SceneSyncWireJson.ExtractString(requestRaw, "reason");
+            if (!string.IsNullOrWhiteSpace(requestReason))
+                builder.Append(",\"requestReason\":\"").Append(SceneSyncWireJson.JsonEscape(requestReason.Trim())).Append("\"");
+            var snapshot = BuildPhysicsSnapshotJson(requestId, "input-log-request");
+            if (!string.IsNullOrWhiteSpace(snapshot))
+                builder.Append(",\"snapshot\":").Append(snapshot);
+            builder.Append(",\"inputCount\":").Append(bodyStateInputHistory.Count.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"inputs\":[");
+            for (var i = 0; i < bodyStateInputHistory.Count; i++)
+            {
+                if (i > 0) builder.Append(",");
+                var input = bodyStateInputHistory[i];
+                builder.Append(BuildBodyStateInputJson(
+                    input.InputId,
+                    input.ObjectId,
+                    input.ApplyTick,
+                    input.TimelineId,
+                    input.TimelineRevision,
+                    input.TimelineClearRevision,
+                    input.EventRevision,
+                    input.InteractionId,
+                    input.Sequence,
+                    input.Phase,
+                    input.BranchTick,
+                    input.Position,
+                    input.Rotation,
+                    input.LinearVelocity,
+                    input.AngularVelocity,
+                    input.ControlMode));
+            }
+            builder.Append("]");
+            builder.Append(",\"sentAt\":").Append(CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
+            builder.Append("}");
+            return builder.ToString();
+        }
+
+        private string BuildPhysicsSnapshotJson(string requestId = null, string requestReason = null)
+        {
+            if (world == null || !world.IsCreated)
+                return null;
+
+            var hash = ComputeStateHashHex();
+            if (string.IsNullOrWhiteSpace(hash))
+                return null;
+
+            var activeTime = sceneClock.Active ? sceneClock.GetTime() : GetCurrentPhysicsTime();
+            var worldAge = Mathf.Max(0f, activeTime - worldEpochTime);
+            var builder = new StringBuilder();
+            builder.Append("{\"kind\":\"scene-physics-snapshot\"");
+            builder.Append(",\"source\":\"physics\"");
+            builder.Append(",\"phase\":\"postPhysics\"");
+            builder.Append(",\"snapshotVersion\":\"").Append(SnapshotVersion).Append("\"");
+            builder.Append(",\"timelineVersion\":\"").Append(TimelineVersion).Append("\"");
+            builder.Append(",\"timelineId\":\"").Append(SceneSyncWireJson.JsonEscape(timelineId)).Append("\"");
+            builder.Append(",\"timelineRevision\":").Append(timelineRevision.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"timelineForkTick\":").Append(timelineForkTick.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"timelineClearRevision\":").Append(timelineClearRevision.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"lastEventRevision\":").Append(lastPhysicsEventRevision.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"profile\":\"").Append(PhysicsProfile).Append("\"");
+            builder.Append(",\"hashVersion\":\"").Append(CanonicalStateHashVersion).Append("\"");
+            builder.Append(",\"rapierCoreVersion\":\"").Append(RapierCoreVersion).Append("\"");
+            builder.Append(",\"tick\":").Append(tick.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"hash\":\"").Append(SceneSyncWireJson.JsonEscape(hash)).Append("\"");
+            builder.Append(",\"timestep\":").Append(scenePhysics.Timestep.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"activeTime\":").Append(activeTime.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"worldAge\":").Append(worldAge.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",\"worldEpochTime\":").Append(worldEpochTime.ToString(CultureInfo.InvariantCulture));
+            if (latestSceneClockRevision != int.MinValue)
+                builder.Append(",\"sceneClockRevision\":").Append(latestSceneClockRevision.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrWhiteSpace(requestId))
+                builder.Append(",\"requestId\":\"").Append(SceneSyncWireJson.JsonEscape(requestId)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(requestReason))
+                builder.Append(",\"requestReason\":\"").Append(SceneSyncWireJson.JsonEscape(requestReason.Trim())).Append("\"");
+            builder.Append(",\"bodies\":[");
+            var bodyIndex = 0;
+            foreach (var pair in bindings.OrderBy(item => item.Key, StringComparer.Ordinal))
+            {
+                var binding = pair.Value;
+                if (binding.IsStatic || !world.TryGetRigidBodyState(binding.Body, out var state))
+                    continue;
+                if (bodyIndex > 0)
+                    builder.Append(",");
+                bodyIndex++;
+                builder.Append("{\"id\":\"").Append(SceneSyncWireJson.JsonEscape(pair.Key)).Append("\"");
+                builder.Append(",\"type\":\"dynamic\"");
+                builder.Append(",\"position\":").Append(FormatVector3Json(state.Transform.Position));
+                builder.Append(",\"rotation\":").Append(FormatQuaternionJson(state.Transform.Rotation));
+                builder.Append(",\"velocity\":").Append(FormatVector3Json(state.LinearVelocity));
+                builder.Append(",\"angularVelocity\":").Append(FormatVector3Json(state.AngularVelocity));
+                builder.Append("}");
+            }
+            builder.Append("]");
+            builder.Append(",\"sentAt\":").Append(CurrentUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
+            builder.Append("}");
+            return builder.ToString();
         }
 
         private void ApplySceneClock(string raw)
@@ -2221,6 +2417,86 @@ namespace Afjk.SceneSync.Rapier
         {
             var value = SceneSyncWireJson.ExtractBoolean(json, field);
             return value ?? fallback;
+        }
+
+        private static List<string> ExtractObjectArrayEntries(string json, string fieldName)
+        {
+            var result = new List<string>();
+            var arrayJson = SceneSyncWireJson.ExtractTopLevelRawValue(json, fieldName);
+            if (string.IsNullOrWhiteSpace(arrayJson))
+                arrayJson = SceneSyncWireJson.ExtractRawValue(json, fieldName);
+            if (string.IsNullOrWhiteSpace(arrayJson))
+                return result;
+
+            arrayJson = arrayJson.Trim();
+            if (arrayJson.Length < 2 || arrayJson[0] != '[')
+                return result;
+
+            var index = 1;
+            while (index < arrayJson.Length - 1)
+            {
+                SkipJsonWhitespaceAndCommas(arrayJson, ref index);
+                if (index >= arrayJson.Length - 1 || arrayJson[index] == ']')
+                    break;
+                if (arrayJson[index] != '{')
+                {
+                    index++;
+                    continue;
+                }
+
+                var end = FindMatchingJson(arrayJson, index, '{', '}');
+                if (end < 0)
+                    break;
+                result.Add(arrayJson.Substring(index, end - index + 1));
+                index = end + 1;
+            }
+
+            return result;
+        }
+
+        private static void SkipJsonWhitespaceAndCommas(string json, ref int index)
+        {
+            while (index < json.Length && (char.IsWhiteSpace(json[index]) || json[index] == ','))
+                index++;
+        }
+
+        private static int FindMatchingJson(string json, int start, char open, char close)
+        {
+            var depth = 0;
+            var inString = false;
+            var escape = false;
+            for (var i = start; i < json.Length; i++)
+            {
+                var ch = json[i];
+                if (escape)
+                {
+                    escape = false;
+                    continue;
+                }
+                if (inString)
+                {
+                    if (ch == '\\')
+                        escape = true;
+                    else if (ch == '"')
+                        inString = false;
+                    continue;
+                }
+                if (ch == '"')
+                {
+                    inString = true;
+                    continue;
+                }
+                if (ch == open)
+                    depth++;
+                else if (ch == close)
+                {
+                    depth--;
+                    if (depth == 0)
+                        return i;
+                }
+            }
+
+            return -1;
         }
 
         private static string NormalizeHash(string value)

--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -75,10 +75,12 @@ namespace Afjk.SceneSync.Rapier
 
         private RapierWorld world;
         private RapierSnapshot initialSnapshot;
+        private AuthoritativeSnapshotBaseline authoritativeSnapshotBaseline;
         private ScenePhysicsDefinition scenePhysics = ScenePhysicsDefinition.Disabled;
         private SceneClockState sceneClock = SceneClockState.Inactive;
         private bool dirty = true;
         private bool hasInitialSnapshot;
+        private bool hasAuthoritativeSnapshotBaseline;
         private bool hasPendingWorldEpochTime;
         private bool lastStepLimited;
         private bool preserveMotionOnNextRebuild = true;
@@ -295,6 +297,9 @@ namespace Afjk.SceneSync.Rapier
             lastCollisionEvents.Clear();
             if (targetTick < tick)
                 RewindBodyStateInputsToInitialSnapshot();
+            var restoredBaseline = false;
+            if (ShouldRestoreAuthoritativeSnapshotBaseline(targetTick))
+                restoredBaseline = RestoreAuthoritativeSnapshotBaseline();
 
             var appliedInputs = ApplyDueBodyStateInputs();
             var maxSteps = Mathf.Max(1, maxClockStepsPerUpdate);
@@ -312,11 +317,11 @@ namespace Afjk.SceneSync.Rapier
             // reflects the hold position rather than the post-step physics drift.
             var heldBodies = ApplyActiveBodyStateHolds();
 
-            if (steps > 0 || targetTick == 0 || appliedInputs || heldBodies)
+            if (steps > 0 || targetTick == 0 || appliedInputs || heldBodies || restoredBaseline)
             {
                 ApplyWorldTransforms();
                 FlushCollisionEvents(clockTime);
-                if (steps > 0 || appliedInputs || heldBodies || string.IsNullOrWhiteSpace(lastStateHash))
+                if (steps > 0 || appliedInputs || heldBodies || restoredBaseline || string.IsNullOrWhiteSpace(lastStateHash))
                     UpdateLastStateHash("targetTick=" + targetTick.ToString(CultureInfo.InvariantCulture));
             }
         }
@@ -814,6 +819,7 @@ namespace Afjk.SceneSync.Rapier
 
             timelineRevision = nextTimelineRevision;
             timelineForkTick = nextForkTick;
+            hasAuthoritativeSnapshotBaseline = false;
             bodyStateInputHistory.RemoveAll(ShouldDropForCurrentTimelineBranch);
             pendingBodyStateInputs.RemoveAll(ShouldDropForCurrentTimelineBranch);
             appliedBodyStateInputIds.Clear();
@@ -857,6 +863,105 @@ namespace Afjk.SceneSync.Rapier
             return lastRevision;
         }
 
+        private bool InputCoveredBySnapshot(BodyStateInput input, int snapshotTick, long snapshotLastEventRevision)
+        {
+            if (input.TimelineClearRevision != timelineClearRevision)
+                return false;
+            if (input.ApplyTick > snapshotTick)
+                return false;
+            if (input.EventRevision > snapshotLastEventRevision)
+                return false;
+            return input.TimelineRevision == timelineRevision || input.ApplyTick <= timelineForkTick;
+        }
+
+        private void MarkInputsCoveredBySnapshot(int snapshotTick, long snapshotLastEventRevision)
+        {
+            for (var i = bodyStateInputHistory.Count - 1; i >= 0; i--)
+            {
+                var input = bodyStateInputHistory[i];
+                if (!InputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision))
+                    continue;
+                appliedBodyStateInputIds.Add(input.InputId);
+                bodyStateInputHistory.RemoveAt(i);
+            }
+
+            for (var i = pendingBodyStateInputs.Count - 1; i >= 0; i--)
+            {
+                var input = pendingBodyStateInputs[i];
+                if (!InputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision))
+                    continue;
+                appliedBodyStateInputIds.Add(input.InputId);
+                pendingBodyStateInputs.RemoveAt(i);
+            }
+
+            foreach (var key in activeBodyStateHolds.Keys.ToList())
+            {
+                if (InputCoveredBySnapshot(activeBodyStateHolds[key], snapshotTick, snapshotLastEventRevision))
+                    activeBodyStateHolds.Remove(key);
+            }
+
+            lastPhysicsEventRevision = Math.Max(lastPhysicsEventRevision, snapshotLastEventRevision);
+            localPhysicsEventRevisionCounter = Math.Max(localPhysicsEventRevisionCounter, lastPhysicsEventRevision);
+        }
+
+        private void SetAuthoritativeSnapshotBaseline(int snapshotTick, long snapshotLastEventRevision)
+        {
+            if (world == null || !world.TryCreateSnapshot(out var snapshot))
+                return;
+
+            authoritativeSnapshotBaseline = new AuthoritativeSnapshotBaseline(
+                snapshotTick,
+                timelineId,
+                timelineRevision,
+                timelineForkTick,
+                timelineClearRevision,
+                snapshotLastEventRevision,
+                worldEpochTime,
+                snapshot);
+            hasAuthoritativeSnapshotBaseline = true;
+        }
+
+        private bool ShouldRestoreAuthoritativeSnapshotBaseline(int targetTick)
+        {
+            return hasAuthoritativeSnapshotBaseline &&
+                tick < authoritativeSnapshotBaseline.Tick &&
+                targetTick >= authoritativeSnapshotBaseline.Tick;
+        }
+
+        private bool RestoreAuthoritativeSnapshotBaseline()
+        {
+            if (!hasAuthoritativeSnapshotBaseline ||
+                world == null ||
+                !world.TryReadSnapshot(authoritativeSnapshotBaseline.Snapshot))
+            {
+                return false;
+            }
+
+            tick = authoritativeSnapshotBaseline.Tick;
+            timelineId = authoritativeSnapshotBaseline.TimelineId;
+            timelineRevision = authoritativeSnapshotBaseline.TimelineRevision;
+            timelineForkTick = authoritativeSnapshotBaseline.TimelineForkTick;
+            timelineClearRevision = authoritativeSnapshotBaseline.TimelineClearRevision;
+            lastPhysicsEventRevision = Math.Max(lastPhysicsEventRevision, authoritativeSnapshotBaseline.LastEventRevision);
+            localPhysicsEventRevisionCounter = Math.Max(localPhysicsEventRevisionCounter, lastPhysicsEventRevision);
+            worldEpochTime = authoritativeSnapshotBaseline.WorldEpochTime;
+            hasPendingWorldEpochTime = false;
+            pendingWorldEpochTime = 0f;
+            accumulator = 0f;
+            lastStepLimited = false;
+            currentCollisionPairs.Clear();
+            previousCollisionPairs.Clear();
+            lastCollisionEvents.Clear();
+            appliedBodyStateInputIds.Clear();
+            activeBodyStateHolds.Clear();
+            pendingBodyStateInputs.Clear();
+            foreach (var input in bodyStateInputHistory)
+                AddPendingBodyStateInput(input);
+            lastStateHash = null;
+            ResetStateHashBroadcastCache();
+            return true;
+        }
+
         public void RebuildWorld()
         {
             RefreshMetadataFromScene();
@@ -875,6 +980,7 @@ namespace Afjk.SceneSync.Rapier
             ResetStateHashBroadcastCache();
             lastStepLimited = false;
             hasInitialSnapshot = false;
+            hasAuthoritativeSnapshotBaseline = false;
             initialSnapshot = default;
             bindings.Clear();
             colliderObjectIds.Clear();
@@ -1195,6 +1301,11 @@ namespace Afjk.SceneSync.Rapier
                 && !string.IsNullOrWhiteSpace(remoteHash)
                 && !string.IsNullOrWhiteSpace(localHash)
                 && string.Equals(remoteHash, localHash, StringComparison.Ordinal);
+            if (hashMatched)
+            {
+                MarkInputsCoveredBySnapshot(payload.tick, payloadLastEventRevision);
+                SetAuthoritativeSnapshotBaseline(payload.tick, payloadLastEventRevision);
+            }
             lastRemoteSnapshotReport = new SceneSyncRapierSnapshotReport(
                 payload?.snapshotVersion,
                 remoteHash,
@@ -1470,6 +1581,7 @@ namespace Afjk.SceneSync.Rapier
             currentCollisionPairs.Clear();
             previousCollisionPairs.Clear();
             lastCollisionEvents.Clear();
+            hasAuthoritativeSnapshotBaseline = false;
             accumulator = 0f;
             tick = 0;
             lastStepLimited = false;
@@ -1598,6 +1710,7 @@ namespace Afjk.SceneSync.Rapier
 
             pendingWorldEpochTime = Mathf.Max(0f, (float)worldEpoch);
             hasPendingWorldEpochTime = true;
+            hasAuthoritativeSnapshotBaseline = false;
             accumulator = 0f;
             lastStepLimited = false;
 
@@ -1966,6 +2079,7 @@ namespace Afjk.SceneSync.Rapier
             world = null;
             initialSnapshot = default;
             hasInitialSnapshot = false;
+            hasAuthoritativeSnapshotBaseline = false;
         }
 
         private static Vector3 UnityToWirePosition(Vector3 value)
@@ -2255,6 +2369,38 @@ namespace Afjk.SceneSync.Rapier
             public Quaternion Rotation { get; }
             public Vector3 LinearVelocity { get; }
             public Vector3 AngularVelocity { get; }
+        }
+
+        private readonly struct AuthoritativeSnapshotBaseline
+        {
+            public AuthoritativeSnapshotBaseline(
+                int tick,
+                string timelineId,
+                int timelineRevision,
+                int timelineForkTick,
+                int timelineClearRevision,
+                long lastEventRevision,
+                float worldEpochTime,
+                RapierSnapshot snapshot)
+            {
+                Tick = Mathf.Max(0, tick);
+                TimelineId = NormalizeTimelineId(timelineId);
+                TimelineRevision = Mathf.Max(0, timelineRevision);
+                TimelineForkTick = Mathf.Max(0, timelineForkTick);
+                TimelineClearRevision = Mathf.Max(0, timelineClearRevision);
+                LastEventRevision = Math.Max(0L, lastEventRevision);
+                WorldEpochTime = Mathf.Max(0f, worldEpochTime);
+                Snapshot = snapshot;
+            }
+
+            public int Tick { get; }
+            public string TimelineId { get; }
+            public int TimelineRevision { get; }
+            public int TimelineForkTick { get; }
+            public int TimelineClearRevision { get; }
+            public long LastEventRevision { get; }
+            public float WorldEpochTime { get; }
+            public RapierSnapshot Snapshot { get; }
         }
 
         private readonly struct BodyStateInput


### PR DESCRIPTION
## Summary
- Port Web-side authoritative snapshot replay handling into the Unity Rapier bridge.
- Add SceneSync physics input-log request/response handling for late joiners on Web and Unity.
- Send a current physics snapshot baseline with input logs, skip inputs already covered by that accepted snapshot, and target Unity late-join requests back to the scene-state sender.

## Why
Continuous playback could converge when seeking slowly, but diverge during normal playback or for late joiners because covered/older body-state inputs were not handled consistently. Also, late joiners were already requesting `scene-physics-input-log`, but no peer actually responded with the log, so interaction history could be incomplete.

This update lets a joining peer receive a current authoritative baseline plus the remaining input history needed after that baseline, avoiding both missing-history replay and reapplying stale covered inputs.

## Review
- Review agent initial pass found Unity input-log handoff envelope and broadcast request issues.
- Fixed in `b66ad0e`; re-review reported no blocking findings.
- Residual gap: no Unity-side automated test harness currently covers the handoff-envelope input-log path.

## Validation
- `git diff --check`
- `node --check html/assets/js/scenesync/scene.js`
- `node --check html/assets/js/scenesync/scene-physics.js`
- `npm run test:physics` (66 passed)
- Unity batchmode compile for `/private/tmp/scenesync-unity-compile` (exit 0, no C# errors/warnings in log)