### PR TITLE
[codex] Allow Loomlet pointer event graph nodes

### DIFF
--- a/docs/scene-sync-loom-ai-skill.md
+++ b/docs/scene-sync-loom-ai-skill.md
@@ -98,6 +98,9 @@ SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. 
 - `cosine` — cosine wave oscillator
 - `add` — addition
 - `multiply` — multiplication
+- `onEvent` — read synchronized frame-local events. Use this for Player Shell pointer interactions. Graph JSON uses `{ "type": "onEvent", "params": { "channel": "pointer.click" } }`; Loomlet DSL should use `onEvent(channel: "pointer.click")`.
+- `list.length` — count events from an `onEvent.event` list
+- `list.at` — select one event from an `onEvent.event` list by index
 - `sceneSetPosition` — set object position (absolute coordinates)
 - `sceneOffsetPosition` — apply x/y/z offsets relative to the object position captured when the Behavior Graph starts evaluating. When the graph is cleared or replaced, Scene Sync restores the captured base position.
 - `sceneSetRotation` — set object rotation
@@ -106,6 +109,14 @@ SceneSync Behavior Graph execution supports a **whitelist** of Loom node types. 
 - `sceneSetVisible` — set object visibility
 
 Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync should provide a suitable room time as `env.time`; Loomlet itself does not synchronize clocks.
+
+Supported synchronized Player Shell event channels are:
+
+- `pointer.click`
+- `pointer.drag.start`
+- `pointer.drag.move`
+- `pointer.drag.end`
+- `pointer.drag.cancel`
 
 ### Forbidden node types:
 
@@ -116,7 +127,7 @@ Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync sh
 - `setAttr` — DOM attribute manipulation
 - `log` — console logging
 
-**Input/Event nodes (not allowed):**
+**Raw local input nodes (not allowed):**
 
 - `pointerClick` — pointer/click events
 - `pointerPosition` — pointer position tracking
@@ -128,7 +139,7 @@ Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync sh
 
 **Reason for restrictions:**
 
-Remote room messages must be safe. DOM and input nodes could introduce security vulnerabilities or break client isolation. SceneSync Behavior Graph execution is intentionally restricted to transformation and visibility control only.
+Remote room messages must be safe. DOM and raw local input nodes could introduce security vulnerabilities or break client isolation. SceneSync Behavior Graph execution only exposes synchronized `scene-event` input through `onEvent`, not direct browser input streams.
 
 ---
 

--- a/docs/scene-sync-loomlet-dsl-ai-authoring.md
+++ b/docs/scene-sync-loomlet-dsl-ai-authoring.md
@@ -87,6 +87,9 @@ The Scene Sync client currently allows these Behavior Graph node types:
 - `cosine`
 - `add`
 - `multiply`
+- `onEvent`
+- `list.length`
+- `list.at`
 - `sceneSetPosition`
 - `sceneOffsetPosition`
 - `sceneSetRotation`
@@ -97,6 +100,18 @@ The Scene Sync client currently allows these Behavior Graph node types:
 Use `clock` for time-driven Loomlet behavior. For shared behavior, Scene Sync should provide a suitable room time as `env.time`; Loomlet itself does not synchronize clocks.
 
 Loomlet DSL authoring should map to those runtime nodes through the compiler/adapter.
+
+For synchronized Player Shell interactions, use `onEvent(channel: "pointer.click")`
+in Loomlet DSL or emit this graph node directly:
+
+```json
+{ "id": "click", "type": "onEvent", "params": { "channel": "pointer.click" } }
+```
+
+Supported synchronized pointer channels are `pointer.click`,
+`pointer.drag.start`, `pointer.drag.move`, `pointer.drag.end`, and
+`pointer.drag.cancel`. Use `list.length` or `list.at` to consume the
+frame-local event list emitted by `onEvent.event`.
 
 ---
 

--- a/packages/scene-sync-mcp/GRAPH_TOOLS.md
+++ b/packages/scene-sync-mcp/GRAPH_TOOLS.md
@@ -86,12 +86,29 @@ Clear the room-level **Scene Behavior Graph**.
 - `add`
 - `multiply`
 - `constant`
+- `onEvent`
+- `list.length`
+- `list.at`
 - `sceneSetPosition`
 - `sceneOffsetPosition`
 - `sceneSetRotation`
 - `sceneSetScale`
 - `sceneSetColor`
 - `sceneSetVisible`
