### PR TITLE
Make Loomlet evaluation deterministic

### DIFF
--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -13,6 +13,46 @@ function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
 
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function compareStrings(left, right) {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+export function compareLoomletRuntimeScopeKeys(left, right) {
+  if (left === right) return 0;
+  if (left === 'scene') return -1;
+  if (right === 'scene') return 1;
+  return compareStrings(left, right);
+}
+
+export function compareLoomletRuntimeEvents(left, right) {
+  return finiteNumber(left?.tick, 0) - finiteNumber(right?.tick, 0)
+    || finiteNumber(left?.applyTick, 0) - finiteNumber(right?.applyTick, 0)
+    || finiteNumber(left?.eventRevision, 0) - finiteNumber(right?.eventRevision, 0)
+    || finiteNumber(left?.sequence, 0) - finiteNumber(right?.sequence, 0)
+    || compareStrings(left?.channel ?? left?.type, right?.channel ?? right?.type)
+    || compareStrings(left?.eventId, right?.eventId);
+}
+
+export function resolveLoomletRuntimeDeltaTime(clockState = null, fallback = 0) {
+  if (Number.isFinite(Number(clockState?.deltaTime))) {
+    return Math.max(0, Number(clockState.deltaTime));
+  }
+  if (Number.isFinite(Number(clockState?.delta))) {
+    return Math.max(0, Number(clockState.delta));
+  }
+  return Math.max(0, finiteNumber(fallback, 0));
+}
+
+export function resolveLoomletRuntimeTick(clockState = null) {
+  const tick = Number(clockState?.tick);
+  return Number.isFinite(tick) ? Math.max(0, Math.floor(tick)) : undefined;
+}
+
 export function normalizeLoomletHostEventsForRuntime(hostEvents, {
   target = null,
   timestamp = 0,
@@ -53,7 +93,7 @@ export function normalizeLoomletHostEventsForRuntime(hostEvents, {
     if (normalized.time === undefined) normalized.time = normalized.timestamp;
     if (target && normalized.objectId === undefined) normalized.objectId = target;
     return normalized;
-  }).filter(Boolean);
+  }).filter(Boolean).sort(compareLoomletRuntimeEvents);
 }
 
 function scopeKey(scope) {
@@ -395,6 +435,8 @@ function createRuntimeManager({
 
     // Build host inputs for object-scoped evaluations
     const inputs = entry.scopeObjectId ? buildHostInputsForObject(entry.scopeObjectId, time, clockState, { getInputRoutingMode }) : {};
+    const deltaTime = resolveLoomletRuntimeDeltaTime(clockState);
+    const tick = resolveLoomletRuntimeTick(clockState);
 
     // Gather host events for object-scoped evaluations
     let events = [];
@@ -405,14 +447,18 @@ function createRuntimeManager({
       });
     }
 
-    entry.runtime.evaluateAt({
+    const env = {
       time,
+      deltaTime,
       scope: entry.scopeObjectId
         ? { type: 'object', id: entry.scopeObjectId }
         : { type: 'scene' },
       inputs,
       events,
-    }, now);
+    };
+    if (tick !== undefined) env.tick = tick;
+
+    entry.runtime.evaluateAt(env, Number.isFinite(time) ? time * 1000 : now);
 
     // Clear events after evaluation
     if (entry.scopeObjectId && clearLoomletHostEvents) {
@@ -438,7 +484,7 @@ function createRuntimeManager({
     tick(clockState = null, now = performance.now()) {
       // clockState: Scene Clock state from host
       // If not provided, fall back to host-provided time
-      for (const [key, entry] of runtimes) {
+      for (const [key, entry] of Array.from(runtimes.entries()).sort(([left], [right]) => compareLoomletRuntimeScopeKeys(left, right))) {
         evaluateRuntime(key, entry, clockState, now);
       }
     },

--- a/html/assets/js/scenesync/loomlet-runtime-integration.test.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.test.js
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { normalizeLoomletHostEventsForRuntime } from './loomlet-runtime-integration.js';
+import {
+  compareLoomletRuntimeScopeKeys,
+  createSceneSyncLoomIntegration,
+  normalizeLoomletHostEventsForRuntime,
+  resolveLoomletRuntimeDeltaTime,
+  resolveLoomletRuntimeTick,
+} from './loomlet-runtime-integration.js';
 
 test('normalizeLoomletHostEventsForRuntime keeps legacy channel sets compatible', () => {
   const events = normalizeLoomletHostEventsForRuntime(new Set(['object.hover.enter']), {
@@ -41,4 +47,90 @@ test('normalizeLoomletHostEventsForRuntime preserves synchronized scene event fi
   assert.equal(events[0].eventId, 'drag-1:event:000002');
   assert.equal(events[0].applyTick, 18);
   assert.deepEqual(events[0].payload, { pointerId: 5, clientX: 10, clientY: 20 });
+});
+
+test('normalizeLoomletHostEventsForRuntime sorts events in canonical replay order', () => {
+  const events = normalizeLoomletHostEventsForRuntime([
+    { channel: 'pointer.drag.end', eventId: 'c', applyTick: 2, eventRevision: 1, sequence: 0, timestamp: 2 },
+    { channel: 'pointer.click', eventId: 'b', applyTick: 1, eventRevision: 2, sequence: 0, timestamp: 1 },
+    { channel: 'pointer.drag.start', eventId: 'a', applyTick: 1, eventRevision: 1, sequence: 0, timestamp: 1 },
+  ], {
+    target: 'box-1',
+    timestamp: 0,
+  });
+
+  assert.deepEqual(events.map(event => event.eventId), ['a', 'b', 'c']);
+});
+
+test('resolveLoomletRuntimeDeltaTime and tick prefer deterministic clock fields', () => {
+  assert.equal(resolveLoomletRuntimeDeltaTime({ deltaTime: 1 / 60, delta: 9 }), 1 / 60);
+  assert.equal(resolveLoomletRuntimeDeltaTime({ delta: 0.25 }), 0.25);
+  assert.equal(resolveLoomletRuntimeDeltaTime({}, 0.5), 0.5);
+  assert.equal(resolveLoomletRuntimeTick({ tick: 12.9 }), 12);
+  assert.equal(resolveLoomletRuntimeTick({}), undefined);
+});
+
+test('compareLoomletRuntimeScopeKeys evaluates scene before object scopes', () => {
+  const keys = ['object:z', 'scene', 'object:a'].sort(compareLoomletRuntimeScopeKeys);
+  assert.deepEqual(keys, ['scene', 'object:a', 'object:z']);
+});
+
+function createPositionObject() {
+  return {
+    position: {
+      x: 0,
+      y: 0,
+      z: 0,
+      set(x, y, z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+      },
+    },
+  };
+}
+
+test('Loomlet integration passes explicit deltaTime instead of frame timestamp delta', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+  });
+  const graph = {
+    nodes: [
+      { id: 'speed', type: 'constant', params: { value: 2 } },
+      { id: 'integrator', type: 'integrate', params: { initial: 0 } },
+      { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+    ],
+    edges: [
+      { from: 'speed.out', to: 'integrator.value' },
+      { from: 'integrator.out', to: 'move.x' },
+    ],
+  };
+
+  integration.handlePayload({ type: 'scene-graph-set', scope: { object: 'box-1' }, graph });
+  integration.tickObjectGraphs({ t: 0, deltaTime: 0.25 }, 1000);
+  assert.equal(object.position.x, 0.5);
+  integration.tickObjectGraphs({ t: 0.25, deltaTime: 0.25 }, 1_000_000);
+  assert.equal(object.position.x, 1);
+});
+
+test('Loomlet integration evaluates scopes in deterministic key order', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+  });
+  const sceneGraph = {
+    nodes: [{ id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', x: 2, y: 0, z: 0 } }],
+    edges: [],
+  };
+  const objectGraph = {
+    nodes: [{ id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', x: 1, y: 0, z: 0 } }],
+    edges: [],
+  };
+
+  integration.handlePayload({ type: 'scene-graph-set', scope: { object: 'box-1' }, graph: objectGraph });
+  integration.handlePayload({ type: 'scene-graph-set', scope: 'scene', graph: sceneGraph });
+  integration.tickObjectGraphs({ t: 0, deltaTime: 0 }, 0);
+
+  assert.equal(object.position.x, 1);
 });

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5150,7 +5150,14 @@ renderer.setAnimationLoop((time, frame) => {
   updateObjectGlbAnimations(now, sceneClockStateForTick);
   updateGazeStateFromCamera();
   updateGazeDwellState(now);
-  loomIntegration?.tickObjectGraphs?.(sceneClockStateForTick);
+  const loomletClockStateForTick = {
+    ...sceneClockStateForTick,
+    ...(Number.isFinite(physicsTick?.tick) ? { tick: physicsTick.tick } : {}),
+    deltaTime: physicsTick?.active && Number.isFinite(physicsTick?.timestep)
+      ? physicsTick.timestep
+      : sceneClockStateForTick.delta,
+  };
+  loomIntegration?.tickObjectGraphs?.(loomletClockStateForTick);
   audioSourceController.tick(now, sceneClockStateForTick);
 
   // Update Scene Clock debug UI


### PR DESCRIPTION
## Summary
- pass explicit `deltaTime` and `tick` into Loomlet evaluation instead of relying on local frame timestamp deltas
- sort Loomlet runtime events and graph scope evaluation in canonical order
- feed physics tick/timestep into SceneSync Loomlet object graph ticks when physics is active

## Tests
- node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js
- node --check html/assets/js/scenesync/loomlet-runtime-integration.js && node --check html/assets/js/scenesync/scene.js
- node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
- npm run test:runtime-schedule
- npm run test:plugins
- npm run test:physics
- git diff --check

## Notes
- This removes the main local frame-time and insertion-order nondeterminism in the Loomlet adapter. Full browser/network multi-peer replay remains an integration-level validation target.