### PR TITLE
fix(scenesync): モバイルで Edit/Play トグルが上部の chip と重ならないよう1段下げる

### DIFF
--- a/html/assets/js/scenesync/shells/shell-mode-switcher.js
+++ b/html/assets/js/scenesync/shells/shell-mode-switcher.js
@@ -52,6 +52,10 @@ function ensureSwitcherStylesheet() {
     body.scene-sync-xr-session #${CONTAINER_ID} {
       display: none;
     }
+    /* モバイルでは上部中央が nickname chip / status と横に重なるため 1 段下げる */
+    body.scene-sync-device-mobile #${CONTAINER_ID} {
+      top: calc(58px + var(--mobile-safe-top, 0px));
+    }
   `;
   document.head.appendChild(style);
 }


### PR DESCRIPTION
スマホ表示では画面上部中央の Edit/Play シェルモードトグルが、
左上の nickname chip と右上の status に横方向で重なっていた。
モバイル時のみトグルを1段下（top: 58px + safe-area）へ移動し、
上部の chip 行と衝突しないようにした。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LeUT1GiKwUDm6SBd2fNDPJ