### PR TITLE
Speed up P2P send throughput, especially on LAN

### DIFF
--- a/docs/pipe-spec.md
+++ b/docs/pipe-spec.md
@@ -279,10 +279,17 @@ sequenceDiagram
 | `HASH_MAX_BYTES` | 256 MB | これを超えるファイルは整合性 SHA-256 をスキップ（大容量ファイルのメモリ枯渇回避）|
 | `MAX_CHUNK_SZ` | 262,144 B (256 KB) | チャンクサイズ上限（Chromium 基準）|
 | `MIN_CHUNK_SZ` | 65,536 B (64 KB) | チャンクサイズ下限（Safari 対応）|
-| `FLOW_HIGH_MULT` | 32 | bufferedAmount の上限 = chunkSize × 32 |
-| `FLOW_LOW_MULT` | 8 | bufferedAmountLow 閾値 = chunkSize × 8 |
+| `FLOW_HIGH_MULT` | 48 | bufferedAmount の上限 = chunkSize × 48（256KB 時 ≈ 12 MiB。Chrome の 16 MiB 上限に余裕をもたせる）|
+| `FLOW_LOW_MULT` | 12 | bufferedAmountLow 閾値 = chunkSize × 12 |
+| `PROGRESS_THROTTLE_MS` | 100ms | 進捗 UI 更新の最小間隔（送受信とも）|
 
 実際のチャンクサイズはブラウザプロファイルに応じて決定される（Safari: 64 KB / Firefox: 128 KB / Chromium: 512 KB、ただし `MAX_CHUNK_SZ` および `pc.sctp.maxMessageSize` で上限される）。
+
+### 送信スループット最適化（特に同一 LAN）
+
+- **1 メッセージ = chunkSize**: 送信は `File.slice(pos, pos+chunkSize).arrayBuffer()` で chunkSize ちょうどのスライスを読み、1 回の `dc.send()` で送る。`Blob.stream()` は Chromium で約 64 KB ずつ chunk を返すため、stream をそのまま送るとメッセージが 256 KB 設定でも 64 KB に細切れになり、メッセージ数・SCTP/JS オーバーヘッドが約 4 倍になっていた。
+- **フロー制御バッファを拡大**: `FLOW_HIGH_MULT` を 32 → 48 に引き上げ、送信バッファをより深く保ってパイプを埋める。ただし Chrome の `bufferedAmount` 上限 16 MiB を超えると `dc.send()` が例外を投げてチャネルが落ちるため、`flowHigh + chunkSize` が 16 MiB を超えない範囲に収める。
+- **進捗 UI のスロットル**: 送受信とも進捗表示（プログレスバー / ステータス）の DOM 更新を `PROGRESS_THROTTLE_MS`（100ms）間隔に制限する。高速 LAN ではチャンクごとの DOM 書き込みがメインスレッドを占有して律速になるため。バイト計数自体は毎チャンク行い、完了時に最終値で 100% に更新する。
 
 ### 大容量ファイルの信頼性
 

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -569,10 +569,12 @@ const ICE_TIMEOUT      = 3000;   // ms: max ICE gathering time
 const DC_TIMEOUT       = 5000;   // ms: wait for DataChannel open
 const MAX_CHUNK_SZ     = 262144; // Upper bound per message (Chrome 126 ≈ 256 KB)
 const MIN_CHUNK_SZ     = 65536;  // Safari 16.x では 64 KB 程度が安全
-// chunkSize * 48 ≈ 12 MiB（256KB chunk 時）。Chrome の bufferedAmount 上限 16 MiB
-// に対し、チェック後に最大 chunkSize 分上乗せされても超えない余裕をもたせる。
 const FLOW_HIGH_MULT   = 48;     // bufferedAmount を chunkSize * 48 まで許容（LAN でパイプを埋める）
 const FLOW_LOW_MULT    = 12;     // bufferedamountlow が発火する閾値倍率
