### PR TITLE
[codex] Play runtime GLB animations

### DIFF
--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -2703,7 +2703,10 @@ namespace Afjk.SceneSync
                 var deferAgent = gameObject.AddComponent<TimeBudgetPerFrameDeferAgent>();
                 var importSettings = new ImportSettings
                 {
-                    AnimationMethod = AnimationMethod.Mecanim,
+                    // glTFast runtime Mecanim import creates clips and an Animator, but no
+                    // runtime AnimatorController. Legacy attaches clips to an Animation
+                    // component, which Scene Sync can immediately play for remote GLBs.
+                    AnimationMethod = AnimationMethod.Legacy,
                 };
                 var gltf = new GltfImport(
                     downloadProvider: null,
@@ -3252,7 +3255,8 @@ namespace Afjk.SceneSync
                 var deferAgent = gameObject.AddComponent<TimeBudgetPerFrameDeferAgent>();
                 var importSettings = new ImportSettings
                 {
-                    AnimationMethod = AnimationMethod.Mecanim,
+                    // Match normal runtime imports so recovered GLBs auto-play animations.
+                    AnimationMethod = AnimationMethod.Legacy,
                 };
                 var gltf = new GltfImport(downloadProvider: null, deferAgent: deferAgent);
                 var success = await gltf.Load("file://" + tempPath, importSettings);


### PR DESCRIPTION
## Summary

- Import runtime GLBs with glTFast `AnimationMethod.Legacy` instead of `Mecanim`.
- Apply the same animation import mode to expired-GLB recovery loads.

## Root Cause

glTFast 6.0 runtime Mecanim import creates animation clips and an `Animator`, but it does not create a runtime `AnimatorController`. Scene Sync then calls `PlayImportedAnimations`, but the imported `Animator` has no controller to play, so animated remote GLBs such as the fox model remain static in Unity Play Mode.

Legacy import attaches the generated clips to an `Animation` component, which Scene Sync already enables and plays after import.

## Impact

Animated remote/web-origin GLB objects should start animating in Unity Play Mode after they are loaded from a Scene Sync room.

## Validation

- `git diff --check`
- Inspected glTFast 6.0 PackageCache behavior in `SceneSyncClient` (`GameObjectInstantiator` and `GltfImport`)

Unity Editor Play Mode validation is still needed in SceneSyncClient.