### PR TITLE
[codex] Fix Unity shared playback animation sampling

### DIFF
--- a/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
+++ b/unity/com.afjk.scene-sync-rapier/Runtime/SceneSyncRapierBridge.cs
@@ -1145,14 +1145,15 @@ namespace Afjk.SceneSync.Rapier
         {
             var raw = message.RawJson;
             if (string.IsNullOrWhiteSpace(raw)) return;
+            var payloadJson = ExtractSceneSyncPayloadJson(raw);
 
-            if (raw.Contains("\"kind\":\"scene-state\""))
+            if (payloadJson.Contains("\"kind\":\"scene-state\""))
             {
                 latestSceneClockRevision = int.MinValue;
-                if (SceneSyncWireJson.HasTopLevelField(raw, "physics"))
-                    scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
+                if (SceneSyncWireJson.HasTopLevelField(payloadJson, "physics"))
+                    scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(payloadJson, "physics"));
 
-                foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(raw, "objects"))
+                foreach (var entry in SceneSyncWireJson.ExtractObjectMapEntries(payloadJson, "objects"))
                 {
                     ApplyObjectPhysicsJson(entry.Key, entry.Value);
                 }
@@ -1162,69 +1163,69 @@ namespace Afjk.SceneSync.Rapier
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-clock\""))
+            if (payloadJson.Contains("\"kind\":\"scene-clock\""))
             {
-                ApplySceneClock(raw);
+                ApplySceneClock(payloadJson);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-snapshot\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-snapshot\""))
             {
-                ApplyScenePhysicsSnapshot(raw, message.FromPeerId);
+                ApplyScenePhysicsSnapshot(payloadJson, message.FromPeerId);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-hash\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-hash\""))
             {
-                ApplyScenePhysicsHash(raw, message.FromPeerId);
+                ApplyScenePhysicsHash(payloadJson, message.FromPeerId);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-input-log-request\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-input-log-request\""))
             {
-                PublishPhysicsInputLog(raw, message.FromPeerId);
+                PublishPhysicsInputLog(payloadJson, message.FromPeerId);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-input-log\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-input-log\""))
             {
-                ApplyScenePhysicsInputLog(raw, message.FromPeerId);
+                ApplyScenePhysicsInputLog(payloadJson, message.FromPeerId);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-input\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-input\""))
             {
-                ApplyScenePhysicsInput(raw);
+                ApplyScenePhysicsInput(payloadJson);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics-input-log-clear\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics-input-log-clear\""))
             {
-                ApplyScenePhysicsInputLogClear(raw);
+                ApplyScenePhysicsInputLogClear(payloadJson);
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-physics\""))
+            if (payloadJson.Contains("\"kind\":\"scene-physics\""))
             {
-                scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(raw, "physics"));
+                scenePhysics = ScenePhysicsDefinition.Parse(SceneSyncWireJson.ExtractTopLevelRawValue(payloadJson, "physics"));
                 dirty = true;
                 return;
             }
 
-            if (raw.Contains("\"kind\":\"scene-remove\"") || raw.Contains("\"kind\":\"scene-delete\""))
+            if (payloadJson.Contains("\"kind\":\"scene-remove\"") || payloadJson.Contains("\"kind\":\"scene-delete\""))
             {
-                var objectId = SceneSyncWireJson.ExtractString(raw, "objectId");
+                var objectId = SceneSyncWireJson.ExtractString(payloadJson, "objectId");
                 if (!string.IsNullOrWhiteSpace(objectId) && objectPhysicsJson.Remove(objectId))
                     dirty = true;
                 return;
             }
 
-            if (!raw.Contains("\"kind\":\"scene-add\"") && !raw.Contains("\"kind\":\"scene-delta\""))
+            if (!payloadJson.Contains("\"kind\":\"scene-add\"") && !payloadJson.Contains("\"kind\":\"scene-delta\""))
                 return;
 
-            var id = SceneSyncWireJson.ExtractString(raw, "objectId");
+            var id = SceneSyncWireJson.ExtractString(payloadJson, "objectId");
             if (string.IsNullOrWhiteSpace(id)) return;
-            if (ApplyObjectPhysicsJson(id, raw))
+            if (ApplyObjectPhysicsJson(id, payloadJson))
                 dirty = true;
         }
 