+// Chrome の RTCDataChannel.bufferedAmount 上限。これを超えて send すると例外が
+// 投げられチャネルが落ちる。flowHigh はここから chunkSize 分の余裕を引いて導出する
+// ので、FLOW_HIGH_MULT や MAX_CHUNK_SZ を上げても自動的に安全側に収まる。
+const MAX_BUFFERED     = 16 * 1024 * 1024;
 const PROGRESS_THROTTLE_MS = 100; // 進捗 UI 更新の最小間隔（高速 LAN で DOM 更新が律速になるのを防ぐ）
 const CHUNK_PROFILE = (() => {
   const ua = navigator.userAgent || '';
@@ -2667,6 +2669,17 @@ function _showRecvPreview(blob, filename) {
   area.appendChild(card);
 }
 
+// Returns a throttle gate for progress UI: invokes fn at most once per
+// PROGRESS_THROTTLE_MS unless force=true. Per-chunk DOM writes otherwise throttle
+// the main thread and become the transfer bottleneck on a fast LAN.
+function makeProgressThrottle(intervalMs = PROGRESS_THROTTLE_MS) {
+  let last = 0;
+  return (fn, force = false) => {
+    const now = performance.now();
+    if (force || now - last >= intervalMs) { last = now; fn(); }
+  };
+}
+
 function resolveChunking(pc) {
   const rawMax = pc.sctp?.maxMessageSize;
   let target = MAX_CHUNK_SZ;
@@ -2675,11 +2688,16 @@ function resolveChunking(pc) {
   else if (CHUNK_PROFILE === 'chromium') target = 512 * 1024;
   const limit  = Number.isFinite(rawMax) && rawMax > 0 ? Math.min(rawMax, target) : target;
   const chunk  = Math.max(MIN_CHUNK_SZ, Math.min(limit, MAX_CHUNK_SZ));
-  return {
-    chunkSize: chunk,
-    flowHigh : chunk * FLOW_HIGH_MULT,
-    flowLow  : chunk * FLOW_LOW_MULT
-  };
+  return { chunkSize: chunk, ...flowFromChunk(chunk) };
+}
+
+// Derive flow-control watermarks from the chunk size, clamped so that even after
+// the pre-send gate (bufferedAmount <= flowHigh) one more chunkSize send cannot
+// exceed MAX_BUFFERED. flowLow stays strictly below flowHigh.
+function flowFromChunk(chunk) {
+  const flowHigh = Math.min(chunk * FLOW_HIGH_MULT, MAX_BUFFERED - chunk);
+  const flowLow  = Math.min(chunk * FLOW_LOW_MULT, Math.floor(flowHigh / 2));
+  return { flowHigh, flowLow };
 }
 
 function shrinkChunk(session) {
@@ -2687,8 +2705,9 @@ function shrinkChunk(session) {
   const next = Math.max(MIN_CHUNK_SZ, Math.floor(session.chunkSize / 2));
   if (next === session.chunkSize) return false;
   session.chunkSize = next;
-  session.flowHigh = next * FLOW_HIGH_MULT;
-  session.flowLow = next * FLOW_LOW_MULT;
+  const flow = flowFromChunk(next);
+  session.flowHigh = flow.flowHigh;
+  session.flowLow = flow.flowLow;
   return true;
 }
 
@@ -3023,7 +3042,7 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
       // chunkSize messages instead of the ~64 KB segments Blob.stream() yields,
       // cutting message count (and per-message SCTP/JS overhead) ~4× on LAN.
       let pos = resumeOffset;
-      let lastProg = 0;
+      const tick = makeProgressThrottle();
       while (pos < total) {
         if (pc.connectionState === 'closed' || pc.connectionState === 'failed') throw new Error('cancelled');
         if (dc.bufferedAmount > flowHigh) {
@@ -3040,13 +3059,7 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
         dc.send(buf);
         totalSent += end - pos;
         pos = end;
-        // Throttle progress UI: per-chunk DOM writes throttle the main thread and
-        // become the bottleneck on a fast LAN.
-        const now = performance.now();
-        if (now - lastProg >= PROGRESS_THROTTLE_MS || pos >= total) {
-          lastProg = now;
-          onProgress(i, pos, total);
-        }
+        tick(() => onProgress(i, pos, total), pos >= total);
       }
 
       await sendDoneFrame(dc, file);
@@ -3086,7 +3099,8 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
 
     await new Promise((resolve, reject) => {
       let meta = null, recvd = 0;
-      let t0 = null, isMulti = false, lastProg = 0;
+      let t0 = null, isMulti = false;
+      const tick = makeProgressThrottle();
       // Bound memory: fold incoming ArrayBuffers into disk-backed Blobs as we go
       // instead of holding the whole file in RAM (peak ~2× file size used to OOM
       // large receives, especially on mobile).
@@ -3125,7 +3139,10 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
             t0 = null;
             isMulti = (msg.count > 1);
             onStatus(t('p2pReceiving')(meta.name));
+            // Reset the bar to 0% for the new file (multi-file transfers).
+            if (onProgress) tick(() => onProgress(0, meta.size), true);
           } else if (msg.t === 'done') {
+            if (!meta) { fail(new Error('done before meta')); return; }
             const elapsed = t0 ? (performance.now() - t0) / 1000 : 0;
             const speed   = elapsed > 0 ? recvd / elapsed : 0;
             const blob    = assembleBlob(meta.mime);
@@ -3137,7 +3154,7 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
                 }
               }).catch(() => {});
             }
-            if (onProgress && meta) onProgress(recvd, meta.size); // ensure bar hits 100%
+            if (onProgress) tick(() => onProgress(recvd, meta.size), true); // ensure bar hits 100%
             onDone(t('p2pRecvDone')(fmt(recvd), elapsed.toFixed(2), fmt(speed)), blob, meta.name);
             if (!isMulti) done();
           } else if (msg.t === 'all-done') {
@@ -3152,12 +3169,10 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
           if (meta) {
             // Throttle progress UI so per-message DOM writes don't throttle the
             // receive loop on a fast LAN.
-            const now = performance.now();
-            if (now - lastProg >= PROGRESS_THROTTLE_MS) {
-              lastProg = now;
+            tick(() => {
               onStatus(t('p2pProgress')(fmt(recvd), fmt(meta.size)));
               if (onProgress) onProgress(recvd, meta.size);
-            }
+            });
           }
         }
       };

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -569,8 +569,11 @@ const ICE_TIMEOUT      = 3000;   // ms: max ICE gathering time
 const DC_TIMEOUT       = 5000;   // ms: wait for DataChannel open
 const MAX_CHUNK_SZ     = 262144; // Upper bound per message (Chrome 126 ≈ 256 KB)
 const MIN_CHUNK_SZ     = 65536;  // Safari 16.x では 64 KB 程度が安全
-const FLOW_HIGH_MULT   = 32;     // bufferedAmount を chunkSize * 32 まで許容
-const FLOW_LOW_MULT    = 8;      // bufferedamountlow が発火する閾値倍率
+// chunkSize * 48 ≈ 12 MiB（256KB chunk 時）。Chrome の bufferedAmount 上限 16 MiB
+// に対し、チェック後に最大 chunkSize 分上乗せされても超えない余裕をもたせる。
+const FLOW_HIGH_MULT   = 48;     // bufferedAmount を chunkSize * 48 まで許容（LAN でパイプを埋める）
+const FLOW_LOW_MULT    = 12;     // bufferedamountlow が発火する閾値倍率
+const PROGRESS_THROTTLE_MS = 100; // 進捗 UI 更新の最小間隔（高速 LAN で DOM 更新が律速になるのを防ぐ）
 const CHUNK_PROFILE = (() => {
   const ua = navigator.userAgent || '';
   const isiOS = /iP(hone|ad|od)/.test(ua);
@@ -3015,47 +3018,35 @@ async function trySendWebRTCFiles(fileEntries, onProgress, onFileDone, onAllDone
         });
       } catch { resumeOffset = 0; }
 
-      let fileSent = resumeOffset;
-      const feed = async view => {
-        let offset = 0;
-        while (offset < view.byteLength) {
-          if (pc.connectionState === 'closed' || pc.connectionState === 'failed') throw new Error('cancelled');
-          if (dc.bufferedAmount > flowHigh) {
-            const stallStart = performance.now();
-            await waitForBufferDrain(dc, flowHigh, flowLow);
-            const stall = performance.now() - stallStart;
-            if (stall > FLOW_STALL_MS && shrinkChunk(session)) {
-              refreshChunks();
-              dc.bufferedAmountLowThreshold = flowLow;
-            }
-          }
-          const size  = Math.min(chunkSize, view.byteLength - offset);
-          const chunk = view.subarray(offset, offset + size);
-          dc.send(chunk);
-          offset   += size;
-          fileSent += size;
-          totalSent += size;
-          onProgress(i, fileSent, total);
-        }
-      };
-
-      const reader = file.stream().getReader();
-      let skipped = 0;
-      try {
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          if (skipped < resumeOffset) {
-            const remaining = resumeOffset - skipped;
-            skipped += value.byteLength;
-            if (value.byteLength <= remaining) continue;
-            await feed(value.subarray(remaining));
-          } else {
-            await feed(value);
+      // Read the file in chunkSize-sized slices and send each as one DataChannel
+      // message. Reading via Blob.slice (not Blob.stream) lets us emit full
+      // chunkSize messages instead of the ~64 KB segments Blob.stream() yields,
+      // cutting message count (and per-message SCTP/JS overhead) ~4× on LAN.
+      let pos = resumeOffset;
+      let lastProg = 0;
+      while (pos < total) {
+        if (pc.connectionState === 'closed' || pc.connectionState === 'failed') throw new Error('cancelled');
+        if (dc.bufferedAmount > flowHigh) {
+          const stallStart = performance.now();
+          await waitForBufferDrain(dc, flowHigh, flowLow);
+          const stall = performance.now() - stallStart;
+          if (stall > FLOW_STALL_MS && shrinkChunk(session)) {
+            refreshChunks();
+            dc.bufferedAmountLowThreshold = flowLow;
           }
         }
-      } finally {
-        reader.releaseLock?.();
+        const end = Math.min(pos + chunkSize, total);
+        const buf = await file.slice(pos, end).arrayBuffer();
+        dc.send(buf);
+        totalSent += end - pos;
+        pos = end;
+        // Throttle progress UI: per-chunk DOM writes throttle the main thread and
+        // become the bottleneck on a fast LAN.
+        const now = performance.now();
+        if (now - lastProg >= PROGRESS_THROTTLE_MS || pos >= total) {
+          lastProg = now;
+          onProgress(i, pos, total);
+        }
       }
 
       await sendDoneFrame(dc, file);
@@ -3095,7 +3086,7 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
 
     await new Promise((resolve, reject) => {
       let meta = null, recvd = 0;
-      let t0 = null, isMulti = false;
+      let t0 = null, isMulti = false, lastProg = 0;
       // Bound memory: fold incoming ArrayBuffers into disk-backed Blobs as we go
       // instead of holding the whole file in RAM (peak ~2× file size used to OOM
       // large receives, especially on mobile).
@@ -3146,6 +3137,7 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
                 }
               }).catch(() => {});
             }
+            if (onProgress && meta) onProgress(recvd, meta.size); // ensure bar hits 100%
             onDone(t('p2pRecvDone')(fmt(recvd), elapsed.toFixed(2), fmt(speed)), blob, meta.name);
             if (!isMulti) done();
           } else if (msg.t === 'all-done') {
@@ -3158,8 +3150,14 @@ async function tryRecvWebRTC(path, onStatus, onDone, onProgress) {
           recvd += e.data.byteLength;
           if (pendingBytes >= RECV_FOLD_BYTES) foldPending();
           if (meta) {
-            onStatus(t('p2pProgress')(fmt(recvd), fmt(meta.size)));
-            if (onProgress) onProgress(recvd, meta.size);
+            // Throttle progress UI so per-message DOM writes don't throttle the
+            // receive loop on a fast LAN.
+            const now = performance.now();
+            if (now - lastProg >= PROGRESS_THROTTLE_MS) {
+              lastProg = now;
+              onStatus(t('p2pProgress')(fmt(recvd), fmt(meta.size)));
+              if (onProgress) onProgress(recvd, meta.size);
+            }
           }
         }
       };


