### PR TITLE
Pre-warm the send PeerConnection to cut P2P connect latency

### DIFF
--- a/docs/pipe-spec.md
+++ b/docs/pipe-spec.md
@@ -233,6 +233,15 @@ ICE サーバー設定は `GET /presence/api/ice-config` から動的取得す�
 
 **デフォルト STUN サーバー:** `stun.l.google.com:19302`
 
+### PeerConnection 事前ウォームアップ
+
+P2P 送信開始の遅い部分は `RTCPeerConnection` 生成＋ICE 収集（WAN では STUN 往復）。ファイル選択時（`setFiles`）に `prewarmSendSession()` で PC・DataChannel 生成と ICE 収集を先行実行しておき、「転送開始」時（`initSendRtcSession`）に再利用することで、実送信は piping シグナリング往復だけで済む。
+
+- 完全にクライアント側のみ。送信が実際に始まるまで piping-server へは何も POST しないため、中継サーバ負荷は増えない（STUN 問い合わせのみ）。
+- 事前生成した候補は `PREWARM_TTL`（25 秒）で失効。失効・ファイル変更・リセット・離脱時は破棄する。
+- ファイルを差し替えると signaling パスが変わるため、古いウォームアップは破棄して新しいパスで作り直す（並走時は最後の 1 つだけが有効）。
+- ウォームアップが間に合わない／失効した場合は従来どおりその場で生成するフォールバック。
+
 ### 単一セッションでの複数ファイル転送プロトコル
 
 1本の DataChannel で全ファイルを順次転送する（`trySendWebRTCFiles`）。

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -567,6 +567,7 @@ let _txtRecvAC = null;                 // text receive
 const SIG_TIMEOUT      = 8000;   // ms: wait for WebRTC signaling peer
 const ICE_TIMEOUT      = 3000;   // ms: max ICE gathering time
 const DC_TIMEOUT       = 5000;   // ms: wait for DataChannel open
+const PREWARM_TTL      = 25000;  // ms: 事前生成した PC/ICE 候補の鮮度上限
 const MAX_CHUNK_SZ     = 262144; // Upper bound per message (Chrome 126 ≈ 256 KB)
 const MIN_CHUNK_SZ     = 65536;  // Safari 16.x では 64 KB 程度が安全
 const FLOW_HIGH_MULT   = 48;     // bufferedAmount を chunkSize * 48 まで許容（LAN でパイプを埋める）
