### PR TITLE
[codex] Route scene physics inputs through event timeline

### DIFF
--- a/html/assets/js/scenesync/runtime/event-timeline.js
+++ b/html/assets/js/scenesync/runtime/event-timeline.js
@@ -257,6 +257,10 @@ export function createSceneEventTimeline(options = {}) {
       return { ok: false, reason: 'stale-event' };
     }
 
+    const existingEvent = eventHistory.find(item => item.eventId === event.eventId)
+      || pendingEvents.find(item => item.eventId === event.eventId)
+      || null;
+    const changed = !existingEvent || JSON.stringify(existingEvent) !== JSON.stringify(event);
     let replayRequired = false;
     if (event.timelineRevision > timelineRevision) {
       replayRequired = advanceTimelineRevision(event.timelineRevision, payload.branchTick ?? event.applyTick);
@@ -266,14 +270,32 @@ export function createSceneEventTimeline(options = {}) {
     const currentTick = Number.isFinite(optionsForQueue.currentTick)
       ? nonNegativeInteger(optionsForQueue.currentTick, 0)
       : null;
+    if (alreadyApplied && !changed) {
+      lastEventRevision = Math.max(lastEventRevision, event.eventRevision || 0);
+      return { ok: true, event, replayRequired: false, unchanged: true };
+    }
     addHistory(event);
     lastEventRevision = Math.max(lastEventRevision, event.eventRevision || 0);
 
-    if (alreadyApplied || (currentTick !== null && event.applyTick <= currentTick)) {
+    const replayRelevantChange = typeof optionsForQueue.isReplayRelevantChange === 'function'
+      ? optionsForQueue.isReplayRelevantChange(existingEvent, event, {
+        alreadyApplied,
+        changed,
+        currentTick,
+      }) === true
+      : changed;
+    if (
+      changed &&
+      replayRelevantChange &&
+      (alreadyApplied || (currentTick !== null && event.applyTick < currentTick))
+    ) {
       replayRequired = true;
     }
+    if (alreadyApplied && !replayRequired && !replayRelevantChange) {
+      return { ok: true, event, replayRequired: false, replayRelevantChange };
+    }
     addPending(event);
-    return { ok: true, event, replayRequired };
+    return { ok: true, event, replayRequired, replayRelevantChange };
   }
 
   function consumeDueEvents(currentTick = 0) {
@@ -289,27 +311,102 @@ export function createSceneEventTimeline(options = {}) {
     return due;
   }
 
-  function clearEventHistory(payload = {}, optionsForClear = {}) {
-    const payloadTimelineId = normalizeSceneEventTimelineId(payload.timelineId);
-    if (payloadTimelineId !== timelineId) return false;
-
-    const hasCanonicalRevision = payload.timelineRevision !== undefined && payload.timelineRevision !== null;
-    const nextClearRevision = nonNegativeInteger(
-      payload.timelineClearRevision,
-      hasCanonicalRevision ? timelineClearRevision + 1 : timelineClearRevision + 1,
-    );
-    if (nextClearRevision <= timelineClearRevision) return false;
-    if (
-      hasCanonicalRevision &&
-      optionsForClear.allowRevisionRegression !== true &&
-      nonNegativeInteger(payload.timelineRevision, timelineRevision) < timelineRevision
-    ) {
-      return false;
+  function processDueEvents(currentTick = 0, handler = () => true) {
+    const tick = nonNegativeInteger(currentTick, 0);
+    let applied = false;
+    let replayRequired = false;
+    for (let index = 0; index < pendingEvents.length;) {
+      const event = pendingEvents[index];
+      if (event.applyTick > tick) break;
+      const decision = handler(event);
+      if (decision?.replayRequired === true) {
+        replayRequired = true;
+        break;
+      }
+      const shouldApply = decision === true || decision?.applied === true;
+      if (shouldApply) {
+        appliedEventIds.add(event.eventId);
+        pendingEvents.splice(index, 1);
+        applied = true;
+        continue;
+      }
+      index += 1;
     }
+    return { applied, replayRequired };
+  }
 
-    timelineRevision = hasCanonicalRevision
-      ? nonNegativeInteger(payload.timelineRevision, timelineRevision)
-      : timelineRevision + 1;
+  function removeEvents(predicate = () => false, optionsForRemove = {}) {
+    const removedById = new Map();
+    const shouldRemove = (event) => {
+      const remove = predicate(event) === true;
+      if (remove) {
+        if (!removedById.has(event.eventId)) {
+          removedById.set(event.eventId, event);
+        }
+        if (optionsForRemove.markApplied === true) {
+          appliedEventIds.add(event.eventId);
+        } else {
+          appliedEventIds.delete(event.eventId);
+        }
+      }
+      return remove;
+    };
+    eventHistory = eventHistory.filter(event => !shouldRemove(event));
+    pendingEvents = pendingEvents.filter(event => !shouldRemove(event));
+    return Array.from(removedById.values()).map(cloneJson);
+  }
+
+  function setTimelineState(nextState = {}, optionsForState = {}) {
+    const nextTimelineId = normalizeSceneEventTimelineId(nextState.timelineId ?? timelineId);
+    timelineId = nextTimelineId;
+    timelineRevision = nonNegativeInteger(nextState.timelineRevision, timelineRevision);
+    timelineForkTick = nonNegativeInteger(nextState.timelineForkTick, timelineForkTick);
+    timelineClearRevision = nonNegativeInteger(nextState.timelineClearRevision, timelineClearRevision);
+    lastEventRevision = nonNegativeInteger(nextState.lastEventRevision, lastEventRevision);
+    if (optionsForState.resetApplied !== false) {
+      appliedEventIds.clear();
+    }
+    if (optionsForState.requeueHistory === true) {
+      pendingEvents = [];
+      for (const event of eventHistory) addPending(event);
+    }
+  }
+
+  function reset(nextState = {}) {
+    timelineId = normalizeSceneEventTimelineId(nextState.timelineId);
+    timelineRevision = nonNegativeInteger(nextState.timelineRevision, 0);
+    timelineForkTick = nonNegativeInteger(nextState.timelineForkTick, 0);
+    timelineClearRevision = nonNegativeInteger(nextState.timelineClearRevision, 0);
+    lastEventRevision = nonNegativeInteger(nextState.lastEventRevision, 0);
+    pendingEvents = [];
+    eventHistory = [];
+    appliedEventIds.clear();
+  }
+
+    function clearEventHistory(payload = {}, optionsForClear = {}) {
+      const payloadTimelineId = normalizeSceneEventTimelineId(payload.timelineId);
+      if (payloadTimelineId !== timelineId) return false;
+
+      const hasCanonicalRevision = payload.timelineRevision !== undefined && payload.timelineRevision !== null;
+      const canonicalRevision = hasCanonicalRevision
+        ? nonNegativeInteger(payload.timelineRevision, timelineRevision)
+        : null;
+      const nextClearRevision = nonNegativeInteger(
+        payload.timelineClearRevision,
+        canonicalRevision ?? timelineClearRevision + 1,
+      );
+      if (nextClearRevision <= timelineClearRevision) return false;
+      if (
+        hasCanonicalRevision &&
+        optionsForClear.allowRevisionRegression !== true &&
+        canonicalRevision < timelineRevision
+      ) {
+        return false;
+      }
+
+      timelineRevision = hasCanonicalRevision
+        ? canonicalRevision
+        : timelineRevision + 1;
     timelineForkTick = nonNegativeInteger(payload.timelineForkTick, 0);
     timelineClearRevision = nextClearRevision;
     lastEventRevision = 0;
@@ -330,8 +427,12 @@ export function createSceneEventTimeline(options = {}) {
   return {
     queueEvent,
     consumeDueEvents,
+    processDueEvents,
+    removeEvents,
     clearEventHistory,
     resetAppliedFromHistory,
+    setTimelineState,
+    reset,
     getTimelineState,
     getPendingEvents,
     getEventHistory,

--- a/html/assets/js/scenesync/runtime/event-timeline.test.js
+++ b/html/assets/js/scenesync/runtime/event-timeline.test.js
@@ -75,6 +75,45 @@ test('timeline reports replay when an already consumed event id is updated', () 
   assert.equal(result.replayRequired, true);
 });
 
+test('timeline does not request replay for unchanged applied event echoes', () => {
+  const timeline = createSceneEventTimeline();
+  const event = { channel: 'pointer.click', eventId: 'click:1', applyTick: 1, payload: { value: 1 } };
+  timeline.queueEvent(event);
+  timeline.consumeDueEvents(1);
+  const result = timeline.queueEvent(event, { currentTick: 3 });
+  assert.equal(result.ok, true);
+  assert.equal(result.replayRequired, false);
+});
+
+test('timeline can update applied metadata without requeueing replay-irrelevant changes', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({
+    channel: 'physics.body.setState',
+    eventId: 'drag:1',
+    eventRevision: 0,
+    applyTick: 1,
+    payload: { x: 1 },
+  });
+  timeline.consumeDueEvents(1);
+  const result = timeline.queueEvent({
+    channel: 'physics.body.setState',
+    eventId: 'drag:1',
+    eventRevision: 7,
+    applyTick: 1,
+    payload: { x: 1 },
+  }, {
+    currentTick: 3,
+    isReplayRelevantChange: (previousEvent, nextEvent) => (
+      previousEvent?.payload?.x !== nextEvent.payload.x
+    ),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.replayRequired, false);
+  assert.deepEqual(timeline.getPendingEvents(), []);
+  assert.equal(timeline.getTimelineState().lastEventRevision, 7);
+  assert.equal(timeline.getEventHistory()[0].eventRevision, 7);
+});
+
 test('timeline advances revision and rejects old future events', () => {
   const timeline = createSceneEventTimeline();
   assert.equal(timeline.queueEvent({ channel: 'future.old', eventId: 'old', applyTick: 20 }).ok, true);
@@ -114,6 +153,17 @@ test('timeline clear drops history and rejects duplicate clears', () => {
     timelineRevision: 2,
     timelineClearRevision: 1,
   }), false);
+});
+
+test('timeline clear defaults clear revision to canonical revision for compatibility', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'pointer.click', eventId: 'click', applyTick: 1 });
+  assert.equal(timeline.clearEventHistory({
+    timelineId: 'default',
+    timelineRevision: 3,
+  }), true);
+  assert.equal(timeline.getTimelineState().timelineRevision, 3);
+  assert.equal(timeline.getTimelineState().timelineClearRevision, 3);
 });
 
 test('sceneEventToRuntimeEvent produces Loomlet-compatible env event fields', () => {
@@ -174,4 +224,66 @@ test('timeline clear can explicitly allow canonical revision regression', () => 
   }, { allowRevisionRegression: true }), true);
   assert.equal(timeline.getTimelineState().timelineRevision, 1);
   assert.equal(timeline.getTimelineState().timelineClearRevision, 1);
+});
+
+test('processDueEvents removes only applied events and keeps failed events pending', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 });
+  timeline.queueEvent({ channel: 'b', eventId: 'b', applyTick: 1 });
+  const processed = timeline.processDueEvents(1, event => event.eventId === 'a');
+  assert.equal(processed.applied, true);
+  assert.equal(processed.replayRequired, false);
+  assert.deepEqual(timeline.getPendingEvents().map(event => event.eventId), ['b']);
+});
+
+test('processDueEvents can stop for replay without consuming the event', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 });
+  const processed = timeline.processDueEvents(2, () => ({ replayRequired: true }));
+  assert.equal(processed.applied, false);
+  assert.equal(processed.replayRequired, true);
+  assert.deepEqual(timeline.getPendingEvents().map(event => event.eventId), ['a']);
+});
+
+test('removeEvents drops matching events from history and pending', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 });
+  timeline.queueEvent({ channel: 'b', eventId: 'b', applyTick: 2 });
+  const removed = timeline.removeEvents(event => event.eventId === 'a', { markApplied: true });
+  assert.deepEqual(removed.map(event => event.eventId), ['a']);
+  assert.deepEqual(timeline.getEventHistory().map(event => event.eventId), ['b']);
+  assert.deepEqual(timeline.getPendingEvents().map(event => event.eventId), ['b']);
+});
+
+test('setTimelineState updates revision metadata and can requeue history', () => {
+  const timeline = createSceneEventTimeline();
+  timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 });
+  timeline.consumeDueEvents(1);
+  timeline.setTimelineState({
+    timelineRevision: 2,
+    timelineForkTick: 1,
+    timelineClearRevision: 1,
+    lastEventRevision: 7,
+  }, { requeueHistory: true });
+  assert.equal(timeline.getTimelineState().timelineRevision, 2);
+  assert.equal(timeline.getTimelineState().timelineForkTick, 1);
+  assert.equal(timeline.getTimelineState().timelineClearRevision, 1);
+  assert.equal(timeline.getTimelineState().lastEventRevision, 7);
+  assert.deepEqual(timeline.getPendingEvents().map(event => event.eventId), ['a']);
+});
+
+test('reset clears events and resets timeline metadata', () => {
+  const timeline = createSceneEventTimeline({ timelineRevision: 5 });
+  timeline.queueEvent({ channel: 'a', eventId: 'a', applyTick: 1 });
+  timeline.reset({ timelineId: 'next' });
+  assert.deepEqual(timeline.getPendingEvents(), []);
+  assert.deepEqual(timeline.getEventHistory(), []);
+  assert.deepEqual(timeline.getTimelineState(), {
+    timelineVersion: 1,
+    timelineId: 'next',
+    timelineRevision: 0,
+    timelineForkTick: 0,
+    timelineClearRevision: 0,
+    lastEventRevision: 0,
+  });
 });