### PR DESCRIPTION
## 概要

- `afjk.jp/pipe` の WebRTC DataChannel 送信スループットを引き上げる（特に同一 LAN）

## 対象repo

- `afjk.jp`

## 対象area

- `file-transfer`

## 変更内容

LAN では回線そのものより「メッセージ数」と「チャンクごとのメインスレッド処理」が律速になる。`html/assets/js/pipe/app.js` に 3 点:

1. **1 メッセージ = chunkSize（256KB）で送信** — `Blob.stream()` は Chromium で約 64KB 単位で chunk を返すため、従来は 256KB 設定でも実送信は 64KB メッセージに細切れになっていた。`File.slice(pos, pos+chunkSize).arrayBuffer()` でちょうど chunkSize を読んで 1 回の `dc.send()` に。メッセージ数・SCTP/JS オーバーヘッドが約 1/4。不要になった reader＋resume-skip 処理も削除。
2. **進捗 UI を `PROGRESS_THROTTLE_MS`（100ms）間隔にスロットル（送受信とも）** — チャンクごとの `getElementById`＋style/textContent 書き込みが高速 LAN でメインスレッドを占有していた。バイト計数は毎チャンク継続し、完了時に最終値で 100% 表示。
3. **フロー制御バッファ拡大 `FLOW_HIGH_MULT` 32→48（≈12MiB）** — 送信バッファを深く保ってパイプを埋める。Chrome の `bufferedAmount` 上限 16MiB を超えると `dc.send()` が例外でチャネルが落ちるため、`flowHigh + chunkSize` が 16MiB 未満に収まる範囲に設定。

