### PR TITLE
[codex] Add Loomlet interaction input API

### DIFF
--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -2,12 +2,29 @@ import {
   createSceneSyncRuntime,
   LoomletSceneSyncRuntimeVersion,
 } from '../../vendor/loomlet/0.3.0/loomlet-scenesync-runtime.browser.js';
+import {
+  createSceneEventTimeline,
+  sceneEventToRuntimeEvent,
+} from './runtime/event-timeline.js';
 
 export const LOOMLET_RUNTIME_METADATA = Object.freeze({
   version: LoomletSceneSyncRuntimeVersion,
   graphVersion: 'scene-sync-graph-json-v1',
   adapter: 'scenesync',
 });
+
+export const LOOMLET_INTERACTION_TIMELINE_ID = 'player-interaction';
+export const LOOMLET_INTERACTION_EVENT_LOG_KIND = 'scene-event-log';
+export const LOOMLET_INTERACTION_EVENT_SOURCE = 'loomlet';
+export const LOOMLET_POINTER_INTERACTION_CHANNELS = Object.freeze([
+  'pointer.click',
+  'pointer.drag.start',
+  'pointer.drag.move',
+  'pointer.drag.end',
+  'pointer.drag.cancel',
+]);
+
+const DEFAULT_LOOMLET_INTERACTION_EVENT_CHANNELS = new Set(LOOMLET_POINTER_INTERACTION_CHANNELS);
 
 function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
@@ -53,15 +70,19 @@ export function resolveLoomletRuntimeTick(clockState = null) {
   return Number.isFinite(tick) ? Math.max(0, Math.floor(tick)) : undefined;
 }
 
