### PR TITLE
[codex] Add SceneSync event timeline

### DIFF
--- a/html/assets/js/scenesync/runtime/event-timeline.js
+++ b/html/assets/js/scenesync/runtime/event-timeline.js
@@ -1,0 +1,339 @@
+export const SCENE_SYNC_EVENT_TIMELINE_VERSION = 1;
+export const DEFAULT_SCENE_EVENT_TIMELINE_ID = 'default';
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeString(value, fallback = '') {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizeOptionalString(value) {
+  const normalized = normalizeString(value, '');
+  return normalized || null;
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(0, Math.floor(number));
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function compareStrings(left, right) {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+const CANONICAL_EVENT_FIELDS = new Set([
+  'kind',
+  'timelineVersion',
+  'timelineId',
+  'timelineRevision',
+  'timelineClearRevision',
+  'branchTick',
+  'eventId',
+  'inputId',
+  'eventRevision',
+  'interactionId',
+  'sequence',
+  'applyTick',
+  'channel',
+  'type',
+  'target',
+  'source',
+  'timestamp',
+  'time',
+  'payload',
+  'sourcePeerId',
+  'sourceUserId',
+  'phase',
+  'sentAt',
+]);
+
+export function normalizeSceneEventTimelineId(value) {
+  return normalizeString(value, DEFAULT_SCENE_EVENT_TIMELINE_ID);
+}
+
+export function compareSceneEvents(left, right) {
+  return nonNegativeInteger(left?.applyTick) - nonNegativeInteger(right?.applyTick)
+    || nonNegativeInteger(left?.timelineRevision) - nonNegativeInteger(right?.timelineRevision)
+    || nonNegativeInteger(left?.eventRevision) - nonNegativeInteger(right?.eventRevision)
+    || compareStrings(left?.interactionId, right?.interactionId)
+    || nonNegativeInteger(left?.sequence) - nonNegativeInteger(right?.sequence)
+    || compareStrings(left?.channel, right?.channel)
+    || compareStrings(left?.eventId, right?.eventId);
+}
+
+export function normalizeSceneEventEnvelope(payload = {}, defaults = {}) {
+  if (!isObject(payload)) return null;
+
+  const channel = normalizeString(payload.channel ?? payload.type, '');
+  if (!channel) return null;
+
+  const target = normalizeOptionalString(payload.target ?? payload.objectId);
+  const applyTick = nonNegativeInteger(payload.applyTick, nonNegativeInteger(defaults.applyTick, 0));
+  const sequence = nonNegativeInteger(payload.sequence, nonNegativeInteger(defaults.sequence, 0));
+  const eventRevision = nonNegativeInteger(
+    payload.eventRevision,
+    nonNegativeInteger(defaults.eventRevision, 0),
+  );
+  const interactionId = normalizeOptionalString(payload.interactionId ?? defaults.interactionId);
+  const eventId = normalizeString(
+    payload.eventId ?? payload.inputId,
+    interactionId
+      ? `${interactionId}:${String(sequence).padStart(6, '0')}`
+      : `${channel}:${target || 'scene'}:${applyTick}:${eventRevision}:${sequence}`,
+  );
+  if (!eventId) return null;
+
+  const timestamp = Number.isFinite(Number(payload.timestamp))
+    ? Number(payload.timestamp)
+    : finiteNumber(payload.time, finiteNumber(defaults.timestamp, 0));
+
+  const envelope = {
+    kind: normalizeString(payload.kind, 'scene-event'),
+    timelineVersion: nonNegativeInteger(
+      payload.timelineVersion,
+      nonNegativeInteger(defaults.timelineVersion, SCENE_SYNC_EVENT_TIMELINE_VERSION),
+    ),
+    timelineId: normalizeSceneEventTimelineId(payload.timelineId ?? defaults.timelineId),
+    timelineRevision: nonNegativeInteger(payload.timelineRevision, defaults.timelineRevision ?? 0),
+    timelineClearRevision: nonNegativeInteger(
+      payload.timelineClearRevision,
+      defaults.timelineClearRevision ?? 0,
+    ),
+    eventId,
+    eventRevision,
+    interactionId,
+    sequence,
+    applyTick,
+    channel,
+    source: normalizeString(payload.source, normalizeString(defaults.source, 'interaction')),
+    timestamp,
+    payload: cloneJson(payload.payload || {}),
+  };
+
+  if (target) envelope.target = target;
+  for (const key of ['sourcePeerId', 'sourceUserId', 'phase']) {
+    const value = normalizeOptionalString(payload[key] ?? defaults[key]);
+    if (value) envelope[key] = value;
+  }
+  if (payload.sentAt !== undefined) envelope.sentAt = payload.sentAt;
+  for (const [key, value] of Object.entries(payload)) {
+    if (CANONICAL_EVENT_FIELDS.has(key) || value === undefined) continue;
+    envelope[key] = cloneJson(value);
+  }
+  return envelope;
+}
+
+export function sceneEventToRuntimeEvent(event) {
+  const normalized = normalizeSceneEventEnvelope(event);
+  if (!normalized) return null;
+  const runtimeEvent = {
+    ...cloneJson(normalized),
+    type: normalized.channel,
+    channel: normalized.channel,
+    timestamp: normalized.timestamp,
+    time: normalized.timestamp,
+    ...(normalized.target ? { target: normalized.target } : {}),
+  };
+  delete runtimeEvent.kind;
+  delete runtimeEvent.timelineVersion;
+  if (normalized.target && runtimeEvent.objectId === undefined) {
+    runtimeEvent.objectId = normalized.target;
+  }
+  return runtimeEvent;
+}
+
+export function createSceneEventTimeline(options = {}) {
+  const maxHistory = nonNegativeInteger(options.maxHistory, 1000);
+  const maxPending = nonNegativeInteger(options.maxPending, 1000);
+  let timelineId = normalizeSceneEventTimelineId(options.timelineId);
+  let timelineRevision = nonNegativeInteger(options.timelineRevision, 0);
+  let timelineForkTick = nonNegativeInteger(options.timelineForkTick, 0);
+  let timelineClearRevision = nonNegativeInteger(options.timelineClearRevision, 0);
+  let lastEventRevision = nonNegativeInteger(options.lastEventRevision, 0);
+  let pendingEvents = [];
+  let eventHistory = [];
+  const appliedEventIds = new Set();
+
+  function defaults() {
+    return {
+      timelineVersion: SCENE_SYNC_EVENT_TIMELINE_VERSION,
+      timelineId,
+      timelineRevision,
+      timelineClearRevision,
+      eventRevision: lastEventRevision,
+    };
+  }
+
+  function getTimelineState() {
+    return {
+      timelineVersion: SCENE_SYNC_EVENT_TIMELINE_VERSION,
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision,
+    };
+  }
+
+  function replaceById(list, event) {
+    const index = list.findIndex(item => item.eventId === event.eventId);
+    if (index < 0) return false;
+    list[index] = event;
+    list.sort(compareSceneEvents);
+    return true;
+  }
+
+  function addHistory(event) {
+    replaceById(eventHistory, event) || eventHistory.push(event);
+    eventHistory.sort(compareSceneEvents);
+    while (eventHistory.length > maxHistory) {
+      const dropped = eventHistory.shift();
+      if (dropped?.eventId) appliedEventIds.delete(dropped.eventId);
+    }
+  }
+
+  function addPending(event) {
+    replaceById(pendingEvents, event) || pendingEvents.push(event);
+    pendingEvents.sort(compareSceneEvents);
+    while (pendingEvents.length > maxPending) {
+      pendingEvents.shift();
+    }
+  }
+
+  function resetAppliedFromHistory() {
+    appliedEventIds.clear();
+    pendingEvents = [];
+    for (const event of eventHistory) {
+      addPending(event);
+    }
+  }
+
+  function advanceTimelineRevision(nextRevision, branchTick) {
+    if (!Number.isInteger(nextRevision) || nextRevision <= timelineRevision) {
+      return false;
+    }
+    const forkTick = nonNegativeInteger(branchTick, 0);
+    const dropsAppliedEvent = eventHistory.some(event => (
+      event.timelineRevision !== nextRevision &&
+      event.applyTick > forkTick &&
+      appliedEventIds.has(event.eventId)
+    ));
+    timelineRevision = nextRevision;
+    timelineForkTick = forkTick;
+
+    const keepEvent = event => event.timelineRevision === timelineRevision || event.applyTick <= timelineForkTick;
+    eventHistory = eventHistory.filter(keepEvent);
+    pendingEvents = pendingEvents.filter(keepEvent);
+    appliedEventIds.clear();
+    lastEventRevision = eventHistory.reduce(
+      (max, event) => Math.max(max, event.eventRevision || 0),
+      0,
+    );
+    return dropsAppliedEvent;
+  }
+
+  function queueEvent(payload = {}, optionsForQueue = {}) {
+    const event = normalizeSceneEventEnvelope(payload, defaults());
+    if (!event) return { ok: false, reason: 'invalid-event' };
+    if (event.timelineId !== timelineId) return { ok: false, reason: 'timeline-mismatch' };
+    if (
+      event.timelineClearRevision !== timelineClearRevision ||
+      (event.timelineRevision < timelineRevision && event.applyTick > timelineForkTick)
+    ) {
+      return { ok: false, reason: 'stale-event' };
+    }
+
+    let replayRequired = false;
+    if (event.timelineRevision > timelineRevision) {
+      replayRequired = advanceTimelineRevision(event.timelineRevision, payload.branchTick ?? event.applyTick);
+    }
+
+    const alreadyApplied = appliedEventIds.has(event.eventId);
+    const currentTick = Number.isFinite(optionsForQueue.currentTick)
+      ? nonNegativeInteger(optionsForQueue.currentTick, 0)
+      : null;
+    addHistory(event);
+    lastEventRevision = Math.max(lastEventRevision, event.eventRevision || 0);
+
+    if (alreadyApplied || (currentTick !== null && event.applyTick <= currentTick)) {
+      replayRequired = true;
+    }
+    addPending(event);
+    return { ok: true, event, replayRequired };
+  }
+
+  function consumeDueEvents(currentTick = 0) {
+    const tick = nonNegativeInteger(currentTick, 0);
+    const due = [];
+    for (let index = 0; index < pendingEvents.length;) {
+      const event = pendingEvents[index];
+      if (event.applyTick > tick) break;
+      due.push(event);
+      appliedEventIds.add(event.eventId);
+      pendingEvents.splice(index, 1);
+    }
+    return due;
+  }
+
+  function clearEventHistory(payload = {}, optionsForClear = {}) {
+    const payloadTimelineId = normalizeSceneEventTimelineId(payload.timelineId);
+    if (payloadTimelineId !== timelineId) return false;
+
+    const hasCanonicalRevision = payload.timelineRevision !== undefined && payload.timelineRevision !== null;
+    const nextClearRevision = nonNegativeInteger(
+      payload.timelineClearRevision,
+      hasCanonicalRevision ? timelineClearRevision + 1 : timelineClearRevision + 1,
+    );
+    if (nextClearRevision <= timelineClearRevision) return false;
+    if (
+      hasCanonicalRevision &&
+      optionsForClear.allowRevisionRegression !== true &&
+      nonNegativeInteger(payload.timelineRevision, timelineRevision) < timelineRevision
+    ) {
+      return false;
+    }
+
+    timelineRevision = hasCanonicalRevision
+      ? nonNegativeInteger(payload.timelineRevision, timelineRevision)
+      : timelineRevision + 1;
+    timelineForkTick = nonNegativeInteger(payload.timelineForkTick, 0);
+    timelineClearRevision = nextClearRevision;
+    lastEventRevision = 0;
+    pendingEvents = [];
+    eventHistory = [];
+    appliedEventIds.clear();
+    return true;
+  }
+
+  function getPendingEvents() {
+    return pendingEvents.map(cloneJson);
+  }
+
+  function getEventHistory() {
+    return eventHistory.map(cloneJson);
+  }
+
+  return {
+    queueEvent,
+    consumeDueEvents,
+    clearEventHistory,
+    resetAppliedFromHistory,
+    getTimelineState,
+    getPendingEvents,
+    getEventHistory,
+  };
+}

--- a/html/assets/js/scenesync/runtime/event-timeline.test.js
+++ b/html/assets/js/scenesync/runtime/event-timeline.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compareSceneEvents,
+  createSceneEventTimeline,
+  normalizeSceneEventEnvelope,
+  sceneEventToRuntimeEvent,
+} from './event-timeline.js';
+
+test('normalizeSceneEventEnvelope creates a canonical scene event', () => {
+  const event = normalizeSceneEventEnvelope({
+    channel: 'pointer.click',
+    target: 'box-1',
+    interactionId: 'click-1',
+    sequence: 2,
+    eventRevision: 5,
+    applyTick: 10,
+    timestamp: 1.25,
+    payload: { button: 0 },
+  });
+  assert.equal(event.kind, 'scene-event');
+  assert.equal(event.timelineId, 'default');
+  assert.equal(event.channel, 'pointer.click');
+  assert.equal(event.target, 'box-1');
+  assert.equal(event.eventId, 'click-1:000002');
+  assert.equal(event.eventRevision, 5);
+  assert.equal(event.applyTick, 10);
+  assert.deepEqual(event.payload, { button: 0 });
+});
+
+test('normalizeSceneEventEnvelope rejects missing channel', () => {
+  assert.equal(normalizeSceneEventEnvelope({ target: 'box-1' }), null);
+});
+
+test('compareSceneEvents sorts by tick, revision, event revision, interaction, sequence, channel, id', () => {
+  const events = [
+    { applyTick: 2, timelineRevision: 0, eventRevision: 1, interactionId: 'b', sequence: 0, channel: 'b', eventId: '2' },
+    { applyTick: 1, timelineRevision: 0, eventRevision: 2, interactionId: 'a', sequence: 1, channel: 'a', eventId: '1' },
+    { applyTick: 1, timelineRevision: 0, eventRevision: 1, interactionId: 'a', sequence: 2, channel: 'a', eventId: '3' },
+  ];
+  const sorted = [...events].sort(compareSceneEvents);
+  assert.equal(sorted[0].eventId, '3');
+  assert.equal(sorted[1].eventId, '1');
+  assert.equal(sorted[2].eventId, '2');
+});
+
+test('timeline queues and consumes due events in canonical order', () => {
+  const timeline = createSceneEventTimeline();
+  assert.equal(timeline.queueEvent({ channel: 'b', eventId: 'b', applyTick: 2 }).ok, true);
+  assert.equal(timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 }).ok, true);
+  assert.deepEqual(timeline.consumeDueEvents(0), []);
+  assert.deepEqual(timeline.consumeDueEvents(1).map(event => event.eventId), ['a']);
+  assert.deepEqual(timeline.consumeDueEvents(2).map(event => event.eventId), ['b']);
+});
+
+test('timeline updates duplicate event ids instead of appending', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'pointer.drag.move', eventId: 'drag:1', applyTick: 2, payload: { x: 1 } });
+  timeline.queueEvent({ channel: 'pointer.drag.move', eventId: 'drag:1', applyTick: 2, payload: { x: 2 } });
+  const due = timeline.consumeDueEvents(2);
+  assert.equal(due.length, 1);
+  assert.deepEqual(due[0].payload, { x: 2 });
+  assert.equal(timeline.getEventHistory().length, 1);
+});
+
+test('timeline reports replay when an already consumed event id is updated', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'pointer.click', eventId: 'click:1', applyTick: 1, payload: { value: 1 } });
+  timeline.consumeDueEvents(1);
+  const result = timeline.queueEvent(
+    { channel: 'pointer.click', eventId: 'click:1', applyTick: 1, payload: { value: 2 } },
+    { currentTick: 3 },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.replayRequired, true);
+});
+
+test('timeline advances revision and rejects old future events', () => {
+  const timeline = createSceneEventTimeline();
+  assert.equal(timeline.queueEvent({ channel: 'future.old', eventId: 'old', applyTick: 20 }).ok, true);
+  const branch = timeline.queueEvent({
+    channel: 'branch',
+    eventId: 'branch',
+    timelineRevision: 1,
+    branchTick: 10,
+    eventRevision: 1,
+    applyTick: 10,
+  });
+  assert.equal(branch.ok, true);
+  assert.equal(timeline.getTimelineState().timelineRevision, 1);
+  assert.equal(timeline.getTimelineState().timelineForkTick, 10);
+  assert.equal(timeline.queueEvent({
+    channel: 'stale.future',
+    eventId: 'stale',
+    timelineRevision: 0,
+    applyTick: 21,
+  }).ok, false);
+});
+
+test('timeline clear drops history and rejects duplicate clears', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'pointer.click', eventId: 'click', applyTick: 1 });
+  assert.equal(timeline.clearEventHistory({
+    timelineId: 'default',
+    timelineRevision: 2,
+    timelineClearRevision: 1,
+  }), true);
+  assert.deepEqual(timeline.getPendingEvents(), []);
+  assert.deepEqual(timeline.getEventHistory(), []);
+  assert.equal(timeline.getTimelineState().timelineRevision, 2);
+  assert.equal(timeline.getTimelineState().timelineClearRevision, 1);
+  assert.equal(timeline.clearEventHistory({
+    timelineId: 'default',
+    timelineRevision: 2,
+    timelineClearRevision: 1,
+  }), false);
+});
+
+test('sceneEventToRuntimeEvent produces Loomlet-compatible env event fields', () => {
+  const runtimeEvent = sceneEventToRuntimeEvent({
+    channel: 'pointer.click',
+    eventId: 'click',
+    eventRevision: 4,
+    applyTick: 8,
+    target: 'box-1',
+    sourcePeerId: 'peer-1',
+    timestamp: 2,
+    payload: { button: 0 },
+  });
+  assert.equal(runtimeEvent.type, 'pointer.click');
+  assert.equal(runtimeEvent.channel, 'pointer.click');
+  assert.equal(runtimeEvent.target, 'box-1');
+  assert.equal(runtimeEvent.objectId, 'box-1');
+  assert.equal(runtimeEvent.timestamp, 2);
+  assert.equal(runtimeEvent.eventRevision, 4);
+  assert.deepEqual(runtimeEvent.payload, { button: 0 });
+});
+
+test('sceneEventToRuntimeEvent preserves collision and schedule fields', () => {
+  const runtimeEvent = sceneEventToRuntimeEvent({
+    channel: 'physics.collision.enter',
+    eventId: 'collision:1',
+    objectIdA: 'box-1',
+    objectIdB: 'sphere-2',
+    pairKey: 'box-1|sphere-2',
+    tick: 75,
+    frameId: 120,
+    timestamp: 1.25,
+  });
+  assert.equal(runtimeEvent.objectIdA, 'box-1');
+  assert.equal(runtimeEvent.objectIdB, 'sphere-2');
+  assert.equal(runtimeEvent.pairKey, 'box-1|sphere-2');
+  assert.equal(runtimeEvent.tick, 75);
+  assert.equal(runtimeEvent.frameId, 120);
+});
+
+test('timeline clear rejects revision regression by default', () => {
+  const timeline = createSceneEventTimeline({ timelineRevision: 3 });
+  assert.equal(timeline.clearEventHistory({
+    timelineId: 'default',
+    timelineRevision: 1,
+    timelineClearRevision: 1,
+  }), false);
+  assert.equal(timeline.getTimelineState().timelineRevision, 3);
+  assert.equal(timeline.getTimelineState().timelineClearRevision, 0);
+});
+
+test('timeline clear can explicitly allow canonical revision regression', () => {
+  const timeline = createSceneEventTimeline({ timelineRevision: 3 });
+  assert.equal(timeline.clearEventHistory({
+    timelineId: 'default',
+    timelineRevision: 1,
+    timelineClearRevision: 1,
+  }, { allowRevisionRegression: true }), true);
+  assert.equal(timeline.getTimelineState().timelineRevision, 1);
+  assert.equal(timeline.getTimelineState().timelineClearRevision, 1);
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
     "test:physics": "node --test html/assets/js/scenesync/physics/rapier-world.test.js html/assets/js/scenesync/physics/rapier-parity-fixture.test.js html/assets/js/scenesync/scene-physics.test.js html/assets/js/scenesync/history/history-manager.test.js html/assets/js/scenesync/shells/player/player-physics-drag-input.test.js",
     "test:loomlet-plugin": "node --test html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
-    "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js",
+    "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js html/assets/js/scenesync/runtime/event-timeline.test.js",
     "test:plugins": "node --test html/assets/js/scenesync/plugins/scene-sync-physics-plugin.test.js html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
     "test:export-behavior-runtime": "node --test html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js",
     "test:scene-sync-export-behaviors": "node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js",


### PR DESCRIPTION
## Summary
- add a generic SceneSync event envelope and timeline utility
- cover canonical ordering, duplicate replacement, revision clears, and runtime-event conversion
- include the new event timeline tests in the runtime schedule test script

## Validation
- npm run test:runtime-schedule
- reviewer sub-agent approved the diff after fixes