仕様書 `docs/pipe-spec.md` のフロー制御パラメータ表を更新し「送信スループット最適化」セクションを追加。

staging で見てほしい点:
- 同一 LAN での大容量ファイル P2P 送信の実効速度（改善前後）
- プログレスバーがスムーズに 0→100% まで進むか（スロットルで飛びすぎていないか）
- Safari / Firefox / Chromium 間の相互送受信でチャネルが落ちないか（特に bufferedAmount 上限）

## 変更していないこと

- HTTP 中継フォールバック・受信のメモリ畳み込み・ハング防止ウォッチドッグなど #481 の挙動は維持
- presence-server / swarm / stream は未変更
- `MAX_CHUNK_SZ`（256KB）は相互運用の安全上限として据え置き

## staging確認

- 未確認（ブラウザ専用変更のため手元では静的解析と境界条件レビューのみ）。staging deploy 後に実機でスループットを計測したい。

## テスト/チェック

- `node --check html/assets/js/pipe/app.js` … 構文OK
- 境界条件レビュー: 空ファイル / 単一チャンク / 最終 100% 表示 / Chrome 16MiB 上限（最大 12.25MiB）/ チャンク縮小時の flowHigh 比例縮小 / テキスト受信（onProgress 未指定）のガード

## リスク

- `FLOW_HIGH_MULT` 引き上げにより送信バッファが深くなる（最大 ≈12.25MiB）。Chrome 16MiB 上限には余裕があるが、ブラウザ実装差には留意。
- 進捗スロットルにより、ごく短時間の転送ではバーの更新回数が減る（完了時に 100% へ補正）。

## follow-up tasks

- 4MB ブロック読み込み＋256KB サブ送信によるディスク read 回数削減（SSD/キャッシュ環境では効果小のため今回見送り）
- Chrome 同士限定での `MAX_CHUNK_SZ` 引き上げ（`pc.sctp.maxMessageSize` 次第、相互運用リスクあり）

## merge方針

- 期待する merge 方法: squash merge
- merge 後に remote branch を削除して良い

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuXf7raLDAPkh4rfRHbHxj)_