--- a/html/assets/js/scenesync/scene-physics.js
+++ b/html/assets/js/scenesync/scene-physics.js
@@ -9,6 +9,7 @@ import {
   RAPIER_CORE_VERSION,
 } from './physics/index.js';
 import { createCollisionPairKey } from './runtime/runtime-events.js';
+import { createSceneEventTimeline } from './runtime/event-timeline.js';
 
 export const DEFAULT_SCENE_PHYSICS_DURATION = 10;
 export const SCENE_SYNC_RAPIER_PROFILE = 'SceneSyncRapierParity-0.30';
@@ -467,6 +468,59 @@ export function createScenePhysicsRuntime({
   let timelineForkTick = 0;
   let timelineClearRevision = 0;
   let lastEventRevision = 0;
+  const bodyStateEventTimeline = createSceneEventTimeline({
+    timelineId: DEFAULT_SCENE_PHYSICS_TIMELINE_ID,
+    maxHistory: MAX_BODY_STATE_INPUT_HISTORY,
+    maxPending: MAX_PENDING_BODY_STATE_INPUTS,
+  });
+
+  function syncBodyStateTimelineState() {
+    const state = bodyStateEventTimeline.getTimelineState();
+    timelineId = state.timelineId;
+    timelineRevision = state.timelineRevision;
+    timelineForkTick = state.timelineForkTick;
+    timelineClearRevision = state.timelineClearRevision;
+    lastEventRevision = state.lastEventRevision;
+  }
+
+  function bodyStateEventFromInput(input) {
+    return {
+      ...input,
+      kind: 'scene-event',
+      channel: 'physics.body.setState',
+      eventId: input.inputId,
+      target: input.objectId,
+      source: 'physics',
+      timestamp: input.applyTick * Math.max(0.000001, timestepSeconds),
+    };
+  }
+
+  function bodyStateInputFromEvent(event) {
+    return {
+      inputId: event.inputId || event.eventId,
+      objectId: event.objectId || event.target,
+      applyTick: nonNegativeInteger(event.applyTick, 0),
+      timelineId: normalizeTimelineId(event.timelineId),
+      timelineRevision: nonNegativeInteger(event.timelineRevision, 0),
+      timelineClearRevision: nonNegativeInteger(event.timelineClearRevision, 0),
+      eventRevision: nonNegativeInteger(event.eventRevision, 0),
+      interactionId: normalizeOptionalString(event.interactionId),
+      sequence: nonNegativeInteger(event.sequence, 0),
+      phase: normalizeOptionalString(event.phase),
+      controlMode: normalizeOptionalString(event.controlMode),
+      branchTick: nonNegativeInteger(event.branchTick, event.applyTick),
+      position: readVec3(event.position, [0, 0, 0]),
+      rotation: readQuaternion(event.rotation, [0, 0, 0, 1]),
+      velocity: readVec3(event.velocity || event.linearVelocity, [0, 0, 0]),
+      angularVelocity: readVec3(event.angularVelocity || event.angvel, [0, 0, 0]),
+    };
+  }
+
+  function syncBodyStateInputListsFromTimeline() {
+    bodyStateInputHistory = bodyStateEventTimeline.getEventHistory().map(bodyStateInputFromEvent);
+    pendingBodyStateInputs = bodyStateEventTimeline.getPendingEvents().map(bodyStateInputFromEvent);
+    syncBodyStateTimelineState();
+  }
 
   function clear({ preserveInputs = false } = {}) {
     world?.free?.();
@@ -491,6 +545,7 @@ export function createScenePhysicsRuntime({
       timelineForkTick = 0;
       timelineClearRevision = 0;
       lastEventRevision = 0;
+      bodyStateEventTimeline.reset({ timelineId });
     }
   }
 
@@ -675,20 +730,9 @@ export function createScenePhysicsRuntime({
       ? Math.max(0, Math.floor(applyTickNumber))
       : (world?.tick || 0);
     const payloadTimelineId = normalizeTimelineId(payload.timelineId);
-    if (payloadTimelineId !== timelineId) return false;
-
     const payloadTimelineRevision = nonNegativeInteger(payload.timelineRevision, timelineRevision);
     const branchTick = nonNegativeInteger(payload.branchTick, applyTick);
     const payloadTimelineClearRevision = nonNegativeInteger(payload.timelineClearRevision, 0);
-    if (
-      payloadTimelineClearRevision !== timelineClearRevision ||
-      (payloadTimelineRevision < timelineRevision && applyTick > timelineForkTick)
-    ) {
-      return false;
-    }
-    if (payloadTimelineRevision > timelineRevision) {
-      advanceTimelineRevision(payloadTimelineRevision, branchTick);
-    }
 
     const interactionId = normalizeOptionalString(payload.interactionId);
     const sequence = nonNegativeInteger(payload.sequence, 0);
@@ -720,34 +764,45 @@ export function createScenePhysicsRuntime({
       rotation: readQuaternion(payload.rotation, [0, 0, 0, 1]),
       velocity: readVec3(payload.velocity || payload.linearVelocity, [0, 0, 0]),
       angularVelocity: readVec3(payload.angularVelocity || payload.angvel, [0, 0, 0]),
-    };
+      };
 
-    if (updateExistingBodyStateInput(input)) {
+      const previousTimelineRevision = timelineRevision;
+      const result = bodyStateEventTimeline.queueEvent(bodyStateEventFromInput(input), {
+        currentTick: world?.tick,
+        isReplayRelevantChange: (previousEvent, nextEvent) => {
+          const previousInput = previousEvent ? bodyStateInputFromEvent(previousEvent) : null;
+          const nextInput = bodyStateInputFromEvent(nextEvent);
+          const physicalStateChanged = !previousInput ||
+            !bodyStateInputPhysicalStateEquals(previousInput, nextInput);
+          const orderChangedWithPeer = Boolean(
+            previousInput &&
+            compareBodyStateInputs(previousInput, nextInput) !== 0 &&
+            hasSameTickInputPeer(nextInput),
+          );
+          return physicalStateChanged || orderChangedWithPeer;
+        },
+      });
+      if (!result.ok) return false;
+
+      syncBodyStateInputListsFromTimeline();
+    if (timelineRevision > previousTimelineRevision) {
+      authoritativeSnapshotBaseline = null;
+      activeBodyStateHolds = new Map();
+      appliedBodyStateInputIds.clear();
+    }
+
+    if (result.replayRequired && world && rewindBodyStateInputsToInitialSnapshot()) {
       return true;
     }
-
-    lastEventRevision = Math.max(lastEventRevision, input.eventRevision);
-    addBodyStateInputHistory(input);
-    if (world && input.applyTick <= world.tick) {
-      if (input.applyTick < world.tick && hasDynamicBody(input.objectId) && rewindBodyStateInputsToInitialSnapshot()) {
-        return true;
+      if (world && input.applyTick === world.tick && result.replayRelevantChange === true) {
+        applyDueBodyStateInputs(world.tick);
       }
-      if (input.applyTick === world.tick && applyBodyStateInput(input)) {
-        return true;
-      }
-    }
-
-    addPendingBodyStateInput(input);
     return true;
   }
 
-  function bodyStateInputEquals(left, right) {
-    return JSON.stringify(left) === JSON.stringify(right);
-  }
-
-  function numberArrayEquals(left, right) {
-    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
-    return left.every((value, index) => value === right[index]);
+    function numberArrayEquals(left, right) {
+      if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+      return left.every((value, index) => value === right[index]);
   }
 
   function bodyStateInputPhysicalStateEquals(left, right) {
@@ -766,53 +821,7 @@ export function createScenePhysicsRuntime({
       || pendingBodyStateInputs.some(item => item.inputId !== input.inputId && item.applyTick === input.applyTick);
   }
 
-  function replaceBodyStateInput(list, input) {
-    const index = list.findIndex((item) => item.inputId === input.inputId);
-    if (index < 0) return false;
-    if (bodyStateInputEquals(list[index], input)) return true;
-    list[index] = input;
-    list.sort(compareBodyStateInputs);
-    return true;
-  }
-
-  function updateExistingBodyStateInput(input) {
-    const hasApplied = appliedBodyStateInputIds.has(input.inputId);
-    const hasHistory = bodyStateInputHistory.some((item) => item.inputId === input.inputId);
-    const hasPending = pendingBodyStateInputs.some((item) => item.inputId === input.inputId);
-    if (!hasApplied && !hasHistory && !hasPending) return false;
-
-    const previous = bodyStateInputHistory.find((item) => item.inputId === input.inputId)
-      || pendingBodyStateInputs.find((item) => item.inputId === input.inputId)
-      || null;
-    const changed = !previous || !bodyStateInputEquals(previous, input);
-    const physicalStateChanged = !previous || !bodyStateInputPhysicalStateEquals(previous, input);
-    const orderChangedWithPeer = Boolean(
-      previous &&
-      compareBodyStateInputs(previous, input) !== 0 &&
-      hasSameTickInputPeer(input),
-    );
-    if (hasHistory) {
-      replaceBodyStateInput(bodyStateInputHistory, input);
-    } else {
-      addBodyStateInputHistory(input);
-    }
-    if (hasPending) {
-      replaceBodyStateInput(pendingBodyStateInputs, input);
-    }
-    lastEventRevision = Math.max(lastEventRevision, input.eventRevision);
-
-    if (
-      changed &&
-      (physicalStateChanged || orderChangedWithPeer) &&
-      world &&
-      (hasApplied || input.applyTick <= world.tick)
-    ) {
-      rewindBodyStateInputsToInitialSnapshot();
-    }
-    return true;
-  }
-
-  function compareBodyStateInputs(left, right) {
+    function compareBodyStateInputs(left, right) {
     return left.applyTick - right.applyTick
       || left.timelineRevision - right.timelineRevision
       || left.eventRevision - right.eventRevision
@@ -846,6 +855,18 @@ export function createScenePhysicsRuntime({
       (max, input) => Math.max(max, input.eventRevision || 0),
       0,
     );
+    bodyStateEventTimeline.setTimelineState({
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision,
+    });
+    bodyStateEventTimeline.removeEvents((event) => {
+      const input = bodyStateInputFromEvent(event);
+      return !(input.timelineRevision === timelineRevision || input.applyTick <= timelineForkTick);
+    });
+    syncBodyStateInputListsFromTimeline();
 
     if (dropsAppliedInput && world && world.tick > timelineForkTick) {
       rewindBodyStateInputsToInitialSnapshot();
@@ -879,27 +900,29 @@ export function createScenePhysicsRuntime({
   }
 
   function markInputsCoveredBySnapshot(snapshotTick, snapshotLastEventRevision) {
-    bodyStateInputHistory = bodyStateInputHistory.filter((input) => {
-      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
-        appliedBodyStateInputIds.add(input.inputId);
-        return false;
-      }
-      return true;
-    });
-    pendingBodyStateInputs = pendingBodyStateInputs.filter((input) => {
-      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
-        appliedBodyStateInputIds.add(input.inputId);
-        return false;
-      }
-      return true;
-    });
-    for (const [objectId, input] of activeBodyStateHolds.entries()) {
-      if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
-        activeBodyStateHolds.delete(objectId);
-      }
+    const removed = bodyStateEventTimeline.removeEvents((event) => {
+      const input = bodyStateInputFromEvent(event);
+      return inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision);
+    }, { markApplied: true });
+    for (const event of removed) {
+      const input = bodyStateInputFromEvent(event);
+      if (input.inputId) appliedBodyStateInputIds.add(input.inputId);
     }
-    lastEventRevision = Math.max(lastEventRevision, snapshotLastEventRevision);
-  }
+    syncBodyStateInputListsFromTimeline();
+      for (const [objectId, input] of activeBodyStateHolds.entries()) {
+        if (inputCoveredBySnapshot(input, snapshotTick, snapshotLastEventRevision)) {
+          activeBodyStateHolds.delete(objectId);
+        }
+      }
+      lastEventRevision = Math.max(lastEventRevision, snapshotLastEventRevision);
+      bodyStateEventTimeline.setTimelineState({
+        timelineId,
+        timelineRevision,
+        timelineForkTick,
+        timelineClearRevision,
+        lastEventRevision,
+      }, { resetApplied: false });
+    }
 
   function setAuthoritativeSnapshotBaseline(snapshotTick, snapshotLastEventRevision) {
     if (!world?.snapshot) return;
@@ -928,10 +951,14 @@ export function createScenePhysicsRuntime({
     previousCollisionPairs = new Set();
     appliedBodyStateInputIds.clear();
     activeBodyStateHolds = new Map();
-    pendingBodyStateInputs = [];
-    for (const input of bodyStateInputHistory) {
-      addPendingBodyStateInput(input);
-    }
+    bodyStateEventTimeline.setTimelineState({
+      timelineId,
+      timelineRevision,
+      timelineForkTick,
+      timelineClearRevision,
+      lastEventRevision,
+    }, { requeueHistory: true });
+    syncBodyStateInputListsFromTimeline();
     return true;
   }
 
@@ -1086,29 +1113,11 @@ export function createScenePhysicsRuntime({
   }
 
   function clearInputHistory(payload = {}) {
-    const payloadTimelineId = normalizeTimelineId(payload.timelineId);
-    if (payloadTimelineId !== timelineId) return false;
-
-    const hasCanonicalRevision = payload.timelineRevision !== undefined && payload.timelineRevision !== null;
-    const canonicalRevision = hasCanonicalRevision
-      ? nonNegativeInteger(payload.timelineRevision, timelineRevision)
-      : null;
-    const payloadTimelineClearRevision = nonNegativeInteger(
-      payload.timelineClearRevision,
-      canonicalRevision ?? timelineClearRevision + 1,
-    );
-    if (payloadTimelineClearRevision < timelineClearRevision) return false;
-    if (payloadTimelineClearRevision === timelineClearRevision) return false;
-    const nextRevision = hasCanonicalRevision
-      ? canonicalRevision
-      : timelineRevision + 1;
-    const forkTick = nonNegativeInteger(payload.timelineForkTick, 0);
-    timelineRevision = nextRevision;
-    timelineForkTick = forkTick;
-    timelineClearRevision = payloadTimelineClearRevision;
-    lastEventRevision = 0;
-    pendingBodyStateInputs = [];
-    bodyStateInputHistory = [];
+    const cleared = bodyStateEventTimeline.clearEventHistory(payload, {
+      allowRevisionRegression: true,
+    });
+    if (!cleared) return false;
+    syncBodyStateInputListsFromTimeline();
     activeBodyStateHolds = new Map();
     appliedBodyStateInputIds.clear();
     previousCollisionPairs = new Set();
@@ -1123,24 +1132,7 @@ export function createScenePhysicsRuntime({
     return true;
   }
 
-  function addBodyStateInputHistory(input) {
-    bodyStateInputHistory.push(input);
-    bodyStateInputHistory.sort(compareBodyStateInputs);
-    while (bodyStateInputHistory.length > MAX_BODY_STATE_INPUT_HISTORY) {
-      bodyStateInputHistory.shift();
-    }
-  }
-
-  function addPendingBodyStateInput(input) {
-    if (pendingBodyStateInputs.some((item) => item.inputId === input.inputId)) return;
-    pendingBodyStateInputs.push(input);
-    pendingBodyStateInputs.sort(compareBodyStateInputs);
-    while (pendingBodyStateInputs.length > MAX_PENDING_BODY_STATE_INPUTS) {
-      pendingBodyStateInputs.shift();
-    }
-  }
-
-  function serializeBodyStateInput(input) {
+    function serializeBodyStateInput(input) {
     return {
       kind: 'scene-physics-input',
       inputType: 'set-body-state',
@@ -1242,20 +1234,15 @@ export function createScenePhysicsRuntime({
       return applyActiveBodyStateHolds();
     }
 
-    let applied = false;
-    for (let index = 0; index < pendingBodyStateInputs.length;) {
-      const input = pendingBodyStateInputs[index];
-      if (input.applyTick > currentTick) break;
+    const processed = bodyStateEventTimeline.processDueEvents(currentTick, (event) => {
+      const input = bodyStateInputFromEvent(event);
       if (input.applyTick < currentTick && hasDynamicBody(input.objectId) && rewindBodyStateInputsToInitialSnapshot()) {
-        return applied;
+        return { replayRequired: true };
       }
-      if (applyBodyStateInput(input)) {
-        pendingBodyStateInputs.splice(index, 1);
-        applied = true;
-        continue;
-      }
-      index += 1;
-    }
+      return applyBodyStateInput(input);
+    });
+    syncBodyStateInputListsFromTimeline();
+    let applied = processed.applied;
     if (applyActiveBodyStateHolds()) {
       applied = true;
     }
@@ -1274,10 +1261,8 @@ export function createScenePhysicsRuntime({
     previousCollisionPairs = new Set();
     appliedBodyStateInputIds.clear();
     activeBodyStateHolds = new Map();
-    pendingBodyStateInputs = [];
-    for (const input of bodyStateInputHistory) {
-      addPendingBodyStateInput(input);
-    }
+    bodyStateEventTimeline.resetAppliedFromHistory();
+    syncBodyStateInputListsFromTimeline();
     return true;
   }
 

--- a/html/assets/js/scenesync/scene-physics.test.js
+++ b/html/assets/js/scenesync/scene-physics.test.js
@@ -339,14 +339,26 @@ test('scene physics runtime drops pending inputs covered by a matching snapshot'
   }), true);
   authority.update({ t: 10 / 60 + 1e-8, transportActive: true });
 
-  const snapshot = authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true });
-  assert.equal(snapshot.lastEventRevision, 1);
-  const report = follower.applySnapshotReport(snapshot, { t: 10 / 60 + 1e-8, transportActive: true });
-  assert.equal(report.applied, true);
-  assert.equal(report.matched, true);
-  assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
+    const snapshot = {
+      ...authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }),
+      lastEventRevision: 10,
+    };
+    assert.equal(authority.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).lastEventRevision, 1);
+    const report = follower.applySnapshotReport(snapshot, { t: 10 / 60 + 1e-8, transportActive: true });
+    assert.equal(report.applied, true);
+    assert.equal(report.matched, true);
+    assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
+    assert.equal(follower.getTimelineState().lastEventRevision, 10);
+    assert.equal(follower.queueInput({
+      ...input,
+      inputId: 'covered-drag-after-snapshot:000001',
+      eventRevision: 1,
+      applyTick: 11,
+      position: [11, 2, 0],
+    }), true);
+    assert.equal(follower.getTimelineState().lastEventRevision, 10);
 
-  follower.update({ t: 10 / 60 + 1e-8, transportActive: true });
+    follower.update({ t: 10 / 60 + 1e-8, transportActive: true });
   assert.equal(follower.createSnapshotReport({ t: 10 / 60 + 1e-8, transportActive: true }).hash, snapshot.hash);
   assertVectorClose(followerObject.position.toArray(), authorityObject.position.toArray());
 


### PR DESCRIPTION
## Summary
- route scene physics body-state input ordering/history/pending state through the shared SceneEventTimeline
- add replay-aware timeline helpers for due processing, removal, reset, and metadata-only updates
- preserve physics snapshot coverage, clear revision compatibility, hold/release, and metadata echo behavior with regression tests

## Review
- Subagent Nash reviewed the diff and approved after fixes for lastEventRevision sync and clear fallback compatibility.

## Tests
- npm run test:runtime-schedule
- npm run test:physics
- git diff --check