### PR TITLE
Scene Sync: Edit | Play shell switcher の追加と Player Shell のローカル再生デフォルト化

### DIFF
--- a/docs/scene-sync-shells.md
+++ b/docs/scene-sync-shells.md
@@ -231,6 +231,20 @@ State is read via `core.getSceneClockState()`:
 
 Player Shell runs a `requestAnimationFrame` loop for smooth time display. The loop is started on `mount()` and cancelled on `unmount()`.
 
+### Clock mode default & persistence
+
+On mount, Player Shell restores the clock mode from `localStorage` (key: `scene-sync-player-clock-mode`). Unknown values, missing values and storage errors fall back to `local-preview`; legacy values are normalized (`local` → `local-preview`, `host-follow` → `room-time`). When the restored mode is `local-preview`, the shell calls `resetSceneClock()` then `playSceneClock()` so entering Play always starts local playback from t=0 (local-preview never broadcasts to the room). Mode changes made in the transport panel are saved back to `localStorage`, so choosing Shared Playback once (e.g. for a second device or multi-user play) is remembered across Edit ↔ Play switches and reloads.
+
+## Shell mode switcher (Edit | Play)
+
+`shells/shell-mode-switcher.js` mounts a shell-independent segmented toggle at the top center of the screen so users can move between the Editor and Player shells without a reload.
+
+- Mounted once by `ui/dom.js` right after the shell runtime manager is created; it lives outside the shell mount/unmount cycle.
+- Clicking a segment calls `runtime.switchShell(id, { updateUrl: true })`, so the `?shell=` URL parameter stays in sync. Buttons are disabled while a switch is in flight.
+- The active segment follows `runtime.onShellChange` (added on the runtime manager, fired with reasons `initial` / `switch` / `fallback`), so programmatic switches via `window.sceneSyncShell.switchTo()` and `?shell=player` startup are reflected too.
+- The switcher is hidden when the current shell is not editor / player (minimal / studio / viewer keep using `?shell=`), and hidden during XR sessions (`body.scene-sync-xr-session`) to leave the top center to the XR buttons.
+- The switcher intentionally has no time-mode UI — clock mode is owned by the Player transport panel (see above).
+
 ## Editor Shell v4: Edit command + state API and chrome wiring migration
 
 The Editor Shell shell-ization is completed by exposing the remaining edit operations as commands and by moving editor chrome wiring out of `scene.js` into the layouts. The standard Editor Shell no longer exposes Edit/Interact switching; it mounts in `edit` input routing mode.

