### PR TITLE
[codex] Fix SceneSync static export viewer assets

### DIFF
--- a/apps/presence-server/tests/build-export-package.test.mjs
+++ b/apps/presence-server/tests/build-export-package.test.mjs
@@ -102,16 +102,36 @@ test('export package construction', async (t) => {
       'viewer/static-asset-resolver.js',
       'viewer/scene-document.js',
       'viewer/export-behavior-runtime.js',
+      'viewer/rapier/rapier.js',
+      'viewer/rapier/rapier_wasm3d_bg.wasm',
       'scenesync/plugins/scene-sync-physics-plugin.js',
       'scenesync/plugins/scene-sync-loomlet-plugin.js',
       'scenesync/runtime/schedule-context.js',
       'scenesync/runtime/runtime-events.js',
+      'scenesync/runtime/event-timeline.js',
       'viewer/viewer.css',
     ];
     const destPaths = VIEWER_SOURCES.map(s => s.dest);
     for (const f of expectedPackageFiles) {
       assert.ok(destPaths.includes(f), `VIEWER_SOURCES should contain ${f}`);
     }
+  });
+
+  await t.test('Rapier runtime is bundled without dangling source map references', () => {
+    const rapierSource = VIEWER_SOURCES.find(s => s.dest === 'viewer/rapier/rapier.js');
+    const rapierWasm = VIEWER_SOURCES.find(s => s.dest === 'viewer/rapier/rapier_wasm3d_bg.wasm');
+
+    assert.ok(rapierSource, 'VIEWER_SOURCES should contain viewer/rapier/rapier.js');
+    assert.ok(rapierWasm, 'VIEWER_SOURCES should contain viewer/rapier/rapier_wasm3d_bg.wasm');
+    assert.equal(rapierWasm.binary, true, 'Rapier WASM must be bundled as binary');
+
+    const transformedSource = readViewerSource(rapierSource);
+    assert.doesNotMatch(transformedSource, /sourceMappingURL=/,
+      'exported Rapier JS should not request a sourcemap that is not included in the ZIP');
+
+    const wasmContent = readViewerSource(rapierWasm);
+    assert.ok(Buffer.isBuffer(wasmContent), 'Rapier WASM source should read as a Buffer');
+    assert.ok(wasmContent.byteLength > 0, 'Rapier WASM source should not be empty');
   });
 
   await t.test('VIEWER_SOURCES dest paths include the vendored Loomlet runtime bundle', () => {

--- a/html/assets/js/scenesync-export/export/build-export-package.js
+++ b/html/assets/js/scenesync-export/export/build-export-package.js
@@ -9,6 +9,10 @@ import {
 } from './export-thumbnail.js';
 import { normalizeExportMetadata } from './export-metadata.js';
 
+function stripSourceMappingUrl(source) {
+  return String(source).replace(/\r?\n?\/\/# sourceMappingURL=.*(?:\r?\n)?$/u, '\n');
+}
+
 // These viewer source files are fetched from the current origin and bundled into the ZIP
 export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync-export/viewer/static-viewer-entry.js', dest: 'viewer/viewer.js' },
@@ -28,7 +32,9 @@ export const VIEWER_SOURCES = [
   {
     src: '/assets/js/scenesync/scene-physics.js',
     dest: 'viewer/scene-physics.js',
-    transform: (source) => source.replaceAll('./runtime/runtime-events.js', '../scenesync/runtime/runtime-events.js'),
+    transform: (source) => source
+      .replaceAll('./runtime/runtime-events.js', '../scenesync/runtime/runtime-events.js')
+      .replaceAll('./runtime/event-timeline.js', '../scenesync/runtime/event-timeline.js'),
   },
   { src: '/assets/js/scenesync/physics/index.js', dest: 'viewer/physics/index.js' },
   { src: '/assets/js/scenesync/physics/rapier-world.js', dest: 'viewer/physics/rapier-world.js' },
@@ -36,9 +42,14 @@ export const VIEWER_SOURCES = [
   { src: '/assets/js/scenesync/plugins/scene-sync-loomlet-plugin.js', dest: 'scenesync/plugins/scene-sync-loomlet-plugin.js' },
   { src: '/assets/js/scenesync/runtime/schedule-context.js', dest: 'scenesync/runtime/schedule-context.js' },
   { src: '/assets/js/scenesync/runtime/runtime-events.js', dest: 'scenesync/runtime/runtime-events.js' },
+  { src: '/assets/js/scenesync/runtime/event-timeline.js', dest: 'scenesync/runtime/event-timeline.js' },
   { src: '/assets/js/scenesync-export/viewer/viewer.css', dest: 'viewer/viewer.css' },
   // deterministic-compat build — must match the build used by rapier-world.js
-  { src: '/assets/vendor/rapier-deterministic/0.19.3/rapier.mjs', dest: 'viewer/rapier/rapier.js' },
+  {
+    src: '/assets/vendor/rapier-deterministic/0.19.3/rapier.mjs',
+    dest: 'viewer/rapier/rapier.js',
+    transform: stripSourceMappingUrl,
+  },
   { src: '/assets/vendor/rapier-deterministic/0.19.3/rapier_wasm3d_bg.wasm', dest: 'viewer/rapier/rapier_wasm3d_bg.wasm', binary: true },
   // Pinned Loomlet behavior graph runtime. Exported viewers must not depend on afjk.jp at runtime.
   {


### PR DESCRIPTION
## Summary
- Bundle the SceneSync event timeline runtime used by the exported static viewer.
- Rewrite the exported scene-physics runtime imports so they resolve inside the ZIP.
- Strip the dangling Rapier source map reference while keeping the Rapier JS/WASM runtime bundled.

## Root Cause
SceneSync export ZIPs could omit runtime files referenced by the static viewer. When served with `python3 -m http.server`, the browser could request missing files such as the event timeline runtime or the Rapier source map.

## Validation
- `node --test apps/presence-server/tests/build-export-package.test.mjs`
- `node --test html/assets/js/scenesync-export/export/build-export-package.test.js`
- `npm run test:scene-sync-export-import`