### PR TITLE
pipe 配信: 視聴側の WHEP 404 をリトライで解消

### DIFF
--- a/docs/pipe-spec.md
+++ b/docs/pipe-spec.md
@@ -488,6 +488,12 @@ sequenceDiagram
     M-->>V: メディアストリーム転送
 ```
 
+### WHEP 404 リトライ
+
+MediaMTX は WHIP の SDP answer を返した後、配信者との ICE/DTLS ハンドシェイクが完了するまでストリームを「利用可能」にしない。一方、配信者は WHIP answer 受信直後に presence hello（`streaming: true`）を送るため、それを見て即座に視聴を開始したクライアントの WHEP は **404（stream not available）** になることがある（LAN で数百 ms、WAN では数秒の窓）。
+
+このため視聴側は WHEP が 404 を返す間、`WHEP_RETRY_DELAY_MS`（1 秒）間隔で最大 `WHEP_MAX_RETRIES`（15 回）リトライする。リトライ中に視聴を中止した・自分が配信を開始した・配信者がいなくなった場合は静かに中断する。404 以外のエラーは従来どおり即座にエラー表示する。
+
 ### 機能
 
 | 機能 | 内容 |

--- a/html/assets/js/pipe/stream.js
+++ b/html/assets/js/pipe/stream.js
@@ -313,7 +313,10 @@ async function _postWhep(url, pc) {
     if (_state.viewerPc !== pc) return null;
     if (res.status !== 404 || attempt >= WHEP_MAX_RETRIES) return res;
     await new Promise(resolve => setTimeout(resolve, WHEP_RETRY_DELAY_MS));
-    if (_state.viewerPc !== pc || _state.isStreaming || !_state.activeStreamerNickname) return null;
+    // broadcastMode is set as soon as a broadcast attempt begins, before
+    // isStreaming flips on WHIP success — check both to stop retrying early
+    if (_state.viewerPc !== pc || _state.isStreaming || _state.broadcastMode ||
+        !_state.activeStreamerNickname) return null;
   }
 }
 
@@ -343,10 +346,11 @@ export async function startWatch() {
 
     const res = await _postWhep(`${getStreamBase()}/room/${roomCode}/whep`, pc);
     if (!res) {
-      // Cancelled; clean up only if this attempt still owns the connection
+      // Cancelled; clean up only if this attempt still owns the connection,
+      // and don't wipe the status a concurrent broadcast attempt is showing
       if (_state.viewerPc === pc) {
         _cleanupViewer();
-        _setStatus('', '');
+        if (!_state.isStreaming && !_state.broadcastMode) _setStatus('', '');
       }
       pc.close();
       _renderTab();

--- a/html/assets/js/pipe/stream.js
+++ b/html/assets/js/pipe/stream.js
@@ -294,6 +294,29 @@ export function stopBroadcast() {
 
 // ── WHEP — view ───────────────────────────────────────────────────────────────
 
+// MediaMTX answers WHEP with 404 until the publisher's media handshake
+// (ICE/DTLS) completes — the "streaming" presence hello is sent right after
+// the WHIP answer, before that point. Viewers that join immediately must
+// retry while the stream becomes ready.
+const WHEP_RETRY_DELAY_MS = 1000;
+const WHEP_MAX_RETRIES = 15;
+
+// Resolves with the WHEP response, or null when the watch attempt was
+// cancelled (watch stopped, broadcast started, or the streamer left).
+async function _postWhep(url, pc) {
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: pc.localDescription.sdp,
+    });
+    if (_state.viewerPc !== pc) return null;
+    if (res.status !== 404 || attempt >= WHEP_MAX_RETRIES) return res;
+    await new Promise(resolve => setTimeout(resolve, WHEP_RETRY_DELAY_MS));
+    if (_state.viewerPc !== pc || _state.isStreaming || !_state.activeStreamerNickname) return null;
+  }
+}
+
 export async function startWatch() {
   if (_state.isWatching || _state.isStreaming) return;
   const { t, fetchIceServers, getStreamBase } = _deps;
@@ -318,11 +341,17 @@ export async function startWatch() {
     await pc.setLocalDescription(offer);
     await _waitForIce(pc);
 
-    const res = await fetch(`${getStreamBase()}/room/${roomCode}/whep`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/sdp' },
-      body: pc.localDescription.sdp,
-    });
+    const res = await _postWhep(`${getStreamBase()}/room/${roomCode}/whep`, pc);
+    if (!res) {
+      // Cancelled; clean up only if this attempt still owns the connection
+      if (_state.viewerPc === pc) {
+        _cleanupViewer();
+        _setStatus('', '');
+      }
+      pc.close();
+      _renderTab();
+      return;
+    }
     if (!res.ok) throw new Error(`WHEP ${res.status}`);
     await pc.setRemoteDescription({ type: 'answer', sdp: await res.text() });
 


### PR DESCRIPTION
## 概要

- pipe の映像配信（WHIP/WHEP）で、視聴側が「接続エラー: WHEP 404」になり復帰しない問題を修正する

## 対象repo

- `afjk.jp`

## 対象area

- `file-transfer`

## 変更内容

- `html/assets/js/pipe/stream.js`: WHEP POST が 404 を返す間、1秒間隔で最大15回リトライする `_postWhep()` を追加
  - 原因はタイミングの競合。配信側は WHIP の SDP answer 直後に presence hello（`streaming: true`）を送るが、MediaMTX は配信者との ICE/DTLS ハンドシェイク完了までストリームを「利用可能」にせず、その間の WHEP に 404 を返す。hello を受けて即座に自動視聴を開始したクライアントがこの窓（LAN で数百 ms、WAN で数秒）に当たると 404 になり、従来は最初の失敗で諦めて固まっていた
  - リトライ中に「視聴を中止」「自分が配信を開始」「配信者が退室」した場合は静かに中断して UI をリセット。404 以外のエラーは従来どおり即エラー表示
- `docs/pipe-spec.md`: §12 に WHEP 404 リトライの仕様を追記
- staging で見てほしい点: 2台で同じルームに入り、片方が配信開始した直後にもう片方の視聴が自動で始まること（エラー表示で止まらないこと）

## 変更していないこと

- 配信側の presence hello 送信タイミング（WHIP answer 直後のまま）
- MediaMTX / nginx / https-portal の設定
- WHIP 側のエラーハンドリング

## staging確認

- 未確認。ローカルで MediaMTX v1.19.2 + presence-server + 実ページを使って再現・修正を検証済み（下記）

## テスト/チェック

- MediaMTX（v1.19.2）+ presence-server + pipe ページを Playwright の2ブラウザで起動して検証:
  - WHIP 201 直後の WHEP プローブが +0〜100ms で 404、+300ms 以降で成功となる「未準備の窓」を実証
  - 配信側のメディア用 UDP(8189) を遮断して報告と同一の「Connection error: WHEP 404」恒久停止を再現
  - 修正後: 404 → リトライ → 201 →「視聴中」（リモートトラック2本受信）を確認
  - 配信が実際に死んだ場合はリトライが中断され UI が初期状態に戻ることを確認
  - 通常の配信→視聴フローに回帰なし

## リスク

- リトライは最大15秒。配信者側のネットワーク起因（UDP 8189 遮断等）でストリームが永遠に準備されない場合は15秒後に従来どおりエラー表示になる
- 視聴の自動開始が「配信準備完了まで」最大数秒待つ形になる（従来は即エラー）

## follow-up tasks

- 配信側の `streaming: true` 通知を PeerConnection `connected` 後に遅らせると、LIVE 表示がより正確になり視聴側のリトライも減る（今回は最小修正のため見送り）

## merge方針

- squash merge
- merge 後に remote branch を削除する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7BbdwQq3cXuvYoK794VLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7BbdwQq3cXuvYoK794VLd)_