@@ -2146,6 +2147,9 @@ function setFiles(files) {
   selFiles = files.map(f => ({ file: f, path: randPath() }));
   if (!selFiles.length) return;
 
+  // Warm up the PeerConnection now so "Start Transfer" only pays for signaling.
+  prewarmSendSession(selFiles[0].path);
+
   renderFileList();
 
   // For a single file show URL + QR; for multiple files hide them
@@ -2345,6 +2349,7 @@ function sendHTTP(body, path, fileIdx = 0, totalFiles = 1) {
 }
 
 function resetSend() {
+  discardPrewarm();
   selFiles = []; fi.value = '';
   const fileList = document.getElementById('file-list');
   if (fileList) {
@@ -2804,17 +2809,70 @@ function disposeRtcSession(session, opts = {}) {
   performClose();
 }
 
+// ── Send-side PeerConnection pre-warming ──────────────────────────────────────
+// Building the PeerConnection + DataChannel and finishing ICE gathering is the
+// slow part of starting a P2P send (a STUN round-trip on WAN). Doing it as soon
+// as files are chosen — before the user hits "Start" — means the actual send only
+// pays for the piping signaling exchange. Purely client-side: nothing is POSTed
+// to the relay until a real transfer begins, so it adds no server/relay traffic.
+let _prewarm = null; // { sigPath, pc, dc, createdAt, ready }
+
+function discardPrewarm() {
+  if (!_prewarm) return;
+  const p = _prewarm;
+  _prewarm = null;
+  try { p.dc?.close(); } catch {}
+  try { p.pc?.close(); } catch {}
+}
+
+async function prewarmSendSession(sigPath) {
+  if (!sigPath || (_prewarm && _prewarm.sigPath === sigPath)) return;
+  discardPrewarm();
+  const entry = { sigPath, pc: null, dc: null, createdAt: performance.now(), ready: false };
+  _prewarm = entry;
+  try {
+    const pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
+    if (_prewarm !== entry) { try { pc.close(); } catch {} return; } // superseded while awaiting
+    entry.pc = pc;
+    entry.dc = pc.createDataChannel('pipe', { ordered: true });
+    await pc.setLocalDescription(await pc.createOffer());
+    await waitForIce(pc);
+    if (_prewarm !== entry) { try { pc.close(); } catch {} return; }
+    entry.ready = true;
+  } catch {
+    if (_prewarm === entry) discardPrewarm();
+  }
+}
+
+// Hand a fresh, fully-gathered prewarm to the caller (ownership transfers), or null.
+function takePrewarm(sigPath) {
+  const e = _prewarm;
+  if (!e || !e.ready || e.sigPath !== sigPath || !e.pc?.localDescription) return null;
+  if (performance.now() - e.createdAt > PREWARM_TTL) { discardPrewarm(); return null; }
+  _prewarm = null;
+  return e;
+}
+
 async function initSendRtcSession(path) {
+  const warm = takePrewarm(path);
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), SIG_TIMEOUT);
-  const pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
+  let pc, dc;
+  if (warm) {
+    pc = warm.pc; dc = warm.dc;
+  } else {
+    discardPrewarm(); // drop any stale/half-ready prewarm; we're going fresh
+    pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
+    dc = pc.createDataChannel('pipe', { ordered: true });
+  }
   _sendPC = pc;
-  const dc = pc.createDataChannel('pipe', { ordered: true });
   const session = { kind: 'send', ac, pc, dc, startedAt: performance.now(), chunkSize: 0 };
   try {
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
-    await waitForIce(pc);
+    if (!warm) {
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      await waitForIce(pc);
+    }
 
     fetch(`${PIPE}/${path}.__offer`, {
       method: 'POST', signal: ac.signal,
@@ -3359,4 +3417,5 @@ Object.assign(window, {
 window.addEventListener('beforeunload', () => {
   unregisterAllLocalSeeders();
   cleanupStream();
+  discardPrewarm();
 });

--- a/html/assets/js/pipe/app.js
+++ b/html/assets/js/pipe/app.js
@@ -2817,6 +2817,14 @@ function disposeRtcSession(session, opts = {}) {
 // to the relay until a real transfer begins, so it adds no server/relay traffic.
 let _prewarm = null; // { sigPath, pc, dc, createdAt, ready }
 
+// Build a send-side PeerConnection + ordered DataChannel. Single seam so the
+// prewarm and inline paths can't drift in PC/DC config.
+async function buildSendPc() {
+  const pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
+  const dc = pc.createDataChannel('pipe', { ordered: true });
+  return { pc, dc };
+}
+
 function discardPrewarm() {
   if (!_prewarm) return;
   const p = _prewarm;
@@ -2831,10 +2839,10 @@ async function prewarmSendSession(sigPath) {
   const entry = { sigPath, pc: null, dc: null, createdAt: performance.now(), ready: false };
   _prewarm = entry;
   try {
-    const pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
+    const { pc, dc } = await buildSendPc();
     if (_prewarm !== entry) { try { pc.close(); } catch {} return; } // superseded while awaiting
     entry.pc = pc;
-    entry.dc = pc.createDataChannel('pipe', { ordered: true });
+    entry.dc = dc;
     await pc.setLocalDescription(await pc.createOffer());
     await waitForIce(pc);
     if (_prewarm !== entry) { try { pc.close(); } catch {} return; }
@@ -2862,8 +2870,7 @@ async function initSendRtcSession(path) {
     pc = warm.pc; dc = warm.dc;
   } else {
     discardPrewarm(); // drop any stale/half-ready prewarm; we're going fresh
-    pc = new RTCPeerConnection({ iceServers: await fetchIceServers() });
-    dc = pc.createDataChannel('pipe', { ordered: true });
+    ({ pc, dc } = await buildSendPc());
   }
   _sendPC = pc;
   const session = { kind: 'send', ac, pc, dc, startedAt: performance.now(), chunkSize: 0 };


### PR DESCRIPTION
## 概要

- P2P 送信の接続確立を速くする（特に WAN）。サーバ負荷は増やさないクライアント側のみの最適化。

## 対象repo

- `afjk.jp`

## 対象area

- `file-transfer`

## 変更内容

P2P 送信開始の遅い部分は `RTCPeerConnection` 生成＋ICE 収集（WAN では STUN 往復）。これをファイル選択時に先行実行する:

- `setFiles()` で `prewarmSendSession(sigPath)` を起動し、PC・DataChannel 生成と ICE 収集を済ませておく。
- `initSendRtcSession()` は signaling パスが一致する温め済み PC を再利用し、`createOffer`/`setLocalDescription`/`waitForIce` をスキップ。実送信は piping シグナリング往復だけになる。
- **完全にクライアント側のみ**。送信が実際に始まるまで piping-server へは何も POST しないため、中継サーバ負荷は増えない（STUN 問い合わせのみ）。

ライフサイクル:
- 事前生成は `PREWARM_TTL`（25秒）で失効。ファイル変更・`resetSend`・`beforeunload` で破棄。
- 並走・置き換え時は古いものを自分で `close()`（最後の 1 つだけ有効）。
- 温めが間に合わない／失効した場合は従来どおりその場生成にフォールバック（挙動不変）。

仕様書 `docs/pipe-spec.md` に「PeerConnection 事前ウォームアップ」節を追加。

staging で見てほしい点:
- WAN（モバイル回線など）での「転送開始」→ 実データ開始までの体感短縮
- ファイル選択 → 別ファイルへ差し替え → 送信、で正しく新パスの PC が使われるか
- ファイル選択のみで送信せずリセット/離脱した際に PC がリークしないか

## 変更していないこと

- 受信・HTTP 中継・スループット系（#481/#482）のロジックは不変
- TURN/STUN サーバ構成や中継サーバ（piping-server）には一切手を入れない
- 送信フォールバック（HTTP 中継）の挙動は不変

## staging確認

- 未確認（ブラウザ専用変更。手元は静的解析＋ライフサイクル/並走レビューのみ）。staging で接続レイテンシを実測したい。

## テスト/チェック

- `node --check html/assets/js/pipe/app.js` … 構文OK
- レビュー観点: 温め済み PC の再利用時に DataChannel の onopen が確立後に発火するか / 並走 setFiles の supersede 競合 / TTL 失効・破棄経路

## リスク

- 事前生成した ICE 候補は最大 `PREWARM_TTL` 秒古くなる。途中でネットワークが変わると接続失敗 → 従来どおり HTTP 中継へフォールバック。
- ファイル選択のたびに PC を作り直すため軽微な生成コスト（STUN 問い合わせ）が増える。中継サーバ負荷は不変。

## follow-up tasks

- A3-lite: P2P 失敗の早期検知（中継は失敗時のみ＝追加コストほぼ無し）
- B2: 受信のディスク直書き（`showSaveFilePicker`）による超大容量の安定化

## merge方針

- 期待する merge 方法: squash merge
- merge 後に remote branch を削除して良い

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuXf7raLDAPkh4rfRHbHxj)_