### PR TITLE
[codex] Wire Player interactions into Loomlet queue

### DIFF
--- a/html/assets/js/scenesync/loomlet-runtime-integration.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.js
@@ -6,6 +6,12 @@ import {
   createSceneEventTimeline,
   sceneEventToRuntimeEvent,
 } from './runtime/event-timeline.js';
+import {
+  PLAYER_INTERACTION_EVENT_LOG_KIND,
+  PLAYER_INTERACTION_EVENT_SOURCE,
+  PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+  PLAYER_POINTER_INTERACTION_CHANNELS,
+} from './runtime/player-interaction-events.js';
 
 export const LOOMLET_RUNTIME_METADATA = Object.freeze({
   version: LoomletSceneSyncRuntimeVersion,
@@ -13,16 +19,10 @@ export const LOOMLET_RUNTIME_METADATA = Object.freeze({
   adapter: 'scenesync',
 });
 
-export const LOOMLET_INTERACTION_TIMELINE_ID = 'player-interaction';
-export const LOOMLET_INTERACTION_EVENT_LOG_KIND = 'scene-event-log';
-export const LOOMLET_INTERACTION_EVENT_SOURCE = 'loomlet';
-export const LOOMLET_POINTER_INTERACTION_CHANNELS = Object.freeze([
-  'pointer.click',
-  'pointer.drag.start',
-  'pointer.drag.move',
-  'pointer.drag.end',
-  'pointer.drag.cancel',
-]);
+export const LOOMLET_INTERACTION_TIMELINE_ID = PLAYER_INTERACTION_EVENT_TIMELINE_ID;
+export const LOOMLET_INTERACTION_EVENT_LOG_KIND = PLAYER_INTERACTION_EVENT_LOG_KIND;
+export const LOOMLET_INTERACTION_EVENT_SOURCE = PLAYER_INTERACTION_EVENT_SOURCE;
+export const LOOMLET_POINTER_INTERACTION_CHANNELS = PLAYER_POINTER_INTERACTION_CHANNELS;
 
 const DEFAULT_LOOMLET_INTERACTION_EVENT_CHANNELS = new Set(LOOMLET_POINTER_INTERACTION_CHANNELS);
 
@@ -351,6 +351,12 @@ function createRuntimeManager({
     return resolveInteractionEventTarget(payload) !== '';
   }
 
+  function hasQueuedInteractionEvent(eventId) {
+    if (!eventId) return false;
+    return interactionEventTimeline.getEventHistory().some(event => event.eventId === eventId) ||
+      interactionEventTimeline.getPendingEvents().some(event => event.eventId === eventId);
+  }
+
   function processDueInteractionEvents(currentTick = lastInteractionTick) {
     const tick = normalizeInteractionTick(currentTick, lastInteractionTick);
     lastInteractionTick = tick;
@@ -375,6 +381,7 @@ function createRuntimeManager({
     const target = resolveInteractionEventTarget(payload);
     const channel = resolveInteractionEventChannel(payload);
     const tick = currentInteractionTick(options);
+    const hadExistingEvent = hasQueuedInteractionEvent(payload.eventId ?? payload.inputId);
     const result = interactionEventTimeline.queueEvent({
       ...payload,
       kind: 'scene-event',
@@ -383,7 +390,7 @@ function createRuntimeManager({
       source: payload.source || LOOMLET_INTERACTION_EVENT_SOURCE,
     }, { currentTick: tick });
     if (!result.ok) return result;
-    if (result.replayRequired === true) {
+    if (result.replayRequired === true && hadExistingEvent) {
       const runtimeEvent = sceneEventToRuntimeEvent(result.event);
       if (replacePendingInteractionRuntimeEvent(runtimeEvent)) {
         consumeInteractionTimelineEventWithoutDelivery(result.event.eventId, tick);

--- a/html/assets/js/scenesync/loomlet-runtime-integration.test.js
+++ b/html/assets/js/scenesync/loomlet-runtime-integration.test.js
@@ -416,3 +416,46 @@ test('Loomlet interaction queue defers replay-required late updates', () => {
   assert.equal(debug.deferredInteractionReplayEvents.at(-1).event.eventId, 'late-click-1');
   assert.equal(debug.deferredInteractionReplayEvents.at(-1).event.payload.clientX, 20);
 });
+
+test('Loomlet interaction queue delivers first-seen late events once for compatibility', () => {
+  const object = createPositionObject();
+  const integration = createSceneSyncLoomIntegration({
+    getObjectById: (objectId) => (objectId === 'box-1' ? object : null),
+    getObjectRuntimeTime: () => 1,
+    enableDebug: true,
+  });
+  integration.handlePayload({
+    type: 'scene-graph-set',
+    scope: { object: 'box-1' },
+    graph: {
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+        { id: 'count', type: 'list.length' },
+        { id: 'move', type: 'scene.setPosition', params: { objectId: 'box-1', y: 0, z: 0 } },
+      ],
+      edges: [
+        { from: 'click.event', to: 'count.list' },
+        { from: 'count.out', to: 'move.x' },
+      ],
+    },
+  });
+
+  const queued = integration.queueInteractionEvent({
+    kind: 'scene-event',
+    timelineId: LOOMLET_INTERACTION_TIMELINE_ID,
+    channel: 'pointer.click',
+    eventId: 'first-late-click-1',
+    target: 'box-1',
+    applyTick: 1,
+    payload: { clientX: 10 },
+  }, { currentTick: 3 });
+
+  assert.equal(queued.ok, true);
+  assert.equal(queued.replayRequired, true);
+  integration.tickObjectGraphs({ t: 3, deltaTime: 0, tick: 3 }, 3000);
+
+  assert.equal(object.position.x, 1);
+  const debug = integration.debugState();
+  assert.equal(debug.eventEvaluations['object:box-1'].at(-1).events[0].eventId, 'first-late-click-1');
+  assert.equal(debug.deferredInteractionReplayEvents.length, 0);
+});

--- a/html/assets/js/scenesync/runtime/player-interaction-events.js
+++ b/html/assets/js/scenesync/runtime/player-interaction-events.js
@@ -1,0 +1,102 @@
+export const PLAYER_INTERACTION_EVENT_TIMELINE_ID = 'player-interaction';
+export const PLAYER_INTERACTION_EVENT_LOG_KIND = 'scene-event-log';
+export const PLAYER_INTERACTION_EVENT_SOURCE = 'player-shell';
+export const PLAYER_POINTER_INTERACTION_CHANNELS = Object.freeze([
+  'pointer.click',
+  'pointer.drag.start',
+  'pointer.drag.move',
+  'pointer.drag.end',
+  'pointer.drag.cancel',
+]);
+
+const PLAYER_POINTER_INTERACTION_CHANNEL_SET = new Set(PLAYER_POINTER_INTERACTION_CHANNELS);
+
+function normalizeString(value, fallback = '') {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizeOptionalString(value) {
+  const normalized = normalizeString(value, '');
+  return normalized || null;
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(0, Math.floor(number));
+}
+
+function cloneArray(value) {
+  return Array.isArray(value) ? value.slice() : value;
+}
+
+export function resolvePlayerInteractionEventChannel(event) {
+  return normalizeString(event?.channel ?? event?.type, '');
+}
+
+export function resolvePlayerInteractionEventTarget(event) {
+  return normalizeOptionalString(event?.target) || normalizeOptionalString(event?.objectId);
+}
+
+export function isPlayerInteractionChannel(channel) {
+  return PLAYER_POINTER_INTERACTION_CHANNEL_SET.has(normalizeString(channel, ''));
+}
+
+export function isPlayerInteractionSceneEvent(payload) {
+  return payload?.kind === 'scene-event' &&
+    isPlayerInteractionChannel(resolvePlayerInteractionEventChannel(payload));
+}
+
+export function normalizePlayerInteractionSceneEvent(payload = {}, { fromPeer = null } = {}) {
+  if (!isPlayerInteractionSceneEvent(payload)) return null;
+  const target = resolvePlayerInteractionEventTarget(payload);
+  if (!target) return null;
+  return {
+    ...payload,
+    kind: 'scene-event',
+    channel: resolvePlayerInteractionEventChannel(payload),
+    target,
+    source: normalizeString(payload.source, PLAYER_INTERACTION_EVENT_SOURCE),
+    sourcePeerId: payload.sourcePeerId || fromPeer?.id || undefined,
+  };
+}
+
+export function createPlayerInteractionPointerPayload({
+  pointerId = null,
+  pointerType = 'mouse',
+  button = 0,
+  clientX = 0,
+  clientY = 0,
+  startClientX = 0,
+  startClientY = 0,
+  maxPointerDistanceSquared = 0,
+  physicsInput = null,
+} = {}) {
+  const payload = {
+    pointerId,
+    pointerType: normalizeString(pointerType, 'mouse'),
+    button: nonNegativeInteger(button, 0),
+    clientX: finiteNumber(clientX, finiteNumber(startClientX, 0)),
+    clientY: finiteNumber(clientY, finiteNumber(startClientY, 0)),
+    startClientX: finiteNumber(startClientX, 0),
+    startClientY: finiteNumber(startClientY, 0),
+    maxPointerDistanceSquared: finiteNumber(maxPointerDistanceSquared, 0),
+  };
+
+  if (physicsInput) {
+    payload.physicsInputId = physicsInput.inputId;
+    payload.physicsPhase = physicsInput.phase;
+    payload.controlMode = physicsInput.controlMode;
+    payload.position = cloneArray(physicsInput.position);
+    payload.velocity = cloneArray(physicsInput.velocity);
+  }
+
+  return payload;
+}

--- a/html/assets/js/scenesync/runtime/player-interaction-events.test.js
+++ b/html/assets/js/scenesync/runtime/player-interaction-events.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createPlayerInteractionPointerPayload,
+  isPlayerInteractionSceneEvent,
+  normalizePlayerInteractionSceneEvent,
+  PLAYER_INTERACTION_EVENT_SOURCE,
+  PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+  PLAYER_POINTER_INTERACTION_CHANNELS,
+  resolvePlayerInteractionEventChannel,
+  resolvePlayerInteractionEventTarget,
+} from './player-interaction-events.js';
+
+test('player interaction constants define the shared pointer contract', () => {
+  assert.equal(PLAYER_INTERACTION_EVENT_TIMELINE_ID, 'player-interaction');
+  assert.equal(PLAYER_INTERACTION_EVENT_SOURCE, 'player-shell');
+  assert.deepEqual(PLAYER_POINTER_INTERACTION_CHANNELS, [
+    'pointer.click',
+    'pointer.drag.start',
+    'pointer.drag.move',
+    'pointer.drag.end',
+    'pointer.drag.cancel',
+  ]);
+});
+
+test('normalizePlayerInteractionSceneEvent accepts pointer scene events with target aliases', () => {
+  const event = normalizePlayerInteractionSceneEvent({
+    kind: 'scene-event',
+    type: 'pointer.click',
+    objectId: 'box-1',
+    eventId: 'click-1',
+    payload: { clientX: 10 },
+  }, {
+    fromPeer: { id: 'peer-1' },
+  });
+
+  assert.equal(event.kind, 'scene-event');
+  assert.equal(event.channel, 'pointer.click');
+  assert.equal(event.target, 'box-1');
+  assert.equal(event.source, PLAYER_INTERACTION_EVENT_SOURCE);
+  assert.equal(event.sourcePeerId, 'peer-1');
+  assert.deepEqual(event.payload, { clientX: 10 });
+});
+
+test('normalizePlayerInteractionSceneEvent falls back from blank target to objectId', () => {
+  const event = normalizePlayerInteractionSceneEvent({
+    kind: 'scene-event',
+    channel: 'pointer.click',
+    target: ' ',
+    objectId: 'box-1',
+  });
+
+  assert.equal(event.target, 'box-1');
+});
+
+test('normalizePlayerInteractionSceneEvent preserves canonical source peer ids', () => {
+  const event = normalizePlayerInteractionSceneEvent({
+    kind: 'scene-event',
+    channel: 'pointer.drag.start',
+    target: 'box-1',
+    source: 'player-shell',
+    sourcePeerId: 'authority-peer',
+  }, {
+    fromPeer: { id: 'relay-peer' },
+  });
+
+  assert.equal(event.sourcePeerId, 'authority-peer');
+});
+
+test('normalizePlayerInteractionSceneEvent rejects unsupported or targetless events', () => {
+  assert.equal(normalizePlayerInteractionSceneEvent({
+    kind: 'scene-event',
+    channel: 'keyboard.down',
+    target: 'box-1',
+  }), null);
+  assert.equal(normalizePlayerInteractionSceneEvent({
+    kind: 'scene-event',
+    channel: 'pointer.click',
+  }), null);
+});
+
+test('player interaction helpers resolve channel and target consistently', () => {
+  assert.equal(resolvePlayerInteractionEventChannel({ type: 'pointer.drag.move' }), 'pointer.drag.move');
+  assert.equal(resolvePlayerInteractionEventTarget({ objectId: 'box-1' }), 'box-1');
+  assert.equal(isPlayerInteractionSceneEvent({ kind: 'scene-event', channel: 'pointer.drag.cancel' }), true);
+  assert.equal(isPlayerInteractionSceneEvent({ kind: 'scene-event', channel: 'object.hover.enter' }), false);
+});
+
+test('createPlayerInteractionPointerPayload normalizes pointer metadata and physics linkage', () => {
+  const payload = createPlayerInteractionPointerPayload({
+    pointerId: 7,
+    pointerType: 'pen',
+    button: 0,
+    clientX: 12,
+    clientY: 24,
+    startClientX: 10,
+    startClientY: 20,
+    maxPointerDistanceSquared: 25,
+    physicsInput: {
+      inputId: 'drag-1:000001',
+      phase: 'grab-move',
+      controlMode: 'hold',
+      position: [1, 2, 3],
+      velocity: [4, 5, 6],
+    },
+  });
+
+  assert.deepEqual(payload, {
+    pointerId: 7,
+    pointerType: 'pen',
+    button: 0,
+    clientX: 12,
+    clientY: 24,
+    startClientX: 10,
+    startClientY: 20,
+    maxPointerDistanceSquared: 25,
+    physicsInputId: 'drag-1:000001',
+    physicsPhase: 'grab-move',
+    controlMode: 'hold',
+    position: [1, 2, 3],
+    velocity: [4, 5, 6],
+  });
+});
+
+test('createPlayerInteractionPointerPayload falls back to drag start coordinates', () => {
+  const payload = createPlayerInteractionPointerPayload({
+    clientX: Number.NaN,
+    clientY: Number.NaN,
+    startClientX: 10,
+    startClientY: 20,
+  });
+
+  assert.equal(payload.clientX, 10);
+  assert.equal(payload.clientY, 20);
+});

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -61,6 +61,13 @@ import { reportPreviousCrashProbe, markCrashProbe, clearCrashProbe } from './uti
 import { isSnapshotRestoreDisabled, isGlbLoadDisabled, logDiagnosticFlags } from './utils/diagnostic-flags.js';
 import { shouldFreezeObjectForEditorRuntime } from './runtime/editing-state.js';
 import { createSceneEventTimeline, sceneEventToRuntimeEvent } from './runtime/event-timeline.js';
+import {
+  createPlayerInteractionPointerPayload,
+  isPlayerInteractionSceneEvent as isPlayerInteractionSceneEventPayload,
+  normalizePlayerInteractionSceneEvent,
+  PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+  PLAYER_POINTER_INTERACTION_CHANNELS,
+} from './runtime/player-interaction-events.js';
 import { calculateScenePlaybackDuration } from './runtime/playback-duration.js';
 import {
   CLOCK_MODE_LABELS,
@@ -1390,15 +1397,8 @@ const PLAYER_PHYSICS_DRAG_MAX_THROW_SPEED = 18;
 const SCENE_SYNC_EVENT_LOG_KIND = 'scene-event-log';
 const SCENE_SYNC_EVENT_LOG_REQUEST_KIND = 'scene-event-log-request';
 const SCENE_PHYSICS_INPUT_LOG_REQUEST_KIND = 'scene-physics-input-log-request';
-const PLAYER_INTERACTION_EVENT_TIMELINE_ID = 'player-interaction';
 const PLAYER_INTERACTION_CLICK_DISTANCE_SQUARED = 25;
-const PLAYER_INTERACTION_EVENT_CHANNELS = new Set([
-  'pointer.drag.start',
-  'pointer.drag.move',
-  'pointer.drag.end',
-  'pointer.drag.cancel',
-  'pointer.click',
-]);
+const PLAYER_INTERACTION_EVENT_CHANNELS = new Set(PLAYER_POINTER_INTERACTION_CHANNELS);
 
 function createSampleCube() {
   const sampleGeo = new THREE.BoxGeometry(1, 1, 1);
@@ -3197,6 +3197,7 @@ const playerPhysicsDragState = {
 
 let currentHoveredObjectId = null;
 const loomletHostEvents = new Map(); // objectId -> Array<eventName | event>
+let loomIntegration = null;
 const tmpViewerPosition = new THREE.Vector3();
 const tmpViewerForward = new THREE.Vector3();
 
@@ -3704,24 +3705,12 @@ function getPlayerInteractionEventTick(fallback = 0) {
 }
 
 function isPlayerInteractionSceneEvent(payload) {
-  const channel = typeof payload?.channel === 'string'
-    ? payload.channel
-    : (typeof payload?.type === 'string' ? payload.type : '');
-  return payload?.kind === 'scene-event' && PLAYER_INTERACTION_EVENT_CHANNELS.has(channel);
+  return isPlayerInteractionSceneEventPayload(payload);
 }
 
 function queuePlayerInteractionSceneEvent(payload = {}, { fromPeer = null, processDue = true } = {}) {
-  if (!isPlayerInteractionSceneEvent(payload)) return null;
-  const target = typeof payload.target === 'string' && payload.target.trim()
-    ? payload.target.trim()
-    : (typeof payload.objectId === 'string' && payload.objectId.trim() ? payload.objectId.trim() : '');
-  if (!target) return null;
-
-  const eventPayload = {
-    ...payload,
-    target,
-    sourcePeerId: payload.sourcePeerId || fromPeer?.id || undefined,
-  };
+  const eventPayload = normalizePlayerInteractionSceneEvent(payload, { fromPeer });
+  if (!eventPayload) return null;
   const currentTick = getPlayerInteractionEventTick();
   const result = playerInteractionEventTimeline.queueEvent(eventPayload, { currentTick });
   if (!result.ok) return null;
@@ -3756,6 +3745,12 @@ function resetPlayerInteractionEventTimeline(reason = 'player-interaction-reset'
     timelineForkTick: getPlayerInteractionEventTick(),
     timelineClearRevision,
   });
+  loomIntegration?.clearInteractionEvents?.({
+    timelineId: state.timelineId || PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+    timelineRevision,
+    timelineForkTick: getPlayerInteractionEventTick(),
+    timelineClearRevision,
+  });
   loomletHostEvents.clear();
   if (isPlayerPhysicsDragging()) {
     clearPlayerPhysicsDragState();
@@ -3765,6 +3760,9 @@ function resetPlayerInteractionEventTimeline(reason = 'player-interaction-reset'
 
 function processDuePlayerInteractionEvents(currentTick = getPlayerInteractionEventTick()) {
   const processed = playerInteractionEventTimeline.processDueEvents(currentTick, (event) => {
+    const queuedForLoomlet = loomIntegration?.queueInteractionEvent?.(event, { currentTick });
+    if (queuedForLoomlet?.ok) return { applied: true };
+
     const runtimeEvent = sceneEventToRuntimeEvent(event);
     const objectId = runtimeEvent?.target || runtimeEvent?.objectId;
     if (!objectId) return true;
@@ -3791,7 +3789,7 @@ function createPlayerInteractionEventPayload({
   const clockState = getSceneClockStateForLoomlet(now);
   const resolvedClientX = Number.isFinite(Number(clientX)) ? Number(clientX) : playerPhysicsDragState.startClientX;
   const resolvedClientY = Number.isFinite(Number(clientY)) ? Number(clientY) : playerPhysicsDragState.startClientY;
-  const payload = {
+  const payload = createPlayerInteractionPointerPayload({
     pointerId: pointerEvent?.pointerId ?? playerPhysicsDragState.pointerId,
     pointerType: pointerEvent?.pointerType || playerPhysicsDragState.pointerType || 'mouse',
     button: pointerEvent?.button ?? playerPhysicsDragState.button ?? 0,
@@ -3800,14 +3798,8 @@ function createPlayerInteractionEventPayload({
     startClientX: playerPhysicsDragState.startClientX,
     startClientY: playerPhysicsDragState.startClientY,
     maxPointerDistanceSquared: playerPhysicsDragState.maxPointerDistanceSquared,
-  };
-  if (physicsInput) {
-    payload.physicsInputId = physicsInput.inputId;
-    payload.physicsPhase = physicsInput.phase;
-    payload.controlMode = physicsInput.controlMode;
-    payload.position = physicsInput.position;
-    payload.velocity = physicsInput.velocity;
-  }
+    physicsInput,
+  });
 
   return {
     kind: 'scene-event',
@@ -6676,7 +6668,7 @@ const audioSourceHostApi = {
   unsync: (objectId, name) => audioSourceController.unsync(objectId, name),
 };
 
-const loomIntegration = createSceneSyncLoomIntegration({
+loomIntegration = createSceneSyncLoomIntegration({
   getObjectById: (objectId) => managedObjects.get(objectId) || null,
   send: (payload) => broadcast(payload),
   getHostTime: () => Date.now() / 1000,
@@ -6695,6 +6687,8 @@ const loomIntegration = createSceneSyncLoomIntegration({
   getInputRoutingMode,
   audioSource: audioSourceHostApi,
   enableDebug: isDevUiEnabled(),
+  interactionTimelineId: PLAYER_INTERACTION_EVENT_TIMELINE_ID,
+  interactionEventChannels: PLAYER_POINTER_INTERACTION_CHANNELS,
 });
 
 // ── Scene Clock Debug UI 制御 ────────────────────────────

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
     "test:physics": "node --test html/assets/js/scenesync/physics/rapier-world.test.js html/assets/js/scenesync/physics/rapier-parity-fixture.test.js html/assets/js/scenesync/scene-physics.test.js html/assets/js/scenesync/history/history-manager.test.js html/assets/js/scenesync/shells/player/player-physics-drag-input.test.js",
     "test:loomlet-plugin": "node --test html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
-    "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js html/assets/js/scenesync/runtime/event-timeline.test.js",
+    "test:runtime-schedule": "node --test html/assets/js/scenesync/runtime/schedule-context.test.js html/assets/js/scenesync/runtime/runtime-events.test.js html/assets/js/scenesync/runtime/event-timeline.test.js html/assets/js/scenesync/runtime/player-interaction-events.test.js",
     "test:plugins": "node --test html/assets/js/scenesync/plugins/scene-sync-physics-plugin.test.js html/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.test.js",
     "test:export-behavior-runtime": "node --test html/assets/js/scenesync-export/viewer/export-behavior-runtime.test.js",
     "test:scene-sync-export-behaviors": "node --test html/assets/js/scenesync/importers/scene-sync-export/apply-scene-behaviors.test.js",


### PR DESCRIPTION
## Summary
- add shared Player pointer interaction event contract helpers
- wire Player Shell scene-event delivery into the Loomlet interaction queue API
- keep hover/gaze host events local while pointer click/drag events use the synchronized queue
- include player interaction contract tests in `test:runtime-schedule`

## Validation
- node --check html/assets/js/scenesync/runtime/player-interaction-events.js
- node --check html/assets/js/scenesync/loomlet-runtime-integration.js
- node --check html/assets/js/scenesync/scene.js
- npm run test:runtime-schedule
- node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js
- npm run test:physics
- node --test apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
- npm run test:loomlet-plugin
- git diff --check

## Review
- reviewed by subagent Lovelace
- initial findings for first-seen late event delivery and blank-target objectId fallback were fixed
- re-review returned no findings

## Notes
- `npm run test:e2e:scene-sync-loomlet-interaction` was attempted but Chromium cannot launch in the current macOS sandbox: MachPortRendezvousServer bootstrap_check_in permission denied.