--- a/html/assets/js/scenesync/scene.js
+++ b/html/assets/js/scenesync/scene.js
@@ -856,6 +856,7 @@ function updateTwoHandGrab() {
 let xrSavedBackground = null;
 
 renderer.xr.addEventListener('sessionstart', async () => {
+  document.body.classList.add('scene-sync-xr-session');
   xrState.active = true;
   const session = renderer.xr.getSession();
   // requestXrSession 経由で開始した場合は xrCurrentMode が設定済み
@@ -912,6 +913,7 @@ renderer.xr.addEventListener('sessionstart', async () => {
 });
 
 renderer.xr.addEventListener('sessionend', () => {
+  document.body.classList.remove('scene-sync-xr-session');
   // トグルボタンと床合わせボタンを隠す
   const xrToggleBtn = dom.xrToggleBtn;
   if (xrToggleBtn) xrToggleBtn.style.display = 'none';

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -1,21 +1,14 @@
-import { createPlayerTransportPanel } from './player-transport.js';
+import { createPlayerTransportPanel, normalizeUiClockMode } from './player-transport.js';
 
 const BODY_CLASS = 'scene-sync-shell-player';
 const CLOCK_MODE_STORAGE_KEY = 'scene-sync-player-clock-mode';
-const CLOCK_MODES = ['local-preview', 'shared-playback', 'room-time'];
-const DEFAULT_CLOCK_MODE = 'local-preview';
 
-function normalizePlayerClockMode(mode) {
-  if (mode === 'local') return 'local-preview';
-  if (mode === 'host-follow') return 'room-time';
-  return CLOCK_MODES.includes(mode) ? mode : null;
-}
-
+// 不正値・未保存・storage 例外は normalizeUiClockMode が 'local-preview' に落とす
 function readStoredClockMode() {
   try {
-    return normalizePlayerClockMode(localStorage.getItem(CLOCK_MODE_STORAGE_KEY)) || DEFAULT_CLOCK_MODE;
+    return normalizeUiClockMode(localStorage.getItem(CLOCK_MODE_STORAGE_KEY));
   } catch {
-    return DEFAULT_CLOCK_MODE;
+    return 'local-preview';
   }
 }
 
@@ -48,7 +41,6 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
 
       transport = createPlayerTransportPanel({
         title: 'SCENE SYNC · PLAYER',
-        activateOnMount: true,
       });
       await transport.mount({ core, root: root || document.body });
 
@@ -61,9 +53,14 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
       }
 
       let lastSavedMode = mode;
-      removeStateListener = core?.onStateChange?.(() => {
-        const nextMode = normalizePlayerClockMode(core?.getSceneClockState?.()?.mode);
-        if (!nextMode || nextMode === lastSavedMode) return;
+      removeStateListener = core?.onStateChange?.((event = {}) => {
+        // mode 変更は必ず scene-clock 系 reason で通知される。高頻度な
+        // scene-delta / physics 系イベントで O(N) の getSceneClockState を呼ばない
+        if (typeof event.reason === 'string' && !event.reason.startsWith('scene-clock')) return;
+        const state = core?.getSceneClockState?.();
+        if (!state) return;
+        const nextMode = normalizeUiClockMode(state.mode);
+        if (nextMode === lastSavedMode) return;
         lastSavedMode = nextMode;
         writeStoredClockMode(nextMode);
       }) ?? null;

--- a/html/assets/js/scenesync/shells/player/player-shell.js
+++ b/html/assets/js/scenesync/shells/player/player-shell.js
@@ -1,10 +1,36 @@
 import { createPlayerTransportPanel } from './player-transport.js';
 
 const BODY_CLASS = 'scene-sync-shell-player';
+const CLOCK_MODE_STORAGE_KEY = 'scene-sync-player-clock-mode';
+const CLOCK_MODES = ['local-preview', 'shared-playback', 'room-time'];
+const DEFAULT_CLOCK_MODE = 'local-preview';
+
+function normalizePlayerClockMode(mode) {
+  if (mode === 'local') return 'local-preview';
+  if (mode === 'host-follow') return 'room-time';
+  return CLOCK_MODES.includes(mode) ? mode : null;
+}
+
+function readStoredClockMode() {
+  try {
+    return normalizePlayerClockMode(localStorage.getItem(CLOCK_MODE_STORAGE_KEY)) || DEFAULT_CLOCK_MODE;
+  } catch {
+    return DEFAULT_CLOCK_MODE;
+  }
+}
+
+function writeStoredClockMode(mode) {
+  try {
+    localStorage.setItem(CLOCK_MODE_STORAGE_KEY, mode);
+  } catch {
+    // storage 不可（プライベートモード等）ではセッション内デフォルトのまま
+  }
+}
 
 export function createSceneSyncShell({ id = 'player', requestedId = 'player', availableShellIds = [] } = {}) {
   let transport = null;
   let mountedCore = null;
+  let removeStateListener = null;
 
   return {
     id,
@@ -25,12 +51,27 @@ export function createSceneSyncShell({ id = 'player', requestedId = 'player', av
         activateOnMount: true,
       });
       await transport.mount({ core, root: root || document.body });
-      core?.commands?.activateSceneClockTransport?.({
-        mode: 'shared-playback',
-      });
+
+      const mode = readStoredClockMode();
+      core?.commands?.activateSceneClockTransport?.({ mode });
+      if (mode === 'local-preview') {
+        // Play に入ったら毎回 t=0 から即ローカル再生（local-preview は broadcast されない）
+        core?.commands?.resetSceneClock?.();
+        core?.commands?.playSceneClock?.();
+      }
+
+      let lastSavedMode = mode;
+      removeStateListener = core?.onStateChange?.(() => {
+        const nextMode = normalizePlayerClockMode(core?.getSceneClockState?.()?.mode);
+        if (!nextMode || nextMode === lastSavedMode) return;
+        lastSavedMode = nextMode;
+        writeStoredClockMode(nextMode);
+      }) ?? null;
     },
 
     unmount() {
+      removeStateListener?.();
+      removeStateListener = null;
       mountedCore?.commands?.deactivateSceneClockTransport?.();
       transport?.unmount?.();
       transport = null;

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -32,7 +32,7 @@ function formatTime(seconds) {
   return `${String(mins).padStart(2, '0')}:${secs}`;
 }
 
-function normalizeUiClockMode(mode) {
+export function normalizeUiClockMode(mode) {
   if (mode === 'local') return 'local-preview';
   if (mode === 'host-follow') return 'room-time';
   return CLOCK_MODES.includes(mode) ? mode : 'local-preview';

--- a/html/assets/js/scenesync/shells/shell-bootstrap.js
+++ b/html/assets/js/scenesync/shells/shell-bootstrap.js
@@ -152,6 +152,17 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
   let currentInputAdapters = [];
   let switchSerial = 0;
   let disposed = false;
+  const shellChangeListeners = new Set();
+
+  function notifyShellChange(shellId, reason) {
+    for (const listener of shellChangeListeners) {
+      try {
+        listener({ shellId, reason });
+      } catch (error) {
+        console.warn('[SceneSyncShell] shell change listener failed:', error);
+      }
+    }
+  }
 
   async function switchShell(nextShellId, options = {}) {
     if (disposed) {
@@ -203,6 +214,8 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
         history.replaceState(null, '', url);
       }
 
+      notifyShellChange(currentShellId, 'switch');
+
       if (core?.debug) {
         console.debug('[SceneSyncShell] switched to shell:', currentShellId);
       }
@@ -216,6 +229,7 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
           currentInputAdapters = mountInputAdaptersForShell(fallbackShell, core);
           currentShell = fallbackShell;
           currentShellId = fallbackShell.id || 'editor';
+          notifyShellChange(currentShellId, 'fallback');
           console.warn('[SceneSyncShell] fell back to editor shell');
         } catch (fallbackError) {
           console.error('[SceneSyncShell] fallback to editor shell failed:', fallbackError);
@@ -229,6 +243,7 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
   currentShell = initialShell;
   currentShellId = initialShell?.id || 'editor';
   currentInputAdapters = mountInputAdaptersForShell(initialShell, core);
+  notifyShellChange(currentShellId, 'initial');
 
   return {
     get core() {
@@ -249,9 +264,17 @@ export async function createSceneSyncShellRuntimeManager(extraCore = {}) {
       return listSceneSyncShellIds();
     },
 
+    onShellChange(listener) {
+      if (typeof listener !== 'function') return () => {};
+      shellChangeListeners.add(listener);
+      return () => shellChangeListeners.delete(listener);
+    },
+
     dispose() {
       if (disposed) return;
       disposed = true;
+
+      shellChangeListeners.clear();
 
       unmountInputAdapters(currentInputAdapters);
       currentInputAdapters = [];

--- a/html/assets/js/scenesync/shells/shell-mode-switcher.js
+++ b/html/assets/js/scenesync/shells/shell-mode-switcher.js
@@ -1,0 +1,133 @@
+const STYLE_ID = 'scene-sync-shell-mode-switcher-style';
+const CONTAINER_ID = 'scene-sync-shell-mode-switcher';
+
+// 将来 shell を増やす場合はここに追加する
+const SWITCHER_SHELLS = [
+  { id: 'editor', label: 'Edit' },
+  { id: 'player', label: 'Play' },
+];
+
+function ensureSwitcherStylesheet() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${CONTAINER_ID} {
+      position: fixed;
+      top: calc(12px + var(--mobile-safe-top, 0px));
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 60;
+      display: flex;
+      gap: 2px;
+      padding: 3px;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+    }
+    #${CONTAINER_ID}[hidden] {
+      display: none;
+    }
+    #${CONTAINER_ID} button {
+      border: none;
+      border-radius: 8px;
+      padding: 5px 14px;
+      background: transparent;
+      color: #ddd;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.2;
+      cursor: pointer;
+    }
+    #${CONTAINER_ID} button[aria-pressed="true"] {
+      background: rgba(68, 136, 255, 0.7);
+      color: #fff;
+    }
+    #${CONTAINER_ID} button:disabled {
+      opacity: 0.55;
+      cursor: default;
+    }
+    /* XR セッション中は中央上を XR ボタン (#xr-toggle-btn 等) に譲る */
+    body.scene-sync-xr-session #${CONTAINER_ID} {
+      display: none;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export function createShellModeSwitcher(runtime) {
+  let container = null;
+  let removeShellChangeListener = null;
+  let switching = false;
+  const buttons = new Map();
+
+  function updateActive(shellId = runtime?.getCurrentShellId?.()) {
+    if (!container) return;
+    container.hidden = !SWITCHER_SHELLS.some((shell) => shell.id === shellId);
+    for (const [id, button] of buttons) {
+      button.setAttribute('aria-pressed', id === shellId ? 'true' : 'false');
+    }
+  }
+
+  function setButtonsDisabled(disabled) {
+    for (const button of buttons.values()) {
+      button.disabled = disabled;
+    }
+  }
+
+  async function handleSwitchClick(shellId) {
+    if (switching || typeof runtime?.switchShell !== 'function') return;
+    if (shellId === runtime.getCurrentShellId?.()) return;
+    switching = true;
+    setButtonsDisabled(true);
+    try {
+      await runtime.switchShell(shellId, { updateUrl: true });
+    } catch (error) {
+      console.warn('[ShellModeSwitcher] shell switch failed:', error);
+    } finally {
+      switching = false;
+      setButtonsDisabled(false);
+      updateActive();
+    }
+  }
+
+  return {
+    mount({ root = document.body } = {}) {
+      if (container) return;
+      ensureSwitcherStylesheet();
+
+      container = document.createElement('div');
+      container.id = CONTAINER_ID;
+      container.setAttribute('role', 'group');
+      container.setAttribute('aria-label', 'Shell mode');
+
+      for (const { id, label } of SWITCHER_SHELLS) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = label;
+        button.setAttribute('aria-pressed', 'false');
+        button.addEventListener('click', () => handleSwitchClick(id));
+        buttons.set(id, button);
+        container.appendChild(button);
+      }
+
+      root.appendChild(container);
+
+      removeShellChangeListener =
+        runtime?.onShellChange?.(({ shellId }) => updateActive(shellId)) ?? null;
+      updateActive();
+    },
+
+    unmount() {
+      removeShellChangeListener?.();
+      removeShellChangeListener = null;
+      container?.remove();
+      container = null;
+      buttons.clear();
+      switching = false;
+    },
+  };
+}
+
+export default createShellModeSwitcher;

--- a/html/assets/js/scenesync/ui/dom.js
+++ b/html/assets/js/scenesync/ui/dom.js
@@ -1,4 +1,5 @@
 import { createSceneSyncShellRuntimeManager } from '../shells/shell-bootstrap.js';
+import { createShellModeSwitcher } from '../shells/shell-mode-switcher.js';
 
 let sceneSyncShellRuntimePromise = null;
 let sceneSyncShellRuntime = null;
@@ -15,6 +16,13 @@ export function mountSceneSyncShellFromDom(core = {}) {
     sceneSyncShellRuntimePromise = createSceneSyncShellRuntimeManager(core)
       .then((runtime) => {
         sceneSyncShellRuntime = runtime;
+
+        // shell の mount/unmount サイクルの外で生存させる
+        try {
+          createShellModeSwitcher(runtime).mount({ root: document.body });
+        } catch (error) {
+          console.warn('[SceneSyncShell] failed to mount shell mode switcher:', error);
+        }
 
         if (typeof window !== 'undefined') {
           window.sceneSyncShell = {


### PR DESCRIPTION
## 概要

- Scene Sync Web に shell 非依存の **Edit | Play** セグメントトグル（画面中央上）を追加し、リロードなしで Editor / Player を行き来できるようにする
- Player Shell の時間モードのデフォルトを一人制作向けに変更（`shared-playback` ハードコード → localStorage 復元、既定 `local-preview` で t=0 から即ローカル再生）

## 対象repo

- `afjk.jp`

## 対象area

- `scenesync`

## 変更内容

- `shells/shell-mode-switcher.js`（新規）: Edit | Play トグル。クリックで `runtime.switchShell(id, { updateUrl: true })`、切替中はボタン disabled、editor / player 以外の shell では非表示、XR セッション中は CSS で非表示。`role="group"` / `aria-pressed` 付与
- `shells/shell-bootstrap.js`: runtime manager に `onShellChange` listener 機構を追加（`initial` / `switch` / `fallback` の3タイミングで通知、`dispose()` でクリア）
- `ui/dom.js`: runtime 生成後に switcher を mount（try/catch で shell runtime 本体には影響させない）。switcher は shell の mount/unmount サイクルの外で生存
- `scene.js`: XR `sessionstart` / `sessionend` で `body.scene-sync-xr-session` class を付け外し
- `shells/player/player-shell.js`: clock mode を localStorage（key: `scene-sync-player-clock-mode`）から復元。不正値・未保存・storage 例外は `local-preview`。`local-preview` なら mount 時に `resetSceneClock()` → `playSceneClock()`（ルームへ broadcast されない）。transport panel での mode 変更を localStorage に保存
- `shells/player/player-transport.js`: `normalizeUiClockMode` を export（player-shell と正規化ロジックを共有）
- `docs/scene-sync-shells.md`: switcher と clock mode 永続化の節を追記
- staging で見てほしい点: `?shell=editor` → Edit | Play 表示と Play 切替で URL が `?shell=player` になり Local Preview で t=0 から再生されること、Shared Playback 選択が Edit ↔ Play 往復後も記憶されること

## 変更していないこと

- switcher への時間モード UI の追加（transport panel と重複するため、タスク仕様で禁止）
- minimal / studio / viewer shell の switcher への追加（`?shell=` 経由のまま）
- XR セッション中の shell 切り替え対応（switcher 非表示で回避）
- transport panel（player-transport.js）の UI / 挙動（`normalizeUiClockMode` の export 化のみ）

## staging確認

- 未確認: このセッションはリモート実行環境のため staging デプロイ・実機ブラウザ確認は未実施。ローカルの構文チェックとユニットテストのみ実施

## テスト/チェック

- `node --check` を全変更 JS ファイルで実行しパス
- `node --test` で `runtime/scene-clock-transport.test.js`・`runtime/editing-state.test.js`・`shells/player/player-physics-drag-input.test.js`・`shells/editor/editor-player-transport.test.js` を実行し 26/26 パス
- コードレビュー（8角度、うち4角度はエージェント、correctness 3角度＋verify はインライン）を実施し、確定した指摘3件（正規化ロジック重複・高頻度イベントでの O(N) 呼び出し・transport 二重活性化）を修正済み

## リスク

- Player Shell を複数人同期用途で使っていた場合、初回起動が `local-preview` になる（transport panel で一度 Shared Playback を選べば以後 localStorage で記憶される）
- editor shell 内蔵の player transport panel（editor-player-transport）は localStorage 永続化の対象外（従来挙動のまま）

## follow-up tasks

- XR セッション中の shell 切り替え対応の検証
- `SWITCHER_SHELLS` を shell registry と突き合わせる validation（現状は仕様通り editor / player のハードコード）

## merge方針

- squash merge
- merge 後に remote branch を削除する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEPDagUK4xNECiFGJ5DC9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEPDagUK4xNECiFGJ5DC9t)_