### PR TITLE
[codex] Raise Scene Sync object limit to 500

### DIFF
--- a/apps/presence-server/src/scenesync/config.mjs
+++ b/apps/presence-server/src/scenesync/config.mjs
@@ -17,7 +17,7 @@ export function createSceneSyncConfig(env = process.env) {
     maxUploadBytes: parseIntEnv(env.SCENE_SYNC_MAX_UPLOAD_BYTES, 524_288_000, 1),
     maxJsonBytes: parseIntEnv(env.SCENE_SYNC_MAX_JSON_BYTES, 1_048_576, 1),
     maxRoomConnections: parseIntEnv(env.SCENE_SYNC_MAX_ROOM_CONNECTIONS, 20, 1),
-    maxObjectsPerRoom: parseIntEnv(env.SCENE_SYNC_MAX_OBJECTS_PER_ROOM, 200, 1),
+    maxObjectsPerRoom: parseIntEnv(env.SCENE_SYNC_MAX_OBJECTS_PER_ROOM, 500, 1),
     logEnabled: parseBoolEnv(env.SCENE_SYNC_LOG_ENABLED, true),
     logDir: env.SCENE_SYNC_LOG_DIR || './logs',
     logMaxLineBytes: parseIntEnv(env.SCENE_SYNC_LOG_MAX_LINE_BYTES, 4096, 256),

--- a/apps/presence-server/tests/scenesync-guards.test.mjs
+++ b/apps/presence-server/tests/scenesync-guards.test.mjs
@@ -10,6 +10,7 @@ import { createPerActorRateLimiter } from '../src/scenesync/rate-limit.mjs';
 import { validateSceneSyncPayload } from '../src/scenesync/message-schema.mjs';
 import { createSceneSyncLogger } from '../src/scenesync/logger.mjs';
 import { createGlbBackupManager, cleanupOldBackups } from '../src/scenesync/glb-backup.mjs';
+import { createSceneSyncConfig } from '../src/scenesync/config.mjs';
 
 const tmpRoot = mkdtempSync(path.join(tmpdir(), 'scenesync-guards-'));
 const logDir = path.join(tmpRoot, 'logs');
@@ -58,6 +59,14 @@ after(async () => {
 });
 
 describe('Scene Sync guard helpers', () => {
+  it('defaults to 500 objects per room', () => {
+    assert.equal(createSceneSyncConfig({}).maxObjectsPerRoom, 500);
+  });
+
+  it('allows object count limit override from env', () => {
+    assert.equal(createSceneSyncConfig({ SCENE_SYNC_MAX_OBJECTS_PER_ROOM: '2' }).maxObjectsPerRoom, 2);
+  });
+
   it('GLB magic check accepts valid glTF header', () => {
     assert.equal(hasValidGlbMagic(Buffer.from('glTFtest')), true);
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
       - MEDIAMTX_API_URL=http://mediamtx:9997
       # Scene Sync GLB upload limit (500 MiB = 524,288,000 bytes)
       - SCENE_SYNC_MAX_UPLOAD_BYTES=${SCENE_SYNC_MAX_UPLOAD_BYTES:-524288000}
+      # Scene Sync room object limit
+      - SCENE_SYNC_MAX_OBJECTS_PER_ROOM=${SCENE_SYNC_MAX_OBJECTS_PER_ROOM:-500}
       # Scene Sync GLB backup driver (local or s3)
       - SCENE_SYNC_GLB_BACKUP_DRIVER=${SCENE_SYNC_GLB_BACKUP_DRIVER:-local}
       - SCENE_SYNC_GLB_BACKUP_S3_ENDPOINT=${SCENE_SYNC_GLB_BACKUP_S3_ENDPOINT:-}


### PR DESCRIPTION
## Summary

- Raise the Scene Sync per-room object limit default from 200 to 500.
- Pass `SCENE_SYNC_MAX_OBJECTS_PER_ROOM=${SCENE_SYNC_MAX_OBJECTS_PER_ROOM:-500}` through `docker-compose.yml` so deploys use the new default unless explicitly overridden.
- Add config coverage for the new default and env override behavior.

## Why

The published `physics-demo-pyramid` world has 388 objects, so the previous 200 object room limit rejects placement/import flows before the scene can be represented.

## Validation

Passed:
- `node --test --test-name-pattern 'objects per room|object count limit|object limit|room connection limit' tests/scenesync-guards.test.mjs`
- `node --check src/scenesync/config.mjs && node --check tests/scenesync-guards.test.mjs`
- `docker compose config --services | rg '^presence-server$'`
- `git diff --check`

Also run:
- `npm test` in `apps/presence-server` currently fails in unrelated existing tests: AI command routing websocket timeouts and clipboard navigator checks with `navigator is not defined`. The object-limit/config tests in the same run pass.
