### PR TITLE
Keep Loomlet/GLB motion running during WebXR by ignoring stale desktop TransformControls

### DIFF
--- a/html/assets/js/scenesync/runtime/editing-state.js
+++ b/html/assets/js/scenesync/runtime/editing-state.js
@@ -14,10 +14,11 @@ export function isObjectActivelyEdited({
   transformObject = null,
   xrTwoHand = null,
   grabbers = [],
+  ignoreTransformObject = false,
 } = {}) {
   if (!objectId) return false;
 
-  if (getSceneObjectId(transformObject) === objectId) {
+  if (!ignoreTransformObject && getSceneObjectId(transformObject) === objectId) {
     return true;
   }
 
@@ -41,10 +42,11 @@ export function shouldFreezeObjectForEditorRuntime({
   xrTwoHand = null,
   grabbers = [],
   transportActive = false,
+  ignoreTransformObject = false,
 } = {}) {
   if (!objectId) return false;
 
-  if (isObjectActivelyEdited({ objectId, transformObject, xrTwoHand, grabbers })) {
+  if (isObjectActivelyEdited({ objectId, transformObject, xrTwoHand, grabbers, ignoreTransformObject })) {
     return true;
   }
 

--- a/html/assets/js/scenesync/runtime/editing-state.test.js
+++ b/html/assets/js/scenesync/runtime/editing-state.test.js
@@ -24,6 +24,28 @@ test('transport active keeps transform editing frozen', () => {
   }), true);
 });
 
+test('XR can ignore a stale desktop transform attachment while transport is active', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    selectedObjectIds: new Set(['object-1']),
+    transformObject: objectWithId('object-1'),
+    ignoreTransformObject: true,
+    transportActive: true,
+  }), false);
+});
+
+test('XR still freezes an actively grabbed object even when transform attachment is ignored', () => {
+  assert.equal(shouldFreezeObjectForEditorRuntime({
+    objectId: 'object-1',
+    transformObject: objectWithId('object-1'),
+    ignoreTransformObject: true,
+    grabbers: [
+      { active: true, object: objectWithId('object-1') },
+    ],
+    transportActive: true,
+  }), true);
+});
+
 test('transport active keeps XR two-hand editing frozen', () => {
   assert.equal(shouldFreezeObjectForEditorRuntime({
     objectId: 'object-1',

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -1815,6 +1815,10 @@ function shouldFreezeRuntimeForEditor(objectId, clockState = null) {
     transformObject: transformCtrl.object,
     xrTwoHand: xrState.twoHand,
     grabbers: xrState.grabbers,
+    // TransformControls can remain attached to the selected object when entering
+    // WebXR, but the desktop gizmo is not an active XR edit. Keep Loomlet/GLB
+    // runtime motion alive in Quest/WebAR unless the object is actually grabbed.
+    ignoreTransformObject: xrState.active === true,
     transportActive: clockState?.transportActive === true,
   });
 }


### PR DESCRIPTION
### Motivation
- Quest/WebAR sessions could retain desktop `TransformControls` attachment on a selected object, causing the object to be treated as "actively edited" and freezing Loomlet/GLB runtime motion during XR sessions.
- WebXR sessions should ignore stale desktop gizmo attachments so AR/Quest viewers still see Loomlet-driven motion while preserving real XR interactions (grabs / two-hand edits).

### Description
- Added an `ignoreTransformObject` parameter to `isObjectActivelyEdited` and `shouldFreezeObjectForEditorRuntime` so callers can opt-out of treating desktop `TransformControls` as an active edit.
- In `scene.js` the freeze decision now passes `ignoreTransformObject: xrState.active === true` to allow WebXR sessions to ignore stale desktop transform attachments while keeping actual XR grabs/two-hand edits honored.
- Added regression tests in `html/assets/js/scenesync/runtime/editing-state.test.js` covering the new behavior: ignoring stale transform attachment in XR and still freezing when an XR grabber is active.

### Testing
- Ran the unit tests for the changed module with `node --test html/assets/js/scenesync/runtime/editing-state.test.js` and all tests passed (7/7).
- Ran Loomlet integration tests with `npm run test:loomlet-runtime` and the suite passed (18/18).
- No repository-level `test` script is present; `npm test -- --runInBand` was not applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e9fb18148320ac14d35e9a99a8e3)