+function toArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return typeof value[Symbol.iterator] === 'function' ? Array.from(value) : [];
+}
+
 export function normalizeLoomletHostEventsForRuntime(hostEvents, {
   target = null,
   timestamp = 0,
 } = {}) {
   if (!hostEvents) return [];
 
-  const source = Array.isArray(hostEvents)
-    ? hostEvents
-    : (typeof hostEvents[Symbol.iterator] === 'function' ? Array.from(hostEvents) : []);
+  const source = toArray(hostEvents);
   return source.map((event) => {
     if (typeof event === 'string') {
       return {
@@ -94,6 +115,30 @@ export function normalizeLoomletHostEventsForRuntime(hostEvents, {
     if (target && normalized.objectId === undefined) normalized.objectId = target;
     return normalized;
   }).filter(Boolean).sort(compareLoomletRuntimeEvents);
+}
+
+function createInteractionChannelSet(channels) {
+  if (!channels) return new Set(DEFAULT_LOOMLET_INTERACTION_EVENT_CHANNELS);
+  return new Set(toArray(channels)
+    .filter(channel => typeof channel === 'string' && channel.trim())
+    .map(channel => channel.trim()));
+}
+
+function resolveInteractionEventChannel(event) {
+  return typeof event?.channel === 'string' && event.channel.trim()
+    ? event.channel.trim()
+    : (typeof event?.type === 'string' && event.type.trim() ? event.type.trim() : '');
+}
+
+function resolveInteractionEventTarget(event) {
+  return typeof event?.target === 'string' && event.target.trim()
+    ? event.target.trim()
+    : (typeof event?.objectId === 'string' && event.objectId.trim() ? event.objectId.trim() : '');
+}
+
+function normalizeInteractionTick(value, fallback = 0) {
+  const tick = Number(value);
+  return Number.isFinite(tick) ? Math.max(0, Math.floor(tick)) : fallback;
 }
 
 function scopeKey(scope) {
@@ -205,6 +250,10 @@ function createRuntimeManager({
   getInputRoutingMode,
   audioSource,
   enableDebug = false,
+  interactionTimelineId = LOOMLET_INTERACTION_TIMELINE_ID,
+  interactionEventChannels = null,
+  interactionMaxHistory = 1000,
+  interactionMaxPending = 1000,
 }) {
   const runtimes = new Map();
   const definitions = new Map();
@@ -212,6 +261,232 @@ function createRuntimeManager({
   const lastEvaluations = new Map();
   const eventEvaluationHistory = new Map();
   const maxDebugEvaluationHistory = 50;
+  const interactionChannels = createInteractionChannelSet(interactionEventChannels);
+  const interactionEventTimeline = createSceneEventTimeline({
+    timelineId: interactionTimelineId,
+    maxHistory: interactionMaxHistory,
+    maxPending: interactionMaxPending,
+  });
+  const pendingInteractionRuntimeEvents = new Map();
+  const blockedInteractionReplayEventIds = new Set();
+  const deferredInteractionReplayEvents = [];
+  let lastInteractionTick = 0;
+
+  function currentInteractionTick(options = {}) {
+    if (Number.isFinite(Number(options.currentTick))) {
+      return normalizeInteractionTick(options.currentTick, lastInteractionTick);
+    }
+    const clockState = getSceneClockStateForLoomlet?.();
+    const tick = resolveLoomletRuntimeTick(clockState);
+    return tick ?? lastInteractionTick;
+  }
+
+  function enqueueInteractionRuntimeEvent(objectId, event) {
+    if (!objectId || !event) return;
+    if (!pendingInteractionRuntimeEvents.has(objectId)) {
+      pendingInteractionRuntimeEvents.set(objectId, []);
+    }
+    const events = pendingInteractionRuntimeEvents.get(objectId);
+    if (event.eventId) {
+      const index = events.findIndex(item => item?.eventId === event.eventId);
+      if (index >= 0) {
+        events[index] = event;
+        events.sort(compareLoomletRuntimeEvents);
+        return;
+      }
+    }
+    events.push(event);
+    events.sort(compareLoomletRuntimeEvents);
+    while (events.length > interactionMaxPending) events.shift();
+  }
+
+  function replacePendingInteractionRuntimeEvent(event) {
+    if (!event?.eventId) return false;
+    const nextObjectId = event.target || event.objectId;
+    if (!nextObjectId) return false;
+    for (const [objectId, events] of pendingInteractionRuntimeEvents) {
+      const index = events.findIndex(item => item?.eventId === event.eventId);
+      if (index < 0) continue;
+      events.splice(index, 1);
+      if (events.length === 0) pendingInteractionRuntimeEvents.delete(objectId);
+      enqueueInteractionRuntimeEvent(nextObjectId, event);
+      return true;
+    }
+    return false;
+  }
+
+  function appendDeferredInteractionReplayEvent(event, reason = 'replay-required') {
+    if (!event?.eventId) return;
+    deferredInteractionReplayEvents.push({
+      reason,
+      event: cloneJson(event),
+    });
+    while (deferredInteractionReplayEvents.length > maxDebugEvaluationHistory) {
+      deferredInteractionReplayEvents.shift();
+    }
+  }
+
+  function consumeInteractionTimelineEventWithoutDelivery(eventId, currentTick) {
+    if (!eventId) return false;
+    let consumed = false;
+    interactionEventTimeline.processDueEvents(currentTick, (event) => {
+      if (event.eventId !== eventId) return false;
+      consumed = true;
+      return { applied: true };
+    });
+    return consumed;
+  }
+
+  function getPendingInteractionRuntimeEvents(objectId) {
+    return pendingInteractionRuntimeEvents.get(objectId)?.slice() || [];
+  }
+
+  function clearPendingInteractionRuntimeEvents(objectId) {
+    pendingInteractionRuntimeEvents.delete(objectId);
+  }
+
+  function isInteractionSceneEvent(payload) {
+    const channel = resolveInteractionEventChannel(payload);
+    if (!channel || !interactionChannels.has(channel)) return false;
+    return resolveInteractionEventTarget(payload) !== '';
+  }
+
+  function processDueInteractionEvents(currentTick = lastInteractionTick) {
+    const tick = normalizeInteractionTick(currentTick, lastInteractionTick);
+    lastInteractionTick = tick;
+    return interactionEventTimeline.processDueEvents(tick, (event) => {
+      if (blockedInteractionReplayEventIds.has(event.eventId)) {
+        blockedInteractionReplayEventIds.delete(event.eventId);
+        appendDeferredInteractionReplayEvent(event);
+        return { applied: true };
+      }
+      const runtimeEvent = sceneEventToRuntimeEvent(event);
+      const objectId = runtimeEvent?.target || runtimeEvent?.objectId;
+      if (!objectId) return true;
+      enqueueInteractionRuntimeEvent(objectId, runtimeEvent);
+      return { applied: true };
+    });
+  }
+
+  function queueInteractionEvent(payload = {}, options = {}) {
+    if (!isInteractionSceneEvent(payload)) {
+      return { ok: false, reason: 'unsupported-interaction-event' };
+    }
+    const target = resolveInteractionEventTarget(payload);
+    const channel = resolveInteractionEventChannel(payload);
+    const tick = currentInteractionTick(options);
+    const result = interactionEventTimeline.queueEvent({
+      ...payload,
+      kind: 'scene-event',
+      channel,
+      target,
+      source: payload.source || LOOMLET_INTERACTION_EVENT_SOURCE,
+    }, { currentTick: tick });
+    if (!result.ok) return result;
+    if (result.replayRequired === true) {
+      const runtimeEvent = sceneEventToRuntimeEvent(result.event);
+      if (replacePendingInteractionRuntimeEvent(runtimeEvent)) {
+        consumeInteractionTimelineEventWithoutDelivery(result.event.eventId, tick);
+        return { ...result, replayRequired: false, replacedPendingRuntimeEvent: true };
+      }
+      blockedInteractionReplayEventIds.add(result.event.eventId);
+    }
+    if (options.processDue !== false) {
+      const processed = processDueInteractionEvents(tick);
+      return { ...result, processed };
+    }
+    return result;
+  }
+
+  function applyInteractionEventLog(payload = {}, options = {}) {
+    const events = Array.isArray(payload?.events) ? payload.events : [];
+    const acceptsLog = payload?.kind === LOOMLET_INTERACTION_EVENT_LOG_KIND ||
+      payload?.kind === 'scene-physics-input-log';
+    if (!acceptsLog || events.length === 0) {
+      return {
+        accepted: false,
+        eventCount: events.length,
+        queuedCount: 0,
+        ignoredCount: events.length,
+        replayRequired: false,
+      };
+    }
+
+    const tick = currentInteractionTick(options);
+    let queuedCount = 0;
+    let ignoredCount = 0;
+    let replayRequired = false;
+    for (const event of events) {
+      const result = queueInteractionEvent(event, {
+        ...options,
+        currentTick: tick,
+        processDue: false,
+      });
+      if (result.ok) {
+        queuedCount += 1;
+        replayRequired ||= result.replayRequired === true;
+      } else {
+        ignoredCount += 1;
+      }
+    }
+    let processed = { applied: false, replayRequired: false };
+    if (queuedCount > 0 && options.processDue !== false) {
+      processed = processDueInteractionEvents(tick);
+      replayRequired ||= processed.replayRequired === true;
+    }
+    return {
+      accepted: queuedCount > 0,
+      eventCount: events.length,
+      queuedCount,
+      ignoredCount,
+      replayRequired,
+      processed,
+    };
+  }
+
+  function createInteractionEventLog(clockState = null, extra = {}) {
+    const events = interactionEventTimeline.getEventHistory();
+    if (events.length === 0) return null;
+    const timelineState = interactionEventTimeline.getTimelineState();
+    return {
+      kind: LOOMLET_INTERACTION_EVENT_LOG_KIND,
+      eventLogKind: LOOMLET_INTERACTION_EVENT_LOG_KIND,
+      source: extra.source || LOOMLET_INTERACTION_EVENT_SOURCE,
+      timelineVersion: timelineState.timelineVersion,
+      timelineId: timelineState.timelineId || interactionTimelineId,
+      timelineRevision: timelineState.timelineRevision,
+      timelineForkTick: timelineState.timelineForkTick,
+      timelineClearRevision: timelineState.timelineClearRevision,
+      lastEventRevision: timelineState.lastEventRevision,
+      eventCount: events.length,
+      events,
+      ...extra,
+      clock: clockState,
+      sentAt: Date.now(),
+    };
+  }
+
+  function clearInteractionEvents(payload = {}) {
+    pendingInteractionRuntimeEvents.clear();
+    blockedInteractionReplayEventIds.clear();
+    const state = interactionEventTimeline.getTimelineState();
+    return interactionEventTimeline.clearEventHistory({
+      timelineId: state.timelineId || interactionTimelineId,
+      timelineRevision: normalizeInteractionTick(
+        payload.timelineRevision,
+        normalizeInteractionTick(state.timelineRevision, 0) + 1,
+      ),
+      timelineForkTick: normalizeInteractionTick(
+        payload.timelineForkTick,
+        lastInteractionTick,
+      ),
+      timelineClearRevision: normalizeInteractionTick(
+        payload.timelineClearRevision,
+        normalizeInteractionTick(state.timelineClearRevision, 0) + 1,
+      ),
+      ...payload,
+    });
+  }
 
   function routeAudioSourceEffect(effect) {
     if (!audioSource) return;
@@ -452,8 +727,12 @@ function createRuntimeManager({
 
     // Gather host events for object-scoped evaluations
     let events = [];
-    if (entry.scopeObjectId && getLoomletHostEvents) {
-      events = normalizeLoomletHostEventsForRuntime(getLoomletHostEvents(entry.scopeObjectId), {
+    if (entry.scopeObjectId) {
+      const hostEvents = getLoomletHostEvents
+        ? toArray(getLoomletHostEvents(entry.scopeObjectId))
+        : [];
+      const queuedEvents = getPendingInteractionRuntimeEvents(entry.scopeObjectId);
+      events = normalizeLoomletHostEventsForRuntime([...hostEvents, ...queuedEvents], {
         target: entry.scopeObjectId,
         timestamp: time,
       });
@@ -489,6 +768,9 @@ function createRuntimeManager({
     if (entry.scopeObjectId && clearLoomletHostEvents) {
       clearLoomletHostEvents(entry.scopeObjectId);
     }
+    if (entry.scopeObjectId) {
+      clearPendingInteractionRuntimeEvents(entry.scopeObjectId);
+    }
   }
 
   return {
@@ -509,9 +791,15 @@ function createRuntimeManager({
     tick(clockState = null, now = performance.now()) {
       // clockState: Scene Clock state from host
       // If not provided, fall back to host-provided time
+      const tick = resolveLoomletRuntimeTick(clockState);
+      if (tick !== undefined) {
+        lastInteractionTick = tick;
+      }
+      processDueInteractionEvents(lastInteractionTick);
       for (const [key, entry] of Array.from(runtimes.entries()).sort(([left], [right]) => compareLoomletRuntimeScopeKeys(left, right))) {
         evaluateRuntime(key, entry, clockState, now);
       }
+      pendingInteractionRuntimeEvents.clear();
     },
     exportState() {
       const state = { scene: null, objects: {} };
@@ -583,8 +871,18 @@ function createRuntimeManager({
       return {
         evaluations,
         eventEvaluations,
+        interactionTimeline: interactionEventTimeline.getTimelineState(),
+        pendingInteractionEvents: interactionEventTimeline.getPendingEvents(),
+        deferredInteractionReplayEvents: cloneJson(deferredInteractionReplayEvents),
       };
     },
+    queueInteractionEvent,
+    applyInteractionEventLog,
+    createInteractionEventLog,
+    clearInteractionEvents,
+    getInteractionTimelineState: () => interactionEventTimeline.getTimelineState(),
+    getPendingInteractionEvents: () => interactionEventTimeline.getPendingEvents(),
+    getInteractionEventHistory: () => interactionEventTimeline.getEventHistory(),
     clearObjectGraph(objectId) {
       if (objectId) clearGraph({ object: objectId });
     },
@@ -622,6 +920,10 @@ export function createSceneSyncLoomIntegration({
   getInputRoutingMode,
   audioSource,
   enableDebug = false,
+  interactionTimelineId,
+  interactionEventChannels,
+  interactionMaxHistory,
+  interactionMaxPending,
 }) {
   const manager = createRuntimeManager({
     resolveTarget: (targetId) => targetId ? getObjectById(targetId) : null,
@@ -639,6 +941,10 @@ export function createSceneSyncLoomIntegration({
     getInputRoutingMode,
     audioSource,
     enableDebug,
+    interactionTimelineId,
+    interactionEventChannels,
+    interactionMaxHistory,
+    interactionMaxPending,
   });
 
   function isSceneGraphMessage(payload) {
@@ -669,6 +975,13 @@ export function createSceneSyncLoomIntegration({
     }),
     importState: (state) => manager.importState(state),
     clearObjectGraph: (objectId) => manager.clearObjectGraph(objectId),
+    queueInteractionEvent: (payload, options) => manager.queueInteractionEvent(payload, options),
+    applyInteractionEventLog: (payload, options) => manager.applyInteractionEventLog(payload, options),
+    createInteractionEventLog: (clockState, extra) => manager.createInteractionEventLog(clockState, extra),
+    clearInteractionEvents: (payload) => manager.clearInteractionEvents(payload),
+    getInteractionTimelineState: () => manager.getInteractionTimelineState(),
+    getPendingInteractionEvents: () => manager.getPendingInteractionEvents(),
+    getInteractionEventHistory: () => manager.getInteractionEventHistory(),
     tickObjectGraphs: (clockState = null, now) => {
       if (typeof clockState === 'number' && now === undefined) {
         manager.tick(null, clockState);

--- a/html/assets/js/scenesync/loomlet-runtime-integration.test.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.test.js
@@ -3,6 +3,8 @@ import test from 'node:test';
 import {
   compareLoomletRuntimeScopeKeys,
   createSceneSyncLoomIntegration,
+  LOOMLET_INTERACTION_EVENT_LOG_KIND,
+  LOOMLET_INTERACTION_TIMELINE_ID,
   normalizeLoomletHostEventsForRuntime,
   resolveLoomletRuntimeDeltaTime,
   resolveLoomletRuntimeTick,
@@ -133,4 +135,284 @@ test('Loomlet integration evaluates scopes in deterministic key order', () => {
   integration.tickObjectGraphs({ t: 0, deltaTime: 0 }, 0);
 
   assert.equal(object.position.x, 1);
+});
+
+test('Loomlet integration queues synchronized pointer events by apply tick', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+    enableDebug: true,
+  });
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'click.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+
+  const queued = integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'click-1',
+    target: 'box-1',
+    applyTick: 4,
+    timestamp: 1,
+    payload: { pointerId: 1, clientX: 10, clientY: 20 },
+  }, { currentTick: 3 });
+
+  assert.equal(queued.ok, true);
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 3 }, 1000);
+  assert.equal(object.position.x, 0);
+
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 4 }, 1000);
+  assert.equal(object.position.x, 1);
+  assert.equal(integration.getInteractionTimelineState().timelineId, LOOMLET_INTERACTION_TIMELINE_ID);
+  assert.equal(integration.getPendingInteractionEvents().length, 0);
+
+  const debug = integration.debugState();
+  const records = debug.eventEvaluations['object:box-1'];
+  assert.equal(records.at(-1).events[0].eventId, 'click-1');
+  assert.deepEqual(records.at(-1).events[0].payload, { pointerId: 1, clientX: 10, clientY: 20 });
+});
+
+test('Loomlet interaction queue exports and applies scene event logs', () => {
+  const object = createPositionObject();
+  const source = createSceneSyncLoomIntegration({
+    getObjectById: () => null,
+    interactionTimelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+  });
+  const target = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+  });
+  target.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'drag', type: 'onEvent', params: { channel: 'pointer.drag.start' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'drag.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+
+  source.queueInteractionEvent({
+    kind: 'scene-event',
+    channel: 'pointer.drag.start',
+    eventId: 'drag-1:event:000000',
+    target: 'box-1',
+    interactionId: 'drag-1',
+    sequence: 0,
+    applyTick: 6,
+    timestamp: 2,
+  }, { currentTick: 0, processDue: false });
+  const log = source.createInteractionEventLog({ t: 2, tick: 6 }, {
+    requestId: 'request-1',
+  });
+
+  assert.equal(log.kind, LOOMLET_INTERACTION_EVENT_LOG_KIND);
+  assert.equal(log.eventCount, 1);
+  assert.equal(log.requestId, 'request-1');
+
+  const report = target.applyInteractionEventLog(log, { currentTick: 6 });
+  assert.equal(report.accepted, true);
+  assert.equal(report.queuedCount, 1);
+  target.tickObjectGraphs({ t: 2, deltaTime: 0, tick: 6 }, 2000);
+  assert.equal(object.position.x, 1);
+});
+
+test('Loomlet interaction queue rejects unsupported channels and targetless events', () => {
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: () => null,
+  });
+
+  assert.equal(integration.queueInteractionEvent({
+    kind: 'scene-event',
+    channel: 'keyboard.down',
+    target: 'box-1',
+  }).ok, false);
+  assert.equal(integration.queueInteractionEvent({
+    kind: 'scene-event',
+    channel: 'pointer.click',
+  }).ok, false);
+});
+
+test('Loomlet interaction queue clears with default timeline metadata', () => {
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: () => null,
+  });
+
+  integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'click-clear-1',
+    target: 'box-1',
+    applyTick: 4,
+  }, { currentTick: 0, processDue: false });
+  assert.equal(integration.getInteractionEventHistory().length, 1);
+
+  assert.equal(integration.clearInteractionEvents(), true);
+  assert.equal(integration.getInteractionEventHistory().length, 0);
+  assert.equal(integration.getInteractionTimelineState().timelineClearRevision, 1);
+});
+
+test('Loomlet interaction queue does not deliver stale frame events to later graphs', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+  });
+
+  integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'stale-click-1',
+    target: 'box-1',
+    applyTick: 4,
+  }, { currentTick: 4 });
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 4 }, 1000);
+
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'click.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 5 }, 1000);
+
+  assert.equal(object.position.x, 0);
+});
+
+test('Loomlet interaction queue replaces same-frame duplicate runtime events', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+    enableDebug: true,
+  });
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'click.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+
+  integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'replace-click-1',
+    target: 'box-1',
+    applyTick: 4,
+    payload: { clientX: 10 },
+  }, { currentTick: 4 });
+  const replacement = integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'replace-click-1',
+    target: 'box-1',
+    applyTick: 4,
+    eventRevision: 2,
+    payload: { clientX: 20 },
+  }, { currentTick: 4 });
+
+  assert.equal(replacement.ok, true);
+  assert.equal(replacement.replacedPendingRuntimeEvent, true);
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 4 }, 1000);
+
+  const records = integration.debugState().eventEvaluations['object:box-1'];
+  assert.equal(records.at(-1).events.length, 1);
+  assert.equal(records.at(-1).events[0].payload.clientX, 20);
+});
+
+test('Loomlet interaction queue defers replay-required late updates', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+    enableDebug: true,
+  });
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'click.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+
+  integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'late-click-1',
+    target: 'box-1',
+    applyTick: 1,
+    payload: { clientX: 10 },
+  }, { currentTick: 1 });
+  integration.tickObjectGraphs({ t: 1, deltaTime: 0, tick: 1 }, 1000);
+  assert.equal(object.position.x, 1);
+
+  const lateUpdate = integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'late-click-1',
+    target: 'box-1',
+    applyTick: 1,
+    eventRevision: 2,
+    payload: { clientX: 20 },
+  }, { currentTick: 3 });
+  assert.equal(lateUpdate.ok, true);
+  assert.equal(lateUpdate.replayRequired, true);
+
+  integration.tickObjectGraphs({ t: 3, deltaTime: 0, tick: 3 }, 3000);
+  const debug = integration.debugState();
+  assert.equal(debug.eventEvaluations['object:box-1'].length, 1);
+  assert.equal(debug.deferredInteractionReplayEvents.at(-1).event.eventId, 'late-click-1');
+  assert.equal(debug.deferredInteractionReplayEvents.at(-1).event.payload.clientX, 20);
 });


### PR DESCRIPTION
## Summary
- add a timeline-backed Loomlet interaction input queue for synchronized pointer click/drag scene events
- expose queue/apply/export/clear helpers on the Scene Sync Loomlet integration adapter
- preserve legacy host events while avoiding stale frame delivery and deferring replay-required late updates

## Validation
- node --check html/assets/js/scenesync/loomlet-runtime-integration.js
- node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js
- node --test apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
- npm run test:loomlet-plugin
- npm run test:runtime-schedule
- npm run test:physics
- git diff --check

## Review
- reviewed by subagent Hegel; initial replay/duplicate findings fixed; re-review returned no findings

## Notes
- replayRequired interaction events are now surfaced as deferred diagnostics; full Loomlet graph replay is intentionally left for the deterministic replay task.