### PR TITLE
Add VR180 and SBS/TB stereo support for Scene Sync image/video assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,30 @@ curl -s "http://localhost:8787/api/room/{room}/scene?name=Claude"
 
 asset.primitive の選択肢: `box`, `sphere`, `cylinder`, `cone`, `plane`, `torus`
 
+image / video asset（URL 直接指定、CORS 必須）:
+
+```json
+{ "type": "image", "source": "url", "url": "https://example.com/photo.jpg" }
+{ "type": "video", "source": "url", "url": "https://example.com/clip.mp4" }
+```
+
+立体視 / VR180 は optional metadata で指定（省略時は 2D plane）:
+
+```json
+{
+  "type": "video",
+  "source": "url",
+  "url": "https://example.com/tour_vr180_sbs.mp4",
+  "projection": "vr180",
+  "stereoLayout": "sbs"
+}
+```
+
+- `projection`: `flat`（既定・plane 表示） | `vr180`（半球ドーム、中心=視点位置）
+- `stereoLayout`: `mono`（既定） | `sbs`（左右） | `tb`（上下・左目が上）
+- VR180 ドームは position を視点高さ（y=1.6 目安）に置く
+- 詳細: `docs/scene-sync-assets-and-cache.md` の「Stereo / VR180 media」
+
 #### scene-delta
 ```json
 {

--- a/docs/scene-sync-ai-openapi.yaml
+++ b/docs/scene-sync-ai-openapi.yaml
@@ -671,6 +671,17 @@ components:
         name:
           type: string
           description: Optional object name.
+        projection:
+          type: string
+          enum: [flat, vr180]
+          description: >
+            Optional stereo projection override. If omitted, the filename is
+            auto-detected and otherwise the existing asset's format is kept.
+            Pass flat + mono to explicitly downgrade to 2D.
+        stereoLayout:
+          type: string
+          enum: [mono, sbs, tb]
+          description: Optional stereo eye layout override (see projection).
       example:
         objectId: media-panel-1
         url: https://example.com/replacement.jpg

--- a/docs/scene-sync-ai-openapi.yaml
+++ b/docs/scene-sync-ai-openapi.yaml
@@ -590,6 +590,19 @@ components:
           $ref: '#/components/schemas/Quat'
         scale:
           $ref: '#/components/schemas/Vec3'
+        projection:
+          type: string
+          enum: [flat, vr180]
+          description: >
+            Stereo projection for addImageFromUrl / addVideoFromUrl.
+            `vr180` renders a half-dome. Omit to auto-detect from the filename.
+        stereoLayout:
+          type: string
+          enum: [mono, sbs, tb]
+          description: >
+            Stereo eye layout for addImageFromUrl / addVideoFromUrl.
+            `sbs` = side-by-side (left eye left), `tb` = top-bottom (left eye top).
+            Omit to auto-detect from the filename.
       example:
         url: https://example.com/reference.jpg
         objectId: ref-image-1

--- a/docs/scene-sync-ai-spec.md
+++ b/docs/scene-sync-ai-spec.md
@@ -91,6 +91,15 @@ Optional params for `addImageFromUrl`, `addVideoFromUrl`, and `addTextFromUrl`:
 - `rotation`
 - `scale`
 
+Optional stereo / VR180 params for `addImageFromUrl` and `addVideoFromUrl`:
+
+- `projection`: `flat`（既定） | `vr180`
+- `stereoLayout`: `mono`（既定） | `sbs` | `tb`
+
+省略時はファイル名の `vr180` / `sbs` / `tb` 等のトークンから自動判定する。
+詳細は [Asset / Blob / Cache](./scene-sync-assets-and-cache.md) の
+「Stereo / VR180 media」を参照。
+
 `setSkyboxFromImageUrl` currently only requires `params.url`.
 
 ## Required and Optional Parameters

--- a/docs/scene-sync-assets-and-cache.md
+++ b/docs/scene-sync-assets-and-cache.md
@@ -198,11 +198,16 @@ Web client は video URL を textured plane として表示する。
   HMD では左右の目に別画像が表示される。
 - 非XR（デスクトップ / モバイル）はメインカメラが layer 1 を有効化しており、
   左目画像のみ表示される。
+- テクスチャは両目で 1 枚を共有し、目ごとの切り出しはジオメトリの UV に
+  焼き込む（GPU アップロードは 1 回。4K 動画でも転送が倍にならない）。
 - `flat` + `sbs` / `tb` は片目分のアスペクト比で plane サイズを計算する
   （full SBS / full TB 前提。squashed half 形式は片目が横 / 縦に伸びる）。
 - `vr180` は半径 3m の半球ドーム。object の scale で拡大できる。
-  layer 0 には選択・raycast 用の不可視 hit proxy
-  （plane または中心の小さな球）を置く。
+- layer 0 には選択・raycast 用の不可視 hit proxy を重ねる。
+  flat はフルサイズ plane、vr180 はドーム表面そのもの
+  （ドームをクリックして選択・移動・削除できる）。
+  vr180 ドームは drop の配置 raycast ターゲットからは除外する
+  （skybox と同じ扱い。ドーム内から drop してもドーム表面に貼り付かない）。
 
 ### 登録 UI
 
@@ -210,13 +215,27 @@ Web client は video URL を textured plane として表示する。
   ファイル drop 画像（carrier GLB 化経路）は未対応。
 - ファイル名 / URL の basename をトークン分割して自動判定する:
   - `vr180`, `180`, `180x180` → `projection: vr180`
-  - `sbs`, `hsbs`, `fsbs`, `lr`, `3dh`, `sidebyside` 等 → `stereoLayout: sbs`
-  - `tb`, `ou`, `overunder`, `topbottom`, `3dv` 等 → `stereoLayout: tb`
+  - `sbs`, `hsbs`, `fsbs`, `3dh`, `sidebyside`, `leftright` 等 → `stereoLayout: sbs`
+  - `overunder`, `topbottom`, `htab`, `ftab`, `3dv` 等 → `stereoLayout: tb`
+  - 曖昧な 2 文字トークン `lr` / `ou` / `tb` は誤爆しやすいため、
+    `vr180` / `180` / `3d` / `stereo` のいずれかが同居する場合のみ有効
+    （例: `scan_lr.png` は 2D、`scan_3d_lr.png` は SBS）
   - `1080p` や `IMG_0180` のような番号は誤検出しない（完全一致トークンのみ）
 - 「メディアURLを追加」ダイアログ（desktop: settings chip 🎬 /
   mobile: 追加シート）では形式を明示選択できる。明示指定は自動判定より優先。
   明示的に 2D を選ぶと自動判定も抑止する。
 - `vr180` は追加時に position.y を視点高さ（1.6m）まで持ち上げる。
+
+### Content replacement
+
+media-panel への drop / メディアURLダイアログ / AI `replaceMediaFromUrl` で
+既存 object の内容を差し替える場合の立体視形式は次の優先順で決まる:
+
+1. 明示指定（ダイアログの形式選択、AI params の `projection` / `stereoLayout`）
+2. 新しい URL のファイル名からの自動判定
+3. どちらも無ければ既存 asset の形式を維持（差し替えで 2D に落ちない）
+
+明示的に 2D（flat / mono）を指定した場合のみ立体視形式を解除する。
 
 実装: `html/assets/js/scenesync/loaders/stereo-media.js`
 （テスト: `npm run test:stereo-media`）

--- a/docs/scene-sync-assets-and-cache.md
+++ b/docs/scene-sync-assets-and-cache.md
@@ -167,6 +167,62 @@ Web client は video URL を textured plane として表示する。
 
 ---
 
+## Stereo / VR180 media
+
+`image` / `video` asset は optional metadata で立体視表示を切り替えられる。
+
+```json
+{
+  "type": "video",
+  "source": "url",
+  "url": "https://example.com/tour_vr180_sbs.mp4",
+  "projection": "vr180",
+  "stereoLayout": "sbs"
+}
+```
+
+| Field | 値 | 意味 |
+|---|---|---|
+| `projection` | `flat`（既定） | 通常の plane 表示 |
+| | `vr180` | 半球ドーム（equirect 180°、正面 -Z、内側から見る） |
+| `stereoLayout` | `mono`（既定） | 単眼素材 |
+| | `sbs` | 左右並び（左目が左半分） |
+| | `tb` | 上下並び（左目が上半分） |
+
+両方省略した場合は従来通りの表示（後方互換）。不正値は既定値に落とす。
+
+### Rendering
+
+- 左目メッシュは three.js layer 1、右目メッシュは layer 2 に置く。
+  WebXR では three.js が左右のカメラに layer 1 / 2 を割り当てるため、
+  HMD では左右の目に別画像が表示される。
+- 非XR（デスクトップ / モバイル）はメインカメラが layer 1 を有効化しており、
+  左目画像のみ表示される。
+- `flat` + `sbs` / `tb` は片目分のアスペクト比で plane サイズを計算する
+  （full SBS / full TB 前提。squashed half 形式は片目が横 / 縦に伸びる）。
+- `vr180` は半径 3m の半球ドーム。object の scale で拡大できる。
+  layer 0 には選択・raycast 用の不可視 hit proxy
+  （plane または中心の小さな球）を置く。
+
+### 登録 UI
+
+- URL drop / clipboard / メディアURLダイアログ / AI import が対象。
+  ファイル drop 画像（carrier GLB 化経路）は未対応。
+- ファイル名 / URL の basename をトークン分割して自動判定する:
+  - `vr180`, `180`, `180x180` → `projection: vr180`
+  - `sbs`, `hsbs`, `fsbs`, `lr`, `3dh`, `sidebyside` 等 → `stereoLayout: sbs`
+  - `tb`, `ou`, `overunder`, `topbottom`, `3dv` 等 → `stereoLayout: tb`
+  - `1080p` や `IMG_0180` のような番号は誤検出しない（完全一致トークンのみ）
+- 「メディアURLを追加」ダイアログ（desktop: settings chip 🎬 /
+  mobile: 追加シート）では形式を明示選択できる。明示指定は自動判定より優先。
+  明示的に 2D を選ぶと自動判定も抑止する。
+- `vr180` は追加時に position.y を視点高さ（1.6m）まで持ち上げる。
+
+実装: `html/assets/js/scenesync/loaders/stereo-media.js`
+（テスト: `npm run test:stereo-media`）
+
+---
+
 ## Text file
 
 Web client は `.txt`, `.md`, `.markdown` を carrier GLB に変換して表示する。

--- a/docs/scene-sync-web-ux.md
+++ b/docs/scene-sync-web-ux.md
@@ -33,6 +33,21 @@ Scene Sync Web は、軽量な共有 3D editor / DevTool として扱う。
 
 ---
 
+## メディアURL登録ダイアログ
+
+動画 / 画像 URL を表示形式付きで登録する UI。
+
+- desktop: settings panel の 🎬 `メディアURL` chip から開く。
+- mobile: 追加シートの `メディアURLを追加（VR180 / 3D）` から開く。
+- 入力: URL、表示形式 select（自動判定 / 2D / 3D SBS / 3D TB / VR180 系）。
+- 「自動判定」選択中は、URL のファイル名から推定した形式をダイアログ内にライブ表示する。
+- 明示指定は自動判定より優先。明示的な 2D 指定は自動判定を抑止する。
+- URL drop / clipboard 経由の追加でも同じ自動判定が走り、判定時は toast で形式を通知する。
+
+詳細は [Asset / Blob / Cache](./scene-sync-assets-and-cache.md) の「Stereo / VR180 media」を参照。
+
+---
+
 ## Drag and Drop placement
 
 ### Hit placement

--- a/html/assets/js/scenesync/core/three-app.js
+++ b/html/assets/js/scenesync/core/three-app.js
@@ -15,6 +15,9 @@ export function createThreeApp() {
     1000
   );
   camera.position.set(5, 5, 5);
+  // 立体視メディアの左目メッシュ（layer 1）を非XR表示でも見せる。
+  // WebXR 中は three.js が左目カメラに layer 1、右目カメラに layer 2 を割り当てる。
+  camera.layers.enable(1);
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setPixelRatio(window.devicePixelRatio);

--- a/html/assets/js/scenesync/loaders/stereo-media.js
+++ b/html/assets/js/scenesync/loaders/stereo-media.js
@@ -43,11 +43,16 @@ export function normalizeStereoMedia(asset) {
 const VR180_TOKENS = new Set(['vr180', '180', '180x180']);
 const SBS_TOKENS = new Set([
   'sbs', 'hsbs', 'fsbs', 'halfsbs', 'fullsbs',
-  'lr', '3dh', 'leftright', 'sidebyside',
+  '3dh', 'leftright', 'sidebyside',
 ]);
 const TB_TOKENS = new Set([
-  'tb', 'htab', 'ftab', 'ou', 'overunder', 'topbottom', '3dv',
+  'htab', 'ftab', 'overunder', 'topbottom', '3dv',
 ]);
+// 2文字の曖昧トークンは誤爆しやすいので、別の立体視シグナル
+// （vr180 / 3d / stereo）が同居する場合だけ有効にする。
+const WEAK_SBS_TOKENS = new Set(['lr']);
+const WEAK_TB_TOKENS = new Set(['tb', 'ou']);
+const STEREO_CONTEXT_TOKENS = new Set(['3d', 'stereo']);
 
 function basenameFromUrlOrName(input) {
   if (!input || typeof input !== 'string') return '';
@@ -77,9 +82,12 @@ export function detectStereoMediaFromName(urlOrName) {
   const has = (set) => tokens.some((t) => set.has(t));
 
   const vr180 = has(VR180_TOKENS);
+  const hasStereoContext = vr180 || has(STEREO_CONTEXT_TOKENS);
   let layout = null;
   if (has(SBS_TOKENS)) layout = 'sbs';
   else if (has(TB_TOKENS)) layout = 'tb';
+  else if (hasStereoContext && has(WEAK_SBS_TOKENS)) layout = 'sbs';
+  else if (hasStereoContext && has(WEAK_TB_TOKENS)) layout = 'tb';
 
   // VR180 でレイアウト不明のまま '3d' が付く場合は SBS 慣行に合わせる
   if (vr180 && !layout && tokens.includes('3d')) layout = 'sbs';
@@ -182,11 +190,28 @@ export function stereoPlaneSize(aspect, stereoLayout, maxEdgeMeters = 2) {
   return { width, height };
 }
 
-function applyEyeTransformToTexture(texture, stereoLayout, eye) {
+/**
+ * 目ごとのテクスチャ領域をジオメトリの UV に焼き込む。
+ * texture.offset/repeat ではなく UV 側で切り出すことで、
+ * 左右の目が 1 枚のテクスチャ（GPU アップロード 1 回）を共有できる。
+ * 変換が恒等（mono）の場合は base geometry をそのまま共有する。
+ */
+function geometryForEye(baseGeometry, stereoLayout, eye) {
   const { offset, repeat } = eyeTextureTransform(stereoLayout, eye);
-  texture.offset.set(offset[0], offset[1]);
-  texture.repeat.set(repeat[0], repeat[1]);
-  return texture;
+  if (offset[0] === 0 && offset[1] === 0 && repeat[0] === 1 && repeat[1] === 1) {
+    return { geometry: baseGeometry, owned: false };
+  }
+  const geometry = baseGeometry.clone();
+  const uv = geometry.attributes.uv;
+  for (let i = 0; i < uv.count; i++) {
+    uv.setXY(
+      i,
+      offset[0] + uv.getX(i) * repeat[0],
+      offset[1] + uv.getY(i) * repeat[1]
+    );
+  }
+  uv.needsUpdate = true;
+  return { geometry, owned: true };
 }
 
 function createInvisibleHitProxyMaterial(THREE) {
@@ -198,12 +223,30 @@ function createInvisibleHitProxyMaterial(THREE) {
   });
 }
 
+const EYES = [
+  { eye: 'left', layer: LAYER_LEFT_EYE },
+  { eye: 'right', layer: LAYER_RIGHT_EYE },
+];
+
+function addEyeMeshes({ THREE, group, baseGeometry, material, stereoLayout, namePrefix, positionY = 0, disposables }) {
+  for (const { eye, layer } of EYES) {
+    const { geometry, owned } = geometryForEye(baseGeometry, stereoLayout, eye);
+    if (owned) disposables.push(geometry);
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = `${namePrefix}-${eye}`;
+    mesh.position.y = positionY;
+    mesh.layers.set(layer);
+    group.add(mesh);
+  }
+}
+
 /**
  * 左右目用の plane を重ねた group を作る（flat + sbs/tb 用）。
  * layer 0 には raycast / 選択用の不可視 hit proxy を置く。
+ * texture は呼び出し側が所有する（dispose は呼び出し側の責務）。
  * @param {object} params
  *   - THREE
- *   - createEyeTexture: () => THREE.Texture（呼ぶたびに新しいテクスチャを返す）
+ *   - texture: 素材全体のテクスチャ（両目で共有）
  *   - aspect: 素材全体の width / height
  *   - stereoLayout: 'sbs' | 'tb' | 'mono'
  *   - maxEdgeMeters
@@ -211,7 +254,7 @@ function createInvisibleHitProxyMaterial(THREE) {
  */
 export function buildStereoPlaneGroup({
   THREE,
-  createEyeTexture,
+  texture,
   aspect,
   stereoLayout,
   maxEdgeMeters = 2,
@@ -219,39 +262,34 @@ export function buildStereoPlaneGroup({
   if (!THREE) throw new Error('THREE is required');
 
   const { width, height } = stereoPlaneSize(aspect, stereoLayout, maxEdgeMeters);
-  const geometry = new THREE.PlaneGeometry(width, height);
-  const disposables = [geometry];
+  const baseGeometry = new THREE.PlaneGeometry(width, height);
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    alphaTest: 0.01,
+    depthWrite: true,
+    side: THREE.DoubleSide,
+    toneMapped: false,
+  });
+  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
+  const disposables = [baseGeometry, material, proxyMaterial];
   const group = new THREE.Group();
 
-  const eyes = [
-    { eye: 'left', layer: LAYER_LEFT_EYE },
-    { eye: 'right', layer: LAYER_RIGHT_EYE },
-  ];
+  addEyeMeshes({
+    THREE,
+    group,
+    baseGeometry,
+    material,
+    stereoLayout,
+    namePrefix: 'stereo-plane',
+    positionY: height / 2,
+    disposables,
+  });
 
-  for (const { eye, layer } of eyes) {
-    const texture = applyEyeTransformToTexture(createEyeTexture(), stereoLayout, eye);
-    const material = new THREE.MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      alphaTest: 0.01,
-      depthWrite: true,
-      side: THREE.DoubleSide,
-      toneMapped: false,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.name = `stereo-plane-${eye}`;
-    mesh.position.y = height / 2;
-    mesh.layers.set(layer);
-    group.add(mesh);
-    disposables.push(texture, material);
-  }
-
-  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
-  const proxy = new THREE.Mesh(geometry, proxyMaterial);
+  const proxy = new THREE.Mesh(baseGeometry, proxyMaterial);
   proxy.name = 'stereo-hit-proxy';
   proxy.position.y = height / 2;
   group.add(proxy);
-  disposables.push(proxyMaterial);
 
   return { group, width, height, disposables };
 }
@@ -259,17 +297,19 @@ export function buildStereoPlaneGroup({
 /**
  * VR180 半球ドームの group を作る。
  * 半球は -Z（正面）を向き、内側から見る前提。mono / sbs / tb に対応。
- * 中心に選択・移動用の小さな不可視 hit proxy 球を置く。
+ * layer 0 には選択・raycast 用の不可視な半球 hit proxy を重ねる
+ * （ドーム表面クリックで選択できる。配置 raycast からは scene.js 側で除外）。
+ * texture は呼び出し側が所有する（dispose は呼び出し側の責務）。
  * @param {object} params
  *   - THREE
- *   - createEyeTexture: () => THREE.Texture
+ *   - texture: 素材全体のテクスチャ（両目で共有）
  *   - stereoLayout
  *   - radius
  * @returns {{ group, radius, disposables: Array<{dispose: Function}> }}
  */
 export function buildVr180DomeGroup({
   THREE,
-  createEyeTexture,
+  texture,
   stereoLayout,
   radius = DEFAULT_VR180_RADIUS,
 }) {
@@ -277,37 +317,65 @@ export function buildVr180DomeGroup({
 
   // phiStart=PI, phiLength=PI + scale(-1,1,1) で
   // 半球正面が -Z、テクスチャ左端が視聴者の左（-X）になる。
-  const geometry = new THREE.SphereGeometry(radius, 64, 32, Math.PI, Math.PI);
-  geometry.scale(-1, 1, 1);
+  const baseGeometry = new THREE.SphereGeometry(radius, 64, 32, Math.PI, Math.PI);
+  baseGeometry.scale(-1, 1, 1);
 
-  const disposables = [geometry];
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    side: THREE.FrontSide,
+    toneMapped: false,
+  });
+  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
+  const disposables = [baseGeometry, material, proxyMaterial];
   const group = new THREE.Group();
 
-  const eyes = [
-    { eye: 'left', layer: LAYER_LEFT_EYE },
-    { eye: 'right', layer: LAYER_RIGHT_EYE },
-  ];
+  addEyeMeshes({
+    THREE,
+    group,
+    baseGeometry,
+    material,
+    stereoLayout,
+    namePrefix: 'vr180-dome',
+    disposables,
+  });
 
-  for (const { eye, layer } of eyes) {
-    const texture = applyEyeTransformToTexture(createEyeTexture(), stereoLayout, eye);
-    const material = new THREE.MeshBasicMaterial({
-      map: texture,
-      side: THREE.FrontSide,
-      toneMapped: false,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.name = `vr180-dome-${eye}`;
-    mesh.layers.set(layer);
-    group.add(mesh);
-    disposables.push(texture, material);
-  }
-
-  const proxyGeometry = new THREE.SphereGeometry(0.15, 12, 8);
-  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
-  const proxy = new THREE.Mesh(proxyGeometry, proxyMaterial);
+  const proxy = new THREE.Mesh(baseGeometry, proxyMaterial);
   proxy.name = 'vr180-hit-proxy';
   group.add(proxy);
-  disposables.push(proxyGeometry, proxyMaterial);
 
   return { group, radius, disposables };
+}
+
+/**
+ * URL import 共通の立体視処理:
+ * 形式解決（明示指定 > ファイル名自動判定）、自動判定トースト、
+ * VR180 の視点高さ持ち上げ、asset に spread する fields をまとめて返す。
+ * @param {object} params
+ *   - explicitFormat: UI からの明示指定（ctx.mediaFormat）
+ *   - url
+ *   - spawnPosition: [x, y, z]
+ *   - showToast
+ * @returns {{ mediaFormat, position, assetFields }}
+ */
+export function prepareStereoMediaImport({ explicitFormat, url, spawnPosition, showToast }) {
+  const mediaFormat = resolveMediaFormat(explicitFormat, url);
+  if (mediaFormat?.detected) {
+    showToast?.({ message: `立体視形式を自動判定: ${stereoMediaLabel(mediaFormat)}` });
+  }
+  // VR180 ドームは中心が視点高さに来るように持ち上げる
+  const position = mediaFormat?.projection === 'vr180'
+    ? [
+      spawnPosition[0],
+      Math.max(spawnPosition[1], DEFAULT_VR180_EYE_HEIGHT),
+      spawnPosition[2],
+    ]
+    : spawnPosition;
+
+  return {
+    mediaFormat,
+    position,
+    assetFields: mediaFormat
+      ? { projection: mediaFormat.projection, stereoLayout: mediaFormat.stereoLayout }
+      : {},
+  };
 }

--- a/html/assets/js/scenesync/loaders/stereo-media.js
+++ b/html/assets/js/scenesync/loaders/stereo-media.js
@@ -1,0 +1,313 @@
+/**
+ * Stereo / VR180 media helpers.
+ *
+ * image / video asset は以下の optional metadata で立体視表示を切り替える。
+ *
+ * - asset.projection:   'flat'（既定） | 'vr180'
+ * - asset.stereoLayout: 'mono'（既定） | 'sbs'（左右） | 'tb'（上下・左目が上）
+ *
+ * 描画は three.js の layer 規約に合わせる:
+ * - 左目メッシュ → layer 1（WebXR 左目カメラ / デスクトップカメラで表示）
+ * - 右目メッシュ → layer 2（WebXR 右目カメラで表示）
+ * デスクトップ表示用にメインカメラは layer 1 を有効化しておくこと。
+ */
+
+export const STEREO_PROJECTIONS = ['flat', 'vr180'];
+export const STEREO_LAYOUTS = ['mono', 'sbs', 'tb'];
+
+export const LAYER_LEFT_EYE = 1;
+export const LAYER_RIGHT_EYE = 2;
+
+export const DEFAULT_VR180_RADIUS = 3;
+export const DEFAULT_VR180_EYE_HEIGHT = 1.6;
+
+/**
+ * asset の projection / stereoLayout を検証して正規化する。
+ * @param {object|null} asset
+ * @returns {{ projection: string, stereoLayout: string, isDefault: boolean }}
+ */
+export function normalizeStereoMedia(asset) {
+  const projection = STEREO_PROJECTIONS.includes(asset?.projection)
+    ? asset.projection
+    : 'flat';
+  const stereoLayout = STEREO_LAYOUTS.includes(asset?.stereoLayout)
+    ? asset.stereoLayout
+    : 'mono';
+  return {
+    projection,
+    stereoLayout,
+    isDefault: projection === 'flat' && stereoLayout === 'mono',
+  };
+}
+
+const VR180_TOKENS = new Set(['vr180', '180', '180x180']);
+const SBS_TOKENS = new Set([
+  'sbs', 'hsbs', 'fsbs', 'halfsbs', 'fullsbs',
+  'lr', '3dh', 'leftright', 'sidebyside',
+]);
+const TB_TOKENS = new Set([
+  'tb', 'htab', 'ftab', 'ou', 'overunder', 'topbottom', '3dv',
+]);
+
+function basenameFromUrlOrName(input) {
+  if (!input || typeof input !== 'string') return '';
+  let path = input;
+  try {
+    path = new URL(input).pathname;
+  } catch {
+    /* URL でなければファイル名として扱う */
+  }
+  const last = path.split('/').pop() || '';
+  // 拡張子は判定対象外
+  return last.replace(/\.[a-z0-9]+$/i, '');
+}
+
+/**
+ * ファイル名 / URL から立体視形式を推定する。
+ * トークン（英数字以外で分割）ベースの保守的な判定。
+ * 判定できない場合は null。
+ * @param {string} urlOrName
+ * @returns {{ projection: string, stereoLayout: string } | null}
+ */
+export function detectStereoMediaFromName(urlOrName) {
+  const base = basenameFromUrlOrName(urlOrName).toLowerCase();
+  if (!base) return null;
+
+  const tokens = base.split(/[^a-z0-9]+/).filter(Boolean);
+  const has = (set) => tokens.some((t) => set.has(t));
+
+  const vr180 = has(VR180_TOKENS);
+  let layout = null;
+  if (has(SBS_TOKENS)) layout = 'sbs';
+  else if (has(TB_TOKENS)) layout = 'tb';
+
+  // VR180 でレイアウト不明のまま '3d' が付く場合は SBS 慣行に合わせる
+  if (vr180 && !layout && tokens.includes('3d')) layout = 'sbs';
+
+  if (!vr180 && !layout) return null;
+
+  return {
+    projection: vr180 ? 'vr180' : 'flat',
+    stereoLayout: layout || 'mono',
+  };
+}
+
+/**
+ * UI 上の明示指定があればそれを優先し、なければファイル名から自動判定する。
+ * @param {{ projection?: string, stereoLayout?: string } | null} explicit
+ * @param {string} urlOrName
+ * @returns {{ projection: string, stereoLayout: string, detected: boolean } | null}
+ */
+export function resolveMediaFormat(explicit, urlOrName) {
+  if (explicit && (explicit.projection || explicit.stereoLayout)) {
+    const normalized = normalizeStereoMedia(explicit);
+    if (!normalized.isDefault) {
+      return { projection: normalized.projection, stereoLayout: normalized.stereoLayout, detected: false };
+    }
+    // 明示的に 2D/mono 指定された場合は自動判定もしない
+    return null;
+  }
+  const detected = detectStereoMediaFromName(urlOrName);
+  return detected ? { ...detected, detected: true } : null;
+}
+
+/**
+ * トースト等に出す日本語ラベル。
+ */
+export function stereoMediaLabel(format) {
+  const { projection, stereoLayout } = normalizeStereoMedia(format);
+  const layoutLabel = stereoLayout === 'sbs'
+    ? '3D 左右(SBS)'
+    : stereoLayout === 'tb'
+      ? '3D 上下(TB)'
+      : '2D';
+  if (projection === 'vr180') {
+    return stereoLayout === 'mono' ? 'VR180 (2D)' : `VR180 ${layoutLabel}`;
+  }
+  return layoutLabel;
+}
+
+/**
+ * 各目が使うテクスチャ領域（offset / repeat）。
+ * tb は VR 慣行に合わせて左目=上段。
+ * @param {string} stereoLayout
+ * @param {'left'|'right'} eye
+ * @returns {{ offset: [number, number], repeat: [number, number] }}
+ */
+export function eyeTextureTransform(stereoLayout, eye) {
+  if (stereoLayout === 'sbs') {
+    return {
+      offset: [eye === 'right' ? 0.5 : 0, 0],
+      repeat: [0.5, 1],
+    };
+  }
+  if (stereoLayout === 'tb') {
+    return {
+      offset: [0, eye === 'right' ? 0 : 0.5],
+      repeat: [1, 0.5],
+    };
+  }
+  return { offset: [0, 0], repeat: [1, 1] };
+}
+
+/**
+ * 素材全体のアスペクト比から、片目分のアスペクト比を求める。
+ * @param {number} aspect - width / height（素材全体）
+ * @param {string} stereoLayout
+ * @returns {number}
+ */
+export function perEyeAspect(aspect, stereoLayout) {
+  const safe = (aspect && aspect > 0) ? aspect : 1;
+  if (stereoLayout === 'sbs') return safe / 2;
+  if (stereoLayout === 'tb') return safe * 2;
+  return safe;
+}
+
+/**
+ * 片目分のアスペクト比から plane サイズを計算（long edge = maxEdgeMeters）。
+ * url-importers/image.js の planeSizeFromAspect と同じ規則。
+ */
+export function stereoPlaneSize(aspect, stereoLayout, maxEdgeMeters = 2) {
+  const minEdge = 0.1;
+  const eyeAspect = perEyeAspect(aspect, stereoLayout);
+  let width;
+  let height;
+  if (eyeAspect >= 1) {
+    width = Math.max(maxEdgeMeters, minEdge);
+    height = Math.max(maxEdgeMeters / eyeAspect, minEdge);
+  } else {
+    height = Math.max(maxEdgeMeters, minEdge);
+    width = Math.max(maxEdgeMeters * eyeAspect, minEdge);
+  }
+  return { width, height };
+}
+
+function applyEyeTransformToTexture(texture, stereoLayout, eye) {
+  const { offset, repeat } = eyeTextureTransform(stereoLayout, eye);
+  texture.offset.set(offset[0], offset[1]);
+  texture.repeat.set(repeat[0], repeat[1]);
+  return texture;
+}
+
+function createInvisibleHitProxyMaterial(THREE) {
+  return new THREE.MeshBasicMaterial({
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+    colorWrite: false,
+  });
+}
+
+/**
+ * 左右目用の plane を重ねた group を作る（flat + sbs/tb 用）。
+ * layer 0 には raycast / 選択用の不可視 hit proxy を置く。
+ * @param {object} params
+ *   - THREE
+ *   - createEyeTexture: () => THREE.Texture（呼ぶたびに新しいテクスチャを返す）
+ *   - aspect: 素材全体の width / height
+ *   - stereoLayout: 'sbs' | 'tb' | 'mono'
+ *   - maxEdgeMeters
+ * @returns {{ group, width, height, disposables: Array<{dispose: Function}> }}
+ */
+export function buildStereoPlaneGroup({
+  THREE,
+  createEyeTexture,
+  aspect,
+  stereoLayout,
+  maxEdgeMeters = 2,
+}) {
+  if (!THREE) throw new Error('THREE is required');
+
+  const { width, height } = stereoPlaneSize(aspect, stereoLayout, maxEdgeMeters);
+  const geometry = new THREE.PlaneGeometry(width, height);
+  const disposables = [geometry];
+  const group = new THREE.Group();
+
+  const eyes = [
+    { eye: 'left', layer: LAYER_LEFT_EYE },
+    { eye: 'right', layer: LAYER_RIGHT_EYE },
+  ];
+
+  for (const { eye, layer } of eyes) {
+    const texture = applyEyeTransformToTexture(createEyeTexture(), stereoLayout, eye);
+    const material = new THREE.MeshBasicMaterial({
+      map: texture,
+      transparent: true,
+      alphaTest: 0.01,
+      depthWrite: true,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = `stereo-plane-${eye}`;
+    mesh.position.y = height / 2;
+    mesh.layers.set(layer);
+    group.add(mesh);
+    disposables.push(texture, material);
+  }
+
+  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
+  const proxy = new THREE.Mesh(geometry, proxyMaterial);
+  proxy.name = 'stereo-hit-proxy';
+  proxy.position.y = height / 2;
+  group.add(proxy);
+  disposables.push(proxyMaterial);
+
+  return { group, width, height, disposables };
+}
+
+/**
+ * VR180 半球ドームの group を作る。
+ * 半球は -Z（正面）を向き、内側から見る前提。mono / sbs / tb に対応。
+ * 中心に選択・移動用の小さな不可視 hit proxy 球を置く。
+ * @param {object} params
+ *   - THREE
+ *   - createEyeTexture: () => THREE.Texture
+ *   - stereoLayout
+ *   - radius
+ * @returns {{ group, radius, disposables: Array<{dispose: Function}> }}
+ */
+export function buildVr180DomeGroup({
+  THREE,
+  createEyeTexture,
+  stereoLayout,
+  radius = DEFAULT_VR180_RADIUS,
+}) {
+  if (!THREE) throw new Error('THREE is required');
+
+  // phiStart=PI, phiLength=PI + scale(-1,1,1) で
+  // 半球正面が -Z、テクスチャ左端が視聴者の左（-X）になる。
+  const geometry = new THREE.SphereGeometry(radius, 64, 32, Math.PI, Math.PI);
+  geometry.scale(-1, 1, 1);
+
+  const disposables = [geometry];
+  const group = new THREE.Group();
+
+  const eyes = [
+    { eye: 'left', layer: LAYER_LEFT_EYE },
+    { eye: 'right', layer: LAYER_RIGHT_EYE },
+  ];
+
+  for (const { eye, layer } of eyes) {
+    const texture = applyEyeTransformToTexture(createEyeTexture(), stereoLayout, eye);
+    const material = new THREE.MeshBasicMaterial({
+      map: texture,
+      side: THREE.FrontSide,
+      toneMapped: false,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = `vr180-dome-${eye}`;
+    mesh.layers.set(layer);
+    group.add(mesh);
+    disposables.push(texture, material);
+  }
+
+  const proxyGeometry = new THREE.SphereGeometry(0.15, 12, 8);
+  const proxyMaterial = createInvisibleHitProxyMaterial(THREE);
+  const proxy = new THREE.Mesh(proxyGeometry, proxyMaterial);
+  proxy.name = 'vr180-hit-proxy';
+  group.add(proxy);
+  disposables.push(proxyGeometry, proxyMaterial);
+
+  return { group, radius, disposables };
+}

--- a/html/assets/js/scenesync/loaders/stereo-media.test.js
+++ b/html/assets/js/scenesync/loaders/stereo-media.test.js
@@ -1,0 +1,190 @@
+// Tests for stereo-media.js
+// Run: node --test html/assets/js/scenesync/loaders/stereo-media.test.js
+
+import { test } from 'node:test';
+import { strictEqual, deepEqual } from 'node:assert';
+import {
+  normalizeStereoMedia,
+  detectStereoMediaFromName,
+  resolveMediaFormat,
+  stereoMediaLabel,
+  eyeTextureTransform,
+  perEyeAspect,
+  stereoPlaneSize,
+} from './stereo-media.js';
+
+// ── normalizeStereoMedia ─────────────────────────────────────────────────────
+
+test('normalizeStereoMedia: 省略時は flat/mono (default)', () => {
+  deepEqual(normalizeStereoMedia(null), {
+    projection: 'flat',
+    stereoLayout: 'mono',
+    isDefault: true,
+  });
+  deepEqual(normalizeStereoMedia({}), {
+    projection: 'flat',
+    stereoLayout: 'mono',
+    isDefault: true,
+  });
+});
+
+test('normalizeStereoMedia: 不正値は既定値に落とす', () => {
+  deepEqual(normalizeStereoMedia({ projection: 'vr360', stereoLayout: 'quad' }), {
+    projection: 'flat',
+    stereoLayout: 'mono',
+    isDefault: true,
+  });
+});
+
+test('normalizeStereoMedia: vr180 / sbs を保持する', () => {
+  deepEqual(normalizeStereoMedia({ projection: 'vr180', stereoLayout: 'sbs' }), {
+    projection: 'vr180',
+    stereoLayout: 'sbs',
+    isDefault: false,
+  });
+});
+
+test('normalizeStereoMedia: flat + sbs も non-default', () => {
+  strictEqual(normalizeStereoMedia({ stereoLayout: 'sbs' }).isDefault, false);
+});
+
+// ── detectStereoMediaFromName ────────────────────────────────────────────────
+
+test('detect: vr180 トークン', () => {
+  deepEqual(detectStereoMediaFromName('https://example.com/clip_vr180.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'mono',
+  });
+});
+
+test('detect: VR180 + SBS', () => {
+  deepEqual(detectStereoMediaFromName('https://example.com/tour_VR180_SBS.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'sbs',
+  });
+});
+
+test('detect: 180 単独トークン', () => {
+  deepEqual(detectStereoMediaFromName('video-180.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'mono',
+  });
+});
+
+test('detect: vr180 + 3d は SBS 扱い', () => {
+  deepEqual(detectStereoMediaFromName('festival_180_3D.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'sbs',
+  });
+});
+
+test('detect: flat SBS 画像', () => {
+  deepEqual(detectStereoMediaFromName('https://example.com/photos/shrine_sbs.jpg'), {
+    projection: 'flat',
+    stereoLayout: 'sbs',
+  });
+  deepEqual(detectStereoMediaFromName('scan_LR.png'), {
+    projection: 'flat',
+    stereoLayout: 'sbs',
+  });
+});
+
+test('detect: flat TB 動画', () => {
+  deepEqual(detectStereoMediaFromName('movie_ou.mp4'), {
+    projection: 'flat',
+    stereoLayout: 'tb',
+  });
+  deepEqual(detectStereoMediaFromName('movie.topbottom.webm'), {
+    projection: 'flat',
+    stereoLayout: 'tb',
+  });
+});
+
+test('detect: 1080p や連番は誤検出しない', () => {
+  strictEqual(detectStereoMediaFromName('movie_1080p.mp4'), null);
+  strictEqual(detectStereoMediaFromName('IMG_0180.jpg'), null);
+  strictEqual(detectStereoMediaFromName('https://example.com/normal-video.mp4'), null);
+});
+
+test('detect: クエリ付き URL でも basename で判定', () => {
+  deepEqual(detectStereoMediaFromName('https://cdn.example.com/a/b/dive_vr180.mp4?token=abc'), {
+    projection: 'vr180',
+    stereoLayout: 'mono',
+  });
+});
+
+test('detect: 空入力は null', () => {
+  strictEqual(detectStereoMediaFromName(''), null);
+  strictEqual(detectStereoMediaFromName(null), null);
+});
+
+// ── resolveMediaFormat ───────────────────────────────────────────────────────
+
+test('resolve: 明示指定が自動判定より優先', () => {
+  deepEqual(
+    resolveMediaFormat({ projection: 'vr180', stereoLayout: 'tb' }, 'clip_sbs.mp4'),
+    { projection: 'vr180', stereoLayout: 'tb', detected: false }
+  );
+});
+
+test('resolve: 明示的な 2D 指定は自動判定を抑止', () => {
+  strictEqual(
+    resolveMediaFormat({ projection: 'flat', stereoLayout: 'mono' }, 'clip_vr180_sbs.mp4'),
+    null
+  );
+});
+
+test('resolve: 指定なしなら自動判定', () => {
+  deepEqual(resolveMediaFormat(null, 'clip_vr180.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'mono',
+    detected: true,
+  });
+  strictEqual(resolveMediaFormat(null, 'clip.mp4'), null);
+});
+
+// ── stereoMediaLabel ─────────────────────────────────────────────────────────
+
+test('label: 表示ラベル', () => {
+  strictEqual(stereoMediaLabel({ projection: 'vr180', stereoLayout: 'sbs' }), 'VR180 3D 左右(SBS)');
+  strictEqual(stereoMediaLabel({ projection: 'vr180', stereoLayout: 'mono' }), 'VR180 (2D)');
+  strictEqual(stereoMediaLabel({ projection: 'flat', stereoLayout: 'tb' }), '3D 上下(TB)');
+  strictEqual(stereoMediaLabel({}), '2D');
+});
+
+// ── eyeTextureTransform ──────────────────────────────────────────────────────
+
+test('transform: sbs は左右半分ずつ（左目が左）', () => {
+  deepEqual(eyeTextureTransform('sbs', 'left'), { offset: [0, 0], repeat: [0.5, 1] });
+  deepEqual(eyeTextureTransform('sbs', 'right'), { offset: [0.5, 0], repeat: [0.5, 1] });
+});
+
+test('transform: tb は上下半分ずつ（左目が上）', () => {
+  deepEqual(eyeTextureTransform('tb', 'left'), { offset: [0, 0.5], repeat: [1, 0.5] });
+  deepEqual(eyeTextureTransform('tb', 'right'), { offset: [0, 0], repeat: [1, 0.5] });
+});
+
+test('transform: mono は全面', () => {
+  deepEqual(eyeTextureTransform('mono', 'left'), { offset: [0, 0], repeat: [1, 1] });
+});
+
+// ── perEyeAspect / stereoPlaneSize ───────────────────────────────────────────
+
+test('perEyeAspect: sbs は半分、tb は倍', () => {
+  strictEqual(perEyeAspect(3840 / 1080, 'sbs'), 3840 / 1080 / 2);
+  strictEqual(perEyeAspect(16 / 18, 'tb'), 16 / 9);
+  strictEqual(perEyeAspect(16 / 9, 'mono'), 16 / 9);
+  strictEqual(perEyeAspect(0, 'sbs'), 0.5);
+});
+
+test('stereoPlaneSize: 片目 16:9 SBS 素材は 2m x 1.125m', () => {
+  const { width, height } = stereoPlaneSize(32 / 9, 'sbs');
+  strictEqual(width, 2);
+  strictEqual(height, 2 / (16 / 9));
+});
+
+test('stereoPlaneSize: 縦長素材は高さ基準', () => {
+  const { width, height } = stereoPlaneSize(0.5, 'mono');
+  strictEqual(height, 2);
+  strictEqual(width, 1);
+});

--- a/html/assets/js/scenesync/loaders/stereo-media.test.js
+++ b/html/assets/js/scenesync/loaders/stereo-media.test.js
@@ -83,19 +83,36 @@ test('detect: flat SBS 画像', () => {
     projection: 'flat',
     stereoLayout: 'sbs',
   });
-  deepEqual(detectStereoMediaFromName('scan_LR.png'), {
-    projection: 'flat',
-    stereoLayout: 'sbs',
-  });
 });
 
 test('detect: flat TB 動画', () => {
-  deepEqual(detectStereoMediaFromName('movie_ou.mp4'), {
+  deepEqual(detectStereoMediaFromName('movie_overunder.mp4'), {
     projection: 'flat',
     stereoLayout: 'tb',
   });
   deepEqual(detectStereoMediaFromName('movie.topbottom.webm'), {
     projection: 'flat',
+    stereoLayout: 'tb',
+  });
+});
+
+test('detect: 曖昧な2文字トークンは単独では発火しない', () => {
+  strictEqual(detectStereoMediaFromName('scan_LR.png'), null);
+  strictEqual(detectStereoMediaFromName('movie_ou.mp4'), null);
+  strictEqual(detectStereoMediaFromName('notes_tb.mp4'), null);
+});
+
+test('detect: 曖昧トークンも立体視シグナル併記なら有効', () => {
+  deepEqual(detectStereoMediaFromName('scan_3d_LR.png'), {
+    projection: 'flat',
+    stereoLayout: 'sbs',
+  });
+  deepEqual(detectStereoMediaFromName('dive_180_ou.mp4'), {
+    projection: 'vr180',
+    stereoLayout: 'tb',
+  });
+  deepEqual(detectStereoMediaFromName('tour_vr180_tb.mp4'), {
+    projection: 'vr180',
     stereoLayout: 'tb',
   });
 });

--- a/html/assets/js/scenesync/loaders/url-importers/image.js
+++ b/html/assets/js/scenesync/loaders/url-importers/image.js
@@ -1,3 +1,9 @@
+import {
+  resolveMediaFormat,
+  stereoMediaLabel,
+  DEFAULT_VR180_EYE_HEIGHT,
+} from '../stereo-media.js';
+
 /**
  * Fetch API を使用して画像を Blob として CORS 付きで取得。
  * Skybox 生成用。
@@ -150,14 +156,35 @@ export async function importImageUrl(url, ctx) {
       ? ctx.placementRotation
       : spawnTransform.rotation;
 
+    // 立体視 / VR180: UI からの明示指定（ctx.mediaFormat）優先、なければファイル名から自動判定
+    const mediaFormat = resolveMediaFormat(ctx.mediaFormat, url);
+    if (mediaFormat?.detected) {
+      ctx.showToast?.({ message: `立体視形式を自動判定: ${stereoMediaLabel(mediaFormat)}` });
+    }
+    // VR180 ドームは中心が視点高さに来るように持ち上げる
+    const position = mediaFormat?.projection === 'vr180'
+      ? [
+        spawnTransform.position[0],
+        Math.max(spawnTransform.position[1], DEFAULT_VR180_EYE_HEIGHT),
+        spawnTransform.position[2],
+      ]
+      : spawnTransform.position;
+
     const payload = {
       kind: 'scene-add',
       objectId,
       name: displayName,
-      position: spawnTransform.position,
+      position,
       rotation: placementRotation,
       scale: spawnTransform.scale,
-      asset: { type: 'image', source: 'url', url },
+      asset: {
+        type: 'image',
+        source: 'url',
+        url,
+        ...(mediaFormat
+          ? { projection: mediaFormat.projection, stereoLayout: mediaFormat.stereoLayout }
+          : {}),
+      },
       metadata: {
         ...existingMetadata,
         role: 'media-panel',

--- a/html/assets/js/scenesync/loaders/url-importers/image.js
+++ b/html/assets/js/scenesync/loaders/url-importers/image.js
@@ -1,8 +1,4 @@
-import {
-  resolveMediaFormat,
-  stereoMediaLabel,
-  DEFAULT_VR180_EYE_HEIGHT,
-} from '../stereo-media.js';
+import { prepareStereoMediaImport, stereoPlaneSize } from '../stereo-media.js';
 
 /**
  * Fetch API を使用して画像を Blob として CORS 付きで取得。
@@ -111,19 +107,7 @@ export async function loadImageTextureFromUrl(url, { timeoutMs = 15000, THREE } 
  * @returns {object} { width, height }
  */
 export function planeSizeFromAspect(aspect, maxEdgeMeters = 2) {
-  const minEdge = 0.1;
-  const safeAspect = (aspect && aspect > 0) ? aspect : 1;
-  let width, height;
-
-  if (safeAspect >= 1) {
-    width = Math.max(maxEdgeMeters, minEdge);
-    height = Math.max(maxEdgeMeters / safeAspect, minEdge);
-  } else {
-    height = Math.max(maxEdgeMeters, minEdge);
-    width = Math.max(maxEdgeMeters * safeAspect, minEdge);
-  }
-
-  return { width, height };
+  return stereoPlaneSize(aspect, 'mono', maxEdgeMeters);
 }
 
 /**
@@ -157,18 +141,12 @@ export async function importImageUrl(url, ctx) {
       : spawnTransform.rotation;
 
     // 立体視 / VR180: UI からの明示指定（ctx.mediaFormat）優先、なければファイル名から自動判定
-    const mediaFormat = resolveMediaFormat(ctx.mediaFormat, url);
-    if (mediaFormat?.detected) {
-      ctx.showToast?.({ message: `立体視形式を自動判定: ${stereoMediaLabel(mediaFormat)}` });
-    }
-    // VR180 ドームは中心が視点高さに来るように持ち上げる
-    const position = mediaFormat?.projection === 'vr180'
-      ? [
-        spawnTransform.position[0],
-        Math.max(spawnTransform.position[1], DEFAULT_VR180_EYE_HEIGHT),
-        spawnTransform.position[2],
-      ]
-      : spawnTransform.position;
+    const { position, assetFields } = prepareStereoMediaImport({
+      explicitFormat: ctx.mediaFormat,
+      url,
+      spawnPosition: spawnTransform.position,
+      showToast: ctx.showToast,
+    });
 
     const payload = {
       kind: 'scene-add',
@@ -177,14 +155,7 @@ export async function importImageUrl(url, ctx) {
       position,
       rotation: placementRotation,
       scale: spawnTransform.scale,
-      asset: {
-        type: 'image',
-        source: 'url',
-        url,
-        ...(mediaFormat
-          ? { projection: mediaFormat.projection, stereoLayout: mediaFormat.stereoLayout }
-          : {}),
-      },
+      asset: { type: 'image', source: 'url', url, ...assetFields },
       metadata: {
         ...existingMetadata,
         role: 'media-panel',

--- a/html/assets/js/scenesync/loaders/url-importers/video.js
+++ b/html/assets/js/scenesync/loaders/url-importers/video.js
@@ -1,4 +1,9 @@
 import { loadVideoTextureFromUrl } from '../video-url-importer.js';
+import {
+  resolveMediaFormat,
+  stereoMediaLabel,
+  DEFAULT_VR180_EYE_HEIGHT,
+} from '../stereo-media.js';
 
 /**
  * URL から動画をロードし、scene-add を broadcast してローカルに配置。
@@ -15,14 +20,35 @@ export async function importVideoUrl(url, ctx) {
     const displayName = (ctx.nameOverride || `video: ${filename}`).slice(0, 60);
     const spawnTransform = ctx.getSpawnTransform();
 
+    // 立体視 / VR180: UI からの明示指定（ctx.mediaFormat）優先、なければファイル名から自動判定
+    const mediaFormat = resolveMediaFormat(ctx.mediaFormat, url);
+    if (mediaFormat?.detected) {
+      ctx.showToast?.({ message: `立体視形式を自動判定: ${stereoMediaLabel(mediaFormat)}` });
+    }
+    // VR180 ドームは中心が視点高さに来るように持ち上げる
+    const position = mediaFormat?.projection === 'vr180'
+      ? [
+        spawnTransform.position[0],
+        Math.max(spawnTransform.position[1], DEFAULT_VR180_EYE_HEIGHT),
+        spawnTransform.position[2],
+      ]
+      : spawnTransform.position;
+
     const payload = {
       kind: 'scene-add',
       objectId,
       name: displayName,
-      position: spawnTransform.position,
+      position,
       rotation: spawnTransform.rotation,
       scale: spawnTransform.scale,
-      asset: { type: 'video', source: 'url', url },
+      asset: {
+        type: 'video',
+        source: 'url',
+        url,
+        ...(mediaFormat
+          ? { projection: mediaFormat.projection, stereoLayout: mediaFormat.stereoLayout }
+          : {}),
+      },
       metadata: {
         role: 'media-panel',
         accepts: ['image', 'video'],

--- a/html/assets/js/scenesync/loaders/url-importers/video.js
+++ b/html/assets/js/scenesync/loaders/url-importers/video.js
@@ -1,9 +1,5 @@
 import { loadVideoTextureFromUrl } from '../video-url-importer.js';
-import {
-  resolveMediaFormat,
-  stereoMediaLabel,
-  DEFAULT_VR180_EYE_HEIGHT,
-} from '../stereo-media.js';
+import { prepareStereoMediaImport } from '../stereo-media.js';
 
 /**
  * URL から動画をロードし、scene-add を broadcast してローカルに配置。
@@ -21,18 +17,12 @@ export async function importVideoUrl(url, ctx) {
     const spawnTransform = ctx.getSpawnTransform();
 
     // 立体視 / VR180: UI からの明示指定（ctx.mediaFormat）優先、なければファイル名から自動判定
-    const mediaFormat = resolveMediaFormat(ctx.mediaFormat, url);
-    if (mediaFormat?.detected) {
-      ctx.showToast?.({ message: `立体視形式を自動判定: ${stereoMediaLabel(mediaFormat)}` });
-    }
-    // VR180 ドームは中心が視点高さに来るように持ち上げる
-    const position = mediaFormat?.projection === 'vr180'
-      ? [
-        spawnTransform.position[0],
-        Math.max(spawnTransform.position[1], DEFAULT_VR180_EYE_HEIGHT),
-        spawnTransform.position[2],
-      ]
-      : spawnTransform.position;
+    const { position, assetFields } = prepareStereoMediaImport({
+      explicitFormat: ctx.mediaFormat,
+      url,
+      spawnPosition: spawnTransform.position,
+      showToast: ctx.showToast,
+    });
 
     const payload = {
       kind: 'scene-add',
@@ -41,14 +31,7 @@ export async function importVideoUrl(url, ctx) {
       position,
       rotation: spawnTransform.rotation,
       scale: spawnTransform.scale,
-      asset: {
-        type: 'video',
-        source: 'url',
-        url,
-        ...(mediaFormat
-          ? { projection: mediaFormat.projection, stereoLayout: mediaFormat.stereoLayout }
-          : {}),
-      },
+      asset: { type: 'video', source: 'url', url, ...assetFields },
       metadata: {
         role: 'media-panel',
         accepts: ['image', 'video'],

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -21,6 +21,11 @@ import { generateTemporaryImageObjectId } from './loaders/image-preview.js';
 import { buildImageSkySphereGlb } from './loaders/image-to-sky-sphere.js';
 import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
+import {
+  normalizeStereoMedia,
+  buildStereoPlaneGroup,
+  buildVr180DomeGroup,
+} from './loaders/stereo-media.js';
 import { classifyUrl, URL_KIND } from './loaders/url-classifier.js';
 import { resolveDroppedUrl } from './loaders/url-resolver.js';
 import { normalizeTextAsset, renderTextPanelCanvas, DEFAULT_TEXT_LAYOUT, DEFAULT_TEXT_SCROLL, estimateTextPanelLayout } from './components/text-panel-renderer.js';
@@ -28,6 +33,7 @@ import { dispatchUrlImport } from './loaders/url-importers/index.js';
 import { getSceneSyncDom, mountSceneSyncShellFromDom } from './ui/dom.js';
 import { showToast } from './ui/toast.js';
 import { createWelcomeDialog } from './ui/welcome-dialog.js';
+import { initMediaUrlDialog } from './ui/media-url-dialog.js';
 import { focusTextInputIfSafe, blurActiveEditableElement } from './ui/input-focus-guard.js';
 import { applySceneSyncDeviceMode, isSceneSyncMobileDevice } from './ui/device-mode.js';
 import { normalizeDisplayName } from './utils/display-name.js';
@@ -8432,6 +8438,7 @@ function createSceneUrlImportContext(options = {}) {
     rotationOverride = null,
     scaleOverride = null,
     extraImporterContext = {},
+    mediaFormat = null,
   } = options;
 
   const position = positionArray;
@@ -8439,6 +8446,8 @@ function createSceneUrlImportContext(options = {}) {
   const scale = scaleOverride || [1, 1, 1];
 
   return {
+    // 立体視 / VR180 の明示指定（{ projection, stereoLayout }）。null なら自動判定に任せる。
+    mediaFormat: mediaFormat || sourceContext?.mediaFormat || null,
     addOrUpdateObject,
     broadcastSceneAdd: broadcast,
     applySceneBgm,
@@ -8551,6 +8560,9 @@ function createAiUrlImportContext(params = {}, context = {}) {
     placementPosition: context.placementPosition || null,
     targetKind: context?.targetKind || 'scene',
     sourceContext: context,
+    mediaFormat: (params.projection || params.stereoLayout)
+      ? { projection: params.projection, stereoLayout: params.stereoLayout }
+      : null,
     generateObjectIdOverride: (prefix) => {
       if (!customObjectIdUsed && typeof params.objectId === 'string' && params.objectId.trim()) {
         customObjectIdUsed = true;
@@ -9472,6 +9484,26 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
   })();
 }
 
+/**
+ * projection / stereoLayout 付き image / video asset 用の group を作る。
+ * flat + sbs/tb は左右目 plane、vr180 は半球ドームになる。
+ */
+function buildStereoMediaGroup({ stereo, aspect, createEyeTexture }) {
+  if (stereo.projection === 'vr180') {
+    return buildVr180DomeGroup({
+      THREE,
+      createEyeTexture,
+      stereoLayout: stereo.stereoLayout,
+    });
+  }
+  return buildStereoPlaneGroup({
+    THREE,
+    createEyeTexture,
+    aspect,
+    stereoLayout: stereo.stereoLayout,
+  });
+}
+
 function loadVideoObject(objectId, info, videoUrl, existing, prebuilt = null, options = {}) {
   addLoadingOverlay(objectId, info.name || objectId, info);
   const promise = prebuilt
@@ -9480,19 +9512,42 @@ function loadVideoObject(objectId, info, videoUrl, existing, prebuilt = null, op
 
   promise.then((bundle) => {
     removeLoadingOverlay(objectId);
-    const { group, material, texture } = createVideoPlaneGroup(bundle, THREE);
+    const stereo = normalizeStereoMedia(info.asset);
+    let group;
+    if (!stereo.isDefault) {
+      const built = buildStereoMediaGroup({
+        stereo,
+        aspect: bundle.aspect,
+        createEyeTexture: () => {
+          const eyeTexture = new THREE.VideoTexture(bundle.video);
+          eyeTexture.colorSpace = THREE.SRGBColorSpace;
+          eyeTexture.minFilter = THREE.LinearFilter;
+          eyeTexture.magFilter = THREE.LinearFilter;
+          return eyeTexture;
+        },
+      });
+      group = built.group;
+      group.userData.disposable = () => {
+        bundle.video?.pause?.();
+        bundle.video && (bundle.video.src = '');
+        bundle.texture?.dispose?.();
+        built.disposables.forEach((item) => item.dispose?.());
+      };
+    } else {
+      const { group: planeGroup, material, texture } = createVideoPlaneGroup(bundle, THREE);
+      group = planeGroup;
+      group.userData.disposable = () => {
+        bundle.video?.pause?.();
+        bundle.video && (bundle.video.src = '');
+        texture.dispose();
+        material.dispose();
+      };
+    }
     group.userData.objectId = objectId;
     group.userData.name = info.name;
     group.userData.video = bundle.video;
     group.userData.assetType = 'video';
     if (info.asset) group.userData.asset = structuredClone(info.asset);
-
-    group.userData.disposable = () => {
-      bundle.video?.pause?.();
-      bundle.video && (bundle.video.src = '');
-      texture.dispose();
-      material.dispose();
-    };
 
     if (existing) {
       group.position.copy(existing.position);
@@ -9543,34 +9598,53 @@ function loadImageObject(objectId, info, imageUrl, existing, prebuilt = null, op
   promise.then((bundle) => {
     removeLoadingOverlay(objectId);
     const { texture, width, height } = bundle;
+    const stereo = normalizeStereoMedia(info.asset);
+    let group;
 
-    const geometry = new THREE.PlaneGeometry(width, height);
-    const material = new THREE.MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      alphaTest: 0.01,
-      depthWrite: true,
-      side: THREE.DoubleSide,
-      toneMapped: false,
-    });
+    if (!stereo.isDefault) {
+      const built = buildStereoMediaGroup({
+        stereo,
+        aspect: bundle.aspect,
+        createEyeTexture: () => {
+          const eyeTexture = texture.clone();
+          eyeTexture.needsUpdate = true;
+          return eyeTexture;
+        },
+      });
+      group = built.group;
+      group.userData.disposable = () => {
+        texture.dispose();
+        built.disposables.forEach((item) => item.dispose?.());
+      };
+    } else {
+      const geometry = new THREE.PlaneGeometry(width, height);
+      const material = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+        alphaTest: 0.01,
+        depthWrite: true,
+        side: THREE.DoubleSide,
+        toneMapped: false,
+      });
 
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.y = height / 2;
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.y = height / 2;
 
-    const group = new THREE.Group();
-    group.add(mesh);
+      group = new THREE.Group();
+      group.add(mesh);
+
+      // Store for disposal
+      group.userData.disposable = () => {
+        texture.dispose();
+        geometry.dispose();
+        material.dispose();
+      };
+    }
 
     group.userData.objectId = objectId;
     group.userData.name = info.name;
     group.userData.assetType = 'image';
     if (info.asset) group.userData.asset = structuredClone(info.asset);
-
-    // Store for disposal
-    group.userData.disposable = () => {
-      texture.dispose();
-      geometry.dispose();
-      material.dispose();
-    };
 
     if (existing) {
       group.position.copy(existing.position);
@@ -12049,6 +12123,25 @@ const mobileDeleteSkyboxBtn = document.getElementById('mobile-delete-skybox-btn'
 const mobileLinkOpenBtn = document.getElementById('mobile-link-open-btn');
 const mobileHelpBtn = document.getElementById('mobile-help-btn');
 const mobileDevOpenBtn = document.getElementById('mobile-dev-open-btn');
+const mediaUrlBtn = document.getElementById('media-url-btn');
+const mobileAddMediaUrlBtn = document.getElementById('mobile-add-media-url-btn');
+
+// ── メディアURL登録ダイアログ（VR180 / 3D 立体視対応） ────────────────
+const mediaUrlDialog = initMediaUrlDialog({
+  showToast,
+  onSubmit: (url, mediaFormat) =>
+    urlImporterCallback(url, getDefaultImportPosition(), { mediaFormat })
+      .catch((error) => {
+        console.warn('[media-url-dialog] import failed:', error);
+        showToast(error?.message || 'メディアURLの追加に失敗しました');
+      }),
+});
+
+mediaUrlBtn?.addEventListener('click', () => mediaUrlDialog.open());
+mobileAddMediaUrlBtn?.addEventListener('click', () => {
+  closeMobileActionSheet();
+  mediaUrlDialog.open();
+});
 
 function closePasteSheet() {
   blurActiveEditableElement();

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -23,6 +23,7 @@ import { buildTextPlaneGlb } from './loaders/text-to-plane.js';
 import { loadVideoTextureFromUrl, createVideoPlaneGroup } from './loaders/video-url-importer.js';
 import {
   normalizeStereoMedia,
+  detectStereoMediaFromName,
   buildStereoPlaneGroup,
   buildVr180DomeGroup,
 } from './loaders/stereo-media.js';
@@ -4910,6 +4911,8 @@ function deleteObjectById(objectId, options = {}) {
   const audioSources = getObjectAudioSourcesForSerialize(attached);
 
   scene.remove(attached);
+  // media object はテクスチャ解放・video 停止を disposable に集約している
+  attached.userData?.disposable?.();
   attached.traverse(child => {
     if (child.geometry) child.geometry.dispose();
     if (child.material) {
@@ -8991,6 +8994,8 @@ async function handleAiCommand(from, payload) {
             source: 'url',
             url,
             name,
+            ...(params.projection ? { projection: params.projection } : {}),
+            ...(params.stereoLayout ? { stereoLayout: params.stereoLayout } : {}),
           });
 
           const targetObj = managedObjects.get(targetObjectId);
@@ -9487,18 +9492,19 @@ function loadMeshObject(objectId, info, meshPath, existing, options = {}) {
 /**
  * projection / stereoLayout 付き image / video asset 用の group を作る。
  * flat + sbs/tb は左右目 plane、vr180 は半球ドームになる。
+ * texture は両目で共有され、所有権（dispose）は呼び出し側に残る。
  */
-function buildStereoMediaGroup({ stereo, aspect, createEyeTexture }) {
+function buildStereoMediaGroup({ stereo, aspect, texture }) {
   if (stereo.projection === 'vr180') {
     return buildVr180DomeGroup({
       THREE,
-      createEyeTexture,
+      texture,
       stereoLayout: stereo.stereoLayout,
     });
   }
   return buildStereoPlaneGroup({
     THREE,
-    createEyeTexture,
+    texture,
     aspect,
     stereoLayout: stereo.stereoLayout,
   });
@@ -9518,13 +9524,7 @@ function loadVideoObject(objectId, info, videoUrl, existing, prebuilt = null, op
       const built = buildStereoMediaGroup({
         stereo,
         aspect: bundle.aspect,
-        createEyeTexture: () => {
-          const eyeTexture = new THREE.VideoTexture(bundle.video);
-          eyeTexture.colorSpace = THREE.SRGBColorSpace;
-          eyeTexture.minFilter = THREE.LinearFilter;
-          eyeTexture.magFilter = THREE.LinearFilter;
-          return eyeTexture;
-        },
+        texture: bundle.texture,
       });
       group = built.group;
       group.userData.disposable = () => {
@@ -9605,11 +9605,7 @@ function loadImageObject(objectId, info, imageUrl, existing, prebuilt = null, op
       const built = buildStereoMediaGroup({
         stereo,
         aspect: bundle.aspect,
-        createEyeTexture: () => {
-          const eyeTexture = texture.clone();
-          eyeTexture.needsUpdate = true;
-          return eyeTexture;
-        },
+        texture,
       });
       group = built.group;
       group.userData.disposable = () => {
@@ -9912,13 +9908,19 @@ function getReplaceTarget(inputKind, hitObjectId = null) {
 
 function findPrimaryMediaMesh(root) {
   let found = null;
+  let fallback = null;
   root.traverse((child) => {
     if (found) return;
     if (child.isMesh && child.geometry) {
-      found = child;
+      if (!fallback) fallback = child;
+      // 立体視 group では layer 1/2 の目メッシュが先に来るため、
+      // フルサイズの layer 0 メッシュ（通常メッシュ / hit proxy）を優先する
+      if ((child.layers.mask & 1) !== 0) {
+        found = child;
+      }
     }
   });
-  return found;
+  return found || fallback;
 }
 
 async function showLocalImageReplacementPreview(objectId, file) {
@@ -10035,6 +10037,31 @@ async function replaceObjectContent(objectId, input, options = {}) {
   let metaRole, metaAccepts, metaFit;
 
   if (input.kind === 'image' || input.kind === 'video') {
+    // 立体視 / VR180 の扱い: 明示指定 > ファイル名自動判定 > 既存 asset の形式を維持。
+    // 明示的な 2D 指定（flat/mono）は既存の立体視形式を意図的に解除する。
+    let stereoFields = null;
+    if (input.projection || input.stereoLayout) {
+      const explicit = normalizeStereoMedia(input);
+      stereoFields = { projection: explicit.projection, stereoLayout: explicit.stereoLayout };
+    } else {
+      const detected = input.source === 'url' || !input.source
+        ? detectStereoMediaFromName(input.url)
+        : null;
+      if (detected) {
+        stereoFields = detected;
+      } else {
+        const existingStereo = normalizeStereoMedia(existing.userData?.asset);
+        if (!existingStereo.isDefault) {
+          stereoFields = {
+            projection: existingStereo.projection,
+            stereoLayout: existingStereo.stereoLayout,
+          };
+        }
+      }
+    }
+    const keepStereoFields = stereoFields
+      && !(stereoFields.projection === 'flat' && stereoFields.stereoLayout === 'mono');
+
     newAsset = {
       type: input.kind,
       source: input.source || 'url',
@@ -10043,6 +10070,7 @@ async function replaceObjectContent(objectId, input, options = {}) {
       ...(input.width ? { width: input.width } : {}),
       ...(input.height ? { height: input.height } : {}),
       ...(input.assetId ? { assetId: input.assetId } : {}),
+      ...(keepStereoFields ? stereoFields : {}),
     };
     metaRole = existingMeta.role || 'media-panel';
     metaAccepts = existingMeta.accepts || ['image', 'video'];
@@ -11732,6 +11760,13 @@ async function urlImporterCallback(url, position, context = {}) {
           kind: inputKind,
           source: 'url',
           url: normalizedUrl,
+          // メディアURLダイアログ等での明示指定を replace 経路にも反映する
+          ...(context.mediaFormat && (inputKind === 'image' || inputKind === 'video')
+            ? {
+              projection: context.mediaFormat.projection,
+              stereoLayout: context.mediaFormat.stereoLayout,
+            }
+            : {}),
           ...(inputKind === 'text' && /\.(md|markdown)(?:$|[?#])/i.test(normalizedUrl)
             ? { format: 'markdown' }
             : {}),
@@ -11778,7 +11813,9 @@ const dragDropManager = new DragDropManager({
   getPlacementTargets: () => {
     const targets = [];
     for (const obj of managedObjects.values()) {
-      if (!isSkySphereThreeObject(obj) && obj.visible !== false) {
+      // VR180 ドームは skybox と同様、drop の配置先にしない（中に居ると全 drop を拾ってしまう）
+      const isVr180Dome = obj.userData?.asset?.projection === 'vr180';
+      if (!isSkySphereThreeObject(obj) && !isVr180Dome && obj.visible !== false) {
         targets.push(obj);
       }
     }

--- a/html/assets/js/scenesync/ui/media-url-dialog.js
+++ b/html/assets/js/scenesync/ui/media-url-dialog.js
@@ -1,0 +1,109 @@
+import { detectStereoMediaFromName, stereoMediaLabel } from '../loaders/stereo-media.js';
+
+/**
+ * メディアURL登録ダイアログ。
+ *
+ * 動画 / 画像 URL と表示形式（2D / 3D SBS / 3D TB / VR180 系）を指定して
+ * シーンに追加する。形式が「自動判定」の場合は URL のファイル名から推定し、
+ * 判定結果をダイアログ内にライブ表示する。
+ *
+ * 期待する DOM（index.html 側で定義）:
+ * - #media-url-dialog（.pairing-dialog モーダル）
+ * - #media-url-input, #media-url-format, #media-url-hint
+ * - #media-url-add-btn, #media-url-cancel-btn
+ */
+export function initMediaUrlDialog({ onSubmit, showToast } = {}) {
+  const dialog = document.getElementById('media-url-dialog');
+  const input = document.getElementById('media-url-input');
+  const formatSelect = document.getElementById('media-url-format');
+  const hint = document.getElementById('media-url-hint');
+  const addBtn = document.getElementById('media-url-add-btn');
+  const cancelBtn = document.getElementById('media-url-cancel-btn');
+
+  if (!dialog || !input || !formatSelect || !addBtn) {
+    return { open: () => {}, close: () => {}, dispose: () => {} };
+  }
+
+  function parseFormatValue(value) {
+    if (!value || value === 'auto') return null;
+    const [projection, stereoLayout] = value.split(':');
+    return { projection, stereoLayout };
+  }
+
+  function updateHint() {
+    if (!hint) return;
+    const value = formatSelect.value;
+    if (value !== 'auto') {
+      const format = parseFormatValue(value);
+      hint.textContent = format ? `形式: ${stereoMediaLabel(format)}` : '';
+      return;
+    }
+    const url = input.value.trim();
+    if (!url) {
+      hint.textContent = '自動判定: ファイル名の vr180 / sbs / tb 等から推定します';
+      return;
+    }
+    const detected = detectStereoMediaFromName(url);
+    hint.textContent = detected
+      ? `自動判定: ${stereoMediaLabel(detected)}`
+      : '自動判定: 2D（立体視ヒントなし）';
+  }
+
+  function close() {
+    dialog.style.display = 'none';
+  }
+
+  function open() {
+    input.value = '';
+    formatSelect.value = 'auto';
+    updateHint();
+    dialog.style.display = 'flex';
+    requestAnimationFrame(() => input.focus());
+  }
+
+  function submit() {
+    const url = input.value.trim();
+    if (!/^https?:\/\//i.test(url)) {
+      showToast?.('http(s) で始まる URL を入力してください');
+      input.focus();
+      return;
+    }
+    const mediaFormat = parseFormatValue(formatSelect.value);
+    close();
+    Promise.resolve(onSubmit?.(url, mediaFormat)).catch((error) => {
+      console.warn('[media-url-dialog] import failed:', error);
+    });
+  }
+
+  const onInput = () => updateHint();
+  const onKeydown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  };
+  const onBackdropClick = (event) => {
+    if (event.target === dialog) close();
+  };
+
+  input.addEventListener('input', onInput);
+  input.addEventListener('keydown', onKeydown);
+  formatSelect.addEventListener('change', onInput);
+  addBtn.addEventListener('click', submit);
+  cancelBtn?.addEventListener('click', close);
+  dialog.addEventListener('mousedown', onBackdropClick);
+
+  function dispose() {
+    input.removeEventListener('input', onInput);
+    input.removeEventListener('keydown', onKeydown);
+    formatSelect.removeEventListener('change', onInput);
+    addBtn.removeEventListener('click', submit);
+    cancelBtn?.removeEventListener('click', close);
+    dialog.removeEventListener('mousedown', onBackdropClick);
+  }
+
+  return { open, close, dispose };
+}

--- a/html/scenesync/index.html
+++ b/html/scenesync/index.html
@@ -782,6 +782,38 @@
       line-height: 1.5;
       color: #cfcfcf !important;
     }
+    .media-url-content {
+      width: min(92vw, 360px);
+      max-width: none;
+    }
+    .media-url-input {
+      display: block;
+      width: 100%;
+      margin: 12px 0;
+      padding: 8px 10px;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      font-size: 13px;
+      font-family: monospace;
+    }
+    .media-url-format-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      margin: 8px 0;
+    }
+    .media-url-format-row select {
+      flex: 1;
+      min-width: 0;
+    }
+    .media-url-hint {
+      min-height: 1.4em;
+      font-size: 12px;
+      color: #8fc7ff !important;
+    }
 
     body.scene-sync-device-desktop #mobile-toolbar {
       display: none !important;
@@ -1391,6 +1423,12 @@
       </button>
     </div>
     <div class="row mobile-collapsible-row">
+      <button id="media-url-btn" class="chip" type="button" title="動画・画像URLを追加（VR180 / 3D対応）">
+        <span>🎬</span>
+        <span>メディアURL</span>
+      </button>
+    </div>
+    <div class="row mobile-collapsible-row">
       <button id="link-btn" class="chip" type="button" title="AI とリンク">
         <span id="link-icon">🔗</span>
         <span id="link-label">AIにリンク</span>
@@ -1458,6 +1496,37 @@
       <div class="pairing-actions">
         <button id="btn-room-full-retry" class="chip" type="button">もう一度試す</button>
         <button id="btn-room-full-new" class="chip primary" type="button">新しいルームを作る</button>
+      </div>
+    </div>
+  </div>
+  <div id="media-url-dialog" class="pairing-dialog" style="display:none;">
+    <div class="pairing-content media-url-content" role="dialog" aria-modal="true" aria-labelledby="media-url-dialog-title">
+      <h3 id="media-url-dialog-title">メディアURLを追加</h3>
+      <p>動画 / 画像の直接 URL を入力してください（CORS 許可が必要）。</p>
+      <input
+        id="media-url-input"
+        class="media-url-input"
+        type="url"
+        placeholder="https://example.com/video_vr180.mp4"
+        autocomplete="off"
+        spellcheck="false"
+      >
+      <label class="media-url-format-row">
+        <span>表示形式</span>
+        <select id="media-url-format" class="chip">
+          <option value="auto">自動判定（ファイル名から）</option>
+          <option value="flat:mono">通常 (2D)</option>
+          <option value="flat:sbs">3D 左右 (SBS)</option>
+          <option value="flat:tb">3D 上下 (TB)</option>
+          <option value="vr180:mono">VR180 (2D)</option>
+          <option value="vr180:sbs">VR180 3D 左右 (SBS)</option>
+          <option value="vr180:tb">VR180 3D 上下 (TB)</option>
+        </select>
+      </label>
+      <p id="media-url-hint" class="media-url-hint"></p>
+      <div class="pairing-buttons">
+        <button id="media-url-cancel-btn" class="chip" type="button">キャンセル</button>
+        <button id="media-url-add-btn" class="chip primary" type="button">追加</button>
       </div>
     </div>
   </div>
@@ -1763,6 +1832,7 @@
       <div class="mobile-sheet-actions">
         <button id="mobile-add-image-btn" class="chip primary" type="button">画像を追加</button>
         <button id="mobile-add-glb-btn" class="chip" type="button">ファイルを追加</button>
+        <button id="mobile-add-media-url-btn" class="chip" type="button">メディアURLを追加（VR180 / 3D）</button>
         <button id="mobile-paste-btn" class="chip" type="button">クリップボードから追加</button>
         <button id="mobile-room-open-btn" class="chip" type="button">ルーム設定</button>
         <button id="mobile-env-open-btn" class="chip" type="button">背景</button>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:expired-glb-recovery": "node --test html/assets/js/scenesync/assets/expired-glb-recovery.test.js",
     "test:mesh-blob-fetch": "node --test html/assets/js/scenesync/assets/mesh-blob-fetch.test.js",
     "test:glb-normalizer": "node --test html/assets/js/scenesync/loaders/glb-normalizer.test.js",
+    "test:stereo-media": "node --test html/assets/js/scenesync/loaders/stereo-media.test.js",
     "test:playback-duration": "node --test html/assets/js/scenesync/runtime/playback-duration.test.js",
     "test:physics": "node --test html/assets/js/scenesync/physics/rapier-world.test.js html/assets/js/scenesync/physics/rapier-parity-fixture.test.js html/assets/js/scenesync/scene-physics.test.js html/assets/js/scenesync/history/history-manager.test.js html/assets/js/scenesync/shells/player/player-physics-drag-input.test.js",
     "test:loomlet-runtime": "node --test html/assets/js/scenesync/loomlet-runtime-integration.test.js html/assets/js/scenesync/loomlet-interaction-replay.test.js",


### PR DESCRIPTION
## 概要

- Scene Sync の image / video asset に立体視（SBS / TB）と VR180 表示を追加する
- 形式を指定して登録できる「メディアURL」ダイアログと、ファイル名からの自動判定を追加する

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- asset に optional metadata `projection`（`flat` | `vr180`）と `stereoLayout`（`mono` | `sbs` | `tb`）を追加（省略時は従来表示・後方互換）
- 左目メッシュ=three.js layer 1、右目=layer 2 で描画。WebXR では左右の目に別画像、非XRはメインカメラが layer 1 を有効化して左目画像を表示（`core/three-app.js`）
- `vr180` は半径3mの内向き半球ドーム（正面 -Z）。追加時に position.y を視点高さ 1.6m へ持ち上げ
- `flat` + `sbs`/`tb` は片目分のアスペクト比で plane サイズを計算
- layer 0 に不可視 hit proxy を置き、選択・移動・削除・raycast は従来どおり動作
- URL drop / clipboard / AI import でファイル名トークン（`vr180`, `sbs`, `tb` 等）から自動判定し、toast で通知
- メディアURL登録ダイアログ（desktop: settings chip 🎬 / mobile: 追加シート）で形式を明示選択可。自動判定結果のライブ表示付き
- AI 連携 `addImageFromUrl` / `addVideoFromUrl` に `projection` / `stereoLayout` params を追加
- 新規モジュール: `loaders/stereo-media.js`, `ui/media-url-dialog.js`
- staging で見てほしい点: VR180 SBS 動画 URL を追加してドームの向き（正面 -Z）と左右の目の割り当て、デスクトップ表示（左目のみ）、通常 2D メディアの回帰

## 変更していないこと

- ローカル画像ファイル drop（carrier GLB 化経路）の立体視対応は out of scope（GLB にレイヤー概念がないため別設計が必要）
- half/squashed SBS のアスペクト補正
- 動画 play/pause/seek 同期（従来どおり muted / loop / autoplay）
- presence-server / Unity / Godot クライアント

## staging確認

- 未確認: 開発環境から CDN（three.js）への外部アクセスが遮断されており、ブラウザ実機確認ができないため。staging デプロイ後に VR180 サンプル URL での確認を推奨

## テスト/チェック

- `npm run test:stereo-media`（新規 23 件、全パス）
- `npm run test:glb-normalizer`（既存 10 件、全パス）
- 変更した全 ES module の `node --check` 構文チェック

## リスク

- 非XRカメラの layer 1 有効化はシーン全体に効くが、layer 1 を使う既存メッシュはないため影響なし
- 自動判定の誤検出（例: `_lr` を含む非立体ファイル名）。完全一致トークンのみで保守的に判定し、ダイアログの明示指定で上書き可能
- VR180 ドームのジオメトリ向きは SphereGeometry の式から導出（実機未確認）

## follow-up tasks

- half SBS（`hsbs`）のアスペクト補正
- ファイル drop 画像の立体視対応
- VR360（全天球）対応の検討

## merge方針

- squash merge
- merge 後 remote branch 削除可

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DYDMXmVGAszP6ZuQZ9JBW

---
_Generated by [Claude Code](https://claude.ai/code/session_017DYDMXmVGAszP6ZuQZ9JBW)_