@@ -1875,11 +1876,12 @@ namespace Afjk.SceneSync.Rapier
 
         private void ApplySceneClock(string raw)
         {
-            var mode = SceneSyncWireJson.ExtractString(raw, "mode") ?? "shared-playback";
+            var payloadJson = ExtractSceneSyncPayloadJson(raw);
+            var mode = SceneSyncWireJson.ExtractString(payloadJson, "mode") ?? "shared-playback";
             if (!string.Equals(mode, "shared-playback", StringComparison.OrdinalIgnoreCase))
                 return;
 
-            var revisionValue = ReadDouble(raw, "revision", double.NaN);
+            var revisionValue = ReadDouble(payloadJson, "revision", double.NaN);
             if (IsFinite(revisionValue))
             {
                 var revision = Mathf.FloorToInt((float)revisionValue);
@@ -1888,12 +1890,18 @@ namespace Afjk.SceneSync.Rapier
                 latestSceneClockRevision = revision;
             }
 
-            sceneClock = SceneClockState.Parse(raw, sceneClock);
+            sceneClock = SceneClockState.Parse(payloadJson, sceneClock);
             var activeTime = sceneClock.GetTime();
-            if (ShouldResetPhysicsForSceneClockPayload(raw, activeTime))
+            if (ShouldResetPhysicsForSceneClockPayload(payloadJson, activeTime))
             {
-                ApplyPhysicsResetBaseline(raw, activeTime);
+                ApplyPhysicsResetBaseline(payloadJson, activeTime);
             }
+        }
+
+        private static string ExtractSceneSyncPayloadJson(string raw)
+        {
+            var payloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "payload");
+            return string.IsNullOrWhiteSpace(payloadJson) ? raw : payloadJson;
         }
 
         private void ApplyPhysicsResetBaseline(string raw, double activeTime)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -3070,6 +3070,12 @@ namespace Afjk.SceneSync
                 || _playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl;
         }
 
