### PR TITLE
Converge Rapier physics across tabs on pause/seek

### DIFF
--- a/docs/scene-sync-physics.md
+++ b/docs/scene-sync-physics.md
@@ -276,6 +276,17 @@ Snapshot bodies use Scene Sync wire coordinates. Followers should only apply a
 snapshot when the snapshot version, hash version, physics profile, and dynamic
 body set match the local world.
 
+In addition to the periodic cadence, the Shared Playback controller forces an
+out-of-cadence `scene-physics-snapshot` at transport convergence points
+(pause and seek). Because deterministic replay can leave followers a few ticks
+ahead of or behind the controller, freezing on a local pause would otherwise
+reveal that drift — the lagging controller's paused time pulls an ahead follower
+backward, so it visibly rewinds to an earlier pose. The forced snapshot lands all
+clients on the controller's exact authoritative pose at the moment of the pause.
+While the local clock is paused, followers also accept a snapshot that sits a few
+ticks behind their drifted local tick (a small rewind), since there is no forward
+simulation left to reconcile.
+
 When Unity receives a `scene-physics-hash` for the same tick and hash version but
 the local hash differs, the bridge publishes a
 `scene-physics-snapshot-request` through the Unity Scene Sync outbound message

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5867,6 +5867,36 @@ function maybeBroadcastScenePhysicsSnapshot(physicsTick, clockState = null) {
   broadcast(snapshot);
 }
 
+// Force an authoritative physics snapshot outside the periodic 120-tick cadence.
+// Used at transport convergence points (pause/seek) so followers that drifted a
+// few ticks adopt the controller's exact pose instead of freezing on their own
+// slightly-different (often visibly rewound) state.
+function broadcastScenePhysicsSnapshotNow(reason = 'transport', now = performance.now()) {
+  if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return false;
+  if (!isSceneClockControllerSelf()) return false;
+
+  const snapshot = createScenePhysicsSnapshotPayload(
+    { t: getSceneClockTime(now) },
+    { snapshotReason: reason },
+  );
+  if (!snapshot) return false;
+
+  const tick = Number(snapshot.tick);
+  const hash = typeof snapshot.hash === 'string' ? snapshot.hash : null;
+  if (Number.isInteger(tick) && tick >= 0 && typeof hash === 'string' && hash.length > 0) {
+    lastScenePhysicsSnapshotBroadcastTick = tick;
+    lastScenePhysicsSnapshotBroadcastHash = hash;
+    lastScenePhysicsSnapshotBroadcastRevision = Number.isFinite(sceneClockState.sharedRevision)
+      ? sceneClockState.sharedRevision
+      : null;
+    lastScenePhysicsSnapshotBroadcastClearRevision = Number.isFinite(snapshot.timelineClearRevision)
+      ? snapshot.timelineClearRevision
+      : null;
+  }
+  broadcast(snapshot);
+  return true;
+}
+
 function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
   const snapshot = scenePhysicsRuntime.createSnapshotReport(clockState);
   if (!snapshot || snapshot.snapshotVersion !== SCENE_SYNC_PHYSICS_SNAPSHOT_VERSION) {
@@ -5885,12 +5915,18 @@ function createScenePhysicsSnapshotPayload(clockState = null, extra = {}) {
 }
 
 function applyScenePhysicsSnapshotPayload(payload = {}, fromPeer = null, options = {}) {
+  // While the shared clock is paused there is no forward simulation to reconcile,
+  // so a follower that drifted ahead must adopt the controller's authoritative pose
+  // even when it sits a few ticks behind the local (paused) tick. Otherwise the two
+  // tabs stay frozen on different poses after a pause.
+  const allowSnapshotRewind = options.allowSnapshotRewind === true || sceneClockState.paused === true;
   const report = scenePhysicsRuntime.applySnapshotReport?.(
     payload,
     getSceneClockStateForLoomlet(performance.now()),
     {
       latestSceneClockRevision: sceneClockState.sharedRevision,
       ...options,
+      allowSnapshotRewind,
     },
   );
   if (!report) return false;
@@ -6404,6 +6440,7 @@ function pauseSceneClock(now = performance.now()) {
   pauseClockState(sceneClockState, getSceneClockSources(now));
   updateClockLegacyFields(now);
   broadcastSceneClockEvent('pause');
+  broadcastScenePhysicsSnapshotNow('scene-clock-pause', now);
   notifySceneSyncShellStateChanged('scene-clock-paused');
 }
 
@@ -6444,6 +6481,7 @@ function seekSceneClock(t, now = performance.now(), options = {}) {
         physicsBaseline,
       } : {}),
     });
+    broadcastScenePhysicsSnapshotNow('scene-clock-seek', now);
   }
   notifySceneSyncShellStateChanged('scene-clock-seek');
 }

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -5875,10 +5875,13 @@ function broadcastScenePhysicsSnapshotNow(reason = 'transport', now = performanc
   if (sceneClockState.mode !== CLOCK_MODES.SHARED_PLAYBACK) return false;
   if (!isSceneClockControllerSelf()) return false;
 
-  const snapshot = createScenePhysicsSnapshotPayload(
-    { t: getSceneClockTime(now) },
-    { snapshotReason: reason },
-  );
+  // Advance the world to the current (post-transport) clock before sampling. The
+  // render loop only re-steps next frame, so without this a seek would broadcast
+  // the stale pre-seek tick/pose; pausing would capture up to a frame of drift.
+  const clockState = getSceneClockStateForLoomlet(now);
+  scenePhysicsRuntime.update(clockState);
+
+  const snapshot = createScenePhysicsSnapshotPayload(clockState, { snapshotReason: reason });
   if (!snapshot) return false;
 
   const tick = Number(snapshot.tick);


### PR DESCRIPTION
## 概要

- 複数タブの Shared Playback で「一時停止すると片方のタブが以前のポーズに巻き戻る」不具合を修正する

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- 各タブはローカルで決定論的に物理を回しており、`worldEpochTime` のリビルド時刻差で再生中に数 tick ドリフトする。一時停止すると、遅れているコントローラの `pausedTime` に合わせて先行タブが巻き戻り、`scene-physics.js` の `update()` で `targetTick < world.tick` となって初期スナップショットから再シミュレーションされ、目に見えて「以前の結果」に変化していた。
- `broadcastScenePhysicsSnapshotNow()` を追加。コントローラが pause / seek 時に、周期（120 tick）に関係なく権威スナップショットを強制送信し、全クライアントをコントローラの正確なポーズへ収束させる。
- サンプリング前に `scenePhysicsRuntime.update()` でワールドを現在のクロックへ進めるため、seek でも目標 tick のポーズを送出し、pause もフレーム単位のずれなく正確になる。
- 一時停止中のフォロワーは `allowSnapshotRewind=true` で権威スナップショットを受け入れる（停止中は前方シミュレーションで埋め合わせる余地がないため、権威ポーズを優先）。
- `docs/scene-sync-physics.md` に挙動を追記。

## 変更していないこと

- ランタイム（`scene-physics.js`）のスナップショット適用ロジック自体は変更なし（既存の `allowSnapshotRewind` を pause/seek 経路に配線しただけ）。
- 再生中の連続同期の厳密化（tick がずれた際の hash-mismatch → snapshot-request 経路など）は out of scope。

## staging確認

- 未確認。ブラウザ実機での複数タブ確認は staging deploy 後に推奨。ロジックはユニットテストで担保。

## テスト/チェック

- `node --check html/assets/js/scenesync/scene.js` OK
- `npm run test:physics` → 68 件すべてパス
- レビューエージェント 2 体で diff をレビュー（正確性 / エッジケース）。指摘された seek 時の stale tick を本 PR 内で修正済み。

## リスク

- 影響範囲は Shared Playback のコントローラの pause/seek 時のスナップショット送出と、停止中フォロワーのスナップショット適用に限定。Local Preview / 非コントローラには影響しない。

## follow-up tasks

- 再生中の tick ドリフトそのものの抑制（hash-mismatch 時に tick がずれていても snapshot-request を出す等）

## merge方針

- squash merge を想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kbqiSRnYoMRjy767rKEa)_