### PR TITLE
[codex] Generic scene event log requests

### DIFF
--- a/apps/presence-server/src/link-token.mjs
+++ b/apps/presence-server/src/link-token.mjs
@@ -156,7 +156,7 @@ export function getActiveLink(linkId) {
 }
 
 // Cleanup expired pairing codes periodically
-setInterval(() => {
+const cleanupExpiredLinkTokensInterval = setInterval(() => {
   const now = Date.now();
   for (const [code, entry] of pairingCodes) {
     if (now > entry.expiresAt) {
@@ -175,3 +175,4 @@ setInterval(() => {
     }
   }
 }, 60000); // Every minute
+cleanupExpiredLinkTokensInterval.unref?.();

--- a/apps/presence-server/src/scenesync/message-schema.mjs
+++ b/apps/presence-server/src/scenesync/message-schema.mjs
@@ -13,8 +13,12 @@ const KNOWN_KINDS = new Set([
   'scene-lock',
   'scene-unlock',
   'scene-physics-hash',
+  'scene-event',
+  'scene-event-log',
+  'scene-event-log-request',
   'scene-physics-input',
   'scene-physics-input-log-clear',
+  'scene-physics-input-log',
   'scene-physics-input-log-request',
   'scene-physics-snapshot',
   'scene-physics-snapshot-request',
@@ -116,6 +120,165 @@ function validateOptionalNonNegativeInteger(payload, key) {
   if (payload[key] === undefined || payload[key] === null) return { ok: true };
   if (!Number.isInteger(payload[key]) || payload[key] < 0) {
     return { ok: false, reason: `${key} must be a non-negative integer` };
+  }
+  return { ok: true };
+}
+
+function validateOptionalTimelineVersion(payload, key, maxStringLength = 128) {
+  if (payload[key] === undefined || payload[key] === null) return { ok: true };
+  if (isReasonableString(payload[key], maxStringLength)) return { ok: true };
+  if (Number.isInteger(payload[key]) && payload[key] >= 0) return { ok: true };
+  return { ok: false, reason: `${key} must be a reasonable string or non-negative integer` };
+}
+
+function validateOptionalObject(payload, key) {
+  if (payload[key] === undefined || payload[key] === null) return { ok: true };
+  if (typeof payload[key] !== 'object' || Array.isArray(payload[key])) {
+    return { ok: false, reason: `${key} must be an object` };
+  }
+  return { ok: true };
+}
+
+function validateSceneEventTimelineMetadata(payload, maxStringLength, prefix = '') {
+  const key = name => `${prefix}${name}`;
+  for (const field of ['eventLogKind', 'source', 'phase', 'timelineId', 'requestId', 'reason', 'requestKind', 'requestReason', 'requestTimelineId']) {
+    const result = validateOptionalReasonableString(payload, field, maxStringLength);
+    if (!result.ok) return { ok: false, reason: `${key(field)} must be a reasonable string` };
+  }
+  const timelineVersionResult = validateOptionalTimelineVersion(payload, 'timelineVersion', maxStringLength);
+  if (!timelineVersionResult.ok) {
+    return { ok: false, reason: `${key('timelineVersion')} must be a reasonable string or non-negative integer` };
+  }
+  for (const field of [
+    'timelineRevision',
+    'timelineForkTick',
+    'timelineClearRevision',
+    'lastEventRevision',
+    'eventCount',
+    'inputCount',
+    'requestTimelineRevision',
+    'requestTimelineClearRevision',
+  ]) {
+    const result = validateOptionalNonNegativeInteger(payload, field);
+    if (!result.ok) return { ok: false, reason: `${key(field)} must be a non-negative integer` };
+  }
+  for (const field of ['sceneClockRevision', 'sentAt']) {
+    const result = validateOptionalFiniteNumber(payload, field);
+    if (!result.ok) return { ok: false, reason: `${key(field)} must be finite` };
+  }
+  return { ok: true };
+}
+
+function validateSceneEventPayload(payload, maxStringLength) {
+  const channel = payload.channel ?? payload.type;
+  if (!isReasonableString(channel, maxStringLength)) {
+    return { ok: false, reason: 'scene-event.channel must be a reasonable string' };
+  }
+  for (const field of ['timelineId', 'eventId', 'inputId', 'interactionId', 'channel', 'type', 'source', 'phase', 'target', 'objectId', 'sourcePeerId', 'sourceUserId']) {
+    const result = validateOptionalReasonableString(payload, field, maxStringLength);
+    if (!result.ok) return result;
+  }
+  const timelineVersionResult = validateOptionalTimelineVersion(payload, 'timelineVersion', maxStringLength);
+  if (!timelineVersionResult.ok) return timelineVersionResult;
+  for (const field of ['timelineRevision', 'timelineClearRevision', 'eventRevision', 'sequence', 'applyTick', 'branchTick']) {
+    const result = validateOptionalNonNegativeInteger(payload, field);
+    if (!result.ok) return result;
+  }
+  for (const field of ['timestamp', 'time', 'sentAt']) {
+    const result = validateOptionalFiniteNumber(payload, field);
+    if (!result.ok) return result;
+  }
+  if (payload.position !== undefined && !hasFiniteNumberArray(payload.position, 3)) {
+    return { ok: false, reason: 'scene-event.position must be finite [x,y,z]' };
+  }
+  if (payload.rotation !== undefined && !hasFiniteNumberArray(payload.rotation, 4)) {
+    return { ok: false, reason: 'scene-event.rotation must be finite quaternion [x,y,z,w]' };
+  }
+  for (const field of ['velocity', 'linearVelocity', 'angularVelocity', 'angvel']) {
+    if (payload[field] !== undefined && !hasFiniteNumberArray(payload[field], 3)) {
+      return { ok: false, reason: `scene-event.${field} must be finite [x,y,z]` };
+    }
+  }
+  const payloadResult = validateOptionalObject(payload, 'payload');
+  if (!payloadResult.ok) return payloadResult;
+  return { ok: true };
+}
+
+function validateSceneEventLogPayload(payload, maxStringLength) {
+  const metadataResult = validateSceneEventTimelineMetadata(payload, maxStringLength);
+  if (!metadataResult.ok) return metadataResult;
+
+  if (payload.events !== undefined) {
+    if (!Array.isArray(payload.events)) {
+      return { ok: false, reason: 'scene-event-log.events must be an array' };
+    }
+    if (payload.events.length > 2000) {
+      return { ok: false, reason: 'scene-event-log.events is too large' };
+    }
+    for (const event of payload.events) {
+      if (!event || typeof event !== 'object' || Array.isArray(event)) {
+        return { ok: false, reason: 'scene-event-log.events entries must be objects' };
+      }
+      const result = validateSceneEventPayload(event, maxStringLength);
+      if (!result.ok) return { ok: false, reason: `invalid scene-event-log event: ${result.reason}` };
+    }
+  }
+
+  if (payload.inputs !== undefined) {
+    if (!Array.isArray(payload.inputs)) {
+      return { ok: false, reason: 'scene-event-log.inputs must be an array' };
+    }
+    if (payload.inputs.length > 2000) {
+      return { ok: false, reason: 'scene-event-log.inputs is too large' };
+    }
+    for (const input of payload.inputs) {
+      if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return { ok: false, reason: 'scene-event-log.inputs entries must be objects' };
+      }
+      const result = validateScenePhysicsInputPayload(input, maxStringLength);
+      if (!result.ok) return { ok: false, reason: `invalid scene-event-log input: ${result.reason}` };
+    }
+  }
+
+  const controllerValidation = validatePhysicsController(payload.controller, maxStringLength);
+  if (!controllerValidation.ok) return controllerValidation;
+  const clockValidation = validateObjectClock(payload.clock, 'scene-event-log.clock');
+  if (!clockValidation.ok) return clockValidation;
+
+  if (payload.snapshot !== undefined && payload.snapshot !== null) {
+    if (typeof payload.snapshot !== 'object' || Array.isArray(payload.snapshot)) {
+      return { ok: false, reason: 'scene-event-log.snapshot must be an object' };
+    }
+    const snapshotValidation = validateScenePhysicsSyncPayload(
+      { ...payload.snapshot, kind: 'scene-physics-snapshot' },
+      maxStringLength,
+    );
+    if (!snapshotValidation.ok) {
+      return { ok: false, reason: `invalid scene-event-log snapshot: ${snapshotValidation.reason}` };
+    }
+  }
+
+  return { ok: true };
+}
+
+function validateSceneEventLogRequestPayload(payload, maxStringLength) {
+  const metadataResult = validateSceneEventTimelineMetadata(payload, maxStringLength);
+  if (!metadataResult.ok) return metadataResult;
+  if (payload.timelines !== undefined) {
+    if (!Array.isArray(payload.timelines)) {
+      return { ok: false, reason: 'scene-event-log-request.timelines must be an array' };
+    }
+    if (payload.timelines.length > 32) {
+      return { ok: false, reason: 'scene-event-log-request.timelines is too large' };
+    }
+    for (let index = 0; index < payload.timelines.length; index += 1) {
+      const timeline = payload.timelines[index];
+      if (!timeline || typeof timeline !== 'object' || Array.isArray(timeline)) {
+        return { ok: false, reason: 'scene-event-log-request.timelines entries must be objects' };
+      }
+      const result = validateSceneEventTimelineMetadata(timeline, maxStringLength, `scene-event-log-request.timelines[${index}].`);
+      if (!result.ok) return result;
+    }
   }
   return { ok: true };
 }
@@ -441,6 +604,18 @@ export function validateSceneSyncPayload(payload, options = {}) {
 
   if (payload.kind === 'scene-physics') {
     return validateScenePhysicsPayload(payload.physics);
+  }
+
+  if (payload.kind === 'scene-event') {
+    return validateSceneEventPayload(payload, maxStringLength);
+  }
+
+  if (payload.kind === 'scene-event-log' || payload.kind === 'scene-physics-input-log') {
+    return validateSceneEventLogPayload(payload, maxStringLength);
+  }
+
+  if (payload.kind === 'scene-event-log-request' || payload.kind === 'scene-physics-input-log-request') {
+    return validateSceneEventLogRequestPayload(payload, maxStringLength);
   }
 
   if (payload.kind === 'scene-physics-input') {

--- a/apps/presence-server/src/server.mjs
+++ b/apps/presence-server/src/server.mjs
@@ -308,6 +308,13 @@ class WsConnection {
     } catch {}
   }
 
+  terminate() {
+    try {
+      this.socket.destroy();
+    } catch {}
+    this.#handleClose();
+  }
+
   #handleClose() {
     if (this.closed) return;
     this.closed = true;
@@ -827,6 +834,35 @@ function sendRoomSceneClock(client) {
   });
 }
 
+function getRequestedRoomPhysicsTimelineId(payload) {
+  if (payload?.kind === 'scene-physics-input-log-request') {
+    return payload.timelineId || null;
+  }
+  if (payload?.kind !== 'scene-event-log-request') {
+    return false;
+  }
+
+  const timelines = Array.isArray(payload.timelines) ? payload.timelines : [];
+  if (timelines.length > 0) {
+    const physicsTimeline = timelines.find(timeline => (
+      timeline &&
+      typeof timeline === 'object' &&
+      !Array.isArray(timeline) &&
+      (
+        timeline.source === 'physics' ||
+        (
+          timeline.source === undefined &&
+          timeline.timelineId !== undefined &&
+          normalizePhysicsTimelineId(timeline.timelineId) === normalizePhysicsTimelineId(payload.timelineId)
+        )
+      )
+    ));
+    return physicsTimeline ? (physicsTimeline.timelineId || null) : false;
+  }
+
+  return payload.timelineId || null;
+}
+
 function sendRoomPhysicsTimeline(client, timelineId = null) {
   const roomTimelines = roomPhysicsTimelines.get(client.roomId);
   if (!roomTimelines) return;
@@ -1235,10 +1271,13 @@ async function runRoomBroadcast({ roomId, payload, onBehalfOfUserId = null, send
     });
   }
 
-  if (nextPayload?.kind === 'scene-physics-input-log-request') {
+  if (
+    nextPayload?.kind === 'scene-physics-input-log-request' ||
+    nextPayload?.kind === 'scene-event-log-request'
+  ) {
     return {
       status: 400,
-      body: { error: 'scene-physics-input-log-request requires a websocket client' },
+      body: { error: `${nextPayload.kind} requires a websocket client` },
     };
   }
 
@@ -1992,6 +2031,14 @@ function createPresenceServer() {
     res.writeHead(200, { 'content-type': 'text/plain' }).end('presence ok');
   });
 
+  const openSockets = new Set();
+  server.on('connection', socket => {
+    openSockets.add(socket);
+    socket.on('close', () => {
+      openSockets.delete(socket);
+    });
+  });
+
   server.on('upgrade', (req, socket) => {
     const url = getRequestUrl(req);
     if (url.pathname !== '/' && url.pathname !== '/ws') {
@@ -2132,6 +2179,13 @@ function createPresenceServer() {
                 return;
               }
 
+              if (data.payload.kind === 'scene-event-log-request') {
+                const requestedTimelineId = getRequestedRoomPhysicsTimelineId(data.payload);
+                if (requestedTimelineId !== false) {
+                  sendRoomPhysicsTimeline(client, requestedTimelineId);
+                }
+              }
+
               const objectLimit = applySceneObjectLimits(roomId, data.payload, actorId);
               if (!objectLimit.ok) {
                 safeSend(conn, {
@@ -2247,7 +2301,10 @@ function createPresenceServer() {
     });
   }, HEARTBEAT_MS);
 
-  server.on('close', () => {
+  let cleanupComplete = false;
+  const cleanupServerState = () => {
+    if (cleanupComplete) return;
+    cleanupComplete = true;
     clearInterval(blobCleanupInterval);
     clearInterval(heartbeatInterval);
     if (connectionSummaryInterval) clearInterval(connectionSummaryInterval);
@@ -2265,13 +2322,32 @@ function createPresenceServer() {
       resolve({ kind: 'ai-result', ok: false, error: 'server stopped' });
     });
     pendingAiCommandResults.clear();
-  });
+  };
+
+  server.on('close', cleanupServerState);
 
   server.stop = () => {
     rooms.forEach(room => {
-      room.forEach(client => client.conn.close());
+      room.forEach(client => client.conn.terminate());
     });
-    return new Promise(resolve => server.close(resolve));
+    openSockets.forEach(socket => {
+      try {
+        socket.destroy();
+      } catch {}
+    });
+    cleanupServerState();
+    return new Promise(resolve => {
+      let resolved = false;
+      const finish = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve();
+      };
+      server.close(finish);
+      server.unref?.();
+      server.closeAllConnections?.();
+      setTimeout(finish, 100);
+    });
   };
 
   return server;

--- a/apps/presence-server/tests/api.test.mjs
+++ b/apps/presence-server/tests/api.test.mjs
@@ -591,7 +591,7 @@ describe('presence REST broadcast API', () => {
     }
   });
 
-  it('replays scene physics input history to late joiners', async () => {
+  it('replays scene physics input history through generic event log requests', async () => {
     const roomId = 'physics-replay-room';
     const sender = await connectClient(roomId, 'Physics Sender');
     const receiver = await connectClient(roomId, 'Physics Receiver');
@@ -629,8 +629,13 @@ describe('presence REST broadcast API', () => {
       lateJoiner.send(JSON.stringify({
         type: 'broadcast',
         payload: {
-          kind: 'scene-physics-input-log-request',
+          kind: 'scene-event-log-request',
+          eventLogKind: 'scene-event-log',
           timelineId: 'default',
+          timelines: [{
+            source: 'physics',
+            timelineId: 'default',
+          }],
         },
       }));
 
@@ -645,6 +650,38 @@ describe('presence REST broadcast API', () => {
         closeClient(sender),
         closeClient(receiver),
         lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
+      ]);
+    }
+  });
+
+  it('relays generic event log requests to peers after optional room replay', async () => {
+    const roomId = 'event-log-request-relay-room';
+    const requester = await connectClient(roomId, 'Event Requester');
+    const receiver = await connectClient(roomId, 'Event Receiver');
+    try {
+      const requestPromise = waitForMessage(receiver, message =>
+        message.type === 'handoff' && message.payload?.kind === 'scene-event-log-request');
+      requester.send(JSON.stringify({
+        type: 'broadcast',
+        payload: {
+          kind: 'scene-event-log-request',
+          eventLogKind: 'scene-event-log',
+          requestId: 'player-shell-request-1',
+          timelines: [{
+            source: 'player-shell',
+            timelineId: 'player-interaction',
+          }],
+        },
+      }));
+
+      const received = await requestPromise;
+      assert.equal(received.from.id, requester.presenceId);
+      assert.equal(received.payload.requestId, 'player-shell-request-1');
+      assert.equal(received.payload.timelines[0].source, 'player-shell');
+    } finally {
+      await Promise.all([
+        closeClient(requester),
+        closeClient(receiver),
       ]);
     }
   });
@@ -1009,6 +1046,24 @@ describe('presence REST broadcast API', () => {
         lateJoiner ? closeClient(lateJoiner) : Promise.resolve(),
       ]);
     }
+  });
+
+  it('rejects event log requests from REST broadcasts', async () => {
+    const response = await fetch(`${baseUrl}/api/room/event-log-rest-room/broadcast?name=Claude`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'scene-event-log-request',
+        eventLogKind: 'scene-event-log',
+        timelines: [{
+          source: 'physics',
+          timelineId: 'default',
+        }],
+      }),
+    });
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error, 'scene-event-log-request requires a websocket client');
   });
 
   it('broadcasts scene-env to change environment', async () => {

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -141,6 +141,165 @@ describe('Scene Sync guard helpers', () => {
     assert.equal(validateSceneSyncPayload({ kind: 'ai-link-revoked', linkId: 'l1' }).ok, true);
   });
 
+  it('accepts scene event log protocol messages', () => {
+    const playerEvent = {
+      kind: 'scene-event',
+      timelineVersion: 1,
+      timelineId: 'player-interaction',
+      timelineRevision: 0,
+      timelineClearRevision: 0,
+      eventRevision: 1,
+      eventId: 'drag-1:event:000001',
+      interactionId: 'drag-1',
+      sequence: 1,
+      applyTick: 12,
+      channel: 'pointer.drag.start',
+      source: 'player-shell',
+      phase: 'grab-start',
+      target: 'live-box',
+      timestamp: 1.2,
+      sourcePeerId: 'peer-web',
+      payload: {
+        pointerId: 1,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 100,
+        clientY: 120,
+      },
+      sentAt: Date.now(),
+    };
+
+    assert.equal(validateSceneSyncPayload(playerEvent).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-event-log-request',
+      eventLogKind: 'scene-event-log',
+      requestId: 'request-1',
+      reason: 'scene-state-handoff',
+      timelineVersion: 'SceneSyncPhysicsTimelineV1',
+      timelineId: 'default',
+      timelines: [
+        {
+          source: 'physics',
+          timelineVersion: 'SceneSyncPhysicsTimelineV1',
+          timelineId: 'default',
+          timelineRevision: 0,
+          timelineClearRevision: 0,
+          lastEventRevision: 1,
+        },
+        {
+          source: 'player-shell',
+          timelineVersion: 1,
+          timelineId: 'player-interaction',
+          timelineRevision: 0,
+          timelineClearRevision: 0,
+          lastEventRevision: 1,
+        },
+      ],
+      sentAt: Date.now(),
+    }).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-input-log-request',
+      eventLogKind: 'scene-event-log',
+      requestId: 'legacy-compatible-request-1',
+      reason: 'scene-state-handoff',
+      timelineVersion: 'SceneSyncPhysicsTimelineV1',
+      timelineId: 'default',
+      timelines: [
+        {
+          source: 'physics',
+          timelineVersion: 'SceneSyncPhysicsTimelineV1',
+          timelineId: 'default',
+        },
+        {
+          source: 'player-shell',
+          timelineVersion: 1,
+          timelineId: 'player-interaction',
+        },
+      ],
+      sentAt: Date.now(),
+    }).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-event-log',
+      eventLogKind: 'scene-event-log',
+      source: 'player-shell',
+      timelineVersion: 1,
+      timelineId: 'player-interaction',
+      timelineRevision: 0,
+      timelineForkTick: 0,
+      timelineClearRevision: 0,
+      lastEventRevision: 1,
+      eventCount: 1,
+      events: [playerEvent],
+      sceneClockRevision: 1,
+      controller: { id: 'peer-web', nickname: 'Web' },
+      clock: { sharedEpochTime: 2.5 },
+      sentAt: Date.now(),
+    }).ok, true);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-physics-input-log',
+      eventLogKind: 'scene-event-log',
+      source: 'physics',
+      timelineVersion: 'SceneSyncPhysicsTimelineV1',
+      timelineId: 'default',
+      timelineRevision: 0,
+      timelineForkTick: 0,
+      timelineClearRevision: 0,
+      lastEventRevision: 1,
+      eventCount: 1,
+      events: [{
+        kind: 'scene-event',
+        timelineVersion: 'SceneSyncPhysicsTimelineV1',
+        timelineId: 'default',
+        timelineRevision: 0,
+        timelineClearRevision: 0,
+        eventRevision: 1,
+        eventId: 'physics-drag:000001',
+        applyTick: 12,
+        channel: 'physics.body-state',
+        source: 'physics',
+        target: 'live-box',
+        timestamp: 0.2,
+        payload: {},
+      }],
+      inputCount: 1,
+      inputs: [{
+        kind: 'scene-physics-input',
+        inputType: 'set-body-state',
+        inputId: 'physics-drag:000001',
+        timelineVersion: 'SceneSyncPhysicsTimelineV1',
+        timelineId: 'default',
+        timelineRevision: 0,
+        timelineClearRevision: 0,
+        eventRevision: 1,
+        objectId: 'live-box',
+        applyTick: 12,
+        position: [1, 2, 3],
+        rotation: [0, 0, 0, 1],
+        velocity: [0, 0, 0],
+        angularVelocity: [0, 0, 0],
+      }],
+      sentAt: Date.now(),
+    }).ok, true);
+  });
+
+  it('rejects invalid scene event log protocol messages', () => {
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-event',
+      timelineId: 'player-interaction',
+    }).ok, false);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-event-log',
+      events: 'not-events',
+    }).ok, false);
+    assert.equal(validateSceneSyncPayload({
+      kind: 'scene-event-log-request',
+      timelines: [{
+        source: 'physics',
+        timelineRevision: -1,
+      }],
+    }).ok, false);
+  });
+
   it('rejects invalid scene-clock numbers', () => {
     const result = validateSceneSyncPayload({
       kind: 'scene-clock',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1387,6 +1387,9 @@ const PLAYER_PHYSICS_DRAG_INPUT_INTERVAL_MS = 50;
 const PLAYER_PHYSICS_DRAG_INPUT_LEAD_TICKS = 8;
 const PLAYER_PHYSICS_DRAG_THROW_VELOCITY_SCALE = 1.2;
 const PLAYER_PHYSICS_DRAG_MAX_THROW_SPEED = 18;
+const SCENE_SYNC_EVENT_LOG_KIND = 'scene-event-log';
+const SCENE_SYNC_EVENT_LOG_REQUEST_KIND = 'scene-event-log-request';
+const SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND = 'scene-physics-input-log-request';
 const PLAYER_INTERACTION_EVENT_TIMELINE_ID = 'player-interaction';
 const PLAYER_INTERACTION_CLICK_DISTANCE_SQUARED = 25;
 const PLAYER_INTERACTION_EVENT_CHANNELS = new Set([
@@ -5929,6 +5932,134 @@ function createScenePhysicsRequestId() {
     : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
 }
 
+function createSceneEventLogTimelineRequest(source, state = {}, fallbackTimelineId = 'default') {
+  return {
+    source,
+    timelineVersion: state.timelineVersion,
+    timelineId: state.timelineId || fallbackTimelineId,
+    timelineRevision: state.timelineRevision,
+    timelineForkTick: state.timelineForkTick,
+    timelineClearRevision: state.timelineClearRevision,
+    lastEventRevision: state.lastEventRevision,
+  };
+}
+
+function createSceneEventLogRequestPayload(reason = 'event-log-request', options = {}) {
+  const physicsTimelineState = scenePhysicsRuntime.getTimelineState?.() || {};
+  const playerInteractionTimelineState = playerInteractionEventTimeline.getTimelineState();
+  return {
+    kind: options.kind || SCENE_SYNC_EVENT_LOG_REQUEST_KIND,
+    eventLogKind: SCENE_SYNC_EVENT_LOG_KIND,
+    timelineVersion: physicsTimelineState.timelineVersion || SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
+    timelineId: physicsTimelineState.timelineId || 'default',
+    timelineRevision: physicsTimelineState.timelineRevision,
+    timelineForkTick: physicsTimelineState.timelineForkTick,
+    timelineClearRevision: physicsTimelineState.timelineClearRevision,
+    lastEventRevision: physicsTimelineState.lastEventRevision,
+    requestId: createScenePhysicsRequestId(),
+    reason,
+    timelines: [
+      createSceneEventLogTimelineRequest('physics', physicsTimelineState, 'default'),
+      createSceneEventLogTimelineRequest(
+        'player-shell',
+        playerInteractionTimelineState,
+        PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+      ),
+    ],
+    sentAt: Date.now(),
+  };
+}
+
+function getRequestedSceneEventTimeline(payload = {}, source, localTimelineId, fallbackTimelineId) {
+  const timelines = Array.isArray(payload.timelines) ? payload.timelines : [];
+  if (timelines.length === 0) return payload;
+  return timelines.find(timeline => {
+    if (!timeline || typeof timeline !== 'object') return false;
+    if (timeline.source === source) return true;
+    const requestedTimelineId = timeline.timelineId || fallbackTimelineId;
+    return requestedTimelineId === (localTimelineId || fallbackTimelineId);
+  }) || null;
+}
+
+function shouldRespondToSceneEventTimelineRequest(
+  request = null,
+  state = {},
+  fallbackTimelineId = 'default',
+  { strictTimelineId = true } = {},
+) {
+  if (!request) return false;
+  if (!strictTimelineId) return true;
+  const requestedTimelineId = request.timelineId || fallbackTimelineId;
+  const localTimelineId = state.timelineId || fallbackTimelineId;
+  return requestedTimelineId === localTimelineId;
+}
+
+function createSceneEventLogResponseMeta(
+  payload = {},
+  request = {},
+  fallbackTimelineId = 'default',
+  { preferFallbackTimelineId = false } = {},
+) {
+  const defaultRequestReason = payload.kind === SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND
+    ? 'input-log-request'
+    : 'event-log-request';
+  return {
+    requestId: payload.requestId,
+    requestKind: payload.kind,
+    requestTimelineId: preferFallbackTimelineId ? fallbackTimelineId : (request.timelineId || fallbackTimelineId),
+    requestTimelineRevision: request.timelineRevision,
+    requestTimelineClearRevision: request.timelineClearRevision,
+    requestReason: payload.reason || defaultRequestReason,
+    eventLogKind: payload.eventLogKind || SCENE_SYNC_EVENT_LOG_KIND,
+  };
+}
+
+function createSceneEventLogResponsePayloads(payload = {}, clockState = null) {
+  const logs = [];
+  const requestedTimelines = Array.isArray(payload.timelines) ? payload.timelines : [];
+  const physicsTimelineState = scenePhysicsRuntime.getTimelineState?.() || {};
+  const physicsRequest = getRequestedSceneEventTimeline(
+    payload,
+    'physics',
+    physicsTimelineState.timelineId,
+    'default',
+  );
+  if (shouldRespondToSceneEventTimelineRequest(physicsRequest, physicsTimelineState, 'default')) {
+    const physicsLog = createScenePhysicsInputLogPayload(
+      clockState,
+      createSceneEventLogResponseMeta(payload, physicsRequest, 'default'),
+    );
+    if (physicsLog) logs.push(physicsLog);
+  }
+
+  const playerTimelineState = playerInteractionEventTimeline.getTimelineState();
+  const playerRequest = getRequestedSceneEventTimeline(
+    payload,
+    'player-shell',
+    playerTimelineState.timelineId,
+    PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+  );
+  if (shouldRespondToSceneEventTimelineRequest(
+    playerRequest,
+    playerTimelineState,
+    PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+    { strictTimelineId: requestedTimelines.length > 0 },
+  )) {
+    const playerInteractionLog = createPlayerInteractionEventLogPayload(
+      clockState,
+      createSceneEventLogResponseMeta(
+        payload,
+        playerRequest,
+        playerTimelineState.timelineId || PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+        { preferFallbackTimelineId: requestedTimelines.length === 0 },
+      ),
+    );
+    if (playerInteractionLog) logs.push(playerInteractionLog);
+  }
+
+  return logs;
+}
+
 function createScenePhysicsInputLogPayload(clockState = null, extra = {}) {
   const log = scenePhysicsRuntime.createInputLogReport?.();
   if (!log || log.kind !== 'scene-physics-input-log') return null;
@@ -5957,8 +6088,8 @@ function createPlayerInteractionEventLogPayload(clockState = null, extra = {}) {
     ? sceneClockState.sharedRevision
     : null;
   return {
-    kind: 'scene-event-log',
-    eventLogKind: 'scene-event-log',
+    kind: SCENE_SYNC_EVENT_LOG_KIND,
+    eventLogKind: SCENE_SYNC_EVENT_LOG_KIND,
     source: 'player-shell',
     timelineVersion: timelineState.timelineVersion,
     timelineId: timelineState.timelineId || PLAYER_INTERACTION_EVENT_TIMELINE_ID,
@@ -7271,9 +7402,10 @@ function handleHandoff(data) {
     payload.kind === 'scene-remove' ||
     payload.kind === 'scene-physics' ||
     payload.kind === 'scene-physics-input-log-clear' ||
-    payload.kind === 'scene-physics-input-log-request' ||
+    payload.kind === SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND ||
+    payload.kind === SCENE_SYNC_EVENT_LOG_REQUEST_KIND ||
     payload.kind === 'scene-physics-input-log' ||
-    payload.kind === 'scene-event-log' ||
+    payload.kind === SCENE_SYNC_EVENT_LOG_KIND ||
     payload.kind === 'scene-event' ||
     payload.kind === 'scene-physics-input'
   ) {
@@ -7337,19 +7469,9 @@ function handleHandoff(data) {
       }
       notifySceneStateChanged('scene-state-handoff');
       publishSharedObjectClockBaselines('scene-state-baseline');
-      const timelineState = scenePhysicsRuntime.getTimelineState?.() || {};
-      const inputLogRequest = {
-        kind: 'scene-physics-input-log-request',
-        timelineVersion: SCENE_SYNC_PHYSICS_TIMELINE_VERSION,
-        timelineId: timelineState.timelineId || 'default',
-        timelineRevision: timelineState.timelineRevision,
-        timelineForkTick: timelineState.timelineForkTick,
-        timelineClearRevision: timelineState.timelineClearRevision,
-        lastEventRevision: timelineState.lastEventRevision,
-        requestId: createScenePhysicsRequestId(),
-        reason: 'scene-state-handoff',
-        sentAt: Date.now(),
-      };
+      const inputLogRequest = createSceneEventLogRequestPayload('scene-state-handoff', {
+        kind: SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND,
+      });
       if (data.from?.id) {
         sendHandoff({ targetId: data.from.id, payload: inputLogRequest });
       } else {
@@ -7629,31 +7751,11 @@ function handleHandoff(data) {
       }
       break;
     }
-    case 'scene-physics-input-log-request': {
+    case SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND:
+    case SCENE_SYNC_EVENT_LOG_REQUEST_KIND: {
       if (isOwn) break;
-      const timelineState = scenePhysicsRuntime.getTimelineState?.() || {};
-      const requestedTimelineId = payload.timelineId || 'default';
-      if (timelineState.timelineId && requestedTimelineId !== timelineState.timelineId) break;
       const logClockState = getSceneClockStateForLoomlet(performance.now());
-      const requestMeta = {
-        requestId: payload.requestId,
-        requestTimelineId: requestedTimelineId,
-        requestTimelineRevision: payload.timelineRevision,
-        requestTimelineClearRevision: payload.timelineClearRevision,
-        requestReason: payload.reason || 'input-log-request',
-      };
-      const inputLog = createScenePhysicsInputLogPayload(
-        logClockState,
-        requestMeta,
-      );
-      const playerInteractionLog = createPlayerInteractionEventLogPayload(
-        logClockState,
-        {
-          ...requestMeta,
-          requestTimelineId: PLAYER_INTERACTION_EVENT_TIMELINE_ID,
-        },
-      );
-      const logs = [inputLog, playerInteractionLog].filter(Boolean);
+      const logs = createSceneEventLogResponsePayloads(payload, logClockState);
       if (logs.length === 0) break;
       for (const logPayload of logs) {
         if (data.from?.id) {


### PR DESCRIPTION
## Summary

- Add generic SceneSync event log request metadata for physics and player-shell timelines while keeping `scene-physics-input-log-request` as the scene-state compatibility carrier.
- Allow `scene-event`, `scene-event-log`, `scene-event-log-request`, and `scene-physics-input-log` through the presence-server schema with focused validation.
- Relay generic event-log requests to peers after optional room physics replay, while preserving legacy room physics replay behavior.
- Make presence-server/link-token shutdown paths stop cleanly in tests.

## Validation

- `node --check html/assets/js/scenesync/scene.js`
- `node --check apps/presence-server/src/server.mjs`
- `node --test apps/presence-server/tests/scenesync-guards.test.mjs`
- `node --test apps/presence-server/tests/api.test.mjs`
- `npm run test:runtime-schedule`
- `npm run test:physics`

## Review

- Subagent review found compatibility and broadcast relay issues in the first pass.
- Both were addressed, and re-review reported no findings.