+        private bool UsesSharedObjectEpochClock()
+        {
+            return _playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl
+                || (_playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackFollow && _sharedSceneClock.Active);
+        }
+
         private void UpdatePlaybackClock(double currentTime)
         {
             if (_lastAppliedPlaybackClockMode != _playbackClockMode)
@@ -3159,7 +3165,7 @@ namespace Afjk.SceneSync
 
         private double GetObjectPlaybackRuntimeTime(string objectId, double sharedTime)
         {
-            if (UsesSharedPlaybackClock() && !string.IsNullOrWhiteSpace(objectId))
+            if (UsesSharedObjectEpochClock() && !string.IsNullOrWhiteSpace(objectId))
             {
                 if (_sharedObjectEpochTimes.TryGetValue(objectId, out var epoch) && IsFinite(epoch))
                 {
@@ -3188,6 +3194,7 @@ namespace Afjk.SceneSync
             {
                 animation.enabled = true;
                 animation.playAutomatically = true;
+                animation.cullingType = AnimationCullingType.AlwaysAnimate;
                 foreach (AnimationState state in animation)
                 {
                     if (state != null) state.speed = 1f;
@@ -3220,6 +3227,22 @@ namespace Afjk.SceneSync
 
             animation.enabled = true;
             animation.playAutomatically = false;
+            animation.cullingType = AnimationCullingType.AlwaysAnimate;
+            if (animation.clip == null && primary.clip != null)
+            {
+                animation.clip = primary.clip;
+            }
+
+            var clipName = primary.clip != null ? primary.clip.name : null;
+            if (!string.IsNullOrEmpty(clipName) && animation.GetClip(clipName) != null)
+            {
+                animation.Play(clipName);
+            }
+            else
+            {
+                animation.Play();
+            }
+
             foreach (AnimationState state in animation)
             {
                 if (state == null) continue;

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -3259,8 +3259,12 @@ namespace Afjk.SceneSync
                 state.speed = 0f;
             }
 
-            primary.time = WrapAnimationTime(time, primary.length);
-            animation.Sample();
+            var wrappedTime = WrapAnimationTime(time, primary.length);
+            primary.time = wrappedTime;
+            if (primary.clip != null)
+                primary.clip.SampleAnimation(animation.gameObject, wrappedTime);
+            else
+                animation.Sample();
         }
 
         private static AnimationState GetPrimaryAnimationState(Animation animation)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -110,7 +110,7 @@ namespace Afjk.SceneSync
         public SceneSyncPlaybackClockMode PlaybackClockMode
         {
             get => _playbackClockMode;
-            set => _playbackClockMode = value;
+            set => SetPlaybackClockMode(value);
         }
         public float SharedPlaybackClockBroadcastInterval
         {
@@ -141,6 +141,32 @@ namespace Afjk.SceneSync
         public event Action<List<PeerInfo>> OnPeersUpdated;
         public event Action<string, GameObject> OnObjectAdded;
         public event Action<string> OnObjectRemoved;
+
+        public void SetPlaybackClockMode(SceneSyncPlaybackClockMode mode)
+        {
+            if (_playbackClockMode == mode) return;
+
+            _playbackClockMode = mode;
+            if (Application.isPlaying && _connected && gameObject.activeInHierarchy)
+            {
+                ApplyPlaybackClockModeChange(Time.realtimeSinceStartup, _lastAppliedPlaybackClockMode);
+            }
+        }
+
+        public void UseLocalPlaybackClock()
+        {
+            SetPlaybackClockMode(SceneSyncPlaybackClockMode.Local);
+        }
+
+        public void FollowSharedPlaybackClock()
+        {
+            SetPlaybackClockMode(SceneSyncPlaybackClockMode.SharedPlaybackFollow);
+        }
+
+        public void ControlSharedPlaybackClock()
+        {
+            SetPlaybackClockMode(SceneSyncPlaybackClockMode.SharedPlaybackControl);
+        }
 
         private void Awake()
         {
@@ -1071,7 +1097,7 @@ namespace Afjk.SceneSync
             }
             else if (raw.Contains("\"kind\":\"scene-clock\""))
             {
-                HandleSceneClock(raw);
+                HandleSceneClock(raw, fromId);
             }
             else if (raw.Contains("\"kind\":\"scene-batch\""))
             {
@@ -1546,7 +1572,7 @@ namespace Afjk.SceneSync
             ApplyScenePhysicsMetadata(raw);
         }
 
-        private void HandleSceneClock(string raw)
+        private void HandleSceneClock(string raw, string fromId = null)
         {
             var payloadJson = ExtractSceneSyncPayloadJson(raw);
             var mode = SceneSyncWireJson.ExtractString(payloadJson, "mode") ?? "shared-playback";
@@ -1563,10 +1589,42 @@ namespace Afjk.SceneSync
             }
 
             if (_playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl)
-                return;
+            {
+                var remoteControllerId = GetRemoteSceneClockControllerId(payloadJson, fromId);
+                if (string.IsNullOrWhiteSpace(remoteControllerId))
+                    return;
+
+                _playbackClockMode = SceneSyncPlaybackClockMode.SharedPlaybackFollow;
+                _lastAppliedPlaybackClockMode = SceneSyncPlaybackClockMode.SharedPlaybackFollow;
+                Debug.Log("[SceneSync] Shared Playback control transferred to " + remoteControllerId + "; switching to Follow");
+            }
 
             _sharedSceneClock = SceneClockState.Parse(payloadJson, _sharedSceneClock);
             ApplyObjectClockBaselines(payloadJson);
+        }
+
+        private string GetRemoteSceneClockControllerId(string payloadJson, string fromId)
+        {
+            var hasControllerField = SceneSyncWireJson.HasTopLevelField(payloadJson, "controller");
+            var controllerJson = SceneSyncWireJson.ExtractTopLevelRawObject(payloadJson, "controller");
+            var controllerId = SceneSyncWireJson.ExtractString(controllerJson, "id");
+            if (!string.IsNullOrWhiteSpace(controllerId))
+            {
+                return IsLocalClientId(controllerId) ? null : controllerId;
+            }
+
+            if (hasControllerField)
+                return null;
+
+            return !string.IsNullOrWhiteSpace(fromId) && !IsLocalClientId(fromId) ? fromId : null;
+        }
+
+        private bool IsLocalClientId(string clientId)
+        {
+            return !string.IsNullOrWhiteSpace(clientId)
+                && _client != null
+                && !string.IsNullOrWhiteSpace(_client.Id)
+                && string.Equals(clientId, _client.Id, StringComparison.Ordinal);
         }
 
         private static string ExtractSceneSyncPayloadJson(string raw)
@@ -1633,9 +1691,53 @@ namespace Afjk.SceneSync
             _ = _client.Broadcast(payload);
         }
 
+        private void BroadcastSharedPlaybackControlRelease(double currentTime)
+        {
+            if (_client == null || !_client.IsConnected) return;
+
+            var revision = Math.Max(1, _sharedSceneClockRevision + 1);
+            _sharedSceneClockRevision = revision;
+            _lastSharedPlaybackClockBroadcastAt = currentTime;
+
+            var roomNow = GetUnixTimeSeconds();
+            var rate = 1d;
+            var activeTime = _sharedPlaybackControlStartedAt > 0d
+                ? Math.Max(0d, currentTime - _sharedPlaybackControlStartedAt)
+                : GetPlaybackClockTime(currentTime);
+            var offset = activeTime - roomNow * rate;
+            var sentAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            _sharedSceneClock = new SceneClockState(
+                true,
+                "room",
+                offset,
+                false,
+                double.NaN,
+                rate,
+                roomNow,
+                sentAt);
+
+            var payload =
+                "{\"kind\":\"scene-clock\"" +
+                ",\"action\":\"controller-release\"" +
+                ",\"mode\":\"shared-playback\"" +
+                ",\"source\":\"room\"" +
+                ",\"offset\":" + FormatDouble(offset) +
+                ",\"paused\":false" +
+                ",\"rate\":" + FormatDouble(rate) +
+                ",\"controller\":null" +
+                ",\"revision\":" + revision +
+                ",\"roomNow\":" + FormatDouble(roomNow) +
+                ",\"sentAt\":" + sentAt +
+                "}";
+
+            _ = _client.Broadcast(payload);
+        }
+
         private static bool ShouldIncludeSharedObjectClockPayload(string action)
         {
             return string.Equals(action, "mode", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(action, "controller", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(action, "tick", StringComparison.OrdinalIgnoreCase);
         }
 
@@ -3087,7 +3189,7 @@ namespace Afjk.SceneSync
         {
             if (_lastAppliedPlaybackClockMode != _playbackClockMode)
             {
-                ApplyPlaybackClockModeChange(currentTime);
+                ApplyPlaybackClockModeChange(currentTime, _lastAppliedPlaybackClockMode);
             }
 
             if (_playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl)
@@ -3101,16 +3203,22 @@ namespace Afjk.SceneSync
             }
         }
 
-        private void ApplyPlaybackClockModeChange(double currentTime)
+        private void ApplyPlaybackClockModeChange(double currentTime, SceneSyncPlaybackClockMode previousMode)
         {
             _lastAppliedPlaybackClockMode = _playbackClockMode;
+
+            if (previousMode == SceneSyncPlaybackClockMode.SharedPlaybackControl
+                && _playbackClockMode != SceneSyncPlaybackClockMode.SharedPlaybackControl)
+            {
+                BroadcastSharedPlaybackControlRelease(currentTime);
+            }
 
             if (_playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl)
             {
                 _sharedPlaybackControlStartedAt = currentTime;
                 _lastSharedPlaybackClockBroadcastAt = double.NegativeInfinity;
                 _sharedObjectEpochTimes.Clear();
-                BroadcastSharedPlaybackClock("mode", currentTime);
+                BroadcastSharedPlaybackClock("controller", currentTime);
             }
             else if (_playbackClockMode == SceneSyncPlaybackClockMode.Local)
             {

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1548,11 +1548,12 @@ namespace Afjk.SceneSync
 
         private void HandleSceneClock(string raw)
         {
-            var mode = SceneSyncWireJson.ExtractString(raw, "mode") ?? "shared-playback";
+            var payloadJson = ExtractSceneSyncPayloadJson(raw);
+            var mode = SceneSyncWireJson.ExtractString(payloadJson, "mode") ?? "shared-playback";
             if (!string.Equals(mode, "shared-playback", StringComparison.OrdinalIgnoreCase))
                 return;
 
-            var revisionValue = ReadTopLevelDouble(raw, "revision", double.NaN);
+            var revisionValue = ReadTopLevelDouble(payloadJson, "revision", double.NaN);
             if (IsFinite(revisionValue))
             {
                 var revision = Mathf.FloorToInt((float)revisionValue);
@@ -1564,8 +1565,14 @@ namespace Afjk.SceneSync
             if (_playbackClockMode == SceneSyncPlaybackClockMode.SharedPlaybackControl)
                 return;
 
-            _sharedSceneClock = SceneClockState.Parse(raw, _sharedSceneClock);
-            ApplyObjectClockBaselines(raw);
+            _sharedSceneClock = SceneClockState.Parse(payloadJson, _sharedSceneClock);
+            ApplyObjectClockBaselines(payloadJson);
+        }
+
+        private static string ExtractSceneSyncPayloadJson(string raw)
+        {
+            var payloadJson = SceneSyncWireJson.ExtractTopLevelRawObject(raw, "payload");
+            return string.IsNullOrWhiteSpace(payloadJson) ? raw : payloadJson;
         }
 
         private void BroadcastSharedPlaybackClockIfNeeded(double currentTime)

--- a/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
+++ b/unity/com.afjk.scene-sync/Runtime/SceneSyncManager.cs
@@ -1605,6 +1605,9 @@ namespace Afjk.SceneSync
 
         private string GetRemoteSceneClockControllerId(string payloadJson, string fromId)
         {
+            if (IsLocalClientId(fromId))
+                return null;
+
             var hasControllerField = SceneSyncWireJson.HasTopLevelField(payloadJson, "controller");
             var controllerJson = SceneSyncWireJson.ExtractTopLevelRawObject(payloadJson, "controller");
             var controllerId = SceneSyncWireJson.ExtractString(controllerJson, "id");
@@ -1645,6 +1648,7 @@ namespace Afjk.SceneSync
         private void BroadcastSharedPlaybackClock(string action, double currentTime)
         {
             if (_client == null || !_client.IsConnected) return;
+            if (string.IsNullOrWhiteSpace(_client.Id)) return;
 
             var revision = Math.Max(1, _sharedSceneClockRevision + 1);
             _sharedSceneClockRevision = revision;
@@ -1666,7 +1670,7 @@ namespace Afjk.SceneSync
                 roomNow,
                 sentAt);
 
-            var controllerId = !string.IsNullOrWhiteSpace(_client.Id) ? _client.Id : "unity-runtime";
+            var controllerId = _client.Id;
             var controllerName = string.IsNullOrWhiteSpace(_nickname) ? "Unity" : _nickname;
             var payload =
                 "{\"kind\":\"scene-clock\"" +
@@ -1694,6 +1698,7 @@ namespace Afjk.SceneSync
         private void BroadcastSharedPlaybackControlRelease(double currentTime)
         {
             if (_client == null || !_client.IsConnected) return;
+            if (string.IsNullOrWhiteSpace(_client.Id)) return;
 
             var revision = Math.Max(1, _sharedSceneClockRevision + 1);
             _sharedSceneClockRevision = revision;


### PR DESCRIPTION
## What changed

- Avoid subtracting per-object shared epoch baselines in Unity Follow mode until an actual Shared Playback scene clock has been received.
- Put legacy `Animation` clips into a playing state before manual `Sample()` in Shared Playback modes.
- Force imported legacy animations to `AlwaysAnimate` so sampling/playback is not culled unexpectedly.

## Why

Local mode uses Unity's normal `Animation.Play()` path, but Shared Playback uses manual sampling. Two issues could freeze imported GLB animations there:

- Follow mode could receive `sharedEpochTime` from Web local-preview scene state, where the epoch is room/unix time, then subtract it from Unity's local realtime fallback before a shared scene clock exists.
- Manual sampling did not explicitly start the legacy animation state, so `Sample()` could be a no-op for freshly imported clips in Shared Playback Follow/Control.

## Validation

- `git diff --check`
- Inspected Web Shared Playback clock/object epoch coordinate handling in `html/assets/js/scenesync/scene.js`

Unity runtime verification still needs to be done in the SceneSyncClient project.