### PR TITLE
Harden pipe file transfer for large files and stalled peers

### DIFF
--- a/docs/pipe-spec.md
+++ b/docs/pipe-spec.md
@@ -272,13 +272,24 @@ sequenceDiagram
 | `ICE_TIMEOUT` | 3,000ms | ICE 収集の最大待機時間 |
 | `DC_TIMEOUT` | 5,000ms | DataChannel open 待機時間 |
 | `RTC_DRAIN_DELAY` | 1,500ms | 最終チャンク送信後の DC クローズ猶予時間 |
-| `FLOW_STALL_MS` | 1,500ms | `bufferedAmount` が下がらない場合のストール検出閾値 |
+| `FLOW_STALL_MS` | 1,500ms | `bufferedAmount` が下がらない場合のストール検出閾値（チャンク縮小の判定）|
+| `DRAIN_TIMEOUT` | 30,000ms | `bufferedAmount` が全く減らない場合に送信を諦める閾値（相手消失時のハング防止 → HTTP フォールバック）|
+| `RECV_INACTIVITY` | 30,000ms | P2P 受信でデータが途絶えた場合に諦める閾値（ハング防止 → HTTP フォールバック）|
+| `RECV_FOLD_BYTES` | 16 MB | 受信チャンクを Blob にまとめてメモリを解放する単位 |
+| `HASH_MAX_BYTES` | 256 MB | これを超えるファイルは整合性 SHA-256 をスキップ（大容量ファイルのメモリ枯渇回避）|
 | `MAX_CHUNK_SZ` | 262,144 B (256 KB) | チャンクサイズ上限（Chromium 基準）|
 | `MIN_CHUNK_SZ` | 65,536 B (64 KB) | チャンクサイズ下限（Safari 対応）|
 | `FLOW_HIGH_MULT` | 32 | bufferedAmount の上限 = chunkSize × 32 |
 | `FLOW_LOW_MULT` | 8 | bufferedAmountLow 閾値 = chunkSize × 8 |
 
-実際のチャンクサイズはブラウザプロファイルに応じて決定される（Safari: 64 KB / Firefox: 128 KB / Chromium: 256 KB）。`pc.sctp.maxMessageSize` が利用可能な場合はそちらを優先する。
+実際のチャンクサイズはブラウザプロファイルに応じて決定される（Safari: 64 KB / Firefox: 128 KB / Chromium: 512 KB、ただし `MAX_CHUNK_SZ` および `pc.sctp.maxMessageSize` で上限される）。
+
+### 大容量ファイルの信頼性
+
+- **送信**: `File.stream()` でディスクから逐次読み出してチャンク送信するため、送信側はファイル全体をメモリに載せない。整合性ハッシュ（SHA-256）は `HASH_MAX_BYTES` を超えるファイルではスキップする（`crypto.subtle.digest` がファイル全体を 1 個の ArrayBuffer に載せるため、数 GB で `RangeError` / OOM になり転送自体が失敗していた）。
+- **受信**: 受信チャンクは `RECV_FOLD_BYTES` ごとにディスクバックされた Blob へ畳み込み、ピークメモリをファイルサイズの約 2 倍から一定量に抑える。
+- **HTTP フォールバック**: ファイルのアップロードは `XMLHttpRequest`（`upload.onprogress`）で行う。ストリーミング `fetch`（`ReadableStream` ボディ）は Chromium で `duplex: 'half'` 必須かつ HTTP/2 依存のため、指定なしでは例外となりフォールバックが機能しなかった。XHR は任意サイズの `File` をディスクから直接ストリーミングし、進捗も取得できる。
+- **ハング防止**: DataChannel 確立後に相手が消失しても、送信側 (`DRAIN_TIMEOUT`) / 受信側 (`RECV_INACTIVITY`) のウォッチドッグで転送を打ち切り、HTTP 中継へフォールバックする。
 
 ---
 

--- a/docs/pipe-spec.md
+++ b/docs/pipe-spec.md
@@ -274,7 +274,7 @@ sequenceDiagram
 | `RTC_DRAIN_DELAY` | 1,500ms | 最終チャンク送信後の DC クローズ猶予時間 |
 | `FLOW_STALL_MS` | 1,500ms | `bufferedAmount` が下がらない場合のストール検出閾値（チャンク縮小の判定）|
 | `DRAIN_TIMEOUT` | 30,000ms | `bufferedAmount` が全く減らない場合に送信を諦める閾値（相手消失時のハング防止 → HTTP フォールバック）|
-| `RECV_INACTIVITY` | 30,000ms | P2P 受信でデータが途絶えた場合に諦める閾値（ハング防止 → HTTP フォールバック）|
+| `RECV_INACTIVITY` | 45,000ms | P2P 受信でデータが途絶えた場合に諦める閾値（ハング防止 → HTTP フォールバック）。送信側が `DRAIN_TIMEOUT` まで一時停止している間に受信側が先に誤検知しないよう、送信側の閾値より長くとる |
 | `RECV_FOLD_BYTES` | 16 MB | 受信チャンクを Blob にまとめてメモリを解放する単位 |
 | `HASH_MAX_BYTES` | 256 MB | これを超えるファイルは整合性 SHA-256 をスキップ（大容量ファイルのメモリ枯渇回避）|
 | `MAX_CHUNK_SZ` | 262,144 B (256 KB) | チャンクサイズ上限（Chromium 基準）|

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -586,6 +586,10 @@ const ENABLE_RTC_POOL  = false;  // 予備: ピアごとの PC/DC を再利用�
 const RTC_IDLE_TIMEOUT = 30000;  // ms: 再利用セッションのアイドル期限（将来利用）
 const RTC_DRAIN_DELAY  = 1500;   // ms: 正常終了時に接続を閉じるまで待つ
 const FLOW_STALL_MS    = 1500;   // ms: bufferedAmount が減らないとみなす閾値
+const DRAIN_TIMEOUT    = 30000;  // ms: bufferedAmount が全く減らない場合に転送を諦める閾値
+const RECV_INACTIVITY  = 30000;  // ms: P2P 受信でデータが途絶えたら諦めてフォールバックする
+const RECV_FOLD_BYTES  = 16 * 1024 * 1024; // 受信チャンクを Blob にまとめてメモリを解放する単位
+const HASH_MAX_BYTES   = 256 * 1024 * 1024; // これを超えるファイルは整合性ハッシュをスキップ（メモリ枯渇回避）
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
 const randPath = () => {
@@ -601,6 +605,14 @@ async function hashBlob(blob) {
   const buf = await blob.arrayBuffer();
   const hash = await crypto.subtle.digest('SHA-256', buf);
   return Array.from(new Uint8Array(hash), b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Compute a SHA-256 only for reasonably-sized blobs. hashBlob() loads the whole
+// blob into a single ArrayBuffer, which throws (RangeError) or OOMs for multi-GB
+// files — the main reason large P2P transfers used to fail. Skip it instead.
+async function maybeHashBlob(blob) {
+  if (!blob || typeof blob.size !== 'number' || blob.size > HASH_MAX_BYTES) return null;
+  try { return await hashBlob(blob); } catch { return null; }
 }
 
 function base32ToHex(str) {
@@ -2220,6 +2232,8 @@ async function startSend() {
     let anyError = false;
     for (let i = 0; i < selFiles.length; i++) {
       if (anyError) break;
+      // Stop the queue if the user cancelled (cancelSend hides this button).
+      if (document.getElementById('cancel-send-btn').style.display === 'none') return;
       const { file, path } = selFiles[i];
       const item = document.getElementById(`fli-${i}`);
       const st   = document.getElementById(`fli-status-${i}`);
@@ -2244,75 +2258,70 @@ async function startSend() {
   }
 }
 
-async function sendHTTP(body, path, fileIdx = 0, totalFiles = 1) {
-  const controller = new AbortController();
-  _sendXHR = controller;
-  const total = body.size || 0;
-  let uploaded = 0;
-  const t0 = performance.now();
+// Upload via piping-server relay. Uses XHR (not fetch) because a streaming
+// ReadableStream fetch body requires `duplex: 'half'` + HTTP/2 and throws on
+// Chromium otherwise — which silently broke every HTTP fallback. XHR streams the
+// File straight from disk (low memory, any size) and gives real upload progress.
+function sendHTTP(body, path, fileIdx = 0, totalFiles = 1) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    _sendXHR = xhr;
+    const total = body.size || 0;
+    const t0 = performance.now();
 
-  const updateProgress = () => {
-    if (!total) return;
-    const p = Math.round(uploaded / total * 100);
-    document.getElementById('prog-bar').style.width = p + '%';
-    const elapsed = (performance.now() - t0) / 1000;
-    const speed   = elapsed > 0 ? uploaded / elapsed : 0;
-    const prefix  = totalFiles > 1 ? t('fileProgress')(fileIdx + 1, totalFiles) + ': ' : '';
-    document.getElementById('prog-text').textContent =
-      `${prefix}${p}%  (${fmt(uploaded)} / ${fmt(total)})  ${fmt(speed)}/s`;
-    if (p > 0 && p < 100) setStatus('send-status', t('transferring'));
-  };
+    xhr.open('POST', `${PIPE}/${path}`);
+    xhr.setRequestHeader('Content-Type', body.type || 'application/octet-stream');
+    xhr.setRequestHeader('Content-Disposition',
+      `attachment; filename="${encodeURIComponent(body.name || 'file')}"`);
 
-  let requestBody = body;
-  if (typeof body.stream === 'function' && typeof ReadableStream === 'function') {
-    const reader = body.stream().getReader();
-    requestBody = new ReadableStream({
-      async pull(ctrl) {
-        const { value, done } = await reader.read();
-        if (done) { ctrl.close(); return; }
-        uploaded += value.byteLength;
-        updateProgress();
-        ctrl.enqueue(value);
-      },
-      cancel() {
-        reader.releaseLock?.();
+    xhr.upload.onprogress = e => {
+      if (!total || !e.lengthComputable) return;
+      const p = Math.round(e.loaded / total * 100);
+      document.getElementById('prog-bar').style.width = p + '%';
+      const elapsed = (performance.now() - t0) / 1000;
+      const speed   = elapsed > 0 ? e.loaded / elapsed : 0;
+      const prefix  = totalFiles > 1 ? t('fileProgress')(fileIdx + 1, totalFiles) + ': ' : '';
+      document.getElementById('prog-text').textContent =
+        `${prefix}${p}%  (${fmt(e.loaded)} / ${fmt(total)})  ${fmt(speed)}/s`;
+      if (p > 0 && p < 100) setStatus('send-status', t('transferring'));
+    };
+
+    xhr.onload = () => {
+      _sendXHR = null;
+      if (xhr.status < 200 || xhr.status >= 300) {
+        setStatus('send-status', t('transferFail'), 'err');
+        _sendEnd();
+        reject(new Error('HTTP upload failed: ' + xhr.status));
+        return;
       }
-    });
-  }
+      const elapsed = (performance.now() - t0) / 1000;
+      const speed   = elapsed > 0 ? total / elapsed : 0;
+      document.getElementById('prog-bar').style.width = '100%';
+      document.getElementById('prog-text').textContent = totalFiles > 1
+        ? t('fileProgress')(fileIdx + 1, totalFiles) + ': 100%'
+        : '100%';
+      if (totalFiles === 1) {
+        setStatus('send-status', t('transferDone')(fmt(total), elapsed.toFixed(2), fmt(speed)), 'ok');
+      }
+      reportTransfer('pipe', total, {
+        transport: 'http',
+        files: totalFiles,
+        transferMs: Math.round(elapsed * 1000)
+      });
+      resolve();
+    };
 
-  try {
-    const res = await fetch(`${PIPE}/${path}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': body.type || 'application/octet-stream',
-        'Content-Disposition': `attachment; filename="${encodeURIComponent(body.name || 'file')}"`
-      },
-      body: requestBody,
-      signal: controller.signal,
-    });
-    _sendXHR = null;
-    if (!res.ok) throw new Error('HTTP upload failed');
-    const elapsed = (performance.now() - t0) / 1000;
-    const speed   = elapsed > 0 ? total / elapsed : 0;
-    document.getElementById('prog-bar').style.width = '100%';
-    document.getElementById('prog-text').textContent = totalFiles > 1
-      ? t('fileProgress')(fileIdx + 1, totalFiles) + ': 100%'
-      : '100%';
-    if (totalFiles === 1) {
-      setStatus('send-status', t('transferDone')(fmt(total), elapsed.toFixed(2), fmt(speed)), 'ok');
-    }
-    reportTransfer('pipe', total, {
-      transport: 'http',
-      files: totalFiles,
-      transferMs: Math.round(elapsed * 1000)
-    });
-  } catch (err) {
-    _sendXHR = null;
-    if (controller.signal.aborted) return;
-    setStatus('send-status', t('transferFail'), 'err');
-    _sendEnd();
-    throw err;
-  }
+    // Abort is a user cancel — resolve quietly so the multi-file loop stops cleanly.
+    xhr.onabort = () => { _sendXHR = null; resolve(); };
+    xhr.onerror = () => {
+      _sendXHR = null;
+      setStatus('send-status', t('transferFail'), 'err');
+      _sendEnd();
+      reject(new Error('HTTP upload error'));
+    };
+
+    xhr.send(body);
+  });
 }
 
 function resetSend() {
@@ -2668,7 +2677,9 @@ function shrinkChunk(session) {
 function waitForBufferDrain(dc, highWater, lowWater) {
   if (dc.bufferedAmount <= highWater) return Promise.resolve();
   return new Promise((resolve, reject) => {
+    let timer = null;
     const cleanup = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
       dc.removeEventListener('bufferedamountlow', onLow);
       dc.removeEventListener('close', onClose);
       dc.removeEventListener('error', onClose);
@@ -2683,6 +2694,12 @@ function waitForBufferDrain(dc, highWater, lowWater) {
       cleanup();
       reject(err instanceof Error ? err : new Error('DataChannel closed'));
     };
+    // If the buffer never drains (peer stalled/gone), give up so the caller can
+    // fall back to HTTP instead of hanging on the progress bar forever.
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('drain timeout'));
+    }, DRAIN_TIMEOUT);
     dc.addEventListener('bufferedamountlow', onLow);
     dc.addEventListener('close', onClose);
     dc.addEventListener('error', onClose);
@@ -2874,7 +2891,10 @@ async function trySendWebRTC(body, path, onProgress, onDone, onReady) {
           const stallStart = performance.now();
           await waitForBufferDrain(dc, flowHigh, flowLow);
           const stall = performance.now() - stallStart;
-          if (stall > FLOW_STALL_MS && shrinkChunk(session)) refreshChunks();
+          if (stall > FLOW_STALL_MS && shrinkChunk(session)) {
+            refreshChunks();
+            dc.bufferedAmountLowThreshold = flowLow;
+          }
         }
         const size  = Math.min(chunkSize, view.byteLength - offset);
         const chunk = view.subarray(offset, offset + size);
@@ -2905,8 +2925,10 @@ async function trySendWebRTC(body, path, onProgress, onDone, onReady) {
       await feed(raw);
     }
 
-    const fileHash = await hashBlob(body);
-    dc.send(JSON.stringify({ t: 'done', sha256: fileHash }));
+    const fileHash = await maybeHashBlob(body);
+    const doneMsg = { t: 'done' };
+    if (fileHash) doneMsg.sha256 = fileHash;
+    dc.send(JSON.stringify(doneMsg));
     const elapsed = (performance.now() - t0) / 1000;
     const speed   = sent / elapsed;
     onDone(t('p2pSendDone')(fmt(sent), elapsed.toFixed(2), fmt(speed)));
@@ -3021,8 +3043,10 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
         reader.releaseLock?.();
       }
 
-      const fileHash = await hashBlob(file);
-      dc.send(JSON.stringify({ t: 'done', sha256: fileHash }));
+      const fileHash = await maybeHashBlob(file);
+      const doneMsg = { t: 'done' };
+      if (fileHash) doneMsg.sha256 = fileHash;
+      dc.send(JSON.stringify(doneMsg));
       onFileDone(i);
     }
 
@@ -3057,19 +3081,42 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
     _recvAC = session.ac;
     onStatus(t('p2pConnected'));
 
-    await new Promise(resolve => {
-      let meta = null, chunks = [], recvd = 0;
+    await new Promise((resolve, reject) => {
+      let meta = null, recvd = 0;
       let t0 = null, isMulti = false;
+      // Bound memory: fold incoming ArrayBuffers into disk-backed Blobs as we go
+      // instead of holding the whole file in RAM (peak ~2× file size used to OOM
+      // large receives, especially on mobile).
+      let parts = [];        // Array<Blob> already folded
+      let pending = [];       // Array<ArrayBuffer> not yet folded
+      let pendingBytes = 0;
+      const foldPending = () => {
+        if (pending.length) { parts.push(new Blob(pending)); pending = []; pendingBytes = 0; }
+      };
+      const resetBuffers = () => { parts = []; pending = []; pendingBytes = 0; recvd = 0; };
+      const assembleBlob = type => { foldPending(); return new Blob(parts, { type }); };
+
+      // Inactivity watchdog: if the stream stalls (peer gone) give up so the
+      // caller falls back to HTTP instead of freezing forever.
+      let watchdog = null;
+      const clearWatch = () => { if (watchdog) { clearTimeout(watchdog); watchdog = null; } };
+      const arm  = () => { clearWatch(); watchdog = setTimeout(() => { clearWatch(); reject(new Error('p2p stalled')); }, RECV_INACTIVITY); };
+      const done = () => { clearWatch(); resolve(); };
+      const fail = err => { clearWatch(); reject(err instanceof Error ? err : new Error('p2p error')); };
+      arm();
+
       dc.onmessage = e => {
+        arm();
         if (typeof e.data === 'string') {
-          const msg = JSON.parse(e.data);
+          let msg;
+          try { msg = JSON.parse(e.data); } catch { return; }
           if (msg.t === 'meta') {
             // If we have leftover chunks from a previous attempt for
             // the same file name + index, keep them for resume
             if (meta && meta.name === msg.name && meta.index === msg.index && recvd > 0 && msg.resumable) {
               dc.send(JSON.stringify({ t: 'resume', index: msg.index, offset: recvd }));
             } else {
-              chunks = []; recvd = 0;
+              resetBuffers();
             }
             meta = msg;
             t0 = null;
@@ -3078,8 +3125,8 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
           } else if (msg.t === 'done') {
             const elapsed = t0 ? (performance.now() - t0) / 1000 : 0;
             const speed   = elapsed > 0 ? recvd / elapsed : 0;
-            const blob    = new Blob(chunks, { type: meta.mime });
-            // Verify integrity if sender provided a hash
+            const blob    = assembleBlob(meta.mime);
+            // Verify integrity if sender provided a hash (small files only)
             if (msg.sha256) {
               hashBlob(blob).then(recvHash => {
                 if (recvHash !== msg.sha256) {
@@ -3088,21 +3135,26 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
               }).catch(() => {});
             }
             onDone(t('p2pRecvDone')(fmt(recvd), elapsed.toFixed(2), fmt(speed)), blob, meta.name);
-            if (!isMulti) resolve();
+            if (!isMulti) done();
           } else if (msg.t === 'all-done') {
-            resolve();
+            done();
           }
         } else {
           if (!t0) t0 = performance.now();
-          chunks.push(e.data);
+          pending.push(e.data);
+          pendingBytes += e.data.byteLength;
           recvd += e.data.byteLength;
+          if (pendingBytes >= RECV_FOLD_BYTES) foldPending();
           if (meta) {
             onStatus(t('p2pProgress')(fmt(recvd), fmt(meta.size)));
             if (onProgress) onProgress(recvd, meta.size);
           }
         }
       };
-      dc.onerror = resolve;
+      dc.onerror = () => fail(new Error('datachannel error'));
+      session.pc.onconnectionstatechange = () => {
+        if (session.pc.connectionState === 'failed') fail(new Error('connection failed'));
+      };
     });
     success = true;
     return true;

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -587,7 +587,9 @@ const RTC_IDLE_TIMEOUT = 30000;  // ms: 再利用セッションのアイドル�
 const RTC_DRAIN_DELAY  = 1500;   // ms: 正常終了時に接続を閉じるまで待つ
 const FLOW_STALL_MS    = 1500;   // ms: bufferedAmount が減らないとみなす閾値
 const DRAIN_TIMEOUT    = 30000;  // ms: bufferedAmount が全く減らない場合に転送を諦める閾値
-const RECV_INACTIVITY  = 30000;  // ms: P2P 受信でデータが途絶えたら諦めてフォールバックする
+// 受信側は送信側の諦め閾値 (DRAIN_TIMEOUT) より長くとる。送信側がフロー制御で
+// 一時停止している間に受信側が先に誤検知してフォールバックするのを防ぐ。
+const RECV_INACTIVITY  = 45000;  // ms: P2P 受信でデータが途絶えたら諦めてフォールバックする
 const RECV_FOLD_BYTES  = 16 * 1024 * 1024; // 受信チャンクを Blob にまとめてメモリを解放する単位
 const HASH_MAX_BYTES   = 256 * 1024 * 1024; // これを超えるファイルは整合性ハッシュをスキップ（メモリ枯渇回避）
 
@@ -613,6 +615,16 @@ async function hashBlob(blob) {
 async function maybeHashBlob(blob) {
   if (!blob || typeof blob.size !== 'number' || blob.size > HASH_MAX_BYTES) return null;
   try { return await hashBlob(blob); } catch { return null; }
+}
+
+// Send the end-of-file frame, attaching a SHA-256 only when it was cheap to
+// compute (small files). Shared by the single- and multi-file send paths so the
+// frame shape can't drift between them.
+async function sendDoneFrame(dc, blob) {
+  const fileHash = await maybeHashBlob(blob);
+  const doneMsg = { t: 'done' };
+  if (fileHash) doneMsg.sha256 = fileHash;
+  dc.send(JSON.stringify(doneMsg));
 }
 
 function base32ToHex(str) {
@@ -2241,6 +2253,9 @@ async function startSend() {
       if (st)   st.textContent = '…';
       try {
         await sendHTTP(file, path, i, selFiles.length);
+        // sendHTTP resolves quietly on user-cancel (xhr abort); don't mark the
+        // aborted file as sent.
+        if (document.getElementById('cancel-send-btn').style.display === 'none') return;
         if (item) { item.classList.remove('sending'); item.classList.add('done'); }
         if (st)   st.textContent = '✓';
         totalSent += file.size;
@@ -2925,10 +2940,7 @@ async function trySendWebRTC(body, path, onProgress, onDone, onReady) {
       await feed(raw);
     }
 
-    const fileHash = await maybeHashBlob(body);
-    const doneMsg = { t: 'done' };
-    if (fileHash) doneMsg.sha256 = fileHash;
-    dc.send(JSON.stringify(doneMsg));
+    await sendDoneFrame(dc, body);
     const elapsed = (performance.now() - t0) / 1000;
     const speed   = sent / elapsed;
     onDone(t('p2pSendDone')(fmt(sent), elapsed.toFixed(2), fmt(speed)));
@@ -3012,7 +3024,10 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
             const stallStart = performance.now();
             await waitForBufferDrain(dc, flowHigh, flowLow);
             const stall = performance.now() - stallStart;
-            if (stall > FLOW_STALL_MS && shrinkChunk(session)) refreshChunks();
+            if (stall > FLOW_STALL_MS && shrinkChunk(session)) {
+              refreshChunks();
+              dc.bufferedAmountLowThreshold = flowLow;
+            }
           }
           const size  = Math.min(chunkSize, view.byteLength - offset);
           const chunk = view.subarray(offset, offset + size);
@@ -3043,10 +3058,7 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
         reader.releaseLock?.();
       }
 
-      const fileHash = await maybeHashBlob(file);
-      const doneMsg = { t: 'done' };
-      if (fileHash) doneMsg.sha256 = fileHash;
-      dc.send(JSON.stringify(doneMsg));
+      await sendDoneFrame(dc, file);
       onFileDone(i);
     }
 


### PR DESCRIPTION
## 概要

- `afjk.jp/pipe`（File Transfer）の送受信失敗、特に大容量ファイルの失敗を全体的に見直し、原因を特定して修正する

## 対象repo

- `afjk.jp`

## 対象area

- `file-transfer`

## 変更内容

主要な変更点（`html/assets/js/pipe/app.js`）:

1. **HTTPフォールバックがChromiumで壊れていた** — `sendHTTP` が `ReadableStream` を `duplex: 'half'` 指定なしで `fetch` に渡しており、Chromium系で同期例外。P2P失敗時のファイル送信が全て「✗ エラー」になっていた。`XMLHttpRequest`（`upload.onprogress`）に書き換え、任意サイズの `File` をディスクから直接ストリーミングしつつ進捗も取得。
2. **大容量ファイルでメモリ枯渇** — 送信時の整合性ハッシュ `hashBlob(file)` がファイル全体を1個の ArrayBuffer に確保し、数GBで `RangeError`／クラッシュ。`HASH_MAX_BYTES`（256MB）超は SHA-256 をスキップ（`maybeHashBlob`）。受信側は元々 `sha256` の有無で分岐済み。
3. **受信が全データをRAM保持** — チャンク配列＋Blobでピーク約2倍。`RECV_FOLD_BYTES`（16MB）ごとにディスクバックされた Blob へ畳み込み、ピークメモリを一定に抑制。
4. **相手消失で永久ハング** — DataChannel確立後に相手が落ちると送受信とも固まりフォールバックも発火せず。送信側ドレインタイムアウト（`DRAIN_TIMEOUT`）＋受信側無通信ウォッチドッグ（`RECV_INACTIVITY`）でP2Pを打ち切りHTTP中継へ。受信は `connectionState === 'failed'` でも即フォールバック。
5. 軽微: チャンク縮小後の `bufferedAmountLowThreshold` 更新、キャンセル時のマルチファイル送信停止、受信ループの `JSON.parse` ガード。

仕様書 `docs/pipe-spec.md` のフロー制御パラメータ表と「大容量ファイルの信頼性」セクションを更新。

staging で見てほしい点:
- 大容量ファイル（数百MB〜GB級）の P2P 送受信が完走するか
- Symmetric NAT 等で P2P が確立できない環境で、HTTP 中継フォールバックが Chrome で正常に動くか
- 転送中に相手タブを閉じた際、固まらずフォールバック／エラー表示に遷移するか

## 変更していないこと

- presence-server / swarm（WebTorrent）/ stream（WHIP/WHEP）のロジックは未変更
- 受信のディスク直書き（File System Access / StreamSaver による完全ストリーミング保存）は今回スコープ外。メモリ畳み込みで現実的に大容量を通せる形に留めた。

## staging確認

- 未確認（ブラウザ専用変更のため手元の静的解析のみ実施）。staging deploy 後に上記 3 点を実機確認したい。

## テスト/チェック

- `node --check html/assets/js/pipe/app.js` … 構文OK
- presence-server テスト（`tests/api.test.mjs`）はこの環境で `ws` 依存が未インストールのため実行不可。今回の変更はブラウザ専用（`app.js` / spec）で presence-server には非干渉。

## リスク

- `sendHTTP` を fetch→XHR に置き換えたため、HTTP 中継経路の挙動が変わる（進捗は XHR `upload.onprogress` ベース）。
- 大容量ファイルでは整合性ハッシュをスキップするため、256MB 超は破損検知が無効（転送経路自体は順序保証あり）。

## follow-up tasks

- 受信側の StreamSaver / File System Access による完全ストリーミング保存（さらに大きいファイルの安定化）
- 大容量でもチェックサム可能な逐次ハッシュ（streaming digest）の導入検討

## merge方針

- 期待する merge 方法: squash merge
- merge 後に remote branch を削除して良い

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuXf7raLDAPkh4rfRHbHxj)_