### PR TITLE
Fix export viewer seek bar not working during playback

### DIFF
--- a/html/assets/js/scenesync-export/viewer/create-viewer-core.js
+++ b/html/assets/js/scenesync-export/viewer/create-viewer-core.js
@@ -15,6 +15,7 @@ import { createSceneSyncLoomletPlugin } from '../../scenesync/plugins/scene-sync
 import {
   calculateViewerPlaybackDuration,
   clipTimeForMode,
+  createMediaClockAlignmentHold,
   createViewerSceneClock,
 } from './viewer-scene-clock.js';
 import { createSceneSyncScheduleContext } from '../../scenesync/runtime/schedule-context.js';
@@ -485,9 +486,14 @@ export async function createViewerCore({
     objectAudioController.tick(now, clockState);
   }
 
+  const mediaClockAlignmentHold = createMediaClockAlignmentHold();
+
   function alignClockToObjectAudio(clockState, now = performance.now()) {
     const mediaClockState = objectAudioController.getMediaClockState(clockState);
     if (!mediaClockState) return clockState;
+    if (!mediaClockAlignmentHold.shouldAlign(clockState?.time, mediaClockState.time, now)) {
+      return clockState;
+    }
     sceneClock.syncPlaybackTime(mediaClockState.time, now);
     return mediaClockState;
   }
@@ -518,7 +524,14 @@ export async function createViewerCore({
     seekSceneClock(seconds) {
       const now = performance.now();
       sceneClock.seek(seconds, now);
-      evaluateAndSyncClock(sceneClock.getState(), now);
+      const clockState = sceneClock.getState();
+      if (!clockState.isPaused) {
+        // 再生中のシークはシーンクロックを正とし、オーディオを即座に追従させる。
+        // メディアクロックへの吸着はオーディオが追いつくまで保留する。
+        mediaClockAlignmentHold.noteUserSeek(now);
+        objectAudioController.seekPlaybackTargets(clockState, now);
+      }
+      evaluateAndSyncClock(clockState, now);
     },
     setSceneClockRate(rate) {
       const now = performance.now();

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.js
@@ -587,6 +587,17 @@ export function createObjectAudioController({
       };
     },
 
+    seekPlaybackTargets(clockState = null, nowMs = now()) {
+      for (const entry of getPlaybackTargetEntries()) {
+        if (entry.oneShotActive || entry.sync) continue;
+        entry.lastMediaClockTime = null;
+        const target = timelineTargetTime(entry, clockState, nowMs, startMs);
+        if (!Number.isFinite(target)) continue;
+        noteAutoSyncTarget(entry, target, nowMs, entry.source, clockState);
+        safeAutoSeek(entry, target, nowMs, { force: true });
+      }
+    },
+
     playPlaybackTargets(clockState = null, nowMs = now()) {
       return Promise.allSettled(getPlaybackTargetEntries().map((entry) => {
         entry.lastMediaClockTime = null;

--- a/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
+++ b/html/assets/js/scenesync-export/viewer/object-audio-controller.test.js
@@ -193,3 +193,43 @@ test('forces auto seek when the player timeline jumps shortly after a resync', (
 
   assert.equal(audio.currentTime, 7);
 });
+
+test('seekPlaybackTargets force-seeks playing audio even mid-seek and within the throttle window', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 60, currentTime: 0 }),
+  });
+
+  controller.tick(1000, { t: 5, isPaused: false, playing: true, rate: 1 });
+  assert.equal(audio.currentTime, 5);
+
+  audio.seeking = true;
+  controller.seekPlaybackTargets({ t: 30, time: 30, isPaused: false, playing: true, rate: 1 }, 1016);
+
+  assert.equal(audio.currentTime, 30);
+});
+
+test('seekPlaybackTargets wraps looping audio by its duration', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 10, currentTime: 0 }),
+  });
+
+  controller.tick(1000, { t: 3, isPaused: false, playing: true, rate: 1 });
+  controller.seekPlaybackTargets({ t: 25, time: 25, isPaused: false, playing: true, rate: 1 }, 1016);
+
+  assert.equal(audio.currentTime, 5);
+});
+
+test('seekPlaybackTargets leaves animation-synced audio to the animation clock', () => {
+  const { audio, controller } = createHarness({
+    audio: new FakeAudio({ duration: 60, currentTime: 2 }),
+    source: { sync: { mode: 'animation' } },
+    getAnimationSample: () => ({ time: 2 }),
+  });
+
+  controller.tick(1000, { t: 2, isPaused: false, playing: true, rate: 1 });
+  const before = audio.currentTime;
+
+  controller.seekPlaybackTargets({ t: 30, time: 30, isPaused: false, playing: true, rate: 1 }, 1016);
+
+  assert.equal(audio.currentTime, before);
+});

--- a/html/assets/js/scenesync-export/viewer/viewer-scene-clock.js
+++ b/html/assets/js/scenesync-export/viewer/viewer-scene-clock.js
@@ -73,6 +73,35 @@ export function calculateViewerPlaybackDuration({
   return Math.ceil(duration * 100) / 100;
 }
 
+// After a user seek, the scene clock stays authoritative until the audio
+// element has caught up (or the hold times out); otherwise the media clock
+// alignment would snap the timeline back to the pre-seek audio position.
+export function createMediaClockAlignmentHold({
+  toleranceSeconds = 0.5,
+  timeoutMs = 2000,
+} = {}) {
+  let heldSinceMs = null;
+
+  return {
+    noteUserSeek(nowMs) {
+      heldSinceMs = Number.isFinite(nowMs) ? nowMs : 0;
+    },
+    shouldAlign(clockTime, mediaTime, nowMs) {
+      if (heldSinceMs == null) return true;
+      const caughtUp = Number.isFinite(clockTime)
+        && Number.isFinite(mediaTime)
+        && Math.abs(mediaTime - clockTime) <= toleranceSeconds;
+      const timedOut = Number.isFinite(nowMs) && nowMs - heldSinceMs >= timeoutMs;
+      if (!caughtUp && !timedOut) return false;
+      heldSinceMs = null;
+      return true;
+    },
+    reset() {
+      heldSinceMs = null;
+    },
+  };
+}
+
 export function createViewerSceneClock({
   duration = DEFAULT_DURATION,
   now = () => performance.now(),

--- a/html/assets/js/scenesync-export/viewer/viewer-scene-clock.test.js
+++ b/html/assets/js/scenesync-export/viewer/viewer-scene-clock.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   calculateViewerPlaybackDuration,
   clipTimeForMode,
+  createMediaClockAlignmentHold,
   createViewerSceneClock,
 } from './viewer-scene-clock.js';
 
@@ -97,4 +98,42 @@ test('viewer playback duration includes animation and physics durations', () => 
 test('viewer clip time wraps loops and clamps once animations', () => {
   assert.equal(clipTimeForMode(3.5, 2, 'loop'), 1.5);
   assert.equal(clipTimeForMode(3.5, 2, 'once'), 2);
+});
+
+test('media clock alignment hold keeps the scene clock authoritative after a user seek', () => {
+  const hold = createMediaClockAlignmentHold({ toleranceSeconds: 0.5, timeoutMs: 2000 });
+
+  // No pending user seek: always align.
+  assert.equal(hold.shouldAlign(5, 5.1, 1000), true);
+
+  // User seeks to 30s while the audio is still at 5s: alignment is held.
+  hold.noteUserSeek(1000);
+  assert.equal(hold.shouldAlign(30, 5, 1016), false);
+  assert.equal(hold.shouldAlign(30.05, 5, 1032), false);
+
+  // Audio caught up near the seek target: alignment resumes and the hold clears.
+  assert.equal(hold.shouldAlign(30.2, 30.1, 1200), true);
+  assert.equal(hold.shouldAlign(30.3, 30.2, 1216), true);
+});
+
+test('media clock alignment hold times out when the audio never catches up', () => {
+  const hold = createMediaClockAlignmentHold({ toleranceSeconds: 0.5, timeoutMs: 2000 });
+
+  hold.noteUserSeek(1000);
+  assert.equal(hold.shouldAlign(30, 5, 2000), false);
+  assert.equal(hold.shouldAlign(31, 5, 3000), true);
+  assert.equal(hold.shouldAlign(31, 5, 3016), true);
+});
+
+test('media clock alignment hold can be reset and restarted per seek', () => {
+  const hold = createMediaClockAlignmentHold({ toleranceSeconds: 0.5, timeoutMs: 2000 });
+
+  hold.noteUserSeek(1000);
+  hold.reset();
+  assert.equal(hold.shouldAlign(30, 5, 1016), true);
+
+  // Consecutive seeks (e.g. dragging the seek bar) extend the hold window.
+  hold.noteUserSeek(1000);
+  hold.noteUserSeek(2900);
+  assert.equal(hold.shouldAlign(40, 5, 3100), false);
 });

--- a/html/assets/js/scenesync/shells/player/player-transport.js
+++ b/html/assets/js/scenesync/shells/player/player-transport.js
@@ -285,6 +285,9 @@ export function createPlayerTransportPanel({
       const seekEl = panel.querySelector('[data-player-seek]');
       disposers.push(
         addListener(seekEl, 'pointerdown', () => { isSeeking = true; }),
+        // タッチ操作が中断された場合でもシークバーの追従を再開させる
+        addListener(seekEl, 'pointerup', () => { isSeeking = false; }),
+        addListener(seekEl, 'pointercancel', () => { isSeeking = false; }),
         addListener(seekEl, 'input', (e) => {
           const value = parseFloat(e.target.value);
           if (!Number.isFinite(value)) return;


### PR DESCRIPTION
## 問題

Exportしたコンテンツの Player UI で、シークバーが一時停止中しか操作できなかった。Editor Shell / Player Shell では再生中もシーク可能。

## 原因

Exportビューア固有のメディアクロック吸着(`alignClockToObjectAudio`)が、毎フレーム再生中オーディオの `currentTime` をシーンクロックへ上書きする。シーク時のオーディオ側への反映はドリフト補正用スロットリング(250ms・小ジャンプ非強制)で間引かれるため、クロックだけ動かしてもすぐ旧オーディオ位置へ引き戻されていた。一時停止中は吸着が働かないためシークできていた。

## 修正

- `create-viewer-core.js`: 再生中のユーザーシークはシーンクロックを正とし、オーディオを即時強制シーク。オーディオが追いつく(±0.5s)か2sタイムアウトまで吸着を保留
- `viewer-scene-clock.js`: 保留ロジック `createMediaClockAlignmentHold` を追加
- `object-audio-controller.js`: スロットリングを迂回する `seekPlaybackTargets` を追加(アニメーション同期オーディオは対象外、ループ音源は折り返し)
- `player-transport.js`(共有パネル): タッチ中断(`pointercancel`)で `isSeeking` が固着しシークバーが凍結する潜在バグを修正

## 音飛び・XRへの影響

定常再生パスは無変更(オーディオがマスターのまま、オーディオへの書き込みなし)。強制シークは明示的なユーザーシーク時のみ。吸着保留は映像側クロックにのみ作用するため音声グリッチは構造上発生しない。immersive-vr ではパネル自体が非表示のため影響なし。

## テスト

- `npm run test:scene-sync-export-import` 97件 pass(新規テスト6件含む)
- `npm run test:e2e:scene-sync-export-static-viewer` pass
- editor-player-transport テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)