+
+## Pointer Event Graphs
+
+Use `onEvent` for synchronized Player Shell pointer interactions. Graph JSON
+should use:
+
+```json
+{ "id": "click", "type": "onEvent", "params": { "channel": "pointer.click" } }
+```
+
+The supported pointer channels are `pointer.click`, `pointer.drag.start`,
+`pointer.drag.move`, `pointer.drag.end`, and `pointer.drag.cancel`. `onEvent`
+outputs an event list on `event`; use `list.length` or `list.at` to turn that
+frame-local event list into graph values.
 
 ## Dry run
 

--- a/packages/scene-sync-mcp/src/scene-graph-tools.mjs
+++ b/packages/scene-sync-mcp/src/scene-graph-tools.mjs
@@ -11,13 +11,16 @@ const store = new SessionStore()
 const GRAPH_TOOL_PATCHED = Symbol.for('scene-sync-mcp.scene-graph-tools.patched')
 const GRAPH_TOOLS_REGISTERED = Symbol.for('scene-sync-mcp.scene-graph-tools.registered')
 
-const supportedGraphNodeTypes = [
+export const supportedGraphNodeTypes = [
   'clock',
   'sine',
   'cosine',
   'add',
   'multiply',
   'constant',
+  'onEvent',
+  'list.length',
+  'list.at',
   'sceneSetPosition',
   'sceneOffsetPosition',
   'sceneSetRotation',
@@ -37,7 +40,7 @@ const graphEdgeSchema = z.object({
   to: z.string().min(1).describe('Destination endpoint, for example "sine.t"')
 }).passthrough()
 
-const graphSchema = z.object({
+export const graphSchema = z.object({
   nodes: z.array(graphNodeSchema).max(100).describe('Scene Sync graph nodes'),
   edges: z.array(graphEdgeSchema).max(300).describe('Scene Sync graph edges')
 }).passthrough()
@@ -47,7 +50,7 @@ function endpointNodeId(endpoint) {
   return index === -1 ? endpoint : endpoint.slice(0, index)
 }
 
-function validateGraph(graph) {
+export function validateGraph(graph) {
   if (!graph || typeof graph !== 'object') {
     throw new ValidationError('graph must be an object with nodes and edges arrays.')
   }

--- a/packages/scene-sync-mcp/src/scene-graph-tools.test.mjs
+++ b/packages/scene-sync-mcp/src/scene-graph-tools.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  graphSchema,
+  supportedGraphNodeTypes,
+  validateGraph
+} from './scene-graph-tools.mjs'
+
+test('scene graph tools allow Loomlet pointer event graph nodes', () => {
+  assert.ok(supportedGraphNodeTypes.includes('onEvent'))
+  assert.ok(supportedGraphNodeTypes.includes('list.length'))
+  assert.ok(supportedGraphNodeTypes.includes('list.at'))
+
+  const graph = {
+    nodes: [
+      { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } },
+      { id: 'count', type: 'list.length' },
+      { id: 'set', type: 'sceneSetPosition', params: { y: 1, z: 0 } }
+    ],
+    edges: [
+      { from: 'click.event', to: 'count.list' },
+      { from: 'count.out', to: 'set.x' }
+    ]
+  }
+
+  const parsed = graphSchema.parse(graph)
+  assert.deepEqual(parsed, graph)
+  assert.equal(validateGraph(parsed), parsed)
+})
+
+test('scene graph tools reject unsupported graph node types', () => {
+  assert.throws(() => {
+    graphSchema.parse({
+      nodes: [{ id: 'bad', type: 'pointerClick' }],
+      edges: []
+    })
+  }, /Invalid enum value/)
+})
+
+test('scene graph tools validate event graph edge references', () => {
+  assert.throws(() => {
+    validateGraph({
+      nodes: [
+        { id: 'click', type: 'onEvent', params: { channel: 'pointer.click' } }
+      ],
+      edges: [
+        { from: 'click.event', to: 'missing.list' }
+      ]
+    })
+  }, /missing destination node/)
+})


### PR DESCRIPTION
## Summary
- allow `onEvent`, `list.length`, and `list.at` in Scene Sync MCP graph tools
- add MCP graph schema tests for pointer event graphs and unsupported node rejection
- document synchronized Player Shell pointer event graph authoring for JSON and Loomlet DSL

## Validation
- npm --prefix packages/scene-sync-mcp install --cache /private/tmp/afjk-npm-cache
- npm --prefix packages/scene-sync-mcp test
- node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js
- node --test apps/presence-server/tests/scenesync-loomlet-runtime-integration.test.mjs
- git diff --check

## Review
- reviewed by subagent Confucius
- initial docs finding corrected: current DSL is `onEvent(channel: "pointer.click")`, not `on("pointer.click")`
- re-review returned no findings

## Notes
- MCP schema does not restrict `onEvent.params.channel` to only pointer channels; it still only allows runtime-supported node types and does not expose